### PR TITLE
refactor(core): share one slug implementation with the Lepton migration

### DIFF
--- a/apps/api/src/lib/event/slug.ts
+++ b/apps/api/src/lib/event/slug.ts
@@ -1,54 +1,18 @@
+import { buildEventSlugBase } from "@photon/core/slug";
 import { type DbTransaction, schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 
 /**
- * Norwegian letters that Unicode does not decompose.
- *
- * NFD splits `å` into `a` plus a combining ring, so stripping combining marks
- * leaves the `a` behind. `ø` and `æ` are letters in their own right — they pass
- * through NFD untouched, fall foul of the `[^a-z0-9]` filter and become
- * hyphens. That turned "Søndagsplask" into `s-ndagsplask`. Map them first.
- */
-const NORWEGIAN_TRANSLITERATIONS: Record<string, string> = {
-    ø: "o",
-    Ø: "o",
-    æ: "ae",
-    Æ: "ae",
-    å: "a",
-    Å: "a",
-};
-
-/** Turns a title into the url-safe stem of a slug. Exported for testing. */
-export const slugifyTitle = (title: string): string =>
-    title
-        .replace(/[øØæÆåÅ]/g, (c) => NORWEGIAN_TRANSLITERATIONS[c] ?? c)
-        .toLowerCase()
-        // normalize unicode (e.g. é → e)
-        .normalize("NFD")
-        // remove combining diacritical marks
-        .replace(/[\p{M}]/gu, "")
-        // replace non-alphanumeric with hyphens
-        .replace(/[^a-z0-9]+/g, "-")
-        // trim hyphens from start and end
-        .replace(/^-+|-+$/g, "")
-        // collapse multiple hyphens
-        .replace(/-{2,}/g, "-");
-
-/** The start date as `2026-11-14`. */
-const isoDate = (date: Date): string => date.toISOString().slice(0, 10);
-
-/**
  * Generates a unique slug for an event from its title and start date.
  *
- * The date is always part of the slug rather than a tie-breaker. Titles repeat
- * constantly — "Søndagsplask" runs weekly — so a title-only slug collides for
- * roughly 40% of TIHLDE's events, and a reader cannot tell which occurrence a
- * link points at. `sondagsplask-2026-03-17` is unambiguous.
+ * The stem — title plus date — comes from `@photon/core/slug`, shared with the
+ * Lepton migration so imported and newly created events cannot drift into
+ * different url formats.
  *
- * A numeric suffix settles the rare case of two events sharing both a title and
- * a day. It counts up instead of appending a random character, so identical
- * input always yields an identical slug — which is what lets a bulk import run
- * twice without minting a second set of urls.
+ * Uniqueness is settled here against the database, since rows written through
+ * the API land one at a time. A numeric suffix covers the rare case of two
+ * events sharing both a title and a day; it counts up instead of appending a
+ * random character, so identical input always yields an identical slug.
  *
  * @param title - The title of the event to generate a slug for.
  * @param startDate - When the event starts; appears in the slug.
@@ -59,7 +23,7 @@ export const generateUniqueEventSlug = async (
     startDate: Date,
     transaction: DbTransaction,
 ): Promise<string> => {
-    const base = `${slugifyTitle(title)}-${isoDate(startDate)}`;
+    const base = buildEventSlugBase(title, startDate);
 
     let slug = base;
     let attempt = 1;

--- a/apps/api/src/test/event/slug.test.ts
+++ b/apps/api/src/test/event/slug.test.ts
@@ -1,28 +1,46 @@
+import { buildEventSlugBase, slugifyText } from "@photon/core/slug";
 import { describe, expect, it } from "vitest";
-import { slugifyTitle } from "~/lib/event/slug";
 
-describe("slugifyTitle", () => {
+describe("slugifyText", () => {
     it("transliterates the Norwegian letters Unicode does not decompose", () => {
         // ø and æ survive NFD, so they used to fall through the a-z filter and
         // become hyphens — "Søndagsplask" turned into "s-ndagsplask".
-        expect(slugifyTitle("Søndagsplask")).toBe("sondagsplask");
-        expect(slugifyTitle("Æresmedlem")).toBe("aeresmedlem");
-        expect(slugifyTitle("Støtt Pythons herrer")).toBe(
+        expect(slugifyText("Søndagsplask")).toBe("sondagsplask");
+        expect(slugifyText("Æresmedlem")).toBe("aeresmedlem");
+        expect(slugifyText("Støtt Pythons herrer")).toBe(
             "stott-pythons-herrer",
         );
     });
 
     it("still strips the accents NFD does decompose", () => {
-        expect(slugifyTitle("Åpningskamp")).toBe("apningskamp");
-        expect(slugifyTitle("Café & Crème")).toBe("cafe-creme");
+        expect(slugifyText("Åpningskamp")).toBe("apningskamp");
+        expect(slugifyText("Café & Crème")).toBe("cafe-creme");
     });
 
     it("collapses punctuation, emoji and whitespace into single hyphens", () => {
-        expect(slugifyTitle("Bedpres  med   Bekk!")).toBe("bedpres-med-bekk");
-        expect(slugifyTitle("Vinkurs 💜 2026")).toBe("vinkurs-2026");
+        expect(slugifyText("Bedpres  med   Bekk!")).toBe("bedpres-med-bekk");
+        expect(slugifyText("Vinkurs 💜 2026")).toBe("vinkurs-2026");
     });
 
     it("trims leading and trailing hyphens", () => {
-        expect(slugifyTitle("!! Julebord !!")).toBe("julebord");
+        expect(slugifyText("!! Julebord !!")).toBe("julebord");
+    });
+});
+
+describe("buildEventSlugBase", () => {
+    it("appends the start date so repeated titles stay distinguishable", () => {
+        expect(
+            buildEventSlugBase(
+                "Søndagsplask",
+                new Date("2026-03-17T18:00:00Z"),
+            ),
+        ).toBe("sondagsplask-2026-03-17");
+    });
+
+    it("falls back to 'event' when a title slugs to nothing", () => {
+        // The migration has titles made only of emoji or punctuation.
+        expect(buildEventSlugBase("💜", new Date("2026-03-17T18:00:00Z"))).toBe(
+            "event-2026-03-17",
+        );
     });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,8 @@
         "./services/cache": "./src/services/cache/index.ts",
         "./services/queue": "./src/services/queue/index.ts",
         "./services/storage": "./src/services/storage/index.ts",
-        "./env": "./src/env.ts"
+        "./env": "./src/env.ts",
+        "./slug": "./src/slug.ts"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.927.0",

--- a/packages/core/src/slug.ts
+++ b/packages/core/src/slug.ts
@@ -1,0 +1,63 @@
+/**
+ * Slug generation, shared by the API and the Lepton migration.
+ *
+ * Both need identical rules — the migration writes the historical events and
+ * the API writes every event created afterwards, and they end up side by side
+ * in the same url space. Keeping one implementation here is what stops the two
+ * from drifting apart again.
+ *
+ * Uniqueness is deliberately *not* handled here: the API resolves collisions
+ * against the database, while a bulk migration resolves them in memory because
+ * its rows are not inserted yet. Only the deterministic part is shared.
+ */
+
+/**
+ * Norwegian letters that Unicode does not decompose.
+ *
+ * NFD splits `å` into `a` plus a combining ring, so stripping combining marks
+ * leaves the `a` behind. `ø` and `æ` are letters in their own right — they pass
+ * through NFD untouched, fall foul of the `[^a-z0-9]` filter and become
+ * hyphens. That turned "Søndagsplask" into `s-ndagsplask`. Map them first.
+ */
+const NORWEGIAN_TRANSLITERATIONS: Record<string, string> = {
+    ø: "o",
+    Ø: "o",
+    æ: "ae",
+    Æ: "ae",
+    å: "a",
+    Å: "a",
+};
+
+/** Turns arbitrary text into a url-safe slug stem. */
+export const slugifyText = (text: string): string =>
+    text
+        .replace(/[øØæÆåÅ]/g, (c) => NORWEGIAN_TRANSLITERATIONS[c] ?? c)
+        .toLowerCase()
+        // normalize unicode (e.g. é → e)
+        .normalize("NFD")
+        // remove combining diacritical marks
+        .replace(/[\p{M}]/gu, "")
+        // replace non-alphanumeric with hyphens
+        .replace(/[^a-z0-9]+/g, "-")
+        // trim hyphens from start and end
+        .replace(/^-+|-+$/g, "")
+        // collapse multiple hyphens
+        .replace(/-{2,}/g, "-");
+
+/** The start date as `2026-11-14`. */
+const isoDate = (date: Date): string => date.toISOString().slice(0, 10);
+
+/**
+ * The stem of an event slug: title plus start date, before any uniqueness
+ * suffix.
+ *
+ * The date is always present rather than acting as a tie-breaker. Titles repeat
+ * constantly — "Søndagsplask" runs weekly — so a title-only slug collides for
+ * roughly 40% of TIHLDE's events, and a reader cannot tell which occurrence a
+ * link points at. Falls back to `event` when a title slugs to nothing at all,
+ * which the migration has seen with emoji-only titles.
+ */
+export const buildEventSlugBase = (title: string, startDate: Date): string => {
+    const stem = slugifyText(title) || "event";
+    return `${stem}-${isoDate(startDate)}`;
+};

--- a/packages/lepton-migration/src/mappings.ts
+++ b/packages/lepton-migration/src/mappings.ts
@@ -2,6 +2,7 @@
  * In-memory ID mapping stores and transformation utilities
  * for migrating from Lepton (MySQL) to Photon (PostgreSQL).
  */
+import { slugifyText } from "@photon/core/slug";
 
 // ===== ID MAPS =====
 
@@ -46,15 +47,16 @@ export function char32ToUuid(hex: string): string {
     return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}`;
 }
 
-/** Generate a URL-safe slug from a string */
+/**
+ * Generate a URL-safe slug from a string.
+ *
+ * Delegates to the shared implementation so migrated rows and rows the API
+ * writes later cannot end up with different rules. The local copy this replaced
+ * stripped combining marks only, which left `\u00f8` and `\u00e6` to become hyphens \u2014
+ * "S\u00f8ndagsplask" migrated as `s-ndagsplask`.
+ */
 export function slugify(text: string): string {
-    return text
-        .toLowerCase()
-        .normalize("NFD")
-        .replace(/[\u0300-\u036f]/g, "") // strip accents
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-+|-+$/g, "")
-        .slice(0, 200);
+    return slugifyText(text).slice(0, 200);
 }
 
 /** Map old gender int to new gender enum */

--- a/packages/lepton-migration/src/phases/04-events.ts
+++ b/packages/lepton-migration/src/phases/04-events.ts
@@ -2,11 +2,11 @@ import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { DbSchema } from "@photon/db";
 import { schema } from "@photon/db";
 import { query } from "../mysql";
+import { buildEventSlugBase } from "@photon/core/slug";
 import {
     userIdMap,
     eventIdMap,
     categoryIdMap,
-    slugify,
     timeToMinutes,
     batchInsert,
 } from "../mappings";
@@ -59,10 +59,18 @@ export async function migrateEvents(
         const newId = crypto.randomUUID();
         eventIdMap.set(e.id, newId);
 
-        let slug = slugify(e.title);
-        if (!slug) slug = "event";
-        slug = `${slug}-${e.id}`;
-        if (usedSlugs.has(slug)) slug = `${slug}-${Date.now()}`;
+        // Same stem the API uses for events created after the migration, so
+        // historical and new events share one url format. Collisions resolve
+        // in memory rather than against the database: these rows are batch
+        // inserted after the loop, so nothing is queryable yet. Counting up
+        // keeps a re-run producing the same slugs instead of new ones.
+        const slugBase = buildEventSlugBase(e.title, e.start_date);
+        let slug = slugBase;
+        let attempt = 1;
+        while (usedSlugs.has(slug)) {
+            attempt += 1;
+            slug = `${slugBase}-${attempt}`;
+        }
         usedSlugs.add(slug);
 
         const categorySlug = e.category_id


### PR DESCRIPTION
Oppfølging av [#164](https://github.com/TIHLDE/Photon/pull/164). Forarbeid til datamigreringen, som kjøres om cirka en uke.

## Problemet

`lepton-migration` hadde sin **egen** `slugify` i `mappings.ts` — med nøyaktig buggen #164 nettopp fjernet:

```javascript
.normalize("NFD")
.replace(/[̀-ͯ]/g, "")   // kun kombinerende tegn — ø og æ overlever
```

Kjørt som den sto, ville migreringen skrevet `s-ndagsplask` for alle 1221 historiske arrangementer. Vi ville altså fjernet buggen fra API-et og så importert den tilbake gjennom bakdøren.

I tillegg bygget [04-events.ts](../blob/main/packages/lepton-migration/src/phases/04-events.ts) sluggen slik:

```javascript
slug = `${slug}-${e.id}`;                                  // tittel + Lepton-id
if (usedSlugs.has(slug)) slug = `${slug}-${Date.now()}`;   // tidsstempel
```

To formater side om side i URL-ene, og `Date.now()` betyr at en avbrutt og gjenstartet migrering gir andre slugger enn første forsøk.

## Løsningen

Den deterministiske delen — translitterasjon, slugifisering og tittel-pluss-dato-stammen — flyttes til `@photon/core/slug`. Begge kallerne bruker den.

**Unikhet deles bevisst ikke.** De to har ulike behov:

| | API | migrering |
|---|---|---|
| skriver | én rad om gangen | batch-innsetting etter løkka |
| kollisjonssjekk | mot databasen | in-memory `Set` |

Kaller migreringen `generateUniqueEventSlug`, som spør databasen, ville alle 28 «Søndagsplask» fått samme slug — radene finnes jo ikke ennå — og innsettingen brutt unikhetskravet. Begge teller nå oppover i stedet for å randomisere, så begge kan kjøres to ganger uten å lage nye URL-er.

`mappings.slugify` delegerer også, så fasene for **brukere og kategorier** får den norske fiksen med på kjøpet.

## Verifisert

Kjørte den delte funksjonen mot alle 1221 ekte arrangementene fra Leptons API, med migreringens in-memory-teller:

```
arrangementer:     1221
unike slugger:     1221
trengte suffiks:      0
titler med ø/æ/å:   318   (alle translittereres)
```

```
'Søndagsplask'                  ->  sondagsplask-2026-03-17
'Påskeegg jakt i A-blokka🐣'    ->  paskeegg-jakt-i-a-blokka-...
'Piknik med JenteKom i Dødens dal' -> piknik-med-jentekom-i-dodens-dal-...
```

- `bun run typecheck` — 7 av 7 pakker
- `vitest run src/test/event/slug.test.ts` — 6 av 6 tester

🤖 Generated with [Claude Code](https://claude.com/claude-code)