### PR TITLE
chore: ignore every .env variant, not just five named ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,10 @@ node_modules
 .pnp
 .pnp.js
 
-# Local env files
-.env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+# Local env files — every variant, so a new one can't be committed by accident.
+# .env.example is the checked-in template and stays tracked.
+.env*
+!.env.example
 
 # Testing
 coverage


### PR DESCRIPTION
## Hva

`.gitignore` listet fem navngitte env-filer. Alt annet — `.env.prod`, `.env.staging`, `.env.bak-*` — var usporet, men fullt mulig å committe ved et uhell.

```diff
-.env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*
+!.env.example
```

## Hvorfor nå

Dukket opp under feilsøking av prod-deployen: en lokal `.env.prod` med produksjonens `DATABASE_URL` lå i repo-roten uten å være ignorert. Ingenting ble commitet, men bare flaks skilte oss fra det.

## Verifisert

Begge templatene forblir sporet — negasjonen slår inn på alle nivåer:

| fil | status |
|---|---|
| `.env`, `.env.prod`, `.env.local`, `.env.bak-3001` | ignorert |
| `apps/kvark/.env.production` | ignorert |
| `.env.example` | spores |
| `apps/kvark/.env.example` | spores |

`git ls-files` bekrefter at ingen sporede filer mister sporing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)