### PR TITLE
feat: working event filters with upcoming/past split and tabs

### DIFF
--- a/apps/api/src/routes/event/list.ts
+++ b/apps/api/src/routes/event/list.ts
@@ -1,5 +1,5 @@
 import { schema } from "@photon/db";
-import { and, eq, gte, ilike, lte, sql } from "drizzle-orm";
+import { and, eq, gte, ilike, inArray, lt, lte, sql } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import type z from "zod";
 import { describeRoute } from "~/lib/openapi";
@@ -29,15 +29,19 @@ export const listRoute = route().get(
     validator("query", eventListFilterSchema),
     async (c) => {
         const { db } = c.get("ctx");
-        const { page, pageSize, search, expired, openSignUp } =
+        const { page, pageSize, search, expired, openSignUp, category } =
             c.req.valid("query");
 
         const filters = and(
             ...[
                 search ? ilike(schema.event.title, `%${search}%`) : undefined,
-                // TODO: Test if works :)
+                category
+                    ? inArray(schema.event.categorySlug, category)
+                    : undefined,
                 expired != null
-                    ? eq(sql`NOW() > ${schema.event.end}`, expired)
+                    ? expired
+                        ? lt(schema.event.end, sql`NOW()`)
+                        : gte(schema.event.end, sql`NOW()`)
                     : undefined,
                 // TODO: Test if works :)
                 openSignUp === true
@@ -56,7 +60,9 @@ export const listRoute = route().get(
         const totalPages = getTotalPages(eventCount, pageSize);
 
         const events = await db.query.event.findMany({
-            orderBy: (event, { desc }) => [desc(event.start)],
+            // Upcoming events read best soonest-first; past events most-recent-first.
+            orderBy: (event, { asc, desc }) =>
+                expired === false ? [asc(event.start)] : [desc(event.start)],
             with: {
                 organizer: true,
                 category: true,

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -381,10 +381,35 @@ export const eventListFilterSchema = PaginationSchema.extend({
     search: z.string().optional().meta({
         description: "Search term to filter events by title",
     }),
-    expired: z.coerce.boolean().optional().meta({
-        description: "Whether to include expired events or not",
+    // Accepts both "?category=a,b" and "?category=a&category=b": Hono hands a
+    // repeated param over as an array, while clients that serialise a list into
+    // a single param send it comma-joined. preprocess (rather than a union)
+    // keeps the documented type a plain string array.
+    category: z
+        .preprocess((value) => {
+            if (value === undefined) return undefined;
+            const slugs = (
+                Array.isArray(value) ? value : String(value).split(",")
+            )
+                .map((slug) => String(slug).trim())
+                .filter(Boolean);
+            return slugs.length > 0 ? slugs : undefined;
+        }, z.array(z.string()).optional())
+        .meta({
+            type: "array",
+            items: { type: "string" },
+            description:
+                "Only return events in these category slugs. Omit to return every category.",
+        }),
+    // stringbool parses the "true"/"false" a query string actually carries;
+    // the meta type keeps it a boolean in OpenAPI, where that encoding is implied.
+    expired: z.stringbool().optional().meta({
+        type: "boolean",
+        description:
+            "Filter on whether the event has already ended. True returns only past events, false only upcoming ones. Omit to return both.",
     }),
-    openSignUp: z.coerce.boolean().optional().meta({
+    openSignUp: z.stringbool().optional().meta({
+        type: "boolean",
         description: "Whether to include only events with open sign-ups",
     }),
 });

--- a/apps/kvark/src/api/queries/events.ts
+++ b/apps/kvark/src/api/queries/events.ts
@@ -41,6 +41,7 @@ export const getEventsQuery = (
                 searchParams: {
                     page,
                     pageSize,
+                    ...filters,
                 },
             }),
     });
@@ -56,6 +57,7 @@ export const getEventsInfiniteQuery = (
                 searchParams: {
                     page: pageParam,
                     pageSize,
+                    ...filters,
                 },
             }),
         initialPageParam: 0,

--- a/apps/kvark/src/components/event-filters.tsx
+++ b/apps/kvark/src/components/event-filters.tsx
@@ -33,14 +33,12 @@ type EventFiltersProps = {
     value: EventFiltersValue;
     categories: Category[];
     onChange: (next: EventFiltersValue) => void;
-    onSubmit: () => void;
 };
 
 export function EventFilters({
     value,
     categories,
     onChange,
-    onSubmit,
 }: EventFiltersProps) {
     const pills = useMemo<FilterPill[]>(() => {
         const next: FilterPill[] = [];
@@ -92,6 +90,7 @@ export function EventFilters({
                     <div className="flex flex-col gap-2">
                         <Label>Kategori</Label>
                         <Select
+                            items={categories}
                             value={value.category}
                             onValueChange={(category) =>
                                 onChange({ ...value, category: category ?? "" })
@@ -114,7 +113,7 @@ export function EventFilters({
                         <span className="text-sm">Alternativer</span>
                         <FilterCheckboxOption
                             title="Tidligere"
-                            description="Vis tidligere arrangementer"
+                            description="Vis kun tidligere arrangementer"
                             checked={value.showPast}
                             onCheckedChange={(showPast) =>
                                 onChange({ ...value, showPast })
@@ -133,7 +132,6 @@ export function EventFilters({
             }
             pills={pills}
             onClearAll={() => onChange(DEFAULT_EVENT_FILTERS)}
-            onSubmit={onSubmit}
         />
     );
 }

--- a/apps/kvark/src/components/filter-shell.tsx
+++ b/apps/kvark/src/components/filter-shell.tsx
@@ -14,7 +14,7 @@ import {
     DrawerTitle,
     DrawerTrigger,
 } from "@tihlde/ui/ui/drawer";
-import { FilterX, Search, SlidersHorizontal } from "lucide-react";
+import { FilterX, SlidersHorizontal } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { FilterPillRow, type FilterPill } from "#/components/filter-pill-row";
@@ -24,7 +24,6 @@ type FilterShellProps = {
     fieldsSlot: ReactNode;
     pills: FilterPill[];
     onClearAll: () => void;
-    onSubmit: () => void;
 };
 
 export function FilterShell({
@@ -32,7 +31,6 @@ export function FilterShell({
     fieldsSlot,
     pills,
     onClearAll,
-    onSubmit,
 }: FilterShellProps) {
     return (
         <>
@@ -55,11 +53,9 @@ export function FilterShell({
                             </DrawerHeader>
                             <div className="flex flex-col gap-4 px-4 pb-6">
                                 {fieldsSlot}
+                                {/* Filters apply as they change; this only closes the drawer. */}
                                 <DrawerClose asChild>
-                                    <Button onClick={onSubmit}>
-                                        <Search />
-                                        Bruk filter
-                                    </Button>
+                                    <Button>Ferdig</Button>
                                 </DrawerClose>
                             </div>
                         </DrawerContent>
@@ -87,10 +83,6 @@ export function FilterShell({
                 <CardContent className="flex flex-col gap-4">
                     {searchSlot}
                     {fieldsSlot}
-                    <Button onClick={onSubmit} className="w-full">
-                        <Search />
-                        Søk
-                    </Button>
                 </CardContent>
             </Card>
         </>

--- a/apps/kvark/src/components/job-filters.tsx
+++ b/apps/kvark/src/components/job-filters.tsx
@@ -28,7 +28,6 @@ type JobFiltersProps = {
     classLevelOptions: Option<number>[];
     jobTypeOptions: Option<JobType>[];
     onChange: (next: JobFiltersValue) => void;
-    onSubmit: () => void;
 };
 
 export function JobFilters({
@@ -36,7 +35,6 @@ export function JobFilters({
     classLevelOptions,
     jobTypeOptions,
     onChange,
-    onSubmit,
 }: JobFiltersProps) {
     const toggleClassLevel = (level: number, checked: boolean) => {
         const next = checked
@@ -137,7 +135,6 @@ export function JobFilters({
             }
             pills={pills}
             onClearAll={() => onChange(DEFAULT_JOB_FILTERS)}
-            onSubmit={onSubmit}
         />
     );
 }

--- a/apps/kvark/src/hooks/use-debounced-value.ts
+++ b/apps/kvark/src/hooks/use-debounced-value.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns `value` only after it has stopped changing for `delayMs`.
+ * Use to keep fast-changing input (typing) out of query keys.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+    const [debounced, setDebounced] = useState(value);
+
+    useEffect(() => {
+        const timeout = setTimeout(() => setDebounced(value), delayMs);
+        return () => clearTimeout(timeout);
+    }, [value, delayMs]);
+
+    return debounced;
+}

--- a/apps/kvark/src/routes/_app/annonser.index.tsx
+++ b/apps/kvark/src/routes/_app/annonser.index.tsx
@@ -56,7 +56,6 @@ function JobsPage() {
                         classLevelOptions={CLASS_LEVELS}
                         jobTypeOptions={JOB_TYPES}
                         onChange={setFilters}
-                        onSubmit={() => {}}
                     />
                 </aside>
 

--- a/apps/kvark/src/routes/_app/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.index.tsx
@@ -1,37 +1,128 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
+import { useDeferredValue, useMemo, useState } from "react";
 
 import { getEventsQuery } from "#/api/queries/events";
 import { EventCard } from "#/components/event-card";
 import {
+    type Category,
     DEFAULT_EVENT_FILTERS,
     EventFilters,
     type EventFiltersValue,
 } from "#/components/event-filters";
+import { useDebouncedValue } from "#/hooks/use-debounced-value";
 import { formatEventDateTime } from "#/lib/event";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const ALL_CATEGORIES = { value: "all", label: "Alle kategorier" };
+
+const EVENT_CATEGORIES: Category[] = [
+    { value: "bedpres", label: "Bedpres" },
+    { value: "sosialt", label: "Sosialt" },
+    { value: "kurs", label: "Kurs" },
+    { value: "fadderuka", label: "Fadderuka" },
+    { value: "annet", label: "Annet" },
+];
+
+const ACTIVITY_CATEGORIES: Category[] = [
+    { value: "aktivitet", label: "Aktivitet" },
+];
+
+type EventTab = "arrangementer" | "aktiviteter";
+
+const TABS: { value: EventTab; label: string; categories: Category[] }[] = [
+    {
+        value: "arrangementer",
+        label: "Arrangementer",
+        categories: EVENT_CATEGORIES,
+    },
+    {
+        value: "aktiviteter",
+        label: "Aktiviteter",
+        categories: ACTIVITY_CATEGORIES,
+    },
+];
+
+// Slugs a tab covers when no single category is picked. The events tab also
+// claims "uncategorized" so those events stay reachable rather than falling
+// between the two tabs; it is deliberately not offered in the dropdown.
+const TAB_SLUGS: Record<EventTab, string[]> = {
+    arrangementer: [
+        ...EVENT_CATEGORIES.map((category) => category.value),
+        "uncategorized",
+    ],
+    aktiviteter: ACTIVITY_CATEGORIES.map((category) => category.value),
+};
+
+const toEventListFilters = (
+    query: string,
+    showPast: boolean,
+    category: string[],
+) => ({
+    search: query.trim() || undefined,
+    expired: showPast,
+    category,
+});
 
 export const Route = createFileRoute("/_app/arrangementer/")({
     component: EventsPage,
     loader: ({ context }) =>
-        context.queryClient.ensureQueryData(getEventsQuery(0)),
+        context.queryClient.ensureQueryData(
+            getEventsQuery(
+                0,
+                toEventListFilters(
+                    DEFAULT_EVENT_FILTERS.query,
+                    DEFAULT_EVENT_FILTERS.showPast,
+                    TAB_SLUGS.arrangementer,
+                ),
+            ),
+        ),
 });
 
-const CATEGORIES = [
-    { value: "all", label: "Alle kategorier" },
-    { value: "kurs", label: "Kurs" },
-    { value: "annet", label: "Annet" },
-    { value: "fadderuka", label: "Fadderuka" },
-    { value: "bedpres", label: "Bedpres" },
-    { value: "sosialt", label: "Sosialt" },
-];
-
 function EventsPage() {
+    const [tab, setTab] = useState<EventTab>("arrangementer");
     const [filters, setFilters] = useState<EventFiltersValue>(
         DEFAULT_EVENT_FILTERS,
     );
 
-    const { data } = useSuspenseQuery(getEventsQuery(0));
+    const categories = useMemo(
+        () => [
+            ALL_CATEGORIES,
+            ...(TABS.find((t) => t.value === tab)?.categories ?? []),
+        ],
+        [tab],
+    );
+
+    // A category picked on one tab never exists on the other, so keeping it
+    // would leave the new tab showing nothing.
+    const changeTab = (next: EventTab) => {
+        setTab(next);
+        setFilters((current) => ({
+            ...current,
+            category: ALL_CATEGORIES.value,
+        }));
+    };
+
+    const debouncedQuery = useDebouncedValue(filters.query, SEARCH_DEBOUNCE_MS);
+    const listFilters = useMemo(
+        () =>
+            toEventListFilters(
+                debouncedQuery,
+                filters.showPast,
+                filters.category === ALL_CATEGORIES.value
+                    ? TAB_SLUGS[tab]
+                    : [filters.category],
+            ),
+        [debouncedQuery, filters.showPast, filters.category, tab],
+    );
+
+    // useSuspenseQuery has no placeholderData, so a changed key would otherwise
+    // drop the list to a fallback on every search. Deferring keeps the current
+    // results on screen until the next ones resolve.
+    const deferredFilters = useDeferredValue(listFilters);
+    const { data } = useSuspenseQuery(getEventsQuery(0, deferredFilters));
     const events = data.items;
 
     return (
@@ -47,13 +138,24 @@ function EventsPage() {
                 <aside>
                     <EventFilters
                         value={filters}
-                        categories={CATEGORIES}
+                        categories={categories}
                         onChange={setFilters}
-                        onSubmit={() => {}}
                     />
                 </aside>
 
                 <section className="flex flex-col gap-3">
+                    <Tabs
+                        value={tab}
+                        onValueChange={(next) => changeTab(next as EventTab)}
+                    >
+                        <TabsList>
+                            {TABS.map((t) => (
+                                <TabsTrigger key={t.value} value={t.value}>
+                                    {t.label}
+                                </TabsTrigger>
+                            ))}
+                        </TabsList>
+                    </Tabs>
                     <p className="text-sm text-muted-foreground">
                         {data.totalCount} arrangementer funnet
                     </p>

--- a/apps/kvark/src/routes/admin/arrangementer.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.tsx
@@ -172,6 +172,10 @@ function EventAdminPage() {
                                     Arrangørgruppe
                                 </FieldLabel>
                                 <Select
+                                    items={groups.map((group) => ({
+                                        value: group.slug,
+                                        label: group.name,
+                                    }))}
                                     value={organizerGroupSlug}
                                     onValueChange={(value) =>
                                         setOrganizerGroupSlug(value ?? "")

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3248,7 +3248,9 @@ export interface operations {
                 page?: number;
                 /** @description Search term to filter events by title */
                 search?: string;
-                /** @description Whether to include expired events or not */
+                /** @description Only return events in these category slugs. Omit to return every category. */
+                category?: string[];
+                /** @description Filter on whether the event has already ended. True returns only past events, false only upcoming ones. Omit to return both. */
                 expired?: boolean;
                 /** @description Whether to include only events with open sign-ups */
                 openSignUp?: boolean;


### PR DESCRIPTION
The events list ignored every filter. The filter state was never passed to the API, so search, category and the past/upcoming toggle all did nothing — and the one filter that *was* wired up returned a 500.

## What changed

**Backend**
- **`expired` filter returned a 500 on every use.** It built `NOW() > "end" = $1`, which Postgres rejects (comparison operators are non-associative). It carried a `// TODO: Test if works :)` — it did not.
- **`z.coerce.boolean()` made `expired=false` mean `true`**, since `Boolean("false")` is truthy. The filter could never mean "upcoming". Now uses `z.stringbool()`, with the OpenAPI type kept as `boolean` so the SDK contract is unchanged.
- **New `category` filter**, accepting both `?category=a,b` and repeated `?category=a&category=b` — clients serialise lists either way (`ky` comma-joins).
- **Ordering** is now contextual: upcoming soonest-first, past most-recent-first.

**Frontend**
- Filters are passed through to the API. The list defaults to **upcoming only**; past events appear only behind the "Tidligere" filter.
- **Search as you type**, debounced 300ms. The value is deferred so results stay on screen while the next ones load — `useSuspenseQuery` omits `placeholderData`, so a naive wiring would drop the list to a fallback on every keystroke.
- **Arrangementer / Aktiviteter tabs.** "Aktivitet" is an event category, so the tabs split on it and the category dropdown follows the active tab. `uncategorized` is folded into the Arrangementer tab so those events stay reachable.
- **Selects showed the raw value instead of the label** ("all" instead of "Alle kategorier"). `@tihlde/ui` builds on Base UI, whose `Select.Value` needs `items` to resolve labels — unlike Radix, which does it automatically. Fixed on both the category and the admin organiser-group picker.
- Removed the dead "Søk" button and its no-op `onSubmit` prop. The mobile drawer keeps its button, since it closes the drawer.

## Verification

All four CI steps pass locally (`lint`, `typecheck`, `build`, `test` — 167 API + 12 UI tests).

API counts cross-checked against the database rather than read off the screen:

| | DB | API |
|---|---|---|
| Arrangementer / kommende | 17 | 17 |
| Arrangementer / tidligere | 825 | 825 |
| Aktiviteter / kommende | 0 | 0 |
| Aktiviteter / tidligere | 164 | 164 |
| Søk "julebord" / tidligere | 7 | 7 |

Both category serialisations verified (`category=a,b` and `category=a&category=b` both return 543 for bedpres+sosialt). Search, tabs, category select and the past/upcoming toggle driven in the browser with no console errors; mobile drawer checked at 375px.

## Notes for review

- **Aktiviteter is empty by default** in dev — none of the 164 activities are upcoming. Correct behaviour, but it looks dead until "Tidligere" is ticked.
- **The category dropdown is redundant on the Aktiviteter tab**, since that tab has only one category.
- Category filtering on the **annonser** page is still unwired (pre-existing); `useDebouncedValue` is reusable there.
- `bun run sdk:generate` is broken — `turbo codegen` isn't defined in `turbo.json`. The SDK was regenerated with `bun run codegen` in `packages/sdk`.
- **CI won't run on this PR**: `ci.yml` only triggers on PRs to `dev`/`main`, not `kvark`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)