### PR TITLE
Refactor auth singleton to factory function for dependency injection

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,6 @@ import { Scalar } from "@scalar/hono-api-reference";
 import { Hono } from "hono";
 import { openAPIRouteHandler } from "hono-openapi";
 import { cors } from "hono/cors";
-import { auth } from "~/lib/auth";
 import { type AppContext, createAppContext } from "~/lib/ctx";
 import { env } from "~/lib/env";
 import { eventRoutes } from "~/routes/event";
@@ -32,6 +31,7 @@ export const createApp = async (variables?: Variables) => {
             }),
         )
         .on(["POST", "GET"], "/auth/*", (c) => {
+            const { auth } = c.get("ctx");
             return auth.handler(c.req.raw);
         })
         .get("/", (c) => {

--- a/apps/api/src/lib/auth/index.ts
+++ b/apps/api/src/lib/auth/index.ts
@@ -6,122 +6,138 @@ import {
     emailOTP,
     openAPI,
 } from "better-auth/plugins";
-import db from "~/db";
 import * as schema from "~/db/schema";
-import { getRedis } from "~/lib/cache/redis";
 import { sendEmail } from "~/lib/email";
 import ChangeEmailVerificationEmail from "~/lib/email/template/change-email-verification";
 import OtpSignInEmail from "~/lib/email/template/otp-sign-in";
 import ResetPasswordEmail from "~/lib/email/template/reset-password";
 import { env } from "~/lib/env";
 import { feidePlugin, syncFeideHook } from "./feide";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type { DbSchema } from "../../db";
+import type { RedisClient } from "../cache/redis";
 
-const redis = await getRedis();
-
-export const auth = betterAuth({
-    database: drizzleAdapter(db, {
-        provider: "pg",
-        schema,
-    }),
-    baseURL: env.ROOT_URL,
-    emailAndPassword: {
-        enabled: true,
-        disableSignUp: true,
-        requireEmailVerification: true,
-        sendResetPassword: async ({ url, user }) => {
-            await sendEmail({
-                component: ResetPasswordEmail({ url }),
-                subject: "Tilbakestill ditt passord",
-                to: user.email,
-            });
-        },
-    },
-    session: {
-        expiresIn: 60 * 60 * 24 * 7, // 7 days
-        updateAge: 60 * 60 * 24, // 1 day
-    },
-    advanced: {
-        crossSubDomainCookies: {
+export const createAuth = (ctx: {
+    db: NodePgDatabase<DbSchema>;
+    /** Redis client instance */
+    redis: RedisClient;
+}) =>
+    betterAuth({
+        database: drizzleAdapter(ctx.db, {
+            provider: "pg",
+            schema,
+        }),
+        baseURL: env.ROOT_URL,
+        emailAndPassword: {
             enabled: true,
-        },
-    },
-    trustedOrigins: [
-        "https://tihlde.org",
-        "https://*.tihlde.org",
-        "localhost:*",
-    ],
-    user: {
-        additionalFields: {
-            /**
-             * @deprecated Backwards-compatibility from Lepton auth system
-             *
-             * Legacy token is a never-changing(!) token that is used to authenticate against Lepton.
-             * Until that API is fully removed, we keep this stored and send as cookie on sign-in
-             * to keep the old endpoints working from the browser.
-             */
-            legacyToken: {
-                type: "string",
-                required: false,
-                unique: false,
-                input: false,
-            },
-        },
-        changeEmail: {
-            enabled: true,
-            sendChangeEmailVerification: async ({ newEmail, url }) => {
-                sendEmail({
-                    component: ChangeEmailVerificationEmail({ url }),
-                    subject: "Verifiser din nye e-postadresse",
-                    to: newEmail,
+            disableSignUp: true,
+            requireEmailVerification: true,
+            sendResetPassword: async ({ url, user }) => {
+                await sendEmail({
+                    component: ResetPasswordEmail({ url }),
+                    subject: "Tilbakestill ditt passord",
+                    to: user.email,
                 });
             },
         },
-    },
-    plugins: [
-        feidePlugin(),
-        openAPI(),
-        emailOTP({
-            // TODO disable signups when in production
-            // users should only sign up via Feide (or be migrated from Lepton)
-            disableSignUp: false,
-            sendVerificationOTP: async ({ email, otp, type }) => {
-                if (type !== "sign-in") return;
-
-                sendEmail({
-                    component: OtpSignInEmail({ otp }),
-                    subject: "Din engangskode",
-                    to: email,
-                });
+        session: {
+            expiresIn: 60 * 60 * 24 * 7, // 7 days
+            updateAge: 60 * 60 * 24, // 1 day
+        },
+        advanced: {
+            crossSubDomainCookies: {
+                enabled: true,
             },
-        }),
-        admin(),
-    ],
-    logger: {
-        disabled: false,
-        level: "debug",
-        log: (level, message, ...args) => {
-            // Custom logging implementation
-            console.log(`[${level}] ${message}`, ...args);
         },
-    },
-    hooks: {
-        after: createAuthMiddleware(async (ctx) => {
-            await syncFeideHook(ctx);
-        }),
-    },
-    secondaryStorage: {
-        get: async (key) => {
-            return await redis.get(key);
+        trustedOrigins: [
+            "https://tihlde.org",
+            "https://*.tihlde.org",
+            "localhost:*",
+        ],
+        user: {
+            additionalFields: {
+                /**
+                 * @deprecated Backwards-compatibility from Lepton auth system
+                 *
+                 * Legacy token is a never-changing(!) token that is used to authenticate against Lepton.
+                 * Until that API is fully removed, we keep this stored and send as cookie on sign-in
+                 * to keep the old endpoints working from the browser.
+                 */
+                legacyToken: {
+                    type: "string",
+                    required: false,
+                    unique: false,
+                    input: false,
+                },
+            },
+            changeEmail: {
+                enabled: true,
+                sendChangeEmailVerification: async ({ newEmail, url }) => {
+                    sendEmail({
+                        component: ChangeEmailVerificationEmail({ url }),
+                        subject: "Verifiser din nye e-postadresse",
+                        to: newEmail,
+                    });
+                },
+            },
         },
-        set: async (key, value, ttl) => {
-            if (ttl) await redis.set(key, value, { EX: ttl });
-            else await redis.set(key, value);
-        },
-        delete: async (key) => {
-            await redis.del(key);
-        },
-    },
-});
+        plugins: [
+            feidePlugin(),
+            openAPI(),
+            emailOTP({
+                // TODO disable signups when in production
+                // users should only sign up via Feide (or be migrated from Lepton)
+                disableSignUp: false,
+                sendVerificationOTP: async ({ email, otp, type }) => {
+                    if (type !== "sign-in") return;
 
-export type Session = typeof auth.$Infer.Session.session;
-export type User = typeof auth.$Infer.Session.user;
+                    sendEmail({
+                        component: OtpSignInEmail({ otp }),
+                        subject: "Din engangskode",
+                        to: email,
+                    });
+                },
+            }),
+            admin(),
+        ],
+        logger: {
+            disabled: false,
+            level: "debug",
+            log: (level, message, ...args) => {
+                // Custom logging implementation
+                console.log(`[${level}] ${message}`, ...args);
+            },
+        },
+        hooks: {
+            after: createAuthMiddleware(async (ctx) => {
+                await syncFeideHook(ctx);
+            }),
+        },
+        secondaryStorage: {
+            get: async (key) => {
+                return await ctx.redis.get(key);
+            },
+            set: async (key, value, ttl) => {
+                if (ttl) await ctx.redis.set(key, value, { EX: ttl });
+                else await ctx.redis.set(key, value);
+            },
+            delete: async (key) => {
+                await ctx.redis.del(key);
+            },
+        },
+    });
+
+/**
+ * The type of the BetterAuth instance
+ */
+export type AuthInstance = ReturnType<typeof createAuth>;
+
+/**
+ * A user session
+ */
+export type Session = AuthInstance["$Infer"]["Session"]["session"];
+
+/**
+ * User data
+ */
+export type User = AuthInstance["$Infer"]["Session"]["user"];

--- a/apps/api/src/lib/cache/redis.ts
+++ b/apps/api/src/lib/cache/redis.ts
@@ -1,13 +1,13 @@
 import { createClient } from "redis";
 import { env } from "~/lib/env";
 
-export type RedisClientType = ReturnType<typeof createClient>;
+export type RedisClient = ReturnType<typeof createClient>;
 
 /**
  * Factory function to create and connect a Redis client.
  * Use this for dependency injection and testing.
  */
-export async function createRedisClient(url: string): Promise<RedisClientType> {
+export async function createRedisClient(url: string): Promise<RedisClient> {
     const client = createClient({ url });
     client.on("error", (err) => {
         console.error("Redis client error:", err);
@@ -21,10 +21,10 @@ export async function createRedisClient(url: string): Promise<RedisClientType> {
  * Singleton Redis client for backward compatibility.
  * Prefer using createRedisClient() and dependency injection in new code.
  */
-let client: RedisClientType | null = null;
-let connectPromise: Promise<RedisClientType> | null = null;
+let client: RedisClient | null = null;
+let connectPromise: Promise<RedisClient> | null = null;
 
-async function connect(): Promise<RedisClientType> {
+async function connect(): Promise<RedisClient> {
     if (client) return client;
     if (connectPromise) return connectPromise;
 
@@ -37,6 +37,6 @@ async function connect(): Promise<RedisClientType> {
     return connectPromise;
 }
 
-export async function getRedis(): Promise<RedisClientType> {
+export async function getRedis(): Promise<RedisClient> {
     return connect();
 }

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,10 +1,12 @@
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
-import { type Session, type User, auth } from "~/lib/auth";
+import type { Session, User } from "~/lib/auth";
+import type { AppContext } from "../lib/ctx";
 
 type AuthVariables = {
     user: User;
     session: Session;
+    ctx: AppContext;
 };
 
 /**
@@ -13,6 +15,7 @@ type AuthVariables = {
  */
 export const requireAuth = createMiddleware<{ Variables: AuthVariables }>(
     async (c, next) => {
+        const { auth } = c.get("ctx");
         const session = await auth.api.getSession({
             headers: c.req.raw.headers,
         });
@@ -35,8 +38,9 @@ export const requireAuth = createMiddleware<{ Variables: AuthVariables }>(
  * `user` and `session` will be made available to the route handler
  */
 export const captureAuth = createMiddleware<{
-    Variables: Partial<AuthVariables>;
+    Variables: Partial<AuthVariables> & { ctx: AppContext };
 }>(async (c, next) => {
+    const { auth } = c.get("ctx");
     const session = await auth.api.getSession({
         headers: c.req.raw.headers,
     });

--- a/apps/api/src/middleware/session.ts
+++ b/apps/api/src/middleware/session.ts
@@ -1,12 +1,15 @@
 import { createMiddleware } from "hono/factory";
-import { type Session, type User, auth } from "~/lib/auth";
+import type { Session, User } from "~/lib/auth";
+import type { AppContext } from "../lib/ctx";
 
 export const session = createMiddleware<{
     Variables: {
         user: User | null;
         session: Session | null;
+        ctx: AppContext;
     };
 }>(async (c, next) => {
+    const { auth } = c.get("ctx");
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
 
     if (!session) {

--- a/apps/api/src/test/integration.ts
+++ b/apps/api/src/test/integration.ts
@@ -15,6 +15,7 @@ import {
 import { createRedisClient } from "../lib/cache/redis";
 import { createDb } from "../db";
 import { createQueueManager } from "../lib/cache/bull";
+import { createAuth } from "../lib/auth";
 
 /**
  * `AppContext` with added shadow variables for doing the grunt-work of running the tests
@@ -62,10 +63,17 @@ async function createTestAppContext(): Promise<TestAppContext> {
     // Setup Bull queues
     const queueManager = createQueueManager(redisUrl);
 
+    // Setup auth
+    const auth = createAuth({
+        db,
+        redis,
+    });
+
     const defaultContext: AppContext = {
         db,
         queueManager,
         redis,
+        auth,
     };
 
     return {


### PR DESCRIPTION
## Summary
- Converted auth singleton to `createAuth()` factory function that accepts db and redis dependencies
- Updated auth instance to be provided through `AppContext` for consistent dependency management
- Modified all middleware to access auth via context instead of importing singleton directly
- Updated type exports to use `AuthInstance` type for better type inference

## Benefits
- **Improved testability**: Test code can now inject mock dependencies for auth
- **Better architecture**: Aligns with existing dependency injection pattern used for db, redis, and queueManager
- **More flexible**: Auth system can be configured differently for different runtime environments