### PR TITLE
fix(turbo): build upstream packages before typecheck

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -33,7 +33,7 @@
             "dependsOn": ["build"],
             "persistent": true
         },
-        "typecheck": { "dependsOn": ["^typecheck"] },
+        "typecheck": { "dependsOn": ["^typecheck", "^build"] },
         "//#quality": {
             "dependsOn": ["//#lint", "//#format"]
         },


### PR DESCRIPTION
## Problem
`bun run typecheck` feiler på en ren checkout — som i CI:
```
src/lib/notification/index.ts(5,8): error TS2307: Cannot find module '@photon/email/templates'
src/routes/email/schema.ts(1,39): error TS2307: Cannot find module '@photon/email/schema'
packages/core/src/services/email/base.ts(1,29): error TS2307: Cannot find module '@photon/email'
```

## Årsak
`@photon/email` eksporterer bygget output, ikke kildekode:
```json
"types": "./dist/index.d.mts",
"exports": { ".": "./dist/index.mjs", "./schema": "./dist/schema.mjs", "./templates": "./dist/templates.mjs" }
```
Men `typecheck` avhang kun av `^typecheck`, og CI kjører `typecheck` **før** `build`. På en ren checkout finnes ikke `packages/email/dist`, så TypeScript finner ikke modulene.

Det feiler derfor alltid i CI, men aldri lokalt — der har man som regel `dist` liggende fra et tidligere bygg.

## Fiks
Legger `^build` til `typecheck`-taskens `dependsOn`, så turbo bygger upstream-pakker før den typechecker. `^typecheck` beholdes, så upstream-typefeil fortsatt fanges først.

## Verifisert lokalt
Reproduserte CI-tilstanden ved å fjerne `packages/email/dist`:

| | Resultat |
|---|---|
| Uten fiks | ❌ samme 6 `TS2307`-feil som i CI |
| Med fiks | ✅ `Tasks: 3 successful, 3 total` |

## Kontekst
Dette er den gjenstående røde sjekken på #155 (`kvark` → `dev`). Docker-bygget der ble fikset av #154. Merk at fordi typecheck feilet, ble **build og tester aldri kjørt** i CI — så det kan dukke opp mer når denne er inne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
