### PR TITLE
Add email notifications for event registration resolution

### DIFF
--- a/src/lib/email/template/registration-blocked.tsx
+++ b/src/lib/email/template/registration-blocked.tsx
@@ -1,0 +1,115 @@
+import {
+    Body,
+    Container,
+    Head,
+    Heading,
+    Html,
+    Img,
+    Text,
+} from "@react-email/components";
+import React from "react";
+import { env } from "../../env";
+
+interface RegistrationBlockedEmailProps {
+    eventName: string;
+    reason?: string;
+}
+
+export const RegistrationBlockedEmail = ({
+    eventName = "Eksempel arrangement",
+    reason = "Du har for mange prikker og kan ikke melde deg på arrangementet enda.",
+}: RegistrationBlockedEmailProps) => {
+    return (
+        <Html>
+            <Head />
+            <Body style={main}>
+                <Container style={container}>
+                    <Img
+                        src={`${env.ROOT_URL}/static/logomark.jpeg`}
+                        width="100"
+                        height="100"
+                        alt="TIHLDE Logomark"
+                        style={logo}
+                    />
+                    <Heading style={secondary}>
+                        Påmelding ble ikke godkjent
+                    </Heading>
+                    <Text style={paragraph}>
+                        Din påmelding til <strong>{eventName}</strong> ble
+                        dessverre ikke godkjent.
+                    </Text>
+                    <Text style={paragraph}>
+                        <strong>Årsak:</strong> {reason}
+                    </Text>
+                    <Text style={paragraph}>
+                        Ta kontakt med arrangementet hvis du mener dette er en
+                        feil.
+                    </Text>
+                </Container>
+                <Text style={footer}>Levert av INDEX</Text>
+            </Body>
+        </Html>
+    );
+};
+
+export default RegistrationBlockedEmail;
+
+const main = {
+    backgroundColor: "#ffffff",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+};
+
+const container = {
+    backgroundColor: "#ffffff",
+    border: "1px solid #eee",
+    borderRadius: "5px",
+    boxShadow: "0 5px 10px rgba(20,50,70,.2)",
+    marginTop: "20px",
+    maxWidth: "360px",
+    margin: "0 auto",
+    padding: "68px 0 130px",
+};
+
+const logo = {
+    margin: "0 auto",
+    marginBottom: "24px",
+};
+
+const secondary = {
+    color: "#000",
+    display: "inline-block",
+    fontFamily: "HelveticaNeue-Medium,Helvetica,Arial,sans-serif",
+    fontSize: "20px",
+    fontWeight: 500,
+    lineHeight: "24px",
+    marginBottom: "0",
+    marginTop: "0",
+    padding: "0 20px",
+    width: "calc(100% - 40px)",
+    textAlign: "center" as const,
+};
+
+const paragraph = {
+    color: "#444",
+    fontSize: "15px",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+    letterSpacing: "0",
+    lineHeight: "23px",
+    padding: "0 40px",
+    margin: "0",
+    marginTop: "10px",
+    textAlign: "center" as const,
+};
+
+const footer = {
+    color: "#000",
+    fontSize: "12px",
+    fontWeight: 800,
+    letterSpacing: "0",
+    lineHeight: "23px",
+    margin: "0",
+    marginTop: "20px",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+    textAlign: "center" as const,
+    textTransform: "uppercase" as const,
+};

--- a/src/lib/email/template/registration-confirmed.tsx
+++ b/src/lib/email/template/registration-confirmed.tsx
@@ -1,0 +1,132 @@
+import {
+    Body,
+    Button,
+    Container,
+    Head,
+    Heading,
+    Html,
+    Img,
+    Text,
+} from "@react-email/components";
+import React from "react";
+import { env } from "../../env";
+
+interface RegistrationConfirmedEmailProps {
+    eventName: string;
+    eventUrl: string;
+}
+
+export const RegistrationConfirmedEmail = ({
+    eventName = "Eksempel arrangement",
+    eventUrl = "https://tihlde.org/arrangementer/eksempel",
+}: RegistrationConfirmedEmailProps) => {
+    return (
+        <Html>
+            <Head />
+            <Body style={main}>
+                <Container style={container}>
+                    <Img
+                        src={`${env.ROOT_URL}/static/logomark.jpeg`}
+                        width="100"
+                        height="100"
+                        alt="TIHLDE Logomark"
+                        style={logo}
+                    />
+                    <Heading style={secondary}>
+                        Du er påmeldt {eventName}!
+                    </Heading>
+                    <Text style={paragraph}>
+                        Gratulerer! Din påmelding til{" "}
+                        <strong>{eventName}</strong> er bekreftet.
+                    </Text>
+                    <Text style={paragraph}>
+                        Du har fått plass og kan glede deg til arrangementet.
+                    </Text>
+                    <Button href={eventUrl} style={button}>
+                        Se arrangement
+                    </Button>
+                    <Text style={paragraph}>
+                        Vi gleder oss til å se deg der!
+                    </Text>
+                </Container>
+                <Text style={footer}>Levert av INDEX</Text>
+            </Body>
+        </Html>
+    );
+};
+
+export default RegistrationConfirmedEmail;
+
+const main = {
+    backgroundColor: "#ffffff",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+};
+
+const container = {
+    backgroundColor: "#ffffff",
+    border: "1px solid #eee",
+    borderRadius: "5px",
+    boxShadow: "0 5px 10px rgba(20,50,70,.2)",
+    marginTop: "20px",
+    maxWidth: "360px",
+    margin: "0 auto",
+    padding: "68px 0 130px",
+};
+
+const logo = {
+    margin: "0 auto",
+    marginBottom: "24px",
+};
+
+const secondary = {
+    color: "#000",
+    display: "inline-block",
+    fontFamily: "HelveticaNeue-Medium,Helvetica,Arial,sans-serif",
+    fontSize: "20px",
+    fontWeight: 500,
+    lineHeight: "24px",
+    marginBottom: "0",
+    marginTop: "0",
+    padding: "0 20px",
+    width: "calc(100% - 40px)",
+    textAlign: "center" as const,
+};
+
+const paragraph = {
+    color: "#444",
+    fontSize: "15px",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+    letterSpacing: "0",
+    lineHeight: "23px",
+    padding: "0 40px",
+    margin: "0",
+    marginTop: "10px",
+    textAlign: "center" as const,
+};
+
+const footer = {
+    color: "#000",
+    fontSize: "12px",
+    fontWeight: 800,
+    letterSpacing: "0",
+    lineHeight: "23px",
+    margin: "0",
+    marginTop: "20px",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+    textAlign: "center" as const,
+    textTransform: "uppercase" as const,
+};
+
+const button = {
+    backgroundColor: "#007ee6",
+    borderRadius: "4px",
+    color: "#fff",
+    fontFamily: "'Open Sans', 'Helvetica Neue', Arial",
+    fontSize: "15px",
+    textDecoration: "none",
+    textAlign: "center" as const,
+    display: "block",
+    width: "210px",
+    margin: "20px auto 0",
+    padding: "14px 7px",
+};

--- a/src/lib/email/template/swapped-to-waitlist.tsx
+++ b/src/lib/email/template/swapped-to-waitlist.tsx
@@ -1,0 +1,172 @@
+import {
+    Body,
+    Button,
+    Container,
+    Head,
+    Heading,
+    Html,
+    Img,
+    Section,
+    Text,
+} from "@react-email/components";
+import React from "react";
+import { env } from "../../env";
+
+interface SwappedToWaitlistEmailProps {
+    eventName: string;
+    eventUrl: string;
+    position: number;
+}
+
+export const SwappedToWaitlistEmail = ({
+    eventName = "Eksempel arrangement",
+    eventUrl = "https://tihlde.org/arrangementer/eksempel",
+    position = 3,
+}: SwappedToWaitlistEmailProps) => {
+    return (
+        <Html>
+            <Head />
+            <Body style={main}>
+                <Container style={container}>
+                    <Img
+                        src={`${env.ROOT_URL}/static/logomark.jpeg`}
+                        width="100"
+                        height="100"
+                        alt="TIHLDE Logomark"
+                        style={logo}
+                    />
+                    <Heading style={secondary}>
+                        Endring i din påmelding til {eventName}
+                    </Heading>
+                    <Text style={paragraph}>
+                        En bruker med prioritet har meldt seg på{" "}
+                        <strong>{eventName}</strong>, og du har derfor blitt
+                        flyttet til ventelisten.
+                    </Text>
+                    <Section style={positionContainer}>
+                        <Text style={positionLabel}>
+                            Din plass på ventelisten:
+                        </Text>
+                        <Text style={positionNumber}>{position}</Text>
+                    </Section>
+                    <Text style={paragraph}>
+                        Du vil få beskjed på e-post hvis det blir ledig plass.
+                    </Text>
+                    <Button href={eventUrl} style={button}>
+                        Se arrangement
+                    </Button>
+                    <Text style={paragraph}>
+                        Vi beklager ulempen og håper du får plass!
+                    </Text>
+                </Container>
+                <Text style={footer}>Levert av INDEX</Text>
+            </Body>
+        </Html>
+    );
+};
+
+export default SwappedToWaitlistEmail;
+
+const main = {
+    backgroundColor: "#ffffff",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+};
+
+const container = {
+    backgroundColor: "#ffffff",
+    border: "1px solid #eee",
+    borderRadius: "5px",
+    boxShadow: "0 5px 10px rgba(20,50,70,.2)",
+    marginTop: "20px",
+    maxWidth: "360px",
+    margin: "0 auto",
+    padding: "68px 0 130px",
+};
+
+const logo = {
+    margin: "0 auto",
+    marginBottom: "24px",
+};
+
+const secondary = {
+    color: "#000",
+    display: "inline-block",
+    fontFamily: "HelveticaNeue-Medium,Helvetica,Arial,sans-serif",
+    fontSize: "20px",
+    fontWeight: 500,
+    lineHeight: "24px",
+    marginBottom: "0",
+    marginTop: "0",
+    padding: "0 20px",
+    width: "calc(100% - 40px)",
+    textAlign: "center" as const,
+};
+
+const positionContainer = {
+    background: "rgba(0,0,0,.05)",
+    borderRadius: "4px",
+    margin: "16px auto 14px",
+    verticalAlign: "middle",
+    width: "280px",
+    padding: "16px 0",
+};
+
+const positionLabel = {
+    color: "#666",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+    fontSize: "14px",
+    fontWeight: 400,
+    margin: "0",
+    textAlign: "center" as const,
+    display: "block",
+};
+
+const positionNumber = {
+    color: "#000",
+    fontFamily: "HelveticaNeue-Bold",
+    fontSize: "48px",
+    fontWeight: 700,
+    lineHeight: "56px",
+    margin: "8px 0 0 0",
+    display: "block",
+    textAlign: "center" as const,
+};
+
+const paragraph = {
+    color: "#444",
+    fontSize: "15px",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+    letterSpacing: "0",
+    lineHeight: "23px",
+    padding: "0 40px",
+    margin: "0",
+    marginTop: "10px",
+    textAlign: "center" as const,
+};
+
+const footer = {
+    color: "#000",
+    fontSize: "12px",
+    fontWeight: 800,
+    letterSpacing: "0",
+    lineHeight: "23px",
+    margin: "0",
+    marginTop: "20px",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+    textAlign: "center" as const,
+    textTransform: "uppercase" as const,
+};
+
+const button = {
+    backgroundColor: "#007ee6",
+    borderRadius: "4px",
+    color: "#fff",
+    fontFamily: "'Open Sans', 'Helvetica Neue', Arial",
+    fontSize: "15px",
+    textDecoration: "none",
+    textAlign: "center" as const,
+    display: "block",
+    width: "210px",
+    margin: "20px auto 0",
+    padding: "14px 7px",
+};

--- a/src/lib/email/template/waitlist-placement.tsx
+++ b/src/lib/email/template/waitlist-placement.tsx
@@ -1,0 +1,168 @@
+import {
+    Body,
+    Button,
+    Container,
+    Head,
+    Heading,
+    Html,
+    Img,
+    Section,
+    Text,
+} from "@react-email/components";
+import React from "react";
+import { env } from "../../env";
+
+interface WaitlistPlacementEmailProps {
+    eventName: string;
+    eventUrl: string;
+    position: number;
+}
+
+export const WaitlistPlacementEmail = ({
+    eventName = "Eksempel arrangement",
+    eventUrl = "https://tihlde.org/arrangementer/eksempel",
+    position = 5,
+}: WaitlistPlacementEmailProps) => {
+    return (
+        <Html>
+            <Head />
+            <Body style={main}>
+                <Container style={container}>
+                    <Img
+                        src={`${env.ROOT_URL}/static/logomark.jpeg`}
+                        width="100"
+                        height="100"
+                        alt="TIHLDE Logomark"
+                        style={logo}
+                    />
+                    <Heading style={secondary}>
+                        Du er på venteliste for {eventName}
+                    </Heading>
+                    <Text style={paragraph}>
+                        Din påmelding til <strong>{eventName}</strong> er
+                        mottatt, men arrangementet er fullt.
+                    </Text>
+                    <Section style={positionContainer}>
+                        <Text style={positionLabel}>
+                            Din plass på ventelisten:
+                        </Text>
+                        <Text style={positionNumber}>{position}</Text>
+                    </Section>
+                    <Text style={paragraph}>
+                        Du vil få beskjed på e-post hvis det blir ledig plass.
+                    </Text>
+                    <Button href={eventUrl} style={button}>
+                        Se arrangement
+                    </Button>
+                </Container>
+                <Text style={footer}>Levert av INDEX</Text>
+            </Body>
+        </Html>
+    );
+};
+
+export default WaitlistPlacementEmail;
+
+const main = {
+    backgroundColor: "#ffffff",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+};
+
+const container = {
+    backgroundColor: "#ffffff",
+    border: "1px solid #eee",
+    borderRadius: "5px",
+    boxShadow: "0 5px 10px rgba(20,50,70,.2)",
+    marginTop: "20px",
+    maxWidth: "360px",
+    margin: "0 auto",
+    padding: "68px 0 130px",
+};
+
+const logo = {
+    margin: "0 auto",
+    marginBottom: "24px",
+};
+
+const secondary = {
+    color: "#000",
+    display: "inline-block",
+    fontFamily: "HelveticaNeue-Medium,Helvetica,Arial,sans-serif",
+    fontSize: "20px",
+    fontWeight: 500,
+    lineHeight: "24px",
+    marginBottom: "0",
+    marginTop: "0",
+    padding: "0 20px",
+    width: "calc(100% - 40px)",
+    textAlign: "center" as const,
+};
+
+const positionContainer = {
+    background: "rgba(0,0,0,.05)",
+    borderRadius: "4px",
+    margin: "16px auto 14px",
+    verticalAlign: "middle",
+    width: "280px",
+    padding: "16px 0",
+};
+
+const positionLabel = {
+    color: "#666",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+    fontSize: "14px",
+    fontWeight: 400,
+    margin: "0",
+    textAlign: "center" as const,
+    display: "block",
+};
+
+const positionNumber = {
+    color: "#000",
+    fontFamily: "HelveticaNeue-Bold",
+    fontSize: "48px",
+    fontWeight: 700,
+    lineHeight: "56px",
+    margin: "8px 0 0 0",
+    display: "block",
+    textAlign: "center" as const,
+};
+
+const paragraph = {
+    color: "#444",
+    fontSize: "15px",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+    letterSpacing: "0",
+    lineHeight: "23px",
+    padding: "0 40px",
+    margin: "0",
+    marginTop: "10px",
+    textAlign: "center" as const,
+};
+
+const footer = {
+    color: "#000",
+    fontSize: "12px",
+    fontWeight: 800,
+    letterSpacing: "0",
+    lineHeight: "23px",
+    margin: "0",
+    marginTop: "20px",
+    fontFamily: "HelveticaNeue,Helvetica,Arial,sans-serif",
+    textAlign: "center" as const,
+    textTransform: "uppercase" as const,
+};
+
+const button = {
+    backgroundColor: "#007ee6",
+    borderRadius: "4px",
+    color: "#fff",
+    fontFamily: "'Open Sans', 'Helvetica Neue', Arial",
+    fontSize: "15px",
+    textDecoration: "none",
+    textAlign: "center" as const,
+    display: "block",
+    width: "210px",
+    margin: "20px auto 0",
+    padding: "14px 7px",
+};


### PR DESCRIPTION
## Summary
- Created four new Norwegian email templates for event registration notifications
- Integrated email sending into the registration resolution workflow
- All emails follow existing TIHLDE email styling

## Email Templates
1. **Registration Blocked**: Notifies users when registration is blocked due to strikes ("prikker")
2. **Registration Confirmed**: Confirms successful registration with event details
3. **Waitlist Placement**: Informs users of waitlist placement with their position number
4. **Swapped to Waitlist**: Notifies users when moved to waitlist by a priority user

## Changes
- Added email templates in `src/lib/email/template/`
- Updated `resolve-registration.ts` to send emails at appropriate points
- Fetch user email from database for notifications
- Use "prikker" terminology instead of "strikes" for Norwegian context

## Test Plan
- [x] Preview all email templates in development
- [x] Test registration blocked email when user has strikes
- [x] Test registration confirmed email for successful registration
- [x] Test waitlist placement email when event is full
- [x] Test swap notification when priority user takes a spot
- [x] Verify all emails render correctly on mobile and desktop
- [x] Verify email content is in Norwegian and follows TIHLDE style