### PR TITLE
feat: to visninger på /grupper — liste (standard) og hierarki

### DIFF
--- a/apps/kvark/src/components/group-list-view.tsx
+++ b/apps/kvark/src/components/group-list-view.tsx
@@ -18,14 +18,21 @@ function flattenBranches(branches: Branch[]): SimpleSection[] {
     });
 }
 
-export function GroupTreeMobile({ tree }: { tree: GroupTreeInput }) {
-    const sections = [...tree.main, ...flattenBranches(tree.branches)];
+/**
+ * Flat, section-by-section card listing of every group. Doubles as the mobile
+ * rendering of the hierarchy view, where the org chart is too wide to read.
+ */
+export function GroupListView({ tree }: { tree: GroupTreeInput }) {
+    const sections = [...tree.main, ...flattenBranches(tree.branches)].filter(
+        (section) => section.items.length > 0,
+    );
+
     return (
         <div className="flex flex-col gap-6">
             {sections.map((section) => (
                 <section key={section.id} className="flex flex-col gap-3">
                     <h2 className="text-lg font-semibold">{section.label}</h2>
-                    <div className="grid gap-2 sm:grid-cols-2">
+                    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
                         {section.items.map((item) => (
                             <Link
                                 key={item.slug}
@@ -33,7 +40,10 @@ export function GroupTreeMobile({ tree }: { tree: GroupTreeInput }) {
                                 to="/grupper/$slug"
                                 params={{ slug: item.slug }}
                             >
-                                <Card size="sm" className="cursor-pointer">
+                                <Card
+                                    size="sm"
+                                    className="h-full cursor-pointer"
+                                >
                                     <CardContent className="flex items-center gap-3">
                                         <GroupIdentity {...item} />
                                     </CardContent>

--- a/apps/kvark/src/routes/_app/grupper.index.tsx
+++ b/apps/kvark/src/routes/_app/grupper.index.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import { ReactFlow, type Node } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useCallback, useMemo } from "react";
+import z from "zod";
 
 import { getGroupsQuery } from "#/api/queries/groups";
-import { GroupTreeMobile } from "#/components/group-tree-mobile";
+import { GroupListView } from "#/components/group-list-view";
 import {
     GroupTreeJunctionNode,
     type GroupTreeNodeData,
@@ -34,8 +36,18 @@ const PRO_OPTIONS = { hideAttribution: true };
 const TRANSPARENT_BG = { background: "transparent" } as const;
 const FIT_VIEW_OPTIONS = { padding: 0.05 };
 
+const VIEWS = [
+    { value: "liste", label: "Liste" },
+    { value: "hierarki", label: "Hierarki" },
+] as const;
+
+const searchSchema = z.object({
+    visning: z.enum(["liste", "hierarki"]).default("liste").catch("liste"),
+});
+
 export const Route = createFileRoute("/_app/grupper/")({
     component: GroupsPage,
+    validateSearch: searchSchema,
     loader: ({ context }) =>
         context.queryClient.ensureQueryData(getGroupsQuery(0)),
 });
@@ -93,6 +105,7 @@ function buildTreeInput(groups: ApiGroup[]): GroupTreeInput {
 function GroupsPage() {
     const { theme } = useTheme();
     const navigate = useNavigate();
+    const { visning } = Route.useSearch();
 
     const { data: groups } = useSuspenseQuery(getGroupsQuery(0));
 
@@ -115,45 +128,81 @@ function GroupsPage() {
         [navigate],
     );
 
+    const changeView = useCallback(
+        (next: string) => {
+            navigate({
+                to: "/grupper",
+                search: { visning: next as (typeof VIEWS)[number]["value"] },
+                replace: true,
+            });
+        },
+        [navigate],
+    );
+
     return (
         <div className="container mx-auto flex w-full flex-col gap-4 px-4 py-8">
             <h1 className="text-center text-2xl">Gruppeoversikt</h1>
 
-            <div className="md:hidden">
-                <GroupTreeMobile tree={tree} />
-            </div>
-
-            <div
-                className="hidden w-full md:block"
-                style={{ aspectRatio: chartAspect }}
+            <Tabs
+                className="self-center"
+                value={visning}
+                onValueChange={changeView}
             >
-                <ReactFlow
-                    colorMode={theme}
-                    defaultEdgeOptions={DEFAULT_EDGE_OPTIONS}
-                    defaultEdges={edges}
-                    defaultNodes={nodes}
-                    edgesFocusable={false}
-                    edgesReconnectable={false}
-                    elementsSelectable={false}
-                    fitView
-                    fitViewOptions={FIT_VIEW_OPTIONS}
-                    maxZoom={1}
-                    minZoom={0.2}
-                    nodeTypes={NODE_TYPES}
-                    nodesConnectable={false}
-                    nodesDraggable={false}
-                    nodesFocusable={false}
-                    onNodeClick={onNodeClick}
-                    panOnDrag={false}
-                    panOnScroll={false}
-                    preventScrolling={false}
-                    proOptions={PRO_OPTIONS}
-                    style={TRANSPARENT_BG}
-                    zoomOnDoubleClick={false}
-                    zoomOnPinch={false}
-                    zoomOnScroll={false}
-                />
-            </div>
+                <TabsList>
+                    {VIEWS.map((view) => (
+                        <TabsTrigger key={view.value} value={view.value}>
+                            {view.label}
+                        </TabsTrigger>
+                    ))}
+                </TabsList>
+            </Tabs>
+
+            {visning === "liste" ? <GroupListView tree={tree} /> : null}
+
+            {/* The chart is mounted only while its tab is active — React Flow
+                measures its container on mount and would lay out against a
+                zero-size box if it were merely hidden with CSS. */}
+            {visning === "hierarki" ? (
+                <>
+                    {/* The org chart is unreadable on narrow screens, so mobile
+                        falls back to the same sectioned list. */}
+                    <div className="md:hidden">
+                        <GroupListView tree={tree} />
+                    </div>
+
+                    <div
+                        className="hidden w-full md:block"
+                        style={{ aspectRatio: chartAspect }}
+                    >
+                        <ReactFlow
+                            colorMode={theme}
+                            defaultEdgeOptions={DEFAULT_EDGE_OPTIONS}
+                            defaultEdges={edges}
+                            defaultNodes={nodes}
+                            edgesFocusable={false}
+                            edgesReconnectable={false}
+                            elementsSelectable={false}
+                            fitView
+                            fitViewOptions={FIT_VIEW_OPTIONS}
+                            maxZoom={1}
+                            minZoom={0.2}
+                            nodeTypes={NODE_TYPES}
+                            nodesConnectable={false}
+                            nodesDraggable={false}
+                            nodesFocusable={false}
+                            onNodeClick={onNodeClick}
+                            panOnDrag={false}
+                            panOnScroll={false}
+                            preventScrolling={false}
+                            proOptions={PRO_OPTIONS}
+                            style={TRANSPARENT_BG}
+                            zoomOnDoubleClick={false}
+                            zoomOnPinch={false}
+                            zoomOnScroll={false}
+                        />
+                    </div>
+                </>
+            ) : null}
         </div>
     );
 }


### PR DESCRIPTION
## Hva

Gruppeoversikten på `/grupper` viste kun organisasjonskartet. Nå kan man velge mellom to visninger via faner:

- **Liste** (standard) — flat kortliste gruppert på Hovedorgan / Undergrupper / Komitéer / Interessegrupper / Idrettslag
- **Hierarki** — organisasjonskartet som før, uendret

Valget ligger i URL-en som `?visning=liste|hierarki`, så det kan deles og overlever refresh. Ugyldige verdier faller tilbake til `liste`.

## Hvordan

- `group-tree-mobile.tsx` → `group-list-view.tsx`: den mobile fallbacken var allerede en seksjonert kortliste, så den er generalisert og gjenbrukes både som egen fane og som mobilvisning av hierarkiet. Tomme seksjoner skjules.
- Kartet monteres kun når hierarki-fanen er aktiv. React Flow måler containeren ved mount, så hvis den bare var skjult med CSS la den ut mot en null-størrelse boks (verifisert — kartet ble ødelagt før denne endringen).

## Verifisert

- `tsc --noEmit` i `apps/kvark` — ingen feil i appens egen kildekode
- `turbo run build --filter=kvark` — grønn
- `oxlint` / `oxfmt --check` — ingen nye funn
- Kjørt lokalt mot dev-API: liste er standard, faneskifte begge veier fungerer, kartet rendrer korrekt både ved direkte navigasjon til `?visning=hierarki` og etter klientside-bytte, og mobil (375px) viser listen i begge faner

🤖 Generated with [Claude Code](https://claude.com/claude-code)