### PR TITLE
fix(kvark): declare Nitro build outputs so Vercel cache hits deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ yarn-error.log*
 
 .alchemy/
 .wrangler/
+.output

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,17 @@
             "dependsOn": ["^build"],
             "outputs": ["dist/**"]
         },
+        "kvark#build": {
+            "dependsOn": ["^build"],
+            // Nitro writes the Build Output API v3 tree to .vercel/output on
+            // Vercel, and .output locally. Both must be declared: on a cache
+            // hit Turbo only restores what it captured, and Vercel then fails
+            // with "No Output Directory named dist found".
+            "outputs": [".vercel/output/**", ".output/**", "dist/**"],
+            // Vite inlines these at build time, so they belong to the cache
+            // key. Turbo's strict env mode also withholds anything undeclared.
+            "env": ["SERVER_URL", "VITE_*"]
+        },
         "start": {
             "dependsOn": ["build"],
             "persistent": true


### PR DESCRIPTION
Redeploying an unchanged commit on Vercel failed with:

```
Cached:    4 cached, 4 total
Time:      1.256s >>> FULL TURBO
Error: No Output Directory named "dist" found after the Build completed.
```

## Årsak

Root-tasken `build` deklarerte kun `outputs: ["dist/**"]`. Kvark bygges med Nitro, som skriver Build Output API v3-treet til `.vercel/output/` på Vercel og `.output/` lokalt — ingen av dem var deklarert.

Turbo fanget derfor aldri de katalogene i cachen. Ved full cache-treff spilte den av build-loggene på ~1s uten å skrive én fil, og Vercel fant ingenting å deploye. Builds gikk kun gjennom så lenge cachen tilfeldigvis bommet, så feilen var latent og trigget av et redeploy av samme commit.

## Endring

Egen `kvark#build`-task med:

- `outputs`: `.vercel/output/**`, `.output/**`, `dist/**`
- `env`: `SERVER_URL`, `VITE_*`

`env`-delen fikser en andre latent bug som Turbo advarte om i samme logg. Strict env mode holder udeklarerte variabler tilbake fra tasken, så `VITE_FEIDE_ENABLED` ville stille falt til `false` i prod (Vite inliner den ved build-tid, se `apps/kvark/src/env.ts`), og endring av en `VITE_*`-verdi ville ikke invalidert cachen.

La også til `.output` i `.gitignore` — kun `.vercel` og `dist` lå der fra før.

## Verifisering

`bunx turbo run build --filter=kvark`, slett `.output`, kjør på nytt:

| | Resultat | `.output/server/index.mjs` |
|---|---|---|
| Med fiksen | `>>> FULL TURBO` (119ms) | gjenopprettet ✅ |
| Med gammel `turbo.json` | `>>> FULL TURBO` (72ms) | mangler ❌ |

Vercel-feilen reprodusert lokalt og bekreftet fikset. `bun run lint` gir kun pre-eksisterende warnings i `forms.test.ts` og `vipps.ts`.

## Merk

Ingen behov for "Redeploy without cache" — endringen i `turbo.json` endrer task-hashen, så neste deploy bygger ekte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)