### PR TITLE
Let card covers sit flush with the top of the card

### DIFF
--- a/apps/kvark/src/components/gallery-card.tsx
+++ b/apps/kvark/src/components/gallery-card.tsx
@@ -24,14 +24,17 @@ export function GalleryCard({
             className="h-full"
             render={<Link to="/galleri/$slug" params={{ slug }} />}
         >
-            <div className="aspect-video w-full overflow-hidden">
-                <img
-                    src={imageUrl}
-                    alt=""
-                    loading="lazy"
-                    className="size-full object-cover"
-                />
-            </div>
+            {/*
+             * Direct child, not wrapped: Card drops its top padding and rounds
+             * the top corners only for an `img:first-child`, so a ratio wrapper
+             * leaves a strip of card above the image. The ratio goes here.
+             */}
+            <img
+                src={imageUrl}
+                alt=""
+                loading="lazy"
+                className="aspect-video w-full object-cover"
+            />
             <CardHeader>
                 <CardTitle>{title}</CardTitle>
                 {description && (

--- a/apps/kvark/src/components/issue-card.tsx
+++ b/apps/kvark/src/components/issue-card.tsx
@@ -29,7 +29,11 @@ export function IssueCard({
                     loading="lazy"
                 />
             ) : (
-                <div className="aspect-[3/4] w-full bg-muted" aria-hidden />
+                <div
+                    data-slot="card-media"
+                    className="aspect-[3/4] w-full bg-muted"
+                    aria-hidden
+                />
             )}
             <CardHeader>
                 <CardTitle>{title}</CardTitle>

--- a/apps/kvark/src/components/issue-card.tsx
+++ b/apps/kvark/src/components/issue-card.tsx
@@ -15,18 +15,22 @@ export function IssueCard({
 }: IssueCardProps) {
     const card = (
         <Card size="sm">
-            <div className="aspect-[3/4] w-full overflow-hidden">
-                {coverUrl ? (
-                    <img
-                        src={coverUrl}
-                        alt={title}
-                        className="size-full object-cover"
-                        loading="lazy"
-                    />
-                ) : (
-                    <div className="size-full bg-muted" aria-hidden />
-                )}
-            </div>
+            {/*
+             * The cover is a direct child on purpose: Card drops its top
+             * padding and rounds the top corners only for an `img:first-child`,
+             * so wrapping it in an aspect-ratio div left a band of card above
+             * the image. The ratio goes on the image itself instead.
+             */}
+            {coverUrl ? (
+                <img
+                    src={coverUrl}
+                    alt={title}
+                    className="aspect-[3/4] w-full object-cover"
+                    loading="lazy"
+                />
+            ) : (
+                <div className="aspect-[3/4] w-full bg-muted" aria-hidden />
+            )}
             <CardHeader>
                 <CardTitle>{title}</CardTitle>
                 <p className="text-muted-foreground">{edition}</p>

--- a/apps/kvark/src/components/news-card.tsx
+++ b/apps/kvark/src/components/news-card.tsx
@@ -27,17 +27,24 @@ export function NewsCard({
             className="h-full"
             render={<Link to="/nyheter/$slug" params={{ slug }} />}
         >
-            <div className="aspect-[16/7] w-full overflow-hidden">
-                {imageUrl ? (
-                    <img
-                        src={imageUrl}
-                        alt=""
-                        className="size-full object-cover"
-                    />
-                ) : (
-                    <div className="size-full bg-muted" aria-hidden />
-                )}
-            </div>
+            {/*
+             * Direct child, not wrapped: Card drops its top padding and rounds
+             * the top corners only for an `img:first-child`, so a ratio wrapper
+             * leaves a strip of card above the image. The ratio goes here.
+             */}
+            {imageUrl ? (
+                <img
+                    src={imageUrl}
+                    alt=""
+                    className="aspect-[16/7] w-full object-cover"
+                />
+            ) : (
+                <div
+                    data-slot="card-media"
+                    className="aspect-[16/7] w-full bg-muted"
+                    aria-hidden
+                />
+            )}
             <CardHeader>
                 <CardTitle>{title}</CardTitle>
                 <CardDescription>{publishedAt}</CardDescription>

--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -15,7 +15,10 @@ function Card({ className, size = "default", render, ...props }: CardProps) {
             "data-slot": "card",
             "data-size": size,
             className: cn(
-                "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+                // `card-media` gets the same flush-to-the-edge treatment as a
+                // bare `img`, so a cover and its placeholder line up instead of
+                // the placeholder sitting inset below a strip of card.
+                "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 has-[>[data-slot=card-media]:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl *:[[data-slot=card-media]:first-child]:rounded-t-xl *:[[data-slot=card-media]:last-child]:rounded-b-xl",
                 className,
             ),
             ...props,


### PR DESCRIPTION
The covers had a strip of card visible above them, so each one looked like it was floating rather than filling the card. Same fault in three components.

## Cause

`Card` in `@tihlde/ui` already handles exactly this case:

```
has-[>img:first-child]:pt-0
*:[img:first-child]:rounded-t-xl
```

Both selectors require the image to be a **direct** child. All three components wrapped it in a `<div>` to carry the aspect ratio, so neither matched and the card kept its top padding.

## Fixed

| component | ratio | seen on |
|---|---|---|
| `issue-card` | 3/4 | TÖDDEL |
| `gallery-card` | 16/9 | /galleri |
| `news-card` | 16/7 | front page, /nyheter |

The ratio moves onto the image itself so it is the direct child the component expects. No new styling — the component's existing behaviour does the work, so the card keeps ownership of its own radius rather than the app hard-coding one.

## The placeholder needed the design system, not a patch

A news article without an image renders a grey box instead, and that has the same problem — but it is a `div` by nature, so the `img` selectors can never match it.

Rather than special-case it in the app, `Card` now treats a `card-media` first child like an image. The rule belongs in the design system, and a cover and its placeholder now line up instead of the placeholder sitting inset below a strip of card. The addition is purely additive: it only matches when `data-slot="card-media"` is present, so no existing card changes.

## Deliberately left alone

- `group-om-tab` already passes the image as a direct child and sets `p-0` itself, because the image is the card's only content.
- `company-offer-card` places its image inside `CardContent` beside text rather than as a cover, with its own `rounded-lg`. A content image, not a cover.

## Verified in the browser

Measured against real production data, on cards actually in the viewport:

| | TÖDDEL cover | gallery cover | news placeholder |
|---|---|---|---|
| card `padding-top` | `0px` | `0px` | `0px` |
| gap above media | **0px** | **0px** | **0px** |
| direct first child | yes | yes | yes |
| fills card width | yes | yes | yes |
| aspect ratio | **0.750** (3/4) | **1.778** (16/9) | **2.286** (16/7) |
| top radius | **14px** | **14px** | **14px** |
| card `overflow` | `hidden` | `hidden` | `hidden` |

TÖDDEL was also checked visually at desktop and mobile (375×812), and the gallery grid at desktop; the covers meet both top corners at each width. The news placeholder was confirmed by measurement rather than screenshot — the browser pane hung before I could capture it.

- `bun run typecheck` — 7/7 packages
- `bun run build --force` — 4/4, 0 cached
- `bun run test` — 204 tests
- `oxlint` / `oxfmt` — clean on all four changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)