### PR TITLE
feat(kvark): show sports teams in the group tree

### DIFF
--- a/apps/kvark/src/routes/_app/grupper.index.tsx
+++ b/apps/kvark/src/routes/_app/grupper.index.tsx
@@ -75,6 +75,8 @@ function buildTreeInput(groups: ApiGroup[]): GroupTreeInput {
             sectionFrom("undergrupper", "Undergrupper", 3, groups, "SUBGROUP"),
             sectionFrom("komiteer", "Komitéer", 3, groups, "COMMITTEE"),
         ],
+        // Sports teams sit alongside interest groups rather than inside them:
+        // same level in the organisation, but a category of their own.
         branches: [
             sectionFrom(
                 "interessegrupper",
@@ -83,6 +85,7 @@ function buildTreeInput(groups: ApiGroup[]): GroupTreeInput {
                 groups,
                 "INTERESTGROUP",
             ),
+            sectionFrom("idrettslag", "Idrettslag", 2, groups, "SPORTSTEAM"),
         ],
     };
 }


### PR DESCRIPTION
## Problemet

Gruppetreet mapper fire hardkodede typer til seksjoner:

```javascript
BOARD → Hovedorgan    SUBGROUP → Undergrupper
COMMITTEE → Komitéer  INTERESTGROUP → Interessegrupper
```

TIHLDE har også fire `SPORTSTEAM`-grupper. De ligger i databasen, men vises **ingen steder** på gruppesiden.

## Endringen

Idrettslag er likestilt med interessegrupper, men er ikke interessegrupper — samme nivå i organisasjonen, egen kategori. De legges derfor til som en egen gren, ikke slås sammen med interessegruppene.

`buildGroupTree` håndterer allerede flere grener og legger `BRANCH_GAP` mellom dem, så oppsettet er det designet for.

## Verifisert

Mot ekte Lepton-data (58 grupper) i en lokal database:

| | |
|---|---|
| Pythons Fotball Damer | pythonsdamer@tihlde.org |
| Pythons Fotball Herrer | pythons@tihlde.org |
| Pythons Håndball | handball@tihlde.org |
| Pythons Volley | mia.tveite@tihlde.org |

Seksjonen rendrer i både tre- og mobilvisning. `bun run typecheck` grønt på 7 av 7 pakker.

## Merknad

`STUDY`, `STUDYYEAR` og `TIHLDE` er fortsatt umappet, så de 17 gruppene forblir usynlige på denne siden. Ikke tatt med her siden det er en egen avgjørelse om de hører hjemme i organisasjonskartet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)