### PR TITLE
fix(kvark): make SSR build deployable on Vercel

### DIFF
--- a/apps/kvark/vite.config.ts
+++ b/apps/kvark/vite.config.ts
@@ -8,8 +8,25 @@ import tailwindcss from "@tailwindcss/vite";
 import { nitro } from "nitro/vite";
 
 const config = defineConfig({
-    resolve: { tsconfigPaths: true },
-    plugins: [devtools(), nitro(), tailwindcss(), tanstackStart(), viteReact()],
+    resolve: {
+        tsconfigPaths: true,
+        // tslib 1.14.1 (pulled in transitively by @posthog/react) ships a UMD
+        // build. rolldown's CJS→ESM interop tree-shakes its module body away via
+        // the `@__PURE__` hint, so helpers like `__extends` are `undefined` at
+        // runtime and SSR crashes ("Cannot destructure property '__extends'").
+        // Point tslib at its ESM entry so it's consumed as real ES exports.
+        alias: [{ find: /^tslib$/, replacement: "tslib/tslib.es6.js" }],
+    },
+    plugins: [
+        devtools(),
+        // On Vercel, Nitro externalizes React but its static tracer misses the
+        // SSR runtime's raw `require("react")`, so React is absent from the
+        // serverless bundle ("Cannot find module 'react'"). Force it to be traced.
+        nitro({ traceDeps: ["react", "react-dom"] }),
+        tailwindcss(),
+        tanstackStart(),
+        viteReact(),
+    ],
 });
 
 export default config;


### PR DESCRIPTION
## Hva
Gjør SSR-bygget av `apps/kvark` deploybart på Vercel. To linjer byggekonfig i `apps/kvark/vite.config.ts` — **ingen funksjonalitet, komponenter, ruter eller logikk er endret.**

## Hvorfor
Med dagens verktøystakk (Vite 8 / rolldown-rc / Nitro 3-beta / TanStack Start) krasjet enhver Vercel-deploy av frontend-en på to interop-bugs i server-render-veien:

1. **`Cannot find module 'react'`** — På Vercel externaliserer Nitro React, men den statiske traceren fanger ikke SSR-runtimens rå `require("react")`, så React manglet i serverless-bundelen.
   → Fikset med `nitro({ traceDeps: ["react", "react-dom"] })`.

2. **`Cannot destructure property '__extends' of '__toESM(...).default'`** — `tslib` 1.14.1 (transitivt via `@posthog/react`) er en UMD-build. rolldowns CJS→ESM-interop tree-shaker bort modul-kroppen via `@__PURE__`, så hjelpere som `__extends` blir `undefined` i runtime → SSR-krasj.
   → Fikset ved å alias-e `tslib` til dens ESM-entry (`tslib/tslib.es6.js`). Samme bibliotek, bare ESM-varianten.

## Verifisert
Deployet til prod (`photon`-prosjektet på Vercel). `/` og `/login` gir nå **HTTP 200 med ekte rendret HTML** — tidligere `{"status":500,...,"message":"HTTPError"}` på alt.

## Utenfor scope (egen sak)
Ruter som gjør et **server-side datakall** (`/arrangementer`, `/nyheter`, `/grupper`) gir fortsatt 500 fordi SSR-loaderens backend-fetch kaster (backend-endepunktene svarer 200 anonymt). Det er en separat SSR-data-sak, ikke byggeblokkeringen denne PR-en løser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
