### PR TITLE
Recover two TÖDDEL issues Lepton records under the wrong URL

### DIFF
--- a/packages/lepton-migration/import-toddel.ts
+++ b/packages/lepton-migration/import-toddel.ts
@@ -44,6 +44,36 @@ type SourceIssue = {
     publishedAt: string;
 };
 
+/**
+ * Issues whose stored PDF url is wrong rather than whose file is missing.
+ *
+ * Both 404 from Lepton, which reads as "the archive has holes" — but the
+ * blobs are still in Azure under a url the database never caught up with, and
+ * this is the last chance to fetch them.
+ *
+ * - Edition 9 is recorded against `tihldestorage` while the file sits in
+ *   `leptonstoragepro` under the same key.
+ * - Edition 12 has two uuids concatenated in front of the filename; only the
+ *   second one addresses a real blob.
+ *
+ * Both recovered files carry a PDF creation date matching their publication
+ * (2023-03-25 for an issue published 2023-03-20; 2023-11-20 for 2023-11-24),
+ * and edition 9's opens on its masthead, so they are the right documents.
+ *
+ * Edition 15 stays lost: both storage accounts, five filename spellings, five
+ * containers, the cover's uuid and the Wayback Machine all come up empty.
+ */
+const RECOVERED_PDF_URLS = new Map<number, string>([
+    [
+        9,
+        "https://leptonstoragepro.blob.core.windows.net/applicationpdf/763fa2f4-0be5-417d-99c7-b644ba4afdd2toddelh23v2_master.pdf",
+    ],
+    [
+        12,
+        "https://leptonstoragepro.blob.core.windows.net/applicationpdf/1bc5df5e-8173-419a-87a5-b1644d49bfb5toddelH23V2Digital%20%281%29.pdf",
+    ],
+]);
+
 const commit = process.argv.includes("--commit");
 const rootUrl = process.env.ROOT_URL ?? "https://photon.tihlde.org";
 const leptonUrl =
@@ -79,7 +109,7 @@ const issues: SourceIssue[] = leptonIssues.map((issue) => ({
     edition: issue.edition,
     title: issue.title,
     sourceImageUrl: issue.image || null,
-    sourcePdfUrl: issue.pdf,
+    sourcePdfUrl: RECOVERED_PDF_URLS.get(issue.edition) ?? issue.pdf,
     // Lepton stores edition 14 as `0024-04-19`. A four-digit year starting
     // "00" is a typo for the 2000s, not a date in antiquity.
     publishedAt: issue.published_at.startsWith("00")


### PR DESCRIPTION
Editions 9 and 12 both 404 from Lepton — including from `api.tihlde.org`, which is why they looked lost in #176 and #177. They are not. The blobs are still in Azure; the stored URL is wrong, not the upload.

## What was actually wrong

| edition | fault | recovered |
|---|---|---|
| 9 — "TIHLDE 30 år" | recorded against `tihldestorage`, file sits in `leptonstoragepro` under the same key | 15.1 MB, 28 pages |
| 12 | two uuids concatenated in front of the filename; only the second addresses a real blob | 17.3 MB |

The second one is visible in the URL itself:

```
.../applicationpdf/174e3231-bf83-45fa-8f05-60cd8af92769 1bc5df5e-8173-419a-87a5-b1644d49bfb5 toddelH23V2Digital(1).pdf
                   └─ addresses nothing ────────────────┘ └─ the real blob ──────────────────┘
```

## Confirming these are the right documents

Not just "a PDF that resolves":

- Edition 9's recovery has a PDF creation date of **2023-03-25** against a publication date of 2023-03-20, and its first pages are the issue's masthead — editor, photographer and contributor credits.
- Edition 12's has a creation date of **2023-11-20** against a publication date of 2023-11-24.

This mattered because edition 9's filename (`toddelh23v2_master.pdf`) is shared with the file edition 10 currently points at, so a filename match alone would not have been evidence.

## Result

**21 of 22 issues** now have a working PDF, up from 19. Verified by HEAD-ing every issue in the live archive with the override applied: 21 return 200, one does not.

## Edition 15 is genuinely gone

"Velkommen til TIHLDE 2024" (`Fadderutgave_h24.pdf`) was not found under: both storage accounts, five filename spellings, five container names, the cover's uuid used as the PDF key, or the Wayback Machine. Its cover still resolves, so if anyone in TIHLDE has the file it can be uploaded by hand later — otherwise it goes when Lepton does.

## Verification

- `bun run lint` — clean on the changed file
- `bun run typecheck` — 7/7 packages
- `bun run build --force` — 4/4, 0 cached
- `bun run test` — 204 tests

Note: typecheck initially failed on `@tihlde/ui` not finding `qrcode.react`, which is a stale `node_modules` after branching from a newer `dev`, not a fault in this change. `bun install` resolved it and left the lockfile unchanged.

**Not verified:** the copy path has still not been re-run end-to-end with this revision. That code is unchanged since #176, where it ran against a local Postgres and MinIO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)