### PR TITLE
feat(api): run database migrations on boot

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "bun --watch src/index.ts",
-        "build": "bun build src/index.ts --outdir dist --target bun --sourcemap",
+        "build": "bun build src/index.ts src/migrate.ts --outdir dist --target bun --sourcemap",
         "start": "bun dist/index.js",
         "test": "vitest run",
         "test:watch": "vitest",

--- a/apps/api/src/migrate.ts
+++ b/apps/api/src/migrate.ts
@@ -1,0 +1,30 @@
+import { env } from "@photon/core/env";
+import { createDb } from "@photon/db";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+
+/**
+ * Applies pending Drizzle migrations, then exits.
+ *
+ * This runs as its own step ahead of the server (see the ENTRYPOINT in
+ * `infra/docker/Dockerfile`) rather than from inside the app, so a failed
+ * migration aborts the boot instead of leaving the API serving requests against
+ * a schema it no longer matches. Deploys only ship a new image — nothing in the
+ * pipeline migrates for us, so the app owns this.
+ *
+ * The folder matches where the Dockerfile copies `packages/db/drizzle`. Local
+ * development syncs the schema with `bun run db:push` instead and never runs
+ * this.
+ */
+const MIGRATIONS_FOLDER = "./drizzle";
+
+console.log(`Applying database migrations from ${MIGRATIONS_FOLDER}`);
+
+try {
+    const db = createDb({ connectionString: env.DATABASE_URL });
+    await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+    console.log("Database migrations applied");
+    process.exit(0);
+} catch (error) {
+    console.error("Database migration failed — aborting startup", error);
+    process.exit(1);
+}

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -33,9 +33,14 @@ RUN bun run build --filter=@photon/api
 FROM oven/bun:1-slim AS release
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/apps/api/dist ./dist
+# Migration SQL, applied by dist/migrate.js on boot — the deploy pipeline only
+# ships a new image and never migrates, so the app has to do it itself.
+COPY --from=build /usr/src/app/packages/db/drizzle ./drizzle
 COPY --from=install /usr/src/app/node_modules ./node_modules
 
 USER bun
 EXPOSE 4000/tcp
-ENTRYPOINT ["bun", "run", "./dist/index.js"]
+# Migrate before serving. `&&` aborts the boot when a migration fails instead of
+# starting the API against a schema it no longer matches.
+ENTRYPOINT ["sh", "-c", "bun run ./dist/migrate.js && bun run ./dist/index.js"]
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -32,7 +32,7 @@
         "dev": "tsdown --watch",
         "codegen": "bun scripts/generate-openapi.ts",
         "typecheck": "tsc --noEmit",
-        "postinstall": "node scripts/postinstall.mjs"
+        "postinstall": "node scripts/postinstall.mjs || true"
     },
     "dependencies": {
         "@photon/api": "workspace:*"


### PR DESCRIPTION
## Hvorfor
Drift bekreftet at de **ikke** kjører migrasjoner — hver app må gjøre det selv («appen burde sjølv handter migrations, for eksempel i dockerfila sin exec command»). I dag gjør ikke API-et det:

- ENTRYPOINT er kun `bun run ./dist/index.js`
- Det finnes ingen `migrate()` i prod-koden (eneste treff er testoppsettet)
- Migrasjons-SQL-en er ikke engang med i runtime-imaget

Konsekvensen er at en deploy ruller ut ny kode mot gammelt skjema. `kvark` har tre migrasjoner som ikke er kjørt i prod (`0013`, `0014`, `0015`), så uten dette ville en release gitt flere feil, ikke færre.

## Hva
- **`apps/api/src/migrate.ts`** (ny): kjører pending Drizzle-migrasjoner og avslutter. Egen prosess i stedet for inne i appen, så en feilet migrasjon **avbryter oppstart** i stedet for å la API-et servere mot feil skjema.
- **`apps/api/package.json`**: bygger `src/migrate.ts` i tillegg til `src/index.ts`.
- **`infra/docker/Dockerfile`**: kopierer `packages/db/drizzle` inn i imaget, og ENTRYPOINT blir `migrate && serve` (`&&` gjør at oppstart stopper hvis migrasjonen feiler).

Migrasjonen er idempotent — Drizzle sporer anvendte migrasjoner i `__drizzle_migrations` og kjører kun det som mangler. Lokal utvikling bruker fortsatt `bun run db:push` og berøres ikke.

## Ekstra fiks som var nødvendig for at imaget skal bygge i det hele tatt
`packages/sdk/package.json` — `postinstall` gjort ikke-fatal (`|| true`).

`turbo prune` gir install-steget kun `package.json`-filene, så `scripts/postinstall.mjs` finnes ikke der, og **hele `bun install` feiler**. Scriptet er kun en versjonssjekk mot npm (en utvikler-hjelp), så det bør aldri kunne velte en installasjon. Verifisert: uten denne feiler `docker build` på `bun install`; med den kommer den videre.

## ⚠️ Ikke fullt verifisert — les dette
Jeg fikk **ikke** bygget imaget helt ferdig lokalt. Etter postinstall-fiksen stopper byggingen på:
```
error: File not found ".../node_modules/.bun/msgpackr@2.0.4/node_modules/msgpackr-extract"
```
Det er en valgfri native-dep og kan være **arm64-spesifikt for min Mac** (CI kjører x86_64). Jeg har derfor ikke kunnet kjøre migrasjonene ende-til-ende mot en database. Selve migrator-kallet følger samme mønster som testoppsettet allerede bruker, men **dette bør verifiseres i CI/staging før merge til `main`**.

## Relatert som bør ses på (ikke gjort her)
- Dockerfile bruker den flytende taggen `oven/bun:1`. Siste vellykkede deploy var **5. mai**; byggemiljøet har drevet siden. Vurder å pinne til `packageManager`-versjonen.
- **CI bygger aldri Docker-imaget** — `ci.yml` kjører kun lint/typecheck/build/test, og kun på PR mot `dev`/`main`. En ødelagt Dockerfile oppdages først ved deploy. Å legge imaget inn i CI ville fanget begge feilene over.
- PR-er mot `kvark` kjører ingen CI i det hele tatt (`ci.yml` lytter kun på `dev` og `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
