### PR TITLE
fix(event): keep ø and æ in slugs, and put the date in them

### DIFF
--- a/apps/api/src/lib/event/slug.ts
+++ b/apps/api/src/lib/event/slug.ts
@@ -2,19 +2,26 @@ import { type DbTransaction, schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 
 /**
- * Generates a unique slug for an event based on the given title.
- * If the initial slug already exists in the database, appends a random character
- * to the slug and checks again, repeating until a unique slug is found.
+ * Norwegian letters that Unicode does not decompose.
  *
- * @param title - The title of the event to generate a slug for.
- * @returns A promise that resolves to a unique slug string.
+ * NFD splits `å` into `a` plus a combining ring, so stripping combining marks
+ * leaves the `a` behind. `ø` and `æ` are letters in their own right — they pass
+ * through NFD untouched, fall foul of the `[^a-z0-9]` filter and become
+ * hyphens. That turned "Søndagsplask" into `s-ndagsplask`. Map them first.
  */
-export const generateUniqueEventSlug = async (
-    title: string,
-    transaction: DbTransaction,
-): Promise<string> => {
-    let isUnique = false;
-    let slug = title
+const NORWEGIAN_TRANSLITERATIONS: Record<string, string> = {
+    ø: "o",
+    Ø: "o",
+    æ: "ae",
+    Æ: "ae",
+    å: "a",
+    Å: "a",
+};
+
+/** Turns a title into the url-safe stem of a slug. Exported for testing. */
+export const slugifyTitle = (title: string): string =>
+    title
+        .replace(/[øØæÆåÅ]/g, (c) => NORWEGIAN_TRANSLITERATIONS[c] ?? c)
         .toLowerCase()
         // normalize unicode (e.g. é → e)
         .normalize("NFD")
@@ -27,20 +34,48 @@ export const generateUniqueEventSlug = async (
         // collapse multiple hyphens
         .replace(/-{2,}/g, "-");
 
-    while (!isUnique) {
+/** The start date as `2026-11-14`. */
+const isoDate = (date: Date): string => date.toISOString().slice(0, 10);
+
+/**
+ * Generates a unique slug for an event from its title and start date.
+ *
+ * The date is always part of the slug rather than a tie-breaker. Titles repeat
+ * constantly — "Søndagsplask" runs weekly — so a title-only slug collides for
+ * roughly 40% of TIHLDE's events, and a reader cannot tell which occurrence a
+ * link points at. `sondagsplask-2026-03-17` is unambiguous.
+ *
+ * A numeric suffix settles the rare case of two events sharing both a title and
+ * a day. It counts up instead of appending a random character, so identical
+ * input always yields an identical slug — which is what lets a bulk import run
+ * twice without minting a second set of urls.
+ *
+ * @param title - The title of the event to generate a slug for.
+ * @param startDate - When the event starts; appears in the slug.
+ * @returns A promise that resolves to a unique slug string.
+ */
+export const generateUniqueEventSlug = async (
+    title: string,
+    startDate: Date,
+    transaction: DbTransaction,
+): Promise<string> => {
+    const base = `${slugifyTitle(title)}-${isoDate(startDate)}`;
+
+    let slug = base;
+    let attempt = 1;
+
+    while (true) {
         const [existingEvent] = await transaction
             .select()
             .from(schema.event)
             .where(eq(schema.event.slug, slug))
             .limit(1);
 
-        if (existingEvent) {
-            // appends one random character
-            slug += `${Math.random().toString(36).charAt(2)}`;
-        } else {
-            isUnique = true;
+        if (!existingEvent) {
+            return slug;
         }
-    }
 
-    return slug;
+        attempt += 1;
+        slug = `${base}-${attempt}`;
+    }
 };

--- a/apps/api/src/routes/event/create.ts
+++ b/apps/api/src/routes/event/create.ts
@@ -35,7 +35,11 @@ export const createRoute = route().post(
         let createdEventId: string | undefined;
 
         await db.transaction(async (tx) => {
-            const slug = await generateUniqueEventSlug(body.title, tx);
+            const slug = await generateUniqueEventSlug(
+                body.title,
+                new Date(body.start),
+                tx,
+            );
             if (slug.length > 256) {
                 throw new HTTPException(400, {
                     message:

--- a/apps/api/src/routes/event/update.ts
+++ b/apps/api/src/routes/event/update.ts
@@ -95,10 +95,15 @@ export const updateRoute = route().put(
                 }
             }
 
-            // If title is updated, generate new slug
+            // If title is updated, generate new slug. A date change alone keeps
+            // the existing slug — rewriting it would break links already shared.
             let slug = event.slug;
             if (body.title && body.title !== event.title) {
-                slug = await generateUniqueEventSlug(body.title, tx);
+                slug = await generateUniqueEventSlug(
+                    body.title,
+                    body.start ? new Date(body.start) : event.start,
+                    tx,
+                );
                 if (slug.length > 256) {
                     throw new HTTPException(400, {
                         message:

--- a/apps/api/src/test/event/slug.test.ts
+++ b/apps/api/src/test/event/slug.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { slugifyTitle } from "~/lib/event/slug";
+
+describe("slugifyTitle", () => {
+    it("transliterates the Norwegian letters Unicode does not decompose", () => {
+        // ø and æ survive NFD, so they used to fall through the a-z filter and
+        // become hyphens — "Søndagsplask" turned into "s-ndagsplask".
+        expect(slugifyTitle("Søndagsplask")).toBe("sondagsplask");
+        expect(slugifyTitle("Æresmedlem")).toBe("aeresmedlem");
+        expect(slugifyTitle("Støtt Pythons herrer")).toBe(
+            "stott-pythons-herrer",
+        );
+    });
+
+    it("still strips the accents NFD does decompose", () => {
+        expect(slugifyTitle("Åpningskamp")).toBe("apningskamp");
+        expect(slugifyTitle("Café & Crème")).toBe("cafe-creme");
+    });
+
+    it("collapses punctuation, emoji and whitespace into single hyphens", () => {
+        expect(slugifyTitle("Bedpres  med   Bekk!")).toBe("bedpres-med-bekk");
+        expect(slugifyTitle("Vinkurs 💜 2026")).toBe("vinkurs-2026");
+    });
+
+    it("trims leading and trailing hyphens", () => {
+        expect(slugifyTitle("!! Julebord !!")).toBe("julebord");
+    });
+});


### PR DESCRIPTION
Forarbeid til innholdsimporten fra Lepton — men begge feilene rammer nye arrangementer i dag, uavhengig av importen.

## 1. `ø` og `æ` ble til bindestrek

```
'Søndagsplask'            ->  's-ndagsplask'
'Støtt Pythons herrer'    ->  'st-tt-pythons-herrer'
```

`å` ble riktig, fordi Unicode dekomponerer den til `a` + ring og `.replace(/[\p{M}]/gu, "")` fjerner ringen. Men `ø` og `æ` er selvstendige bokstaver — de overlever `NFD`, faller gjennom `[^a-z0-9]` og blir bindestrek.

**169 av 1221** historiske titler er berørt. De translittereres nå før normalisering.

## 2. Kollisjonshåndteringen skalerte ikke

Slug på tittel alene gir **145 duplikate slugger som dekker 489 arrangementer — 40 %**. «Søndagsplask» forekommer 28 ganger fordi den er ukentlig.

Den gamle løsningen la på ett tilfeldig tegn per kollisjon: `sondagsplask`, `sondagsplaskq`, `sondagsplaskq4`. Leseren kan ikke se hvilken forekomst en lenke peker på, og resultatet er forskjellig hver kjøring.

Startdatoen er nå alltid med:

```
sondagsplask-2026-03-17
```

| strategi | unike | kolliderer |
|---|---|---|
| tittel alene | 876 | 145 |
| tittel + år | 1068 | 79 |
| **tittel + full dato** | **1221** | **0** |

År alene holder ikke — ukentlige arrangementer kolliderer fortsatt. Full dato gir 1221 unike av 1221.

Det numeriske suffikset som er igjen dekker kun to arrangementer med samme tittel samme dag, og teller oppover i stedet for å randomisere. Det gjør en bulk-import gjentakbar i stedet for å lage nye URL-er hver gang.

## Merk

Endrer man kun datoen på et arrangement, beholdes eksisterende slug — å skrive den om ville brutt lenker som allerede er delt. Ny slug genereres fortsatt bare ved tittelendring, som før.

`generateUniqueEventSlug` tar nå `startDate` som andre argument. Begge kallstedene er oppdatert.

## Verifisert

- Docker-bygget går grønt (typesjekker begge kallsteder)
- Ny enhetstest i `apps/api/src/test/event/slug.test.ts`
- Kjørte den faktiske `slugifyTitle` mot alle 1221 titler fra Lepton-API-et: 0 kollisjoner, ingen `ø`/`æ` igjen som bindestrek

🤖 Generated with [Claude Code](https://claude.com/claude-code)