### PR TITLE
feat(kvark): build out admin pages against the backend

### DIFF
--- a/apps/kvark/src/components/admin-empty-state.tsx
+++ b/apps/kvark/src/components/admin-empty-state.tsx
@@ -1,0 +1,45 @@
+import {
+    Empty,
+    EmptyContent,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from "@tihlde/ui/ui/empty";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+type AdminEmptyStateProps = {
+    icon: LucideIcon;
+    title: string;
+    description?: ReactNode;
+    /** Optional actions (buttons, links) rendered below the description. */
+    children?: ReactNode;
+};
+
+/**
+ * Consistent empty / placeholder state for admin sections — used both for
+ * "nothing here yet" tables and for pages whose backend endpoint does not
+ * exist yet.
+ */
+export function AdminEmptyState({
+    icon: Icon,
+    title,
+    description,
+    children,
+}: AdminEmptyStateProps) {
+    return (
+        <Empty>
+            <EmptyHeader>
+                <EmptyMedia variant="icon">
+                    <Icon />
+                </EmptyMedia>
+                <EmptyTitle>{title}</EmptyTitle>
+                {description && (
+                    <EmptyDescription>{description}</EmptyDescription>
+                )}
+            </EmptyHeader>
+            {children && <EmptyContent>{children}</EmptyContent>}
+        </Empty>
+    );
+}

--- a/apps/kvark/src/components/admin-group-picker.tsx
+++ b/apps/kvark/src/components/admin-group-picker.tsx
@@ -1,0 +1,48 @@
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@tihlde/ui/ui/select";
+import type { Group } from "@tihlde/sdk";
+
+type AdminGroupPickerProps = {
+    groups: Group[];
+    value: string | null;
+    onValueChange: (slug: string | null) => void;
+    placeholder?: string;
+};
+
+/**
+ * Group selector used by admin sections that are scoped per group (members,
+ * fines). Keeps the choice controlled by the parent route.
+ */
+export function AdminGroupPicker({
+    groups,
+    value,
+    onValueChange,
+    placeholder = "Velg gruppe",
+}: AdminGroupPickerProps) {
+    return (
+        <Select
+            items={groups.map((group) => ({
+                value: group.slug,
+                label: group.name,
+            }))}
+            value={value ?? ""}
+            onValueChange={(next) => onValueChange(next || null)}
+        >
+            <SelectTrigger className="w-full sm:w-72">
+                <SelectValue placeholder={placeholder} />
+            </SelectTrigger>
+            <SelectContent>
+                {groups.map((group) => (
+                    <SelectItem key={group.slug} value={group.slug}>
+                        {group.name}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    );
+}

--- a/apps/kvark/src/components/admin-page-header.tsx
+++ b/apps/kvark/src/components/admin-page-header.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+type AdminPageHeaderProps = {
+    title: string;
+    description?: ReactNode;
+    action?: ReactNode;
+};
+
+/**
+ * Shared header for admin pages: a title, an optional supporting description,
+ * and an optional action slot (usually a primary button) aligned to the end.
+ */
+export function AdminPageHeader({
+    title,
+    description,
+    action,
+}: AdminPageHeaderProps) {
+    return (
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="flex flex-col gap-1">
+                <h1 className="text-3xl">{title}</h1>
+                {description && (
+                    <p className="text-muted-foreground">{description}</p>
+                )}
+            </div>
+            {action && <div className="flex shrink-0 gap-2">{action}</div>}
+        </div>
+    );
+}

--- a/apps/kvark/src/components/admin-stat-card.tsx
+++ b/apps/kvark/src/components/admin-stat-card.tsx
@@ -1,0 +1,53 @@
+import { Link, type LinkOptions } from "@tanstack/react-router";
+import { Card, CardContent } from "@tihlde/ui/ui/card";
+import type { LucideIcon } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
+
+type AdminStatCardProps = {
+    label: string;
+    value: number | string;
+    icon: LucideIcon;
+    hint?: string;
+    /** When provided, the whole card becomes a link into that section. */
+    link?: LinkOptions;
+};
+
+/**
+ * Compact metric tile for the admin dashboard. Renders a labelled count with an
+ * icon; when a link is supplied the entire card is clickable.
+ */
+export function AdminStatCard({
+    label,
+    value,
+    icon: Icon,
+    hint,
+    link,
+}: AdminStatCardProps) {
+    const content = (
+        <CardContent className="flex items-start justify-between gap-4">
+            <div className="flex flex-col gap-1">
+                <span className="text-sm text-muted-foreground">{label}</span>
+                <span className="text-3xl leading-none">{value}</span>
+                {hint && (
+                    <span className="text-xs text-muted-foreground">
+                        {hint}
+                    </span>
+                )}
+            </div>
+            <div className="flex items-center gap-1 text-muted-foreground">
+                <Icon className="size-5" />
+                {link && <ArrowUpRight className="size-4" />}
+            </div>
+        </CardContent>
+    );
+
+    if (link) {
+        return (
+            <Card render={<Link {...link} />} className="cursor-pointer">
+                {content}
+            </Card>
+        );
+    }
+
+    return <Card>{content}</Card>;
+}

--- a/apps/kvark/src/routes/admin/_super-admin/api-keys.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/api-keys.tsx
@@ -1,9 +1,549 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import {
+    KeyIcon,
+    PencilIcon,
+    PlusIcon,
+    RefreshCwIcon,
+    Trash2,
+} from "lucide-react";
+import { Suspense, useState } from "react";
+
+import type { ApiKey } from "@tihlde/sdk";
+import { Badge } from "@tihlde/ui/ui/badge";
+import { Button } from "@tihlde/ui/ui/button";
+import { Card, CardContent, CardFooter } from "@tihlde/ui/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@tihlde/ui/ui/dialog";
+import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
+import { Input } from "@tihlde/ui/ui/input";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@tihlde/ui/ui/table";
+import { Textarea } from "@tihlde/ui/ui/textarea";
+
+import {
+    createApiKeyMutation,
+    deleteApiKeyMutation,
+    getApiKeysQuery,
+    regenerateApiKeyMutation,
+    updateApiKeyMutation,
+} from "#/api/queries/api-keys";
+import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminPageHeader } from "#/components/admin-page-header";
 
 export const Route = createFileRoute("/admin/_super-admin/api-keys")({
-    component: RouteComponent,
+    component: ApiKeysPage,
+    loader: async ({ context }) => {
+        await context.queryClient.ensureQueryData(getApiKeysQuery(0));
+        return { breadcrumbs: "API Nøkler" };
+    },
 });
 
-function RouteComponent() {
-    return <div>Hello "/admin/_super-admin/api-keys"!</div>;
+function ApiKeysPage() {
+    const [createOpen, setCreateOpen] = useState(false);
+    const [editKey, setEditKey] = useState<ApiKey | null>(null);
+    const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
+
+    return (
+        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+            <AdminPageHeader
+                title="API Nøkler"
+                description="Nøkler gir tjenester programmatisk tilgang til API-et. Hemmeligheten vises kun én gang."
+                action={
+                    <Button onClick={() => setCreateOpen(true)}>
+                        <PlusIcon className="size-4" />
+                        Ny nøkkel
+                    </Button>
+                }
+            />
+
+            <Suspense fallback={<TableSkeleton />}>
+                <ApiKeysTable
+                    onEdit={setEditKey}
+                    onRevealSecret={setRevealedSecret}
+                />
+            </Suspense>
+
+            <CreateApiKeyDialog
+                open={createOpen}
+                onOpenChange={setCreateOpen}
+                onCreated={(secret) => setRevealedSecret(secret)}
+            />
+
+            <EditApiKeyDialog
+                apiKey={editKey}
+                onOpenChange={(open) => {
+                    if (!open) setEditKey(null);
+                }}
+            />
+
+            <SecretRevealDialog
+                secret={revealedSecret}
+                onClose={() => setRevealedSecret(null)}
+            />
+        </div>
+    );
+}
+
+function ApiKeysTable({
+    onEdit,
+    onRevealSecret,
+}: {
+    onEdit: (apiKey: ApiKey) => void;
+    onRevealSecret: (secret: string) => void;
+}) {
+    const { data: apiKeys } = useSuspenseQuery(getApiKeysQuery(0));
+    const regenerate = useMutation(regenerateApiKeyMutation);
+    const remove = useMutation(deleteApiKeyMutation);
+
+    if (apiKeys.length === 0) {
+        return (
+            <Card>
+                <CardContent>
+                    <AdminEmptyState
+                        icon={KeyIcon}
+                        title="Ingen API-nøkler"
+                        description="Opprett en nøkkel for å gi en tjeneste tilgang til API-et."
+                    />
+                </CardContent>
+            </Card>
+        );
+    }
+
+    async function handleRegenerate(apiKey: ApiKey) {
+        if (
+            window.confirm(
+                `Regenerere nøkkelen "${apiKey.name}"? Den gamle nøkkelen slutter å virke umiddelbart.`,
+            )
+        ) {
+            const result = await regenerate.mutateAsync({
+                apiKeyId: apiKey.id,
+            });
+            onRevealSecret(result.key);
+        }
+    }
+
+    function handleDelete(apiKey: ApiKey) {
+        if (
+            window.confirm(
+                `Slette nøkkelen "${apiKey.name}"? Dette kan ikke angres.`,
+            )
+        ) {
+            remove.mutate({ apiKeyId: apiKey.id });
+        }
+    }
+
+    return (
+        <Card>
+            <CardContent className="p-0">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Navn</TableHead>
+                            <TableHead>Prefiks</TableHead>
+                            <TableHead>Tilganger</TableHead>
+                            <TableHead>Sist brukt</TableHead>
+                            <TableHead className="text-right">
+                                Handlinger
+                            </TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {apiKeys.map((apiKey) => (
+                            <TableRow key={apiKey.id}>
+                                <TableCell>
+                                    <div className="flex flex-col gap-0.5">
+                                        <span>{apiKey.name}</span>
+                                        <span className="text-xs text-muted-foreground">
+                                            {apiKey.description}
+                                        </span>
+                                    </div>
+                                </TableCell>
+                                <TableCell>
+                                    <code className="text-xs">
+                                        {apiKey.keyPrefix}…
+                                    </code>
+                                </TableCell>
+                                <TableCell>
+                                    <div className="flex flex-wrap gap-1">
+                                        {apiKey.permissions.length === 0 ? (
+                                            <span className="text-xs text-muted-foreground">
+                                                Ingen
+                                            </span>
+                                        ) : (
+                                            apiKey.permissions.map(
+                                                (permission) => (
+                                                    <Badge
+                                                        key={permission}
+                                                        variant="secondary"
+                                                    >
+                                                        {permission}
+                                                    </Badge>
+                                                ),
+                                            )
+                                        )}
+                                    </div>
+                                </TableCell>
+                                <TableCell>
+                                    {apiKey.lastUsedAt
+                                        ? new Date(
+                                              apiKey.lastUsedAt,
+                                          ).toLocaleDateString("nb-NO")
+                                        : "Aldri"}
+                                </TableCell>
+                                <TableCell>
+                                    <div className="flex justify-end gap-2">
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() => onEdit(apiKey)}
+                                        >
+                                            <PencilIcon className="size-4" />
+                                        </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            disabled={regenerate.isPending}
+                                            onClick={() =>
+                                                handleRegenerate(apiKey)
+                                            }
+                                        >
+                                            <RefreshCwIcon className="size-4" />
+                                            Roter
+                                        </Button>
+                                        <Button
+                                            variant="destructive"
+                                            size="sm"
+                                            disabled={remove.isPending}
+                                            onClick={() => handleDelete(apiKey)}
+                                        >
+                                            <Trash2 className="size-4" />
+                                        </Button>
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </CardContent>
+        </Card>
+    );
+}
+
+function CreateApiKeyDialog({
+    open,
+    onOpenChange,
+    onCreated,
+}: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onCreated: (secret: string) => void;
+}) {
+    const [name, setName] = useState("");
+    const [description, setDescription] = useState("");
+    const [permissionsRaw, setPermissionsRaw] = useState("");
+    const [error, setError] = useState<string | null>(null);
+
+    const create = useMutation(createApiKeyMutation);
+
+    function reset() {
+        setName("");
+        setDescription("");
+        setPermissionsRaw("");
+        setError(null);
+    }
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setError(null);
+        const permissions = parsePermissions(permissionsRaw);
+        if (permissions.length === 0) {
+            setError("Minst én tilgang er påkrevd.");
+            return;
+        }
+        try {
+            const result = await create.mutateAsync({
+                data: { name, description, permissions },
+            });
+            onCreated(result.key);
+            reset();
+            onOpenChange(false);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        }
+    }
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(next) => {
+                if (!next) reset();
+                onOpenChange(next);
+            }}
+        >
+            <DialogContent>
+                <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                    <DialogHeader>
+                        <DialogTitle>Ny API-nøkkel</DialogTitle>
+                        <DialogDescription>
+                            Nøkkelen vises kun én gang etter oppretting.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <ApiKeyFields
+                        name={name}
+                        description={description}
+                        permissionsRaw={permissionsRaw}
+                        onNameChange={setName}
+                        onDescriptionChange={setDescription}
+                        onPermissionsChange={setPermissionsRaw}
+                    />
+                    {error && (
+                        <p className="text-sm text-destructive" role="alert">
+                            {error}
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            Avbryt
+                        </Button>
+                        <Button type="submit" disabled={create.isPending}>
+                            Opprett
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function EditApiKeyDialog({
+    apiKey,
+    onOpenChange,
+}: {
+    apiKey: ApiKey | null;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const [name, setName] = useState("");
+    const [description, setDescription] = useState("");
+    const [permissionsRaw, setPermissionsRaw] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [loadedId, setLoadedId] = useState<string | null>(null);
+
+    const update = useMutation(updateApiKeyMutation);
+
+    // Sync local form state whenever a different key is opened for editing.
+    if (apiKey && apiKey.id !== loadedId) {
+        setLoadedId(apiKey.id);
+        setName(apiKey.name);
+        setDescription(apiKey.description);
+        setPermissionsRaw(apiKey.permissions.join("\n"));
+        setError(null);
+    }
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!apiKey) return;
+        setError(null);
+        const permissions = parsePermissions(permissionsRaw);
+        if (permissions.length === 0) {
+            setError("Minst én tilgang er påkrevd.");
+            return;
+        }
+        try {
+            await update.mutateAsync({
+                apiKeyId: apiKey.id,
+                data: { name, description, permissions },
+            });
+            onOpenChange(false);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        }
+    }
+
+    return (
+        <Dialog
+            open={apiKey !== null}
+            onOpenChange={(next) => {
+                if (!next) setLoadedId(null);
+                onOpenChange(next);
+            }}
+        >
+            <DialogContent>
+                <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                    <DialogHeader>
+                        <DialogTitle>Rediger API-nøkkel</DialogTitle>
+                    </DialogHeader>
+                    <ApiKeyFields
+                        name={name}
+                        description={description}
+                        permissionsRaw={permissionsRaw}
+                        onNameChange={setName}
+                        onDescriptionChange={setDescription}
+                        onPermissionsChange={setPermissionsRaw}
+                    />
+                    {error && (
+                        <p className="text-sm text-destructive" role="alert">
+                            {error}
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            Avbryt
+                        </Button>
+                        <Button type="submit" disabled={update.isPending}>
+                            Lagre
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function ApiKeyFields({
+    name,
+    description,
+    permissionsRaw,
+    onNameChange,
+    onDescriptionChange,
+    onPermissionsChange,
+}: {
+    name: string;
+    description: string;
+    permissionsRaw: string;
+    onNameChange: (value: string) => void;
+    onDescriptionChange: (value: string) => void;
+    onPermissionsChange: (value: string) => void;
+}) {
+    return (
+        <FieldGroup>
+            <Field>
+                <FieldLabel htmlFor="api-key-name">Navn</FieldLabel>
+                <Input
+                    id="api-key-name"
+                    required
+                    value={name}
+                    onChange={(event) => onNameChange(event.target.value)}
+                    placeholder="f.eks. Wiki-integrasjon"
+                />
+            </Field>
+            <Field>
+                <FieldLabel htmlFor="api-key-description">
+                    Beskrivelse
+                </FieldLabel>
+                <Textarea
+                    id="api-key-description"
+                    required
+                    rows={2}
+                    value={description}
+                    onChange={(event) =>
+                        onDescriptionChange(event.target.value)
+                    }
+                    placeholder="Hva brukes nøkkelen til?"
+                />
+            </Field>
+            <Field>
+                <FieldLabel htmlFor="api-key-permissions">
+                    Tilganger (én per linje)
+                </FieldLabel>
+                <Textarea
+                    id="api-key-permissions"
+                    rows={4}
+                    value={permissionsRaw}
+                    onChange={(event) =>
+                        onPermissionsChange(event.target.value)
+                    }
+                    placeholder={"email:send\nnews:create"}
+                />
+            </Field>
+        </FieldGroup>
+    );
+}
+
+function SecretRevealDialog({
+    secret,
+    onClose,
+}: {
+    secret: string | null;
+    onClose: () => void;
+}) {
+    return (
+        <Dialog
+            open={secret !== null}
+            onOpenChange={(open) => {
+                if (!open) onClose();
+            }}
+        >
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>API-nøkkel opprettet</DialogTitle>
+                    <DialogDescription>
+                        Kopier nøkkelen nå — du kan ikke se den igjen.
+                    </DialogDescription>
+                </DialogHeader>
+                {secret && (
+                    <Card>
+                        <CardContent className="p-4">
+                            <code className="text-sm break-all">{secret}</code>
+                        </CardContent>
+                        <CardFooter>
+                            <Button
+                                type="button"
+                                onClick={() =>
+                                    void navigator.clipboard.writeText(secret)
+                                }
+                            >
+                                Kopier nøkkel
+                            </Button>
+                        </CardFooter>
+                    </Card>
+                )}
+                <DialogFooter>
+                    <Button type="button" onClick={onClose}>
+                        Lukk
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function parsePermissions(raw: string): string[] {
+    return raw
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+}
+
+function TableSkeleton() {
+    return (
+        <Card>
+            <CardContent className="flex flex-col gap-3">
+                {Array.from({ length: 3 }).map((_, index) => (
+                    <Skeleton key={index} className="h-12 w-full" />
+                ))}
+            </CardContent>
+        </Card>
+    );
 }

--- a/apps/kvark/src/routes/admin/_super-admin/database.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/database.tsx
@@ -1,9 +1,47 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { DatabaseIcon } from "lucide-react";
+
+import { Button } from "@tihlde/ui/ui/button";
+import { Card, CardContent } from "@tihlde/ui/ui/card";
+
+import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminPageHeader } from "#/components/admin-page-header";
 
 export const Route = createFileRoute("/admin/_super-admin/database")({
-    component: RouteComponent,
+    component: DatabaseViewerPage,
+    loader: () => ({ breadcrumbs: "Database Viewer" }),
 });
 
-function RouteComponent() {
-    return <div>Hello "/admin/_super-admin/database"!</div>;
+function DatabaseViewerPage() {
+    return (
+        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+            <AdminPageHeader
+                title="Database Viewer"
+                description="Inspiser databasen direkte for feilsøking."
+            />
+
+            <Card>
+                <CardContent>
+                    <AdminEmptyState
+                        icon={DatabaseIcon}
+                        title="Bruk Drizzle Studio"
+                        description="Kvark eksponerer ikke database-innhold over API-et av sikkerhetsgrunner. For direkte inspeksjon i utvikling, bruk Drizzle Studio."
+                    >
+                        <Button
+                            variant="outline"
+                            render={
+                                <a
+                                    href="https://orm.drizzle.team/docs/drizzle-kit-studio"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    Om Drizzle Studio
+                                </a>
+                            }
+                        />
+                    </AdminEmptyState>
+                </CardContent>
+            </Card>
+        </div>
+    );
 }

--- a/apps/kvark/src/routes/admin/_super-admin/logs.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/logs.tsx
@@ -1,9 +1,33 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { LogsIcon } from "lucide-react";
+
+import { Card, CardContent } from "@tihlde/ui/ui/card";
+
+import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminPageHeader } from "#/components/admin-page-header";
 
 export const Route = createFileRoute("/admin/_super-admin/logs")({
-    component: RouteComponent,
+    component: LogsPage,
+    loader: () => ({ breadcrumbs: "Logs" }),
 });
 
-function RouteComponent() {
-    return <div>Hello "/admin/_super-admin/logs"!</div>;
+function LogsPage() {
+    return (
+        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+            <AdminPageHeader
+                title="Logs"
+                description="Applikasjons- og revisjonslogger."
+            />
+
+            <Card>
+                <CardContent>
+                    <AdminEmptyState
+                        icon={LogsIcon}
+                        title="Venter på logg-endepunkt"
+                        description="API-et eksponerer ennå ikke strukturerte logger. Når et logg-endepunkt finnes, vil denne siden vise og filtrere hendelser her. I mellomtiden ligger runtime-logger hos hosting-plattformen (Railway)."
+                    />
+                </CardContent>
+            </Card>
+        </div>
+    );
 }

--- a/apps/kvark/src/routes/admin/annonser.tsx
+++ b/apps/kvark/src/routes/admin/annonser.tsx
@@ -1,9 +1,658 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import {
+    BriefcaseBusinessIcon,
+    PencilIcon,
+    PlusIcon,
+    Trash2,
+} from "lucide-react";
+import { Suspense, useMemo, useState } from "react";
+
+import type { JobListItem } from "@tihlde/sdk";
+import { Badge } from "@tihlde/ui/ui/badge";
+import { Button } from "@tihlde/ui/ui/button";
+import { Card, CardContent } from "@tihlde/ui/ui/card";
+import { Checkbox } from "@tihlde/ui/ui/checkbox";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@tihlde/ui/ui/dialog";
+import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
+import { Input } from "@tihlde/ui/ui/input";
+import { Label } from "@tihlde/ui/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@tihlde/ui/ui/select";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@tihlde/ui/ui/table";
+import { Textarea } from "@tihlde/ui/ui/textarea";
+
+import {
+    createJobMutation,
+    deleteJobMutation,
+    getJobsQuery,
+    updateJobMutation,
+} from "#/api/queries/jobs";
+import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminPageHeader } from "#/components/admin-page-header";
+
+const JOB_TYPES = ["full_time", "part_time", "summer_job", "other"] as const;
+type JobType = (typeof JOB_TYPES)[number];
+
+const CLASSES = [
+    "first",
+    "second",
+    "third",
+    "fourth",
+    "fifth",
+    "alumni",
+] as const;
+type UserClass = (typeof CLASSES)[number];
+
+const JOB_TYPE_LABELS: Record<JobType, string> = {
+    full_time: "Fulltid",
+    part_time: "Deltid",
+    summer_job: "Sommerjobb",
+    other: "Annet",
+};
+
+const CLASS_LABELS: Record<UserClass, string> = {
+    first: "1. klasse",
+    second: "2. klasse",
+    third: "3. klasse",
+    fourth: "4. klasse",
+    fifth: "5. klasse",
+    alumni: "Alumni",
+};
 
 export const Route = createFileRoute("/admin/annonser")({
-    component: RouteComponent,
+    component: JobsAdminPage,
+    loader: async ({ context }) => {
+        await context.queryClient.ensureQueryData(
+            getJobsQuery(0, { expired: true }),
+        );
+        return { breadcrumbs: "Annonser" };
+    },
 });
 
-function RouteComponent() {
-    return <div>Hello "/admin/annonser"!</div>;
+function JobsAdminPage() {
+    const [search, setSearch] = useState("");
+    const [jobType, setJobType] = useState<JobType | "all">("all");
+    const [showExpired, setShowExpired] = useState(true);
+    const [dialog, setDialog] = useState<
+        { mode: "create" } | { mode: "edit"; job: JobListItem } | null
+    >(null);
+
+    return (
+        <div className="container mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8">
+            <AdminPageHeader
+                title="Annonser"
+                description="Opprett og administrer stillingsannonser fra bedrifter."
+                action={
+                    <Button onClick={() => setDialog({ mode: "create" })}>
+                        <PlusIcon className="size-4" />
+                        Ny annonse
+                    </Button>
+                }
+            />
+
+            <Card>
+                <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-end">
+                    <Field className="flex-1">
+                        <FieldLabel htmlFor="job-search">Søk</FieldLabel>
+                        <Input
+                            id="job-search"
+                            type="search"
+                            placeholder="Tittel eller bedrift"
+                            value={search}
+                            onChange={(event) => setSearch(event.target.value)}
+                        />
+                    </Field>
+                    <Field className="sm:w-52">
+                        <FieldLabel htmlFor="job-type-filter">Type</FieldLabel>
+                        <Select
+                            items={[
+                                { value: "all", label: "Alle typer" },
+                                ...JOB_TYPES.map((type) => ({
+                                    value: type,
+                                    label: JOB_TYPE_LABELS[type],
+                                })),
+                            ]}
+                            value={jobType}
+                            onValueChange={(value) =>
+                                setJobType((value as JobType | "all") ?? "all")
+                            }
+                        >
+                            <SelectTrigger id="job-type-filter">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="all">Alle typer</SelectItem>
+                                {JOB_TYPES.map((type) => (
+                                    <SelectItem key={type} value={type}>
+                                        {JOB_TYPE_LABELS[type]}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </Field>
+                    <div className="flex items-center gap-2 sm:pb-2">
+                        <Checkbox
+                            id="job-show-expired"
+                            checked={showExpired}
+                            onCheckedChange={(checked) =>
+                                setShowExpired(Boolean(checked))
+                            }
+                        />
+                        <Label htmlFor="job-show-expired">Vis utløpte</Label>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Suspense fallback={<TableSkeleton />}>
+                <JobsTable
+                    search={search}
+                    jobType={jobType}
+                    showExpired={showExpired}
+                    onEdit={(job) => setDialog({ mode: "edit", job })}
+                />
+            </Suspense>
+
+            <JobDialog
+                key={dialog?.mode === "edit" ? dialog.job.id : "create"}
+                open={dialog !== null}
+                job={dialog?.mode === "edit" ? dialog.job : null}
+                onOpenChange={(open) => {
+                    if (!open) setDialog(null);
+                }}
+            />
+        </div>
+    );
+}
+
+function JobsTable({
+    search,
+    jobType,
+    showExpired,
+    onEdit,
+}: {
+    search: string;
+    jobType: JobType | "all";
+    showExpired: boolean;
+    onEdit: (job: JobListItem) => void;
+}) {
+    const { data } = useSuspenseQuery(getJobsQuery(0, { expired: true }));
+    const remove = useMutation(deleteJobMutation);
+
+    const filtered = useMemo(() => {
+        const term = search.trim().toLowerCase();
+        return data.items.filter((job) => {
+            if (!showExpired && job.expired) return false;
+            if (jobType !== "all" && job.jobType !== jobType) return false;
+            if (
+                term &&
+                !job.title.toLowerCase().includes(term) &&
+                !job.company.toLowerCase().includes(term)
+            ) {
+                return false;
+            }
+            return true;
+        });
+    }, [data.items, search, jobType, showExpired]);
+
+    if (filtered.length === 0) {
+        return (
+            <Card>
+                <CardContent>
+                    <AdminEmptyState
+                        icon={BriefcaseBusinessIcon}
+                        title="Ingen annonser"
+                        description="Ingen annonser matcher filtrene, eller ingen er opprettet ennå."
+                    />
+                </CardContent>
+            </Card>
+        );
+    }
+
+    function handleDelete(job: JobListItem) {
+        if (
+            window.confirm(
+                `Slette annonsen "${job.title}"? Dette kan ikke angres.`,
+            )
+        ) {
+            remove.mutate({ jobId: job.id });
+        }
+    }
+
+    return (
+        <Card>
+            <CardContent className="p-0">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Tittel</TableHead>
+                            <TableHead>Bedrift</TableHead>
+                            <TableHead>Type</TableHead>
+                            <TableHead>Frist</TableHead>
+                            <TableHead>Status</TableHead>
+                            <TableHead className="text-right">
+                                Handlinger
+                            </TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {filtered.map((job) => (
+                            <TableRow key={job.id}>
+                                <TableCell>{job.title}</TableCell>
+                                <TableCell>{job.company}</TableCell>
+                                <TableCell>
+                                    {JOB_TYPE_LABELS[job.jobType as JobType] ??
+                                        job.jobType}
+                                </TableCell>
+                                <TableCell>
+                                    {job.isContinuouslyHiring
+                                        ? "Fortløpende"
+                                        : formatDeadline(job.deadline)}
+                                </TableCell>
+                                <TableCell>
+                                    {job.expired ? (
+                                        <Badge variant="outline">Utløpt</Badge>
+                                    ) : (
+                                        <Badge variant="secondary">Aktiv</Badge>
+                                    )}
+                                </TableCell>
+                                <TableCell>
+                                    <div className="flex justify-end gap-2">
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() => onEdit(job)}
+                                        >
+                                            <PencilIcon className="size-4" />
+                                            Rediger
+                                        </Button>
+                                        <Button
+                                            variant="destructive"
+                                            size="sm"
+                                            disabled={remove.isPending}
+                                            onClick={() => handleDelete(job)}
+                                        >
+                                            <Trash2 className="size-4" />
+                                        </Button>
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </CardContent>
+        </Card>
+    );
+}
+
+function JobDialog({
+    open,
+    job,
+    onOpenChange,
+}: {
+    open: boolean;
+    job: JobListItem | null;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const isEdit = job !== null;
+
+    const [title, setTitle] = useState(job?.title ?? "");
+    const [company, setCompany] = useState(job?.company ?? "");
+    const [location, setLocation] = useState(job?.location ?? "");
+    const [jobType, setJobType] = useState<JobType>(
+        (job?.jobType as JobType) ?? "other",
+    );
+    const [classStart, setClassStart] = useState<UserClass>(
+        (job?.classStart as UserClass) ?? "first",
+    );
+    const [classEnd, setClassEnd] = useState<UserClass>(
+        (job?.classEnd as UserClass) ?? "fifth",
+    );
+    const [deadline, setDeadline] = useState(toDatetimeLocal(job?.deadline));
+    const [isContinuouslyHiring, setIsContinuouslyHiring] = useState(
+        job?.isContinuouslyHiring ?? false,
+    );
+    const [email, setEmail] = useState(job?.email ?? "");
+    const [link, setLink] = useState(job?.link ?? "");
+    const [ingress, setIngress] = useState(job?.ingress ?? "");
+    const [body, setBody] = useState(job?.body ?? "");
+    const [error, setError] = useState<string | null>(null);
+
+    const create = useMutation(createJobMutation);
+    const update = useMutation(updateJobMutation);
+    const isPending = create.isPending || update.isPending;
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setError(null);
+
+        const deadlineIso = deadline ? new Date(deadline).toISOString() : null;
+
+        try {
+            if (isEdit && job) {
+                await update.mutateAsync({
+                    jobId: job.id,
+                    data: {
+                        title,
+                        company,
+                        location,
+                        jobType,
+                        classStart,
+                        classEnd,
+                        deadline: deadlineIso,
+                        isContinuouslyHiring,
+                        email: email || null,
+                        link: link || null,
+                        ingress,
+                        body,
+                    },
+                });
+            } else {
+                await create.mutateAsync({
+                    data: {
+                        title,
+                        company,
+                        location,
+                        jobType,
+                        classStart,
+                        classEnd,
+                        deadline: deadlineIso ?? undefined,
+                        isContinuouslyHiring,
+                        email: email || undefined,
+                        link: link || undefined,
+                        ingress,
+                        body,
+                    },
+                });
+            }
+            onOpenChange(false);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+                <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                    <DialogHeader>
+                        <DialogTitle>
+                            {isEdit ? "Rediger annonse" : "Ny annonse"}
+                        </DialogTitle>
+                    </DialogHeader>
+                    <FieldGroup>
+                        <Field>
+                            <FieldLabel htmlFor="job-title">Tittel</FieldLabel>
+                            <Input
+                                id="job-title"
+                                required
+                                value={title}
+                                onChange={(event) =>
+                                    setTitle(event.target.value)
+                                }
+                            />
+                        </Field>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <Field>
+                                <FieldLabel htmlFor="job-company">
+                                    Bedrift
+                                </FieldLabel>
+                                <Input
+                                    id="job-company"
+                                    required
+                                    value={company}
+                                    onChange={(event) =>
+                                        setCompany(event.target.value)
+                                    }
+                                />
+                            </Field>
+                            <Field>
+                                <FieldLabel htmlFor="job-location">
+                                    Sted
+                                </FieldLabel>
+                                <Input
+                                    id="job-location"
+                                    required
+                                    value={location}
+                                    onChange={(event) =>
+                                        setLocation(event.target.value)
+                                    }
+                                />
+                            </Field>
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-3">
+                            <Field>
+                                <FieldLabel htmlFor="job-type">Type</FieldLabel>
+                                <Select
+                                    items={JOB_TYPES.map((type) => ({
+                                        value: type,
+                                        label: JOB_TYPE_LABELS[type],
+                                    }))}
+                                    value={jobType}
+                                    onValueChange={(value) =>
+                                        setJobType(
+                                            (value as JobType) ?? "other",
+                                        )
+                                    }
+                                >
+                                    <SelectTrigger id="job-type">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {JOB_TYPES.map((type) => (
+                                            <SelectItem key={type} value={type}>
+                                                {JOB_TYPE_LABELS[type]}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </Field>
+                            <Field>
+                                <FieldLabel htmlFor="job-class-start">
+                                    Fra klasse
+                                </FieldLabel>
+                                <Select
+                                    items={CLASSES.map((cls) => ({
+                                        value: cls,
+                                        label: CLASS_LABELS[cls],
+                                    }))}
+                                    value={classStart}
+                                    onValueChange={(value) =>
+                                        setClassStart(
+                                            (value as UserClass) ?? "first",
+                                        )
+                                    }
+                                >
+                                    <SelectTrigger id="job-class-start">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {CLASSES.map((cls) => (
+                                            <SelectItem key={cls} value={cls}>
+                                                {CLASS_LABELS[cls]}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </Field>
+                            <Field>
+                                <FieldLabel htmlFor="job-class-end">
+                                    Til klasse
+                                </FieldLabel>
+                                <Select
+                                    items={CLASSES.map((cls) => ({
+                                        value: cls,
+                                        label: CLASS_LABELS[cls],
+                                    }))}
+                                    value={classEnd}
+                                    onValueChange={(value) =>
+                                        setClassEnd(
+                                            (value as UserClass) ?? "fifth",
+                                        )
+                                    }
+                                >
+                                    <SelectTrigger id="job-class-end">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {CLASSES.map((cls) => (
+                                            <SelectItem key={cls} value={cls}>
+                                                {CLASS_LABELS[cls]}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </Field>
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <Field>
+                                <FieldLabel htmlFor="job-deadline">
+                                    Søknadsfrist
+                                </FieldLabel>
+                                <Input
+                                    id="job-deadline"
+                                    type="datetime-local"
+                                    value={deadline}
+                                    disabled={isContinuouslyHiring}
+                                    onChange={(event) =>
+                                        setDeadline(event.target.value)
+                                    }
+                                />
+                            </Field>
+                            <div className="flex items-center gap-2 sm:self-end sm:pb-2">
+                                <Checkbox
+                                    id="job-continuous"
+                                    checked={isContinuouslyHiring}
+                                    onCheckedChange={(checked) =>
+                                        setIsContinuouslyHiring(
+                                            Boolean(checked),
+                                        )
+                                    }
+                                />
+                                <Label htmlFor="job-continuous">
+                                    Fortløpende ansettelse
+                                </Label>
+                            </div>
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <Field>
+                                <FieldLabel htmlFor="job-email">
+                                    Kontakt-e-post
+                                </FieldLabel>
+                                <Input
+                                    id="job-email"
+                                    type="email"
+                                    value={email}
+                                    onChange={(event) =>
+                                        setEmail(event.target.value)
+                                    }
+                                />
+                            </Field>
+                            <Field>
+                                <FieldLabel htmlFor="job-link">
+                                    Søknadslenke
+                                </FieldLabel>
+                                <Input
+                                    id="job-link"
+                                    type="url"
+                                    value={link}
+                                    onChange={(event) =>
+                                        setLink(event.target.value)
+                                    }
+                                    placeholder="https://"
+                                />
+                            </Field>
+                        </div>
+                        <Field>
+                            <FieldLabel htmlFor="job-ingress">
+                                Ingress
+                            </FieldLabel>
+                            <Textarea
+                                id="job-ingress"
+                                rows={2}
+                                value={ingress}
+                                onChange={(event) =>
+                                    setIngress(event.target.value)
+                                }
+                            />
+                        </Field>
+                        <Field>
+                            <FieldLabel htmlFor="job-body">
+                                Beskrivelse
+                            </FieldLabel>
+                            <Textarea
+                                id="job-body"
+                                rows={6}
+                                value={body}
+                                onChange={(event) =>
+                                    setBody(event.target.value)
+                                }
+                            />
+                        </Field>
+                    </FieldGroup>
+                    {error && (
+                        <p className="text-sm text-destructive" role="alert">
+                            {error}
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            Avbryt
+                        </Button>
+                        <Button type="submit" disabled={isPending}>
+                            {isEdit ? "Lagre" : "Opprett"}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function toDatetimeLocal(iso: string | null | undefined): string {
+    if (!iso) return "";
+    const date = new Date(iso);
+    const offset = date.getTimezoneOffset();
+    const local = new Date(date.getTime() - offset * 60_000);
+    return local.toISOString().slice(0, 16);
+}
+
+function formatDeadline(iso: string | null): string {
+    if (!iso) return "—";
+    return new Date(iso).toLocaleDateString("nb-NO");
+}
+
+function TableSkeleton() {
+    return (
+        <Card>
+            <CardContent className="flex flex-col gap-3">
+                {Array.from({ length: 4 }).map((_, index) => (
+                    <Skeleton key={index} className="h-10 w-full" />
+                ))}
+            </CardContent>
+        </Card>
+    );
 }

--- a/apps/kvark/src/routes/admin/bannere.tsx
+++ b/apps/kvark/src/routes/admin/bannere.tsx
@@ -1,9 +1,33 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { BookmarkIcon } from "lucide-react";
+
+import { Card, CardContent } from "@tihlde/ui/ui/card";
+
+import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminPageHeader } from "#/components/admin-page-header";
 
 export const Route = createFileRoute("/admin/bannere")({
-    component: RouteComponent,
+    component: BannersAdminPage,
+    loader: () => ({ breadcrumbs: "Bannere" }),
 });
 
-function RouteComponent() {
-    return <div>Hello "/admin/bannere"!</div>;
+function BannersAdminPage() {
+    return (
+        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+            <AdminPageHeader
+                title="Bannere"
+                description="Tidsstyrte toppbannere for viktige beskjeder på forsiden."
+            />
+
+            <Card>
+                <CardContent>
+                    <AdminEmptyState
+                        icon={BookmarkIcon}
+                        title="Venter på API-endepunkt"
+                        description="Bannerhåndtering krever et banner-endepunkt i API-et, som ennå ikke finnes. Når det er på plass, vil denne siden la deg opprette, tidsstyre og publisere bannere."
+                    />
+                </CardContent>
+            </Card>
+        </div>
+    );
 }

--- a/apps/kvark/src/routes/admin/brukere.tsx
+++ b/apps/kvark/src/routes/admin/brukere.tsx
@@ -1,9 +1,369 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { InfoIcon, PlusIcon, Trash2, UsersIcon } from "lucide-react";
+import { useState } from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
+import { Button } from "@tihlde/ui/ui/button";
+import { Card, CardContent } from "@tihlde/ui/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@tihlde/ui/ui/dialog";
+import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
+import { Input } from "@tihlde/ui/ui/input";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@tihlde/ui/ui/select";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@tihlde/ui/ui/table";
+import type { GroupMember } from "@tihlde/sdk";
+
+import {
+    addGroupMemberMutation,
+    getGroupMembersQuery,
+    getGroupsQuery,
+    removeGroupMemberMutation,
+    updateGroupMemberRoleMutation,
+} from "#/api/queries/groups";
+import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminGroupPicker } from "#/components/admin-group-picker";
+import { AdminPageHeader } from "#/components/admin-page-header";
+
+const ROLE_LABELS: Record<string, string> = {
+    leader: "Leder",
+    member: "Medlem",
+};
 
 export const Route = createFileRoute("/admin/brukere")({
-    component: RouteComponent,
+    component: UsersAdminPage,
+    loader: async ({ context }) => {
+        await context.queryClient.ensureQueryData(getGroupsQuery(0));
+        return { breadcrumbs: "Brukere" };
+    },
 });
 
-function RouteComponent() {
-    return <div>Hello "/admin/brukere"!</div>;
+function UsersAdminPage() {
+    const { data: groups } = useSuspenseQuery(getGroupsQuery(0));
+    const [groupSlug, setGroupSlug] = useState<string | null>(
+        groups[0]?.slug ?? null,
+    );
+    const [addOpen, setAddOpen] = useState(false);
+
+    return (
+        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+            <AdminPageHeader
+                title="Brukere"
+                description="Administrer medlemskap og roller per gruppe."
+            />
+
+            <Alert>
+                <InfoIcon className="size-4" />
+                <AlertTitle>Gruppebasert medlemshåndtering</AlertTitle>
+                <AlertDescription>
+                    API-et har ennå ikke et globalt brukerregister. Brukere
+                    administreres derfor per gruppe her. Når et endepunkt for å
+                    liste alle brukere finnes, kan denne siden utvides med et
+                    fullt brukersøk.
+                </AlertDescription>
+            </Alert>
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                <Field className="sm:max-w-72">
+                    <FieldLabel>Gruppe</FieldLabel>
+                    <AdminGroupPicker
+                        groups={groups}
+                        value={groupSlug}
+                        onValueChange={setGroupSlug}
+                    />
+                </Field>
+                {groupSlug && (
+                    <Button onClick={() => setAddOpen(true)}>
+                        <PlusIcon className="size-4" />
+                        Legg til medlem
+                    </Button>
+                )}
+            </div>
+
+            {groupSlug ? (
+                <MembersTable groupSlug={groupSlug} />
+            ) : (
+                <Card>
+                    <CardContent>
+                        <AdminEmptyState
+                            icon={UsersIcon}
+                            title="Velg en gruppe"
+                            description="Velg en gruppe for å se og administrere medlemmene."
+                        />
+                    </CardContent>
+                </Card>
+            )}
+
+            {groupSlug && (
+                <AddMemberDialog
+                    groupSlug={groupSlug}
+                    open={addOpen}
+                    onOpenChange={setAddOpen}
+                />
+            )}
+        </div>
+    );
+}
+
+function MembersTable({ groupSlug }: { groupSlug: string }) {
+    const { data: members, isPending } = useQuery(
+        getGroupMembersQuery(groupSlug, 0),
+    );
+    const updateRole = useMutation(updateGroupMemberRoleMutation);
+    const remove = useMutation(removeGroupMemberMutation);
+
+    if (isPending) {
+        return (
+            <Card>
+                <CardContent className="flex flex-col gap-3">
+                    {Array.from({ length: 4 }).map((_, index) => (
+                        <Skeleton key={index} className="h-10 w-full" />
+                    ))}
+                </CardContent>
+            </Card>
+        );
+    }
+
+    if (!members || members.length === 0) {
+        return (
+            <Card>
+                <CardContent>
+                    <AdminEmptyState
+                        icon={UsersIcon}
+                        title="Ingen medlemmer"
+                        description="Denne gruppen har ingen medlemmer ennå."
+                    />
+                </CardContent>
+            </Card>
+        );
+    }
+
+    function handleRemove(member: GroupMember) {
+        if (
+            window.confirm(
+                `Fjerne bruker ${member.userId} fra gruppen? Dette kan ikke angres.`,
+            )
+        ) {
+            remove.mutate({ groupSlug, userId: member.userId });
+        }
+    }
+
+    return (
+        <Card>
+            <CardContent className="p-0">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Bruker-ID</TableHead>
+                            <TableHead>Rolle</TableHead>
+                            <TableHead>Medlem siden</TableHead>
+                            <TableHead className="text-right">
+                                Handlinger
+                            </TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {members.map((member) => (
+                            <TableRow key={member.userId}>
+                                <TableCell>
+                                    <code className="text-xs">
+                                        {member.userId}
+                                    </code>
+                                </TableCell>
+                                <TableCell>
+                                    <Select
+                                        items={Object.entries(ROLE_LABELS).map(
+                                            ([value, label]) => ({
+                                                value,
+                                                label,
+                                            }),
+                                        )}
+                                        value={member.role}
+                                        onValueChange={(value) => {
+                                            if (
+                                                !value ||
+                                                value === member.role
+                                            ) {
+                                                return;
+                                            }
+                                            updateRole.mutate({
+                                                groupSlug,
+                                                userId: member.userId,
+                                                data: {
+                                                    role: value as
+                                                        | "member"
+                                                        | "leader",
+                                                },
+                                            });
+                                        }}
+                                    >
+                                        <SelectTrigger className="w-36">
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {Object.entries(ROLE_LABELS).map(
+                                                ([value, label]) => (
+                                                    <SelectItem
+                                                        key={value}
+                                                        value={value}
+                                                    >
+                                                        {label}
+                                                    </SelectItem>
+                                                ),
+                                            )}
+                                        </SelectContent>
+                                    </Select>
+                                </TableCell>
+                                <TableCell>
+                                    {new Date(
+                                        member.createdAt,
+                                    ).toLocaleDateString("nb-NO")}
+                                </TableCell>
+                                <TableCell>
+                                    <div className="flex justify-end">
+                                        <Button
+                                            variant="destructive"
+                                            size="sm"
+                                            disabled={remove.isPending}
+                                            onClick={() => handleRemove(member)}
+                                        >
+                                            <Trash2 className="size-4" />
+                                            Fjern
+                                        </Button>
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </CardContent>
+        </Card>
+    );
+}
+
+function AddMemberDialog({
+    groupSlug,
+    open,
+    onOpenChange,
+}: {
+    groupSlug: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const [userId, setUserId] = useState("");
+    const [role, setRole] = useState<"member" | "leader">("member");
+    const [error, setError] = useState<string | null>(null);
+
+    const add = useMutation(addGroupMemberMutation);
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setError(null);
+        try {
+            await add.mutateAsync({
+                groupSlug,
+                data: { userId: userId.trim(), role },
+            });
+            setUserId("");
+            setRole("member");
+            onOpenChange(false);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                    <DialogHeader>
+                        <DialogTitle>Legg til medlem</DialogTitle>
+                    </DialogHeader>
+                    <FieldGroup>
+                        <Field>
+                            <FieldLabel htmlFor="member-user-id">
+                                Bruker-ID
+                            </FieldLabel>
+                            <Input
+                                id="member-user-id"
+                                required
+                                value={userId}
+                                onChange={(event) =>
+                                    setUserId(event.target.value)
+                                }
+                                placeholder="Feide-/bruker-ID"
+                            />
+                        </Field>
+                        <Field>
+                            <FieldLabel htmlFor="member-role">Rolle</FieldLabel>
+                            <Select
+                                items={Object.entries(ROLE_LABELS).map(
+                                    ([value, label]) => ({ value, label }),
+                                )}
+                                value={role}
+                                onValueChange={(value) =>
+                                    setRole(
+                                        (value as "member" | "leader") ??
+                                            "member",
+                                    )
+                                }
+                            >
+                                <SelectTrigger id="member-role">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {Object.entries(ROLE_LABELS).map(
+                                        ([value, label]) => (
+                                            <SelectItem
+                                                key={value}
+                                                value={value}
+                                            >
+                                                {label}
+                                            </SelectItem>
+                                        ),
+                                    )}
+                                </SelectContent>
+                            </Select>
+                        </Field>
+                    </FieldGroup>
+                    {error && (
+                        <p className="text-sm text-destructive" role="alert">
+                            {error}
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            Avbryt
+                        </Button>
+                        <Button type="submit" disabled={add.isPending}>
+                            Legg til
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
 }

--- a/apps/kvark/src/routes/admin/index.tsx
+++ b/apps/kvark/src/routes/admin/index.tsx
@@ -1,12 +1,253 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { nb } from "date-fns/locale";
+import {
+    BriefcaseBusinessIcon,
+    CalendarIcon,
+    FileSignatureIcon,
+    NewspaperIcon,
+    PlusIcon,
+    Users2Icon,
+} from "lucide-react";
+import { Suspense } from "react";
+
+import { Button } from "@tihlde/ui/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+
+import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminPageHeader } from "#/components/admin-page-header";
+import { AdminStatCard } from "#/components/admin-stat-card";
+import { getContractListQuery } from "#/api/queries/contracts";
+import { getEventsQuery } from "#/api/queries/events";
+import { getGroupsQuery } from "#/api/queries/groups";
+import { getJobsQuery } from "#/api/queries/jobs";
+import { getNewsQuery } from "#/api/queries/news";
 
 export const Route = createFileRoute("/admin/")({
-    component: RouteComponent,
-    loader: () => ({
-        breadcrumbs: "Dashboard",
-    }),
+    component: DashboardPage,
+    loader: async ({ context }) => {
+        await Promise.all([
+            context.queryClient.ensureQueryData(getEventsQuery(0)),
+            context.queryClient.ensureQueryData(getNewsQuery(0)),
+            context.queryClient.ensureQueryData(getJobsQuery(0)),
+            context.queryClient.ensureQueryData(getGroupsQuery(0)),
+            context.queryClient.ensureQueryData(getContractListQuery()),
+        ]);
+        return { breadcrumbs: "Dashboard" };
+    },
 });
 
-function RouteComponent() {
-    return <div>Hello "/admin/"!</div>;
+function DashboardPage() {
+    return (
+        <div className="container mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-8">
+            <AdminPageHeader
+                title="Dashboard"
+                description="Oversikt over innhold og administrasjon i Kvark."
+                action={
+                    <Button render={<Link to="/admin/arrangementer" />}>
+                        <PlusIcon className="size-4" />
+                        Nytt arrangement
+                    </Button>
+                }
+            />
+
+            <Suspense fallback={<StatsSkeleton />}>
+                <StatsGrid />
+            </Suspense>
+
+            <QuickActions />
+
+            <div className="grid gap-6 lg:grid-cols-2">
+                <Suspense fallback={<ListCardSkeleton />}>
+                    <RecentEvents />
+                </Suspense>
+                <Suspense fallback={<ListCardSkeleton />}>
+                    <RecentNews />
+                </Suspense>
+            </div>
+        </div>
+    );
+}
+
+function StatsGrid() {
+    const { data: events } = useSuspenseQuery(getEventsQuery(0));
+    const { data: news } = useSuspenseQuery(getNewsQuery(0));
+    const { data: jobs } = useSuspenseQuery(getJobsQuery(0));
+    const { data: groups } = useSuspenseQuery(getGroupsQuery(0));
+    const { data: contracts } = useSuspenseQuery(getContractListQuery());
+
+    return (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <AdminStatCard
+                label="Arrangementer"
+                value={events.totalCount}
+                icon={CalendarIcon}
+                link={{ to: "/admin/arrangementer" }}
+            />
+            <AdminStatCard
+                label="Nyheter"
+                value={news.totalCount}
+                icon={NewspaperIcon}
+                link={{ to: "/admin/nyheter" }}
+            />
+            <AdminStatCard
+                label="Annonser"
+                value={jobs.totalCount}
+                icon={BriefcaseBusinessIcon}
+                link={{ to: "/admin/annonser" }}
+            />
+            <AdminStatCard
+                label="Grupper"
+                value={groups.length}
+                icon={Users2Icon}
+                link={{ to: "/admin/grupper" }}
+            />
+            <AdminStatCard
+                label="Kontrakter"
+                value={contracts.length}
+                icon={FileSignatureIcon}
+                hint={
+                    contracts.some((contract) => contract.isActive)
+                        ? "Én aktiv kontrakt"
+                        : "Ingen aktiv kontrakt"
+                }
+                link={{ to: "/admin/opptak" }}
+            />
+        </div>
+    );
+}
+
+function QuickActions() {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Hurtighandlinger</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-wrap gap-3">
+                <Button variant="outline" render={<Link to="/admin/nyheter" />}>
+                    <NewspaperIcon className="size-4" />
+                    Ny nyhet
+                </Button>
+                <Button
+                    variant="outline"
+                    render={<Link to="/admin/annonser" />}
+                >
+                    <BriefcaseBusinessIcon className="size-4" />
+                    Ny annonse
+                </Button>
+                <Button variant="outline" render={<Link to="/admin/opptak" />}>
+                    <FileSignatureIcon className="size-4" />
+                    Last opp kontrakt
+                </Button>
+                <Button variant="outline" render={<Link to="/admin/grupper" />}>
+                    <Users2Icon className="size-4" />
+                    Administrer grupper
+                </Button>
+            </CardContent>
+        </Card>
+    );
+}
+
+function RecentEvents() {
+    const { data: events } = useSuspenseQuery(getEventsQuery(0));
+    const recent = events.items.slice(0, 5);
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Siste arrangementer</CardTitle>
+            </CardHeader>
+            <CardContent>
+                {recent.length === 0 ? (
+                    <AdminEmptyState
+                        icon={CalendarIcon}
+                        title="Ingen arrangementer ennå"
+                    />
+                ) : (
+                    <ul className="flex flex-col divide-y">
+                        {recent.map((event) => (
+                            <li
+                                key={event.id}
+                                className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0"
+                            >
+                                <div className="flex min-w-0 flex-col">
+                                    <span className="truncate">
+                                        {event.title}
+                                    </span>
+                                    <span className="text-xs text-muted-foreground">
+                                        {event.organizer?.name ?? "Ukjent"}
+                                    </span>
+                                </div>
+                                <span className="shrink-0 text-sm text-muted-foreground">
+                                    {formatDate(event.startTime)}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function RecentNews() {
+    const { data: news } = useSuspenseQuery(getNewsQuery(0));
+    const recent = news.items.slice(0, 5);
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Siste nyheter</CardTitle>
+            </CardHeader>
+            <CardContent>
+                {recent.length === 0 ? (
+                    <AdminEmptyState
+                        icon={NewspaperIcon}
+                        title="Ingen nyheter ennå"
+                    />
+                ) : (
+                    <ul className="flex flex-col divide-y">
+                        {recent.map((article) => (
+                            <li
+                                key={article.id}
+                                className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0"
+                            >
+                                <div className="flex min-w-0 flex-col">
+                                    <span className="truncate">
+                                        {article.title}
+                                    </span>
+                                    <span className="truncate text-xs text-muted-foreground">
+                                        {article.header}
+                                    </span>
+                                </div>
+                                <span className="shrink-0 text-sm text-muted-foreground">
+                                    {formatDate(article.createdAt)}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function formatDate(iso: string): string {
+    return format(new Date(iso), "d. MMM yyyy", { locale: nb });
+}
+
+function StatsSkeleton() {
+    return (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 5 }).map((_, index) => (
+                <Skeleton key={index} className="h-24 w-full" />
+            ))}
+        </div>
+    );
+}
+
+function ListCardSkeleton() {
+    return <Skeleton className="h-64 w-full" />;
 }

--- a/apps/kvark/src/routes/admin/prikker.tsx
+++ b/apps/kvark/src/routes/admin/prikker.tsx
@@ -1,9 +1,466 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { GavelIcon, InfoIcon, PlusIcon, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
+import { Badge } from "@tihlde/ui/ui/badge";
+import { Button } from "@tihlde/ui/ui/button";
+import { Card, CardContent } from "@tihlde/ui/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@tihlde/ui/ui/dialog";
+import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
+import { Input } from "@tihlde/ui/ui/input";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@tihlde/ui/ui/select";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@tihlde/ui/ui/table";
+import { Textarea } from "@tihlde/ui/ui/textarea";
+import type { Fine } from "@tihlde/sdk";
+
+import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminGroupPicker } from "#/components/admin-group-picker";
+import { AdminPageHeader } from "#/components/admin-page-header";
+import { AdminStatCard } from "#/components/admin-stat-card";
+import {
+    createFineMutation,
+    deleteFineMutation,
+    getGroupFinesQuery,
+    getGroupsQuery,
+    updateFineMutation,
+} from "#/api/queries/groups";
+
+const STATUSES = ["pending", "approved", "paid", "rejected"] as const;
+type FineStatus = (typeof STATUSES)[number];
+
+const STATUS_LABELS: Record<FineStatus, string> = {
+    pending: "Venter",
+    approved: "Godkjent",
+    paid: "Betalt",
+    rejected: "Avvist",
+};
+
+const STATUS_VARIANTS: Record<
+    FineStatus,
+    "default" | "secondary" | "outline" | "destructive"
+> = {
+    pending: "outline",
+    approved: "secondary",
+    paid: "default",
+    rejected: "destructive",
+};
 
 export const Route = createFileRoute("/admin/prikker")({
-    component: RouteComponent,
+    component: FinesAdminPage,
+    loader: async ({ context }) => {
+        await context.queryClient.ensureQueryData(getGroupsQuery(0));
+        return { breadcrumbs: "Prikker" };
+    },
 });
 
-function RouteComponent() {
-    return <div>Hello "/admin/prikker"!</div>;
+function FinesAdminPage() {
+    const { data: groups } = useSuspenseQuery(getGroupsQuery(0));
+    const [groupSlug, setGroupSlug] = useState<string | null>(
+        groups.find((group) => group.finesActivated)?.slug ??
+            groups[0]?.slug ??
+            null,
+    );
+    const [createOpen, setCreateOpen] = useState(false);
+
+    return (
+        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+            <AdminPageHeader
+                title="Prikker og bøter"
+                description="Se og administrer bøter medlemmer har fått i en gruppe."
+            />
+
+            <Alert>
+                <InfoIcon className="size-4" />
+                <AlertTitle>Bøtesystem per gruppe</AlertTitle>
+                <AlertDescription>
+                    Bøter (prikker) er knyttet til enkeltgrupper. Velg en gruppe
+                    for å se, opprette og oppdatere bøtene dens. Grupper som
+                    ikke har aktivert bøtesystemet vil normalt være tomme.
+                </AlertDescription>
+            </Alert>
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                <Field className="sm:max-w-72">
+                    <FieldLabel>Gruppe</FieldLabel>
+                    <AdminGroupPicker
+                        groups={groups}
+                        value={groupSlug}
+                        onValueChange={setGroupSlug}
+                    />
+                </Field>
+                {groupSlug && (
+                    <Button onClick={() => setCreateOpen(true)}>
+                        <PlusIcon className="size-4" />
+                        Ny bot
+                    </Button>
+                )}
+            </div>
+
+            {groupSlug ? (
+                <FinesSection groupSlug={groupSlug} />
+            ) : (
+                <Card>
+                    <CardContent>
+                        <AdminEmptyState
+                            icon={GavelIcon}
+                            title="Velg en gruppe"
+                            description="Velg en gruppe for å se bøtene."
+                        />
+                    </CardContent>
+                </Card>
+            )}
+
+            {groupSlug && (
+                <CreateFineDialog
+                    groupSlug={groupSlug}
+                    open={createOpen}
+                    onOpenChange={setCreateOpen}
+                />
+            )}
+        </div>
+    );
+}
+
+function FinesSection({ groupSlug }: { groupSlug: string }) {
+    const { data: fines, isPending } = useQuery(
+        getGroupFinesQuery(groupSlug, 0),
+    );
+    const update = useMutation(updateFineMutation);
+    const remove = useMutation(deleteFineMutation);
+
+    const stats = useMemo(() => {
+        const list = fines ?? [];
+        const sumFor = (status: FineStatus) =>
+            list
+                .filter((fine) => fine.status === status)
+                .reduce((sum, fine) => sum + fine.amount, 0);
+        return {
+            pending: sumFor("pending"),
+            approved: sumFor("approved"),
+            paid: sumFor("paid"),
+        };
+    }, [fines]);
+
+    if (isPending) {
+        return (
+            <Card>
+                <CardContent className="flex flex-col gap-3">
+                    {Array.from({ length: 4 }).map((_, index) => (
+                        <Skeleton key={index} className="h-10 w-full" />
+                    ))}
+                </CardContent>
+            </Card>
+        );
+    }
+
+    if (!fines || fines.length === 0) {
+        return (
+            <Card>
+                <CardContent>
+                    <AdminEmptyState
+                        icon={GavelIcon}
+                        title="Ingen bøter"
+                        description="Denne gruppen har ingen registrerte bøter."
+                    />
+                </CardContent>
+            </Card>
+        );
+    }
+
+    function handleDelete(fine: Fine) {
+        if (window.confirm("Slette denne boten? Dette kan ikke angres.")) {
+            remove.mutate({ groupSlug, fineId: fine.id });
+        }
+    }
+
+    return (
+        <div className="flex flex-col gap-6">
+            <div className="grid gap-4 sm:grid-cols-3">
+                <AdminStatCard
+                    label="Venter"
+                    value={`${stats.pending} kr`}
+                    icon={GavelIcon}
+                />
+                <AdminStatCard
+                    label="Godkjent"
+                    value={`${stats.approved} kr`}
+                    icon={GavelIcon}
+                />
+                <AdminStatCard
+                    label="Betalt"
+                    value={`${stats.paid} kr`}
+                    icon={GavelIcon}
+                />
+            </div>
+
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Bruker-ID</TableHead>
+                                <TableHead>Begrunnelse</TableHead>
+                                <TableHead>Beløp</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead className="text-right">
+                                    Handlinger
+                                </TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {fines.map((fine) => (
+                                <TableRow key={fine.id}>
+                                    <TableCell>
+                                        <code className="text-xs">
+                                            {fine.userId}
+                                        </code>
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex flex-col gap-0.5">
+                                            <span>{fine.reason}</span>
+                                            {fine.defense && (
+                                                <span className="text-xs text-muted-foreground">
+                                                    Forsvar: {fine.defense}
+                                                </span>
+                                            )}
+                                        </div>
+                                    </TableCell>
+                                    <TableCell>{fine.amount} kr</TableCell>
+                                    <TableCell>
+                                        <div className="flex flex-col gap-1">
+                                            <Badge
+                                                variant={
+                                                    STATUS_VARIANTS[
+                                                        fine.status as FineStatus
+                                                    ] ?? "outline"
+                                                }
+                                            >
+                                                {STATUS_LABELS[
+                                                    fine.status as FineStatus
+                                                ] ?? fine.status}
+                                            </Badge>
+                                            <Select
+                                                items={STATUSES.map(
+                                                    (status) => ({
+                                                        value: status,
+                                                        label: STATUS_LABELS[
+                                                            status
+                                                        ],
+                                                    }),
+                                                )}
+                                                value={fine.status}
+                                                onValueChange={(value) => {
+                                                    if (
+                                                        !value ||
+                                                        value === fine.status
+                                                    ) {
+                                                        return;
+                                                    }
+                                                    update.mutate({
+                                                        groupSlug,
+                                                        fineId: fine.id,
+                                                        data: {
+                                                            status: value as FineStatus,
+                                                        },
+                                                    });
+                                                }}
+                                            >
+                                                <SelectTrigger className="w-32">
+                                                    <SelectValue />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    {STATUSES.map((status) => (
+                                                        <SelectItem
+                                                            key={status}
+                                                            value={status}
+                                                        >
+                                                            {
+                                                                STATUS_LABELS[
+                                                                    status
+                                                                ]
+                                                            }
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </div>
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex justify-end">
+                                            <Button
+                                                variant="destructive"
+                                                size="sm"
+                                                disabled={remove.isPending}
+                                                onClick={() =>
+                                                    handleDelete(fine)
+                                                }
+                                            >
+                                                <Trash2 className="size-4" />
+                                            </Button>
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+function CreateFineDialog({
+    groupSlug,
+    open,
+    onOpenChange,
+}: {
+    groupSlug: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const [userId, setUserId] = useState("");
+    const [reason, setReason] = useState("");
+    const [amount, setAmount] = useState("");
+    const [defense, setDefense] = useState("");
+    const [error, setError] = useState<string | null>(null);
+
+    const create = useMutation(createFineMutation);
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setError(null);
+        const amountValue = Number(amount);
+        if (!Number.isInteger(amountValue) || amountValue <= 0) {
+            setError("Beløp må være et positivt heltall.");
+            return;
+        }
+        try {
+            await create.mutateAsync({
+                groupSlug,
+                data: {
+                    userId: userId.trim(),
+                    groupSlug,
+                    reason: reason.trim(),
+                    amount: amountValue,
+                    defense: defense.trim() || undefined,
+                },
+            });
+            setUserId("");
+            setReason("");
+            setAmount("");
+            setDefense("");
+            onOpenChange(false);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                    <DialogHeader>
+                        <DialogTitle>Ny bot</DialogTitle>
+                    </DialogHeader>
+                    <FieldGroup>
+                        <Field>
+                            <FieldLabel htmlFor="fine-user-id">
+                                Bruker-ID
+                            </FieldLabel>
+                            <Input
+                                id="fine-user-id"
+                                required
+                                value={userId}
+                                onChange={(event) =>
+                                    setUserId(event.target.value)
+                                }
+                                placeholder="Feide-/bruker-ID"
+                            />
+                        </Field>
+                        <Field>
+                            <FieldLabel htmlFor="fine-reason">
+                                Begrunnelse
+                            </FieldLabel>
+                            <Textarea
+                                id="fine-reason"
+                                required
+                                rows={2}
+                                value={reason}
+                                onChange={(event) =>
+                                    setReason(event.target.value)
+                                }
+                            />
+                        </Field>
+                        <Field>
+                            <FieldLabel htmlFor="fine-amount">
+                                Beløp (NOK)
+                            </FieldLabel>
+                            <Input
+                                id="fine-amount"
+                                type="number"
+                                min={1}
+                                required
+                                value={amount}
+                                onChange={(event) =>
+                                    setAmount(event.target.value)
+                                }
+                            />
+                        </Field>
+                        <Field>
+                            <FieldLabel htmlFor="fine-defense">
+                                Forsvar (valgfritt)
+                            </FieldLabel>
+                            <Textarea
+                                id="fine-defense"
+                                rows={2}
+                                value={defense}
+                                onChange={(event) =>
+                                    setDefense(event.target.value)
+                                }
+                            />
+                        </Field>
+                    </FieldGroup>
+                    {error && (
+                        <p className="text-sm text-destructive" role="alert">
+                            {error}
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            Avbryt
+                        </Button>
+                        <Button type="submit" disabled={create.isPending}>
+                            Opprett
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
 }


### PR DESCRIPTION
## Summary

Fleshes out every stub admin page in Kvark so admins have real, usable tooling instead of `Hello "/admin/..."` placeholders. Each page uses the existing `@tihlde/sdk` query hooks, Suspense + skeletons, and `@tihlde/ui` components per the app conventions.

## Fully wired (backend-backed)

- **Dashboard** (`/admin`) — live counts (arrangementer, nyheter, annonser, grupper, kontrakter), quick actions, and recent events/news lists.
- **Annonser** (jobs) — full CRUD: searchable + type/expired-filterable table, create + edit dialog, delete. Wired to `/api/jobs`.
- **API Nøkler** — full CRUD: create with one-time secret reveal, rotate (reveal), edit, delete. Wired to `/api/api-keys`.

## Partially wired (best available backend)

- **Brukere** — group-scoped membership management (role change, add by user-ID, remove) with an honest banner that a global user-directory endpoint is still pending (the API only exposes `/api/user/me/*` and group members today).
- **Prikker** — group-scoped bøter: status stat cards, create fine, status change, delete. Wired to `/api/groups/{slug}/fines`.

## Honest placeholders (no backend endpoint yet)

- **Bannere**, **Database Viewer**, **Logs** — polished empty states that explain what's required, with no fabricated data.

## Reusable components

Adds four dumb components composed from `@tihlde/ui`: `admin-page-header`, `admin-stat-card`, `admin-empty-state`, `admin-group-picker`.

## Verification

- `bun run build` (kvark) and `bunx tsc --noEmit` pass with no errors in the changed files; oxlint/oxfmt clean.
- Exercised end-to-end in the browser against the local API (logged in as an admin): job **create + delete** and api-key **create → secret reveal → delete** round-trip through the API and refresh the lists. Dashboard, Brukere, Prikker, and all placeholders render with real data / correct empty states. Zero console errors.
- Fixed a layout bug found during verification: the `Field` component applies `*:w-full` to children in its default vertical orientation, which stretched inline `Checkbox`es — replaced those with a plain `Label` + `Checkbox` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)