### PR TITLE
feat: footer social links, sponsor logos and personvern page

### DIFF
--- a/apps/kvark/src/components/site-footer.tsx
+++ b/apps/kvark/src/components/site-footer.tsx
@@ -1,5 +1,6 @@
+import { Link } from "@tanstack/react-router";
 import { Separator } from "@tihlde/ui/ui/separator";
-import { Facebook, Instagram } from "lucide-react";
+import { Facebook, Instagram, Linkedin } from "lucide-react";
 
 export function SiteFooter() {
     return (
@@ -10,7 +11,9 @@ export function SiteFooter() {
                     <h3 className="font-heading text-sm font-semibold">
                         Kontakt
                     </h3>
-                    <p>E-post: hs@tihlde.org</p>
+                    <p>
+                        E-post: <a href="mailto:hs@tihlde.org">hs@tihlde.org</a>
+                    </p>
                     <p>Lokasjon: c/o IDI, NTNU</p>
                     <p>Org.nr: 998 952 183</p>
                 </div>
@@ -19,25 +22,71 @@ export function SiteFooter() {
                     <h3 className="font-heading text-sm font-semibold">
                         Hovedsamarbeidspartner
                     </h3>
-                    <div className="flex h-12 w-40 items-center justify-center bg-muted">
-                        <span className="text-xs">DNV</span>
-                    </div>
+                    <a
+                        href="https://www.dnv.no/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="DNV"
+                        className="rounded-lg bg-white p-4"
+                    >
+                        <img
+                            src="https://cdn.onedesign.dnv.com/onedesigncdn/3.7.0/images/DNV_logo_RGB.svg"
+                            alt="DNV"
+                            loading="lazy"
+                            className="w-48"
+                        />
+                    </a>
                     <div className="flex items-center gap-3">
-                        <a href="#" aria-label="Facebook">
+                        <a
+                            href="https://www.facebook.com/tihlde"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label="Facebook"
+                        >
                             <Facebook className="size-5" />
                         </a>
-                        <a href="#" aria-label="Instagram">
+                        <a
+                            href="https://www.instagram.com/tihlde"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label="Instagram"
+                        >
                             <Instagram className="size-5" />
+                        </a>
+                        <a
+                            href="https://www.linkedin.com/company/tihlde"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label="LinkedIn"
+                        >
+                            <Linkedin className="size-5" />
                         </a>
                     </div>
                 </div>
 
-                <div className="flex flex-col gap-2 md:items-end">
+                <div className="flex flex-col gap-3 md:items-end">
                     <h3 className="font-heading text-sm font-semibold">
                         Samarbeid
                     </h3>
-                    <p>NITO</p>
+                    <a
+                        href="https://www.nito.no/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="NITO"
+                    >
+                        <img
+                            src="data:image/svg+xml,%3csvg%20width='2100'%20height='484'%20viewBox='0%200%202100%20484'%20fill='none'%20xmlns='http://www.w3.org/2000/svg'%3e%3cpath%20fill-rule='evenodd'%20clip-rule='evenodd'%20d='M471%20473H11V13H471V473ZM89%20395H300L89%2090V395ZM183%2090L394%20395V90H183Z'%20fill='%232EC78F'/%3e%3cpath%20d='M626%20473H704V154L947%20473H1015V12H937V332L694%2012H626V473Z'%20fill='%232EC78F'/%3e%3cpath%20d='M1115%20472V12L1193%2012.1054V472H1115Z'%20fill='%232EC78F'/%3e%3cpath%20d='M1393%2086V473H1471V86H1617V12H1251V86H1393Z'%20fill='%232EC78F'/%3e%3cpath%20fill-rule='evenodd'%20clip-rule='evenodd'%20d='M1855%205C1985.89%205%202092%20111.109%202092%20242C2092%20372.891%201985.89%20479%201855%20479C1724.11%20479%201618%20372.891%201618%20242C1618%20111.109%201724.11%205%201855%205ZM1855.5%2087C1769.62%2087%201700%20156.62%201700%20242.5C1700%20328.38%201769.62%20398%201855.5%20398C1941.38%20398%202011%20328.38%202011%20242.5C2011%20156.62%201941.38%2087%201855.5%2087Z'%20fill='%232EC78F'/%3e%3c/svg%3e"
+                            alt="NITO"
+                            loading="lazy"
+                            className="w-28"
+                        />
+                    </a>
                 </div>
+            </div>
+            <Separator />
+            <div className="container mx-auto flex flex-col items-center justify-between gap-2 px-4 py-6 md:flex-row">
+                <p>© {new Date().getFullYear()} TIHLDE</p>
+                <Link to="/personvern">Personvernerklæring</Link>
             </div>
         </footer>
     );

--- a/apps/kvark/src/routeTree.gen.ts
+++ b/apps/kvark/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as AuthRegisterRouteImport } from './routes/_auth/register'
 import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as AuthForgotPasswordRouteImport } from './routes/_auth/forgot-password'
 import { Route as AppToddelRouteImport } from './routes/_app/toddel'
+import { Route as AppPersonvernRouteImport } from './routes/_app/personvern'
 import { Route as AppKontraktRouteImport } from './routes/_app/kontrakt'
 import { Route as AppKokebokRouteImport } from './routes/_app/kokebok'
 import { Route as AppNyheterIndexRouteImport } from './routes/_app/nyheter.index'
@@ -146,6 +147,11 @@ const AuthForgotPasswordRoute = AuthForgotPasswordRouteImport.update({
 const AppToddelRoute = AppToddelRouteImport.update({
   id: '/toddel',
   path: '/toddel',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppPersonvernRoute = AppPersonvernRouteImport.update({
+  id: '/personvern',
+  path: '/personvern',
   getParentRoute: () => AppRoute,
 } as any)
 const AppKontraktRoute = AppKontraktRouteImport.update({
@@ -266,6 +272,7 @@ export interface FileRoutesByFullPath {
   '/admin': typeof AdminSuperAdminRouteWithChildren
   '/kokebok': typeof AppKokebokRoute
   '/kontrakt': typeof AppKontraktRoute
+  '/personvern': typeof AppPersonvernRoute
   '/toddel': typeof AppToddelRoute
   '/forgot-password': typeof AuthForgotPasswordRoute
   '/login': typeof AuthLoginRoute
@@ -305,6 +312,7 @@ export interface FileRoutesByTo {
   '/': typeof AppIndexRoute
   '/kokebok': typeof AppKokebokRoute
   '/kontrakt': typeof AppKontraktRoute
+  '/personvern': typeof AppPersonvernRoute
   '/toddel': typeof AppToddelRoute
   '/forgot-password': typeof AuthForgotPasswordRoute
   '/login': typeof AuthLoginRoute
@@ -347,6 +355,7 @@ export interface FileRoutesById {
   '/admin': typeof AdminRouteWithChildren
   '/_app/kokebok': typeof AppKokebokRoute
   '/_app/kontrakt': typeof AppKontraktRoute
+  '/_app/personvern': typeof AppPersonvernRoute
   '/_app/toddel': typeof AppToddelRoute
   '/_auth/forgot-password': typeof AuthForgotPasswordRoute
   '/_auth/login': typeof AuthLoginRoute
@@ -391,6 +400,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/kokebok'
     | '/kontrakt'
+    | '/personvern'
     | '/toddel'
     | '/forgot-password'
     | '/login'
@@ -430,6 +440,7 @@ export interface FileRouteTypes {
     | '/'
     | '/kokebok'
     | '/kontrakt'
+    | '/personvern'
     | '/toddel'
     | '/forgot-password'
     | '/login'
@@ -471,6 +482,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/_app/kokebok'
     | '/_app/kontrakt'
+    | '/_app/personvern'
     | '/_app/toddel'
     | '/_auth/forgot-password'
     | '/_auth/login'
@@ -658,6 +670,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppToddelRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/personvern': {
+      id: '/_app/personvern'
+      path: '/personvern'
+      fullPath: '/personvern'
+      preLoaderRoute: typeof AppPersonvernRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/_app/kontrakt': {
       id: '/_app/kontrakt'
       path: '/kontrakt'
@@ -838,6 +857,7 @@ const AppProfilIdRouteWithChildren = AppProfilIdRoute._addFileChildren(
 interface AppRouteChildren {
   AppKokebokRoute: typeof AppKokebokRoute
   AppKontraktRoute: typeof AppKontraktRoute
+  AppPersonvernRoute: typeof AppPersonvernRoute
   AppToddelRoute: typeof AppToddelRoute
   AppIndexRoute: typeof AppIndexRoute
   AppAnnonserSlugRoute: typeof AppAnnonserSlugRoute
@@ -857,6 +877,7 @@ interface AppRouteChildren {
 const AppRouteChildren: AppRouteChildren = {
   AppKokebokRoute: AppKokebokRoute,
   AppKontraktRoute: AppKontraktRoute,
+  AppPersonvernRoute: AppPersonvernRoute,
   AppToddelRoute: AppToddelRoute,
   AppIndexRoute: AppIndexRoute,
   AppAnnonserSlugRoute: AppAnnonserSlugRoute,

--- a/apps/kvark/src/routes/_app/personvern.tsx
+++ b/apps/kvark/src/routes/_app/personvern.tsx
@@ -1,0 +1,332 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
+import { Separator } from "@tihlde/ui/ui/separator";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@tihlde/ui/ui/table";
+
+export const Route = createFileRoute("/_app/personvern")({
+    component: PrivacyPolicy,
+});
+
+function PrivacyPolicy() {
+    return (
+        <div className="container mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-8">
+            <Card>
+                <CardHeader>
+                    <CardTitle>Personvernerklæring</CardTitle>
+                    <p>Sist oppdatert: Mars 2026</p>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-8">
+                    <section className="flex flex-col gap-4">
+                        <h2>1. Behandlingsansvarlig</h2>
+                        <p>
+                            TIHLDE (Trondheim IngeniørHøgskoles Linjeforening
+                            for Dannede EDBere) er behandlingsansvarlig for
+                            personopplysninger som samles inn via tihlde.org.
+                        </p>
+                        <p>
+                            Kontakt:{" "}
+                            <a href="mailto:hs@tihlde.org">hs@tihlde.org</a>
+                        </p>
+                    </section>
+
+                    <Separator />
+
+                    <section className="flex flex-col gap-4">
+                        <h2>2. Hvilke personopplysninger vi samler inn</h2>
+
+                        <div className="flex flex-col gap-2">
+                            <h3>2.1 Ved registrering</h3>
+                            <ul className="ml-4 list-inside list-disc">
+                                <li>Navn (fornavn og etternavn)</li>
+                                <li>E-postadresse</li>
+                                <li>Brukernavn (Feide-brukernavn)</li>
+                                <li>Studieprogram og årskull</li>
+                                <li>Kjønn (valgfritt)</li>
+                            </ul>
+                        </div>
+
+                        <div className="flex flex-col gap-2">
+                            <h3>2.2 Ved bruk av tjenesten</h3>
+                            <ul className="ml-4 list-inside list-disc">
+                                <li>Profilbilde (valgfritt)</li>
+                                <li>
+                                    Allergier (ved påmelding til arrangementer
+                                    med servering)
+                                </li>
+                                <li>Gruppemedlemskap</li>
+                                <li>Arrangementshistorikk</li>
+                                <li>Svar på spørreskjemaer</li>
+                                <li>Badges og aktivitetsdata</li>
+                                <li>
+                                    Bio og annen frivillig profilinformasjon
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div className="flex flex-col gap-2">
+                            <h3>2.3 Betalingsopplysninger</h3>
+                            <p>
+                                Ved betaling for arrangementer behandles
+                                betalingen av Vipps AS. Vi lagrer kun
+                                informasjon om hvorvidt betaling er gjennomført,
+                                ikke betalingsdetaljer som kortnummer eller
+                                lignende.
+                            </p>
+                        </div>
+
+                        <div className="flex flex-col gap-2">
+                            <h3>2.4 Automatisk innsamlet informasjon</h3>
+                            <p>
+                                Vi bruker Vercel Analytics og PostHog for å
+                                samle bruksstatistikk og forbedre
+                                brukeropplevelsen. PostHog brukes til
+                                sesjonsopptak og analyse, men all personlig
+                                identifiserbar informasjon (som e-postadresser,
+                                navn og andre sensitive data) maskeres
+                                automatisk og vises som «*****» i opptakene.
+                                Dette sikrer at vi kan analysere brukeratferd
+                                uten å lagre personopplysninger.
+                            </p>
+                        </div>
+                    </section>
+
+                    <Separator />
+
+                    <section className="flex flex-col gap-4">
+                        <h2>3. Formål og rettslig grunnlag</h2>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Formål</TableHead>
+                                    <TableHead>
+                                        Rettslig grunnlag (GDPR)
+                                    </TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                <TableRow>
+                                    <TableCell>Medlemsadministrasjon</TableCell>
+                                    <TableCell>
+                                        Berettiget interesse (Art. 6(1)(f))
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell>
+                                        Arrangementsadministrasjon
+                                    </TableCell>
+                                    <TableCell>Avtale (Art. 6(1)(b))</TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell>Allergihåndtering</TableCell>
+                                    <TableCell>
+                                        Samtykke (Art. 6(1)(a))
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell>Bildepublisering</TableCell>
+                                    <TableCell>
+                                        Samtykke (Art. 6(1)(a))
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell>Nyhetsbrev/varsler</TableCell>
+                                    <TableCell>
+                                        Samtykke (Art. 6(1)(a))
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell>Betalingsbekreftelser</TableCell>
+                                    <TableCell>
+                                        Avtale og rettslig forpliktelse (Art.
+                                        6(1)(b) og (c))
+                                    </TableCell>
+                                </TableRow>
+                            </TableBody>
+                        </Table>
+                    </section>
+
+                    <Separator />
+
+                    <section className="flex flex-col gap-4">
+                        <h2>4. Deling av personopplysninger</h2>
+                        <p>
+                            Vi deler personopplysninger med følgende
+                            tredjeparter:
+                        </p>
+                        <ul className="ml-4 list-inside list-disc">
+                            <li>
+                                <strong>Feide/NTNU:</strong> For autentisering
+                                ved innlogging
+                            </li>
+                            <li>
+                                <strong>Vipps AS:</strong> For
+                                betalingsbehandling
+                            </li>
+                            <li>
+                                <strong>Vercel:</strong> Hosting og anonymisert
+                                analyse
+                            </li>
+                            <li>
+                                <strong>PostHog:</strong> Sesjonsopptak og
+                                analyse (persondata maskeres automatisk)
+                            </li>
+                            <li>
+                                <strong>Discord (valgfritt):</strong> Ved
+                                kobling av Discord-konto
+                            </li>
+                        </ul>
+                        <p>
+                            Vi selger aldri personopplysninger til tredjeparter
+                            og deler kun data som er nødvendig for tjenestens
+                            funksjon.
+                        </p>
+                    </section>
+
+                    <Separator />
+
+                    <section className="flex flex-col gap-4">
+                        <h2>5. Oppbevaring</h2>
+                        <ul className="ml-4 list-inside list-disc">
+                            <li>
+                                <strong>Brukerkontoer:</strong> Så lenge kontoen
+                                er aktiv
+                            </li>
+                            <li>
+                                <strong>Arrangementsdata:</strong> 3 år etter
+                                arrangementsdato
+                            </li>
+                            <li>
+                                <strong>Betalingsbekreftelser:</strong> 5 år
+                                (regnskapskrav)
+                            </li>
+                            <li>
+                                <strong>Botsystem-data:</strong> Så lenge
+                                brukeren er medlem av gruppen
+                            </li>
+                        </ul>
+                    </section>
+
+                    <Separator />
+
+                    <section className="flex flex-col gap-4">
+                        <h2>6. Dine rettigheter</h2>
+                        <p>Du har følgende rettigheter under GDPR:</p>
+                        <ul className="ml-4 flex list-inside list-disc flex-col gap-2">
+                            <li>
+                                <strong>Innsyn:</strong> Du kan eksportere all
+                                din data under «Innstillinger» i profilen
+                            </li>
+                            <li>
+                                <strong>Retting:</strong> Du kan redigere din
+                                informasjon i profilen
+                            </li>
+                            <li>
+                                <strong>Sletting:</strong> Du kan slette din
+                                konto under «Innstillinger» i profilen
+                            </li>
+                            <li>
+                                <strong>Dataportabilitet:</strong> Eksporter din
+                                data i maskinlesbart format via profilen
+                            </li>
+                            <li>
+                                <strong>Protest:</strong> Kontakt oss for å
+                                protestere mot behandling
+                            </li>
+                            <li>
+                                <strong>Trekke samtykke:</strong> Du kan når som
+                                helst endre samtykkeinnstillinger i profilen
+                            </li>
+                        </ul>
+                    </section>
+
+                    <Separator />
+
+                    <section className="flex flex-col gap-4">
+                        <h2>7. Informasjonskapsler (cookies)</h2>
+                        <p>
+                            Vi bruker kun teknisk nødvendige informasjonskapsler
+                            for å holde deg innlogget. Disse krever ikke
+                            samtykke etter ePrivacy-direktivet.
+                        </p>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Navn</TableHead>
+                                    <TableHead>Formål</TableHead>
+                                    <TableHead>Varighet</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                <TableRow>
+                                    <TableCell>access_token</TableCell>
+                                    <TableCell>Autentisering</TableCell>
+                                    <TableCell>Sesjonsbasert</TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell>refresh_token</TableCell>
+                                    <TableCell>Fornyet autentisering</TableCell>
+                                    <TableCell>30 dager</TableCell>
+                                </TableRow>
+                            </TableBody>
+                        </Table>
+                    </section>
+
+                    <Separator />
+
+                    <section className="flex flex-col gap-4">
+                        <h2>8. Sikkerhet</h2>
+                        <p>
+                            Vi tar datasikkerhet på alvor og har implementert
+                            følgende tiltak:
+                        </p>
+                        <ul className="ml-4 list-inside list-disc">
+                            <li>Kryptert kommunikasjon (HTTPS)</li>
+                            <li>Sikker lagring av passord (hashing)</li>
+                            <li>Tilgangskontroll basert på roller</li>
+                            <li>Regelmessige sikkerhetsoppdateringer</li>
+                        </ul>
+                    </section>
+
+                    <Separator />
+
+                    <section className="flex flex-col gap-4">
+                        <h2>9. Kontakt og klage</h2>
+                        <p>
+                            For spørsmål om personvern eller for å utøve dine
+                            rettigheter, kontakt oss på{" "}
+                            <a href="mailto:hs@tihlde.org">hs@tihlde.org</a>.
+                        </p>
+                        <p>
+                            Du har også rett til å klage til Datatilsynet:{" "}
+                            <a
+                                href="https://www.datatilsynet.no"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                www.datatilsynet.no
+                            </a>
+                        </p>
+                    </section>
+
+                    <Separator />
+
+                    <section className="flex flex-col gap-4">
+                        <h2>10. Endringer</h2>
+                        <p>
+                            Denne personvernerklæringen kan oppdateres ved
+                            behov. Ved vesentlige endringer vil vi informere
+                            brukere via e-post eller på nettsiden.
+                        </p>
+                    </section>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}


### PR DESCRIPTION
- Link Facebook/Instagram to TIHLDE pages and add LinkedIn icon
- Add DNV and NITO sponsor logos to footer (matching tihlde.org)
- Make footer email a mailto link
- Add personvern route ported from tihlde.org and link it in footer