### PR TITLE
fix(core): slug events by their Oslo date, not the UTC one

### DIFF
--- a/apps/api/src/test/event/slug.test.ts
+++ b/apps/api/src/test/event/slug.test.ts
@@ -37,6 +37,28 @@ describe("buildEventSlugBase", () => {
         ).toBe("sondagsplask-2026-03-17");
     });
 
+    it("uses the Oslo date, not the UTC one, for midnight starts", () => {
+        // 15 Jan 00:00 in Oslo is 14 Jan 23:00 UTC. Slugging off the UTC date
+        // put 22 of TIHLDE's events on the wrong day, and made the API import
+        // and the MySQL migration disagree about the same event.
+        expect(
+            buildEventSlugBase(
+                "TIHLDE til Åre",
+                new Date("2026-01-15T00:00:00+01:00"),
+            ),
+        ).toBe("tihlde-til-are-2026-01-15");
+    });
+
+    it("uses the Oslo date during summer time too", () => {
+        // +02:00 in July, so midnight local is 22:00 UTC the previous day.
+        expect(
+            buildEventSlugBase(
+                "Sommerfest",
+                new Date("2026-07-04T00:00:00+02:00"),
+            ),
+        ).toBe("sommerfest-2026-07-04");
+    });
+
     it("falls back to 'event' when a title slugs to nothing", () => {
         // The migration has titles made only of emoji or punctuation.
         expect(buildEventSlugBase("💜", new Date("2026-03-17T18:00:00Z"))).toBe(

--- a/packages/core/src/slug.ts
+++ b/packages/core/src/slug.ts
@@ -44,8 +44,30 @@ export const slugifyText = (text: string): string =>
         // collapse multiple hyphens
         .replace(/-{2,}/g, "-");
 
-/** The start date as `2026-11-14`. */
-const isoDate = (date: Date): string => date.toISOString().slice(0, 10);
+/** The timezone every TIHLDE event's wall-clock time is expressed in. */
+const EVENT_TIMEZONE = "Europe/Oslo";
+
+const OSLO_DATE_FORMAT = new Intl.DateTimeFormat("en-CA", {
+    timeZone: EVENT_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+});
+
+/**
+ * The date an event falls on in Norway, as `2026-11-14`.
+ *
+ * Deliberately not `toISOString()`, which yields the UTC date. Events are
+ * stored as `timestamp without time zone` — wall-clock time in Oslo — and 22 of
+ * TIHLDE's historical events start at midnight, so their UTC date is the day
+ * before. "TIHLDE TIL ÅRE 2026" starts on 15 January and would have slugged as
+ * `2026-01-14`.
+ *
+ * Pinning the zone also keeps the slug independent of the server's clock: the
+ * production container runs UTC while a developer's machine does not, and both
+ * must produce the same slug for the same event.
+ */
+const eventDate = (date: Date): string => OSLO_DATE_FORMAT.format(date);
 
 /**
  * The stem of an event slug: title plus start date, before any uniqueness
@@ -59,5 +81,5 @@ const isoDate = (date: Date): string => date.toISOString().slice(0, 10);
  */
 export const buildEventSlugBase = (title: string, startDate: Date): string => {
     const stem = slugifyText(title) || "event";
-    return `${stem}-${isoDate(startDate)}`;
+    return `${stem}-${eventDate(startDate)}`;
 };


### PR DESCRIPTION
Funnet mens jeg forberedte importen av kommende arrangementer. Feilen er i koden fra [#165](https://github.com/TIHLDE/Photon/pull/165) — min egen.

## Problemet

`buildEventSlugBase` formaterte datoen med `toISOString()`, som gir **UTC**. Arrangementer lagres som `timestamp without time zone`, altså veggklokke-tid i Oslo, og **22 av 1221** starter ved midnatt:

```
'TIHLDE TIL ÅRE 2026!!!'   starter 15. januar 00:00 (+01:00)
                           → UTC 14. januar 23:00
                           → slug ...-2026-01-14   ✗
```

## Hvorfor det betyr mer enn én dag feil

Sluggen ble avhengig av serverens klokke. Det bryter dedup-planen for datamigreringen:

| kilde | tidsstempel | avledet dato |
|---|---|---|
| API-import | `2026-01-15T00:00:00+01:00` | `2026-01-14` |
| MySQL-migrering | `2026-01-15 00:00:00` (naiv) | `2026-01-15` |

Samme arrangement, to ulike slugger. `ON CONFLICT (slug) DO NOTHING` — som skal hindre at migreringen dupliserer allerede importerte arrangementer — ville rett og slett bommet, og dere hadde fått duplikatet mekanismen skulle forhindre.

## Løsningen

Formaterer i `Europe/Oslo` med `Intl.DateTimeFormat` i stedet. Sluggen blir datoen en norsk leser ville oppgitt, uansett hvilken tidssone serveren kjører i — prod-containeren kjører UTC, utviklermaskiner gjør det ikke.

## Verifisert

Mot alle 1221 arrangementene fra Leptons API:

```
              TZ=UTC   TZ=Europe/Oslo
unike slugger   1221         1221
dato-avvik         0            0
```

Null avvik mot datoen Lepton selv oppgir, og bit-identisk resultat under begge tidssoner.

- 8 enhetstester, kjørt under både `TZ=UTC` og `TZ=Europe/Oslo`
- `bun run typecheck` — 7 av 7 pakker
- To nye tester dekker midnattsstart i både vinter- (+01:00) og sommertid (+02:00)

🤖 Generated with [Claude Code](https://claude.com/claude-code)