### PR TITLE
feat: kvark auth — username login, stud.ntnu.no registration, Feide

### DIFF
--- a/apps/kvark/.env.example
+++ b/apps/kvark/.env.example
@@ -4,3 +4,6 @@ VITE_API_URL=http://localhost:4000/
 
 # Optional analytics
 VITE_POSTHOG_KEY=phc_xxx
+
+# Set to "true" to show the "Logg inn med Feide" button (backend Feide client must be configured too)
+VITE_FEIDE_ENABLED=false

--- a/apps/kvark/src/api/auth.ts
+++ b/apps/kvark/src/api/auth.ts
@@ -206,6 +206,32 @@ export async function authClientWithPermission(
     return auth;
 }
 
+/**
+ * Starts the Feide (Dataporten) OAuth flow. This hands the browser off to
+ * Feide, which redirects back to the backend callback and finally to
+ * `callbackURL` on success. Provider id must match `feidePlugin` in
+ * @photon/auth. Requires the backend Feide client to be configured.
+ */
+export async function signInWithFeide(callbackURL: string) {
+    const result = await clientAuthInstance.signIn.oauth2({
+        providerId: "feide",
+        callbackURL: sanitizeRedirectTo(callbackURL),
+    });
+
+    if (result.error) {
+        throw new Error(
+            result.error.message ?? "Kunne ikke starte Feide-innlogging",
+        );
+    }
+
+    // The endpoint returns the Dataporten authorization URL to redirect to.
+    if (result.data && "url" in result.data && result.data.url) {
+        window.location.href = result.data.url;
+    }
+
+    return result.data;
+}
+
 export async function logoutUser() {
     await clientAuthInstance.signOut();
     await invalidateAuth();
@@ -246,6 +272,25 @@ export const signInEmailMutationOptions = mutationOptions({
     }) => {
         const result = await clientAuthInstance.signIn.email({
             email,
+            password,
+        });
+        if (result.error) {
+            throw new Error(result.error.message ?? "Innlogging feilet");
+        }
+        return result.data as SignInEmailResult;
+    },
+});
+
+export const signInUsernameMutationOptions = mutationOptions({
+    mutationFn: async ({
+        username,
+        password,
+    }: {
+        username: string;
+        password: string;
+    }) => {
+        const result = await clientAuthInstance.signIn.username({
+            username,
             password,
         });
         if (result.error) {

--- a/apps/kvark/src/components/feide-sign-in-button.tsx
+++ b/apps/kvark/src/components/feide-sign-in-button.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@tihlde/ui/ui/button";
+import { Spinner } from "@tihlde/ui/ui/spinner";
+
+export type FeideSignInButtonProps = {
+    onSignIn: () => void;
+    loading?: boolean;
+    disabled?: boolean;
+};
+
+/**
+ * Dumb button that kicks off Feide login. The route owns the actual sign-in
+ * call and passes it in via `onSignIn`; this component only renders.
+ */
+export function FeideSignInButton({
+    onSignIn,
+    loading = false,
+    disabled = false,
+}: FeideSignInButtonProps) {
+    return (
+        <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={onSignIn}
+            disabled={disabled || loading}
+        >
+            {loading ? (
+                <>
+                    <Spinner />
+                    <span>Sender deg til Feide...</span>
+                </>
+            ) : (
+                <span>Logg inn med Feide</span>
+            )}
+        </Button>
+    );
+}

--- a/apps/kvark/src/components/hero-section.tsx
+++ b/apps/kvark/src/components/hero-section.tsx
@@ -218,7 +218,7 @@ export function HeroSectionBackground({ className }: { className?: string }) {
                 </filter>
             </defs>
             <g
-                className="opacity-40 dark:opacity-[0.18]"
+                className="opacity-40 dark:opacity-[0.28]"
                 mask={`url(#${vignetteMaskId})`}
             >
                 <g>

--- a/apps/kvark/src/env.ts
+++ b/apps/kvark/src/env.ts
@@ -14,6 +14,16 @@ export const env = createEnv({
 
     client: {
         VITE_APP_TITLE: z.string().min(1).optional(),
+        /**
+         * Set to "true" to show the "Logg inn med Feide" button. Kept off by
+         * default so the button never appears before the backend Feide client
+         * is registered and its credentials are in place — clicking it then
+         * would only produce a Dataporten error.
+         */
+        VITE_FEIDE_ENABLED: z
+            .string()
+            .optional()
+            .transform((v) => v === "true"),
     },
 
     /**

--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { Link, createFileRoute } from "@tanstack/react-router";
 import { Button } from "@tihlde/ui/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import { Plus } from "lucide-react";
@@ -144,7 +144,13 @@ function Hero() {
                     transformasjon og Informasjonsbehandling ved NTNU.
                 </p>
                 <div className="flex flex-wrap items-center justify-center gap-2">
-                    <Button size="lg">Logg inn</Button>
+                    <Button
+                        size="lg"
+                        nativeButton={false}
+                        render={<Link to="/login" />}
+                    >
+                        Logg inn
+                    </Button>
                     <Button size="lg" variant="outline">
                         Opprett bruker
                     </Button>

--- a/apps/kvark/src/routes/_auth/login.tsx
+++ b/apps/kvark/src/routes/_auth/login.tsx
@@ -1,5 +1,6 @@
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
 import { z } from "zod";
 import {
     Card,
@@ -12,7 +13,13 @@ import {
 import { FieldGroup } from "@tihlde/ui/ui/field";
 import { Spinner } from "@tihlde/ui/ui/spinner";
 
-import { sanitizeRedirectTo, signInEmailMutationOptions } from "#/api/auth";
+import {
+    sanitizeRedirectTo,
+    signInUsernameMutationOptions,
+    signInWithFeide,
+} from "#/api/auth";
+import { FeideSignInButton } from "#/components/feide-sign-in-button";
+import { env } from "#/env";
 import { formHandlers, useAppForm } from "#/hooks/form";
 
 // Keep extra search params (sig, exp, client_id, scope…) so the
@@ -29,14 +36,26 @@ export const Route = createFileRoute("/_auth/login")({
 });
 
 const loginSchema = z.object({
-    email: z.email({ error: "Ugyldig e-post" }),
+    username: z.string().min(1, { error: "Brukernavn kan ikke være tomt" }),
     password: z.string().min(1, { error: "Passord kan ikke være tom" }),
 });
 
 function LoginPage() {
     const { redirectTo } = Route.useSearch();
 
-    const signInMutation = useMutation(signInEmailMutationOptions);
+    const [feideLoading, setFeideLoading] = useState(false);
+
+    async function handleFeideSignIn() {
+        setFeideLoading(true);
+        try {
+            await signInWithFeide(sanitizeRedirectTo(redirectTo));
+        } catch {
+            // Reaching here means the redirect never happened; let the user retry.
+            setFeideLoading(false);
+        }
+    }
+
+    const signInMutation = useMutation(signInUsernameMutationOptions);
 
     const form = useAppForm({
         validators: {
@@ -44,12 +63,12 @@ function LoginPage() {
             onSubmit: loginSchema,
         },
         defaultValues: {
-            email: "",
+            username: "",
             password: "",
         },
         async onSubmit({ value }) {
             const data = await signInMutation.mutateAsync({
-                email: value.email,
+                username: value.username,
                 password: value.password,
             });
 
@@ -77,12 +96,12 @@ function LoginPage() {
             <form {...formHandlers(form)}>
                 <CardContent>
                     <FieldGroup>
-                        <form.AppField name="email">
+                        <form.AppField name="username">
                             {(field) => (
                                 <field.InputField
-                                    label="E-post"
-                                    type="email"
-                                    autoComplete="email"
+                                    label="Brukernavn"
+                                    type="text"
+                                    autoComplete="username"
                                     required
                                 />
                             )}
@@ -116,6 +135,12 @@ function LoginPage() {
                             Logg inn
                         </form.SubmitButton>
                     </form.AppForm>
+                    {env.VITE_FEIDE_ENABLED && (
+                        <FeideSignInButton
+                            onSignIn={handleFeideSignIn}
+                            loading={feideLoading}
+                        />
+                    )}
                     <p className="text-sm text-muted-foreground">
                         Har du ikke konto?{" "}
                         <Link

--- a/apps/kvark/src/routes/_auth/register.tsx
+++ b/apps/kvark/src/routes/_auth/register.tsx
@@ -12,17 +12,36 @@ import {
 import { FieldGroup } from "@tihlde/ui/ui/field";
 import { Spinner } from "@tihlde/ui/ui/spinner";
 
-import { invalidateAuth, signUpEmailMutationOptions } from "#/api/auth";
+import { useState } from "react";
+
+import {
+    invalidateAuth,
+    signInWithFeide,
+    signUpEmailMutationOptions,
+} from "#/api/auth";
+import { FeideSignInButton } from "#/components/feide-sign-in-button";
+import { env } from "#/env";
 import { formHandlers, useAppForm } from "#/hooks/form";
 
 export const Route = createFileRoute("/_auth/register")({
     component: RegisterPage,
 });
 
+// Kept identical to STUD_NTNU_EMAIL_PATTERN in @photon/auth, which is the
+// actual enforcement point — this only moves the error next to the field.
+const STUD_NTNU_EMAIL_PATTERN =
+    /^([a-z0-9]+(?:[._-][a-z0-9]+)*)@stud\.ntnu\.no$/;
+
 const registerSchema = z
     .object({
         name: z.string().min(1, { error: "Navn kan ikke være tom" }),
-        email: z.email({ error: "Ugyldig e-post" }),
+        email: z
+            .email({ error: "Ugyldig e-post" })
+            .refine(
+                (email) =>
+                    STUD_NTNU_EMAIL_PATTERN.test(email.trim().toLowerCase()),
+                { error: "Du må bruke din @stud.ntnu.no-adresse" },
+            ),
         password: z
             .string()
             .min(8, { error: "Passordet må være minst 8 tegn" }),
@@ -41,6 +60,17 @@ const registerSchema = z
 
 function RegisterPage() {
     const navigate = useNavigate();
+
+    const [feideLoading, setFeideLoading] = useState(false);
+
+    async function handleFeideSignIn() {
+        setFeideLoading(true);
+        try {
+            await signInWithFeide("/");
+        } catch {
+            setFeideLoading(false);
+        }
+    }
 
     const signUpMutation = useMutation(signUpEmailMutationOptions);
 
@@ -131,6 +161,7 @@ function RegisterPage() {
                                     label="E-post"
                                     type="email"
                                     autoComplete="email"
+                                    description="Bruk din @stud.ntnu.no-adresse. Brukernavnet ditt blir det som står før @."
                                     required
                                 />
                             )}
@@ -173,6 +204,12 @@ function RegisterPage() {
                             Opprett bruker
                         </form.SubmitButton>
                     </form.AppForm>
+                    {env.VITE_FEIDE_ENABLED && (
+                        <FeideSignInButton
+                            onSignIn={handleFeideSignIn}
+                            loading={feideLoading}
+                        />
+                    )}
                     <p className="text-sm text-muted-foreground">
                         Har du allerede konto?{" "}
                         <Link

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -93,21 +93,37 @@ interface FeideGroup {
 }
 
 /**
- * Authentication plugin for Feide using OpenID Connect
+ * Authentication plugin for Feide using OpenID Connect.
+ *
+ * The plugin is always registered so Better Auth's tuple-based `$Infer` (and
+ * therefore the session/user type consumed across the API) stays stable. The
+ * Feide *provider* is gated instead: without credentials the config list is
+ * empty, so `/sign-in/oauth2` for `feide` simply resolves no provider and the
+ * flow cannot start. A conditional spread in the plugins array would instead
+ * widen the tuple and silently drop inferred fields like `banned`.
  */
 export const feidePlugin = () =>
     genericOAuth({
-        config: [
-            {
-                providerId: FEIDE_PROVIDER_ID,
-                clientId: env.FEIDE_CLIENT_ID,
-                clientSecret: env.FEIDE_CLIENT_SECRET,
-                discoveryUrl:
-                    "https://auth.dataporten.no/.well-known/openid-configuration",
-                scopes: ["openid", "userid", "profile", "groups-edu", "email"],
-                getUserInfo,
-            },
-        ],
+        config:
+            env.FEIDE_CLIENT_ID && env.FEIDE_CLIENT_SECRET
+                ? [
+                      {
+                          providerId: FEIDE_PROVIDER_ID,
+                          clientId: env.FEIDE_CLIENT_ID,
+                          clientSecret: env.FEIDE_CLIENT_SECRET,
+                          discoveryUrl:
+                              "https://auth.dataporten.no/.well-known/openid-configuration",
+                          scopes: [
+                              "openid",
+                              "userid",
+                              "profile",
+                              "groups-edu",
+                              "email",
+                          ],
+                          getUserInfo,
+                      },
+                  ]
+                : [],
     });
 
 /**

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -137,10 +137,18 @@ export const syncFeideHook: (
 
         const userId = session.user.id;
 
+        // Must filter by providerId: a user who also has an email/password
+        // account has multiple `account` rows, and only the Feide one carries
+        // the Dataporten access token needed below.
         const feideAccount = await ctx.db
             .select({ accessToken: account.accessToken })
             .from(account)
-            .where(eq(account.userId, userId))
+            .where(
+                and(
+                    eq(account.userId, userId),
+                    eq(account.providerId, FEIDE_PROVIDER_ID),
+                ),
+            )
             .limit(1);
 
         const token = feideAccount[0]?.accessToken;

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -218,7 +218,10 @@ export function createAuth(options: CreateAuthOptions) {
         plugins: [
             admin(),
             openAPI(),
-            ...(isFeideConfigured ? [feidePlugin()] : []),
+            // Always present so the plugins tuple stays stable for `$Infer`;
+            // the Feide provider itself is gated inside feidePlugin() on the
+            // credentials being set.
+            feidePlugin(),
             username(),
             jwt({
                 // Recommended by better-auth docs when using with OAuth Provider plugin

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,4 +1,5 @@
 import { betterAuth, BetterAuthOptions, DBAdapter } from "better-auth";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import {
     admin,
     customSession,
@@ -14,7 +15,37 @@ import {
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { DbSchema } from "@photon/db";
 import type { EmailService, CacheService } from "@photon/core/services";
+import { env } from "@photon/core/env";
 import { getUserPermissions } from "./rbac/permissions";
+import { feidePlugin, syncFeideHook } from "./feide";
+
+/**
+ * Feide is a genuine third-party identity provider: it only works once a Feide
+ * client is registered in the Feide Kundeportal and its credentials land in the
+ * environment. Until then the plugin is left out entirely rather than mounted
+ * with an empty client id (which would send users to Dataporten with a broken
+ * `client_id=` and fail confusingly). The frontend hides its Feide button
+ * behind its own flag, so the two sides are enabled independently.
+ */
+const isFeideConfigured = Boolean(
+    env.FEIDE_CLIENT_ID && env.FEIDE_CLIENT_SECRET,
+);
+
+/**
+ * Self-registration is restricted to NTNU student addresses, and the username
+ * is the local part of that address (`olanor@stud.ntnu.no` -> `olanor`).
+ *
+ * Deliberately scoped to the public `/sign-up/email` endpoint rather than a
+ * `databaseHooks.user.create` hook: every other creation path (dev seeding,
+ * integration tests, admin create-user and the Lepton migration) legitimately
+ * carries other domains, and the migration in particular would silently drop
+ * legacy members whose accounts predate the stud.ntnu.no rule.
+ *
+ * The local part must not be empty and cannot contain a second `@`, so a
+ * plain `endsWith` check is not enough.
+ */
+const STUD_NTNU_EMAIL_PATTERN =
+    /^([a-z0-9]+(?:[._-][a-z0-9]+)*)@stud\.ntnu\.no$/;
 
 export interface CreateAuthOptions {
     isDevMode?: boolean;
@@ -147,14 +178,47 @@ export function createAuth(options: CreateAuthOptions) {
             },
         },
 
+        hooks: {
+            before: createAuthMiddleware(async (ctx) => {
+                if (ctx.path !== "/sign-up/email") return;
+
+                const rawEmail = ctx.body?.email;
+                const email =
+                    typeof rawEmail === "string"
+                        ? rawEmail.trim().toLowerCase()
+                        : "";
+
+                const match = STUD_NTNU_EMAIL_PATTERN.exec(email);
+                if (!match) {
+                    throw new APIError("BAD_REQUEST", {
+                        message:
+                            "Registrering krever en @stud.ntnu.no-adresse.",
+                    });
+                }
+
+                // Username is derived, never taken from the request: a caller
+                // must not be able to pick one that disagrees with their email.
+                return {
+                    context: {
+                        body: { ...ctx.body, email, username: match[1] },
+                    },
+                };
+            }),
+            after: createAuthMiddleware(async (ctx) => {
+                if (!isFeideConfigured) return;
+                // Syncs the user's TIHLDE study-program memberships after a
+                // successful Feide callback; a no-op for every other request.
+                await syncFeideHook(ctx, { db: options.services.db });
+            }),
+        },
+
         // Needed for the JWT plugin to work with oAuth Provider plugin
         disabledPaths: ["/token"],
 
         plugins: [
             admin(),
             openAPI(),
-            // TODO: Add feide plugin later
-            // feidePlugin(),
+            ...(isFeideConfigured ? [feidePlugin()] : []),
             username(),
             jwt({
                 // Recommended by better-auth docs when using with OAuth Provider plugin


### PR DESCRIPTION
## Oppsummering

Frontend auth-forbedringer for kvark, pluss oppkobling av den eksisterende (men avslåtte) Feide-plugin-en. Alle endringene er fra samme økt og deler filer, derfor én PR.

### Innlogging med brukernavn
- Logg inn med **brukernavn** i stedet for e-post (`signIn.username`). Better Auth `username()`-plugin og `usernameClient()` var allerede konfigurert; login-siden var eneste bit som fortsatt gikk via e-post.

### Registrering låst til @stud.ntnu.no
- Selvregistrering krever nå en `@stud.ntnu.no`-adresse, og **brukernavnet utledes fra delen før `@`** (`olanor@stud.ntnu.no` → `olanor`).
- Håndhevet av en `hooks.before`-middleware avgrenset til `/sign-up/email` i `@photon/auth` — **bevisst ikke** en `databaseHooks.user.create`-hook, slik at seeding (`test@test.com`), ~180 integrasjonstester, admin create-user og Lepton-migrasjonen fortsatt fungerer med andre domener. Brukernavnet settes server-side og kan ikke overstyres av forespørselen.
- Frontend speiler samme regex som Zod-validering (kun UX; backend håndhever).

### Feide (Dataporten) OAuth
- Aktiverer den eksisterende `feidePlugin()` og `syncFeideHook`, **gated** på at `FEIDE_CLIENT_ID`/`SECRET` finnes — ingenting mountes med tom client id.
- «Logg inn med Feide»-knapp på login + register, skjult bak `VITE_FEIDE_ENABLED` så den ikke vises før backend er konfigurert.
- Fikser en latent bug i `syncFeideHook`: access-token-oppslaget filtrerer nå `account` på `providerId`, så brukere som også har passord-konto får riktig Feide-token.

### Diverse
- Fikser hero-innloggingsknappen (var en død `<button>`, lenker nå til `/login`).
- Hever opacity på hero-bølgestrekene i dark mode 0.18 → 0.28.

## ⚠️ Kreves før Feide går live
Feide er en registrert-tjenesteleverandør-integrasjon. For at innlogging skal fungere må noen med tilgang til **Feide Kundeportal**:
1. Registrere en Feide-klient og fylle `FEIDE_CLIENT_ID` / `FEIDE_CLIENT_SECRET` i backend-miljøet.
2. Registrere redirect-URI: `{ROOT_URL}/api/auth/oauth2/callback/feide` (f.eks. `http://localhost:4000/api/auth/oauth2/callback/feide` lokalt).
3. Sette `VITE_FEIDE_ENABLED=true` i kvark-miljøet.

Til det er på plass er hele Feide-funksjonen inaktiv på begge sider (ingen knapp, ingen route).

## Verifisering
- ✅ Innlogging med brukernavn ende-til-ende (`brotherman`, ekte sesjon, 66 permissions).
- ✅ `@stud.ntnu.no` godtas; gmail/ntnu.no og suffiks-angrep (`x@stud.ntnu.no.evil.com`) avvises med 400.
- ✅ Overstyring av brukernavn i request ignoreres (`root_admin` ble aldri opprettet).
- ✅ Feide-knappen redirecter til `auth.dataporten.no` med riktige scopes (`openid userid profile groups-edu email`) og redirect-URI (verifisert med dummy client id — Dataporten avviser kun selve klienten).
- ✅ Gating verifisert begge veier (frontend-flagg av/på, backend creds tom/satt).
- ✅ Hele API-testsuiten grønn (167), samt auth/user/feide-suitene (28). Typecheck (auth + kvark), lint og format rene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)