### PR TITLE
feat(kvark): gjør hele TIHLDE-logoen blå (også teksten)

### DIFF
--- a/apps/kvark/src/components/site-header.tsx
+++ b/apps/kvark/src/components/site-header.tsx
@@ -46,7 +46,11 @@ export function SiteHeader({ navItems, user }: SiteHeaderProps) {
     return (
         <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur">
             <div className="container mx-auto flex h-14 items-center justify-between gap-4 px-4">
-                <Link to="/" className="flex items-center gap-0">
+                <Link
+                    to="/"
+                    className="flex items-center gap-0"
+                    style={{ color: "var(--color-logo, currentColor)" }}
+                >
                     <div className="size-8">
                         <TihldeLogo />
                     </div>

--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -129,8 +129,10 @@ function Hero() {
         <div className="relative">
             <HeroSectionBackground className="h-full text-primary -z-50" />
             <section className="container mx-auto flex w-full flex-col items-center gap-6 px-4 py-50 text-center">
-                <div className="flex items-center gap-1">
-                    {/* TODO: Change color here */}
+                <div
+                    className="flex items-center gap-1"
+                    style={{ color: "var(--color-logo, currentColor)" }}
+                >
                     <div className="size-20">
                         <TihldeLogo />
                     </div>


### PR DESCRIPTION
## Hva
Gjør hele TIHLDE-logoen blå i light mode — ikke bare ikonet, men også `TIHLDE`-teksten ved siden av.

Tidligere brukte kun ikonet `--color-logo`-tokenet, mens ordmerket arvet `foreground` (svart). Nå setter jeg tokenet på logo-wrapperen slik at teksten arver samme farge.

- `site-header.tsx` og `_app/index.tsx`: wrapper får `style={{ color: "var(--color-logo, currentColor)" }}`.
- Ingen fargeklasser i app-en — fargen kommer fra `--color-logo`-tokenet i `@tihlde/ui` (samme mønster som SVG-ens `fill`), per app-reglene.

## Resultat
- **Light mode**: ikon + tekst = `rgb(28, 69, 138)` = `#1C458A` ✓ (verifisert i header og hero)
- **Dark mode**: ikon + tekst = `#f5f7f9` (foreground) for kontrast på navy ✓
- `oxfmt` / `oxlint` rene

🤖 Generated with [Claude Code](https://claude.com/claude-code)