### PR TITLE
feat: add frontend SDK package

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,46 @@
+name: Publish SDK
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Publish SDK to GitHub Package Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@tihlde"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Set version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "Setting SDK version to $VERSION"
+          cd packages/sdk
+          npm version $VERSION --no-git-tag-version
+
+      - name: Build SDK
+        run: pnpm --filter @tihlde/photon-sdk build
+
+      - name: Publish SDK
+        run: pnpm --filter @tihlde/photon-sdk publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,115 @@
+# @tihlde/photon-sdk
+
+TypeScript SDK for the TIHLDE Photon API.
+
+## Installation
+
+```bash
+# Configure npm to use GitHub Package Registry for @tihlde packages
+echo "@tihlde:registry=https://npm.pkg.github.com" >> .npmrc
+
+# Install the SDK
+pnpm add @tihlde/photon-sdk
+```
+
+## Usage
+
+### Authentication
+
+The SDK provides a typed Better Auth client for authentication:
+
+```ts
+import { createAuthClient } from "@tihlde/photon-sdk/auth";
+
+const auth = createAuthClient({
+  baseURL: "https://api.tihlde.org",
+});
+
+// Sign in with email OTP
+await auth.signIn.emailOtp({
+  email: "user@ntnu.no",
+  otp: "123456",
+});
+
+// Get current session
+const { data: session } = await auth.getSession();
+if (session) {
+  console.log(`Logged in as ${session.user.name}`);
+}
+
+// Sign out
+await auth.signOut();
+```
+
+### Types
+
+Import types for session data, permissions, and groups:
+
+```ts
+import type {
+  User,
+  Session,
+  ExtendedSession,
+  GroupMembership,
+  Permission,
+} from "@tihlde/photon-sdk/types";
+
+function handleSession(session: ExtendedSession) {
+  console.log(`User: ${session.user.name}`);
+  console.log(`Permissions: ${session.permissions.join(", ")}`);
+  console.log(`Groups: ${session.groups.map((g) => g.slug).join(", ")}`);
+}
+```
+
+### API Client (Coming Soon)
+
+The API client module is a placeholder for an OpenAPI-generated client. Once configured, it will provide typed methods for all API endpoints:
+
+```ts
+import { createApiClient } from "@tihlde/photon-sdk/api";
+
+const api = createApiClient({
+  baseUrl: "https://api.tihlde.org",
+});
+
+// Future usage (after OpenAPI generation is configured):
+// const events = await api.events.list();
+// const event = await api.events.get({ id: "123" });
+```
+
+## Module Exports
+
+The SDK provides multiple entry points for tree-shaking:
+
+- `@tihlde/photon-sdk` - All modules
+- `@tihlde/photon-sdk/auth` - Authentication client
+- `@tihlde/photon-sdk/types` - TypeScript types
+- `@tihlde/photon-sdk/api` - API client (placeholder)
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the SDK
+pnpm --filter @tihlde/photon-sdk build
+
+# Type check
+pnpm --filter @tihlde/photon-sdk typecheck
+```
+
+## Publishing
+
+The SDK is automatically published to GitHub Package Registry when a version tag is pushed:
+
+```bash
+# Bump version and create tag
+cd packages/sdk
+npm version patch  # or minor, major
+git push --follow-tags
+```
+
+## License
+
+MIT

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,47 @@
+{
+    "name": "@tihlde/photon-sdk",
+    "version": "0.0.1",
+    "description": "TypeScript SDK for the Photon API",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/index.js",
+            "types": "./dist/index.d.ts"
+        },
+        "./api": {
+            "import": "./dist/api/index.js",
+            "types": "./dist/api/index.d.ts"
+        },
+        "./auth": {
+            "import": "./dist/auth/index.js",
+            "types": "./dist/auth/index.d.ts"
+        },
+        "./types": {
+            "import": "./dist/types/index.js",
+            "types": "./dist/types/index.d.ts"
+        }
+    },
+    "scripts": {
+        "build": "tsup",
+        "typecheck": "tsc --noEmit"
+    },
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/TIHLDE/Photon.git",
+        "directory": "packages/sdk"
+    },
+    "keywords": ["tihlde", "photon", "sdk", "api", "client"],
+    "license": "MIT",
+    "dependencies": {
+        "better-auth": "^1.3.26"
+    },
+    "devDependencies": {
+        "tsup": "^8.5.0",
+        "typescript": "^5.9.2"
+    }
+}

--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -1,0 +1,63 @@
+/**
+ * API client module - Placeholder for OpenAPI-generated client.
+ *
+ * TODO: Configure an OpenAPI code generator to generate typed API client.
+ *
+ * Recommended tools:
+ * - openapi-typescript + openapi-fetch: https://openapi-ts.dev
+ * - hey-api/openapi-ts: https://heyapi.dev
+ * - orval: https://orval.dev
+ *
+ * Example configuration for openapi-typescript:
+ *
+ * ```bash
+ * pnpm add -D openapi-typescript
+ * pnpm add openapi-fetch
+ * ```
+ *
+ * ```ts
+ * // openapi-ts.config.ts
+ * import { defineConfig } from "@hey-api/openapi-ts";
+ *
+ * export default defineConfig({
+ *   input: "https://api.tihlde.org/openapi",
+ *   output: "src/api/generated",
+ *   client: "fetch",
+ * });
+ * ```
+ *
+ * Once generated, export the client from this file:
+ *
+ * ```ts
+ * export * from "./generated";
+ * export { createClient } from "./generated";
+ * ```
+ */
+
+/**
+ * Placeholder API client type.
+ * Will be replaced by generated types.
+ */
+export type ApiClient = Record<string, unknown>;
+
+/**
+ * Placeholder for API client factory.
+ *
+ * @example
+ * ```ts
+ * import { createApiClient } from "@tihlde/photon-sdk/api";
+ *
+ * const api = createApiClient({
+ *   baseUrl: "https://api.tihlde.org",
+ * });
+ *
+ * // Once generated, you'll have typed methods:
+ * // const events = await api.events.list();
+ * ```
+ */
+export function createApiClient(_options: { baseUrl: string }): ApiClient {
+    // TODO: Return generated API client instance
+    throw new Error(
+        "API client not yet implemented. Configure an OpenAPI generator to generate the client.",
+    );
+}

--- a/packages/sdk/src/auth/index.ts
+++ b/packages/sdk/src/auth/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Auth client factory for the Photon SDK.
+ *
+ * Creates a typed Better Auth client configured for the Photon backend.
+ */
+
+import { createAuthClient as createBetterAuthClient } from "better-auth/client";
+import {
+    adminClient,
+    emailOTPClient,
+    usernameClient,
+} from "better-auth/client/plugins";
+import type {
+    BasicSession,
+    ExtendedSession,
+    GroupMembership,
+    Permission,
+    Session,
+    User,
+} from "../types";
+
+/**
+ * Options for creating the auth client.
+ */
+export interface AuthClientOptions {
+    /**
+     * The base URL of the Photon API server.
+     * @example "https://api.tihlde.org"
+     */
+    baseURL: string;
+
+    /**
+     * Custom fetch implementation.
+     * Useful for testing or adding custom headers.
+     */
+    fetchOptions?: {
+        customFetchImpl?: typeof fetch;
+        headers?: Record<string, string>;
+    };
+}
+
+/**
+ * Creates a typed Better Auth client for the Photon API.
+ *
+ * @example
+ * ```ts
+ * import { createAuthClient } from "@tihlde/photon-sdk/auth";
+ *
+ * const auth = createAuthClient({
+ *   baseURL: "https://api.tihlde.org",
+ * });
+ *
+ * // Sign in with email OTP
+ * await auth.signIn.emailOtp({ email: "user@example.com" });
+ *
+ * // Get current session
+ * const session = await auth.getSession();
+ * ```
+ */
+export function createAuthClient(options: AuthClientOptions) {
+    const client = createBetterAuthClient({
+        baseURL: options.baseURL,
+        fetchOptions: options.fetchOptions,
+        plugins: [adminClient(), emailOTPClient(), usernameClient()],
+    });
+
+    return client;
+}
+
+/**
+ * Type of the auth client returned by createAuthClient.
+ */
+export type AuthClient = ReturnType<typeof createAuthClient>;
+
+// Re-export types for convenience
+export type {
+    BasicSession,
+    ExtendedSession,
+    GroupMembership,
+    Permission,
+    Session,
+    User,
+};

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Photon SDK
+ *
+ * TypeScript SDK for the TIHLDE Photon API.
+ *
+ * @example
+ * ```ts
+ * import { createAuthClient } from "@tihlde/photon-sdk/auth";
+ * import type { ExtendedSession } from "@tihlde/photon-sdk/types";
+ *
+ * const auth = createAuthClient({
+ *   baseURL: "https://api.tihlde.org",
+ * });
+ *
+ * const session = await auth.getSession();
+ * ```
+ */
+
+// Re-export all modules
+export * from "./auth";
+export * from "./types";
+export * from "./api";

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared types for the Photon SDK.
+ *
+ * These types mirror the backend's session and permission structures.
+ */
+
+/**
+ * User data from the session.
+ */
+export interface User {
+    id: string;
+    name: string;
+    email: string;
+    emailVerified: boolean;
+    image: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    role: string | null;
+    banned: boolean | null;
+    banReason: string | null;
+    banExpires: Date | null;
+    username: string | null;
+    displayUsername: string | null;
+}
+
+/**
+ * Session metadata.
+ */
+export interface Session {
+    id: string;
+    expiresAt: Date;
+    token: string;
+    createdAt: Date;
+    updatedAt: Date;
+    ipAddress: string | null;
+    userAgent: string | null;
+    userId: string;
+    impersonatedBy: string | null;
+}
+
+/**
+ * Group membership role type.
+ */
+export type GroupMembershipRole = "member" | "leader";
+
+/**
+ * A user's group membership information.
+ */
+export interface GroupMembership {
+    slug: string;
+    role: GroupMembershipRole;
+}
+
+/**
+ * Permission string type.
+ *
+ * Format: "domain:action" or "domain:subdomain:action"
+ * Examples: "events:create", "events:registrations:view", "root"
+ */
+export type Permission = string;
+
+/**
+ * Extended session data with permissions and groups.
+ *
+ * This is the full session object returned when fetching the current session
+ * with extended data enabled.
+ */
+export interface ExtendedSession {
+    session: Session;
+    user: User;
+    permissions: Permission[];
+    groups: GroupMembership[];
+}
+
+/**
+ * Basic session data without permissions and groups.
+ */
+export interface BasicSession {
+    session: Session;
+    user: User;
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,32 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"lib": [
+			"ES2022",
+			"DOM"
+		],
+		"types": [],
+		"strict": true,
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"isolatedModules": true,
+		"skipLibCheck": true,
+		"resolveJsonModule": true,
+		"noUncheckedIndexedAccess": true,
+		"forceConsistentCasingInFileNames": true,
+		"declaration": true,
+		"declarationMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"noEmit": true
+	},
+	"include": [
+		"src/**/*"
+	],
+	"exclude": [
+		"node_modules",
+		"dist"
+	]
+}

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    entry: [
+        "src/index.ts",
+        "src/api/index.ts",
+        "src/auth/index.ts",
+        "src/types/index.ts",
+    ],
+    format: ["esm"],
+    target: "es2022",
+    outDir: "dist",
+    clean: true,
+    sourcemap: true,
+    dts: true,
+    splitting: false,
+    treeshake: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,19 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
+  packages/sdk:
+    dependencies:
+      better-auth:
+        specifier: ^1.3.26
+        version: 1.3.34(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+    devDependencies:
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+
   packages/tsconfig: {}
 
 packages:


### PR DESCRIPTION
## Summary
- Add `@tihlde/photon-sdk` package for frontend applications
- Auth module with `createAuthClient()` factory using Better Auth
- Types module with `User`, `Session`, `ExtendedSession`, `GroupMembership`, `Permission`
- API module placeholder for future OpenAPI-generated client
- GitHub Actions workflow to auto-publish on version tags (`v*`)

## Package Exports
- `@tihlde/photon-sdk` - All modules
- `@tihlde/photon-sdk/auth` - Authentication client
- `@tihlde/photon-sdk/types` - TypeScript types
- `@tihlde/photon-sdk/api` - API client (placeholder)

## TODO (future work)
- [ ] Add TanStack Query options for data fetching
- [ ] Generate API types automatically from Photon OpenAPI spec
- [ ] Refactor auth types to a separate shared package to avoid importing directly from backend (blocked by active auth/permissions PRs)

## Test plan
- [x] `pnpm install` recognizes new package
- [x] `pnpm --filter @tihlde/photon-sdk build` succeeds
- [x] `pnpm --filter @tihlde/photon-sdk typecheck` succeeds
- [x] `pnpm lint` passes
- [ ] Test publishing with a version tag after merge