### PR TITLE
fix(ui): lik cover-høyde på list-kort og TIHLDE-fallback overalt

### DIFF
--- a/apps/kvark/src/components/detail-hero.tsx
+++ b/apps/kvark/src/components/detail-hero.tsx
@@ -1,3 +1,5 @@
+import { DEFAULT_COVER_IMAGE } from "#/lib/image";
+
 type DetailHeroProps = {
     imageUrl?: string;
     alt?: string;
@@ -6,13 +8,11 @@ type DetailHeroProps = {
 export function DetailHero({ imageUrl, alt = "" }: DetailHeroProps) {
     return (
         <div className="aspect-[16/7] w-full overflow-hidden rounded-xl bg-muted">
-            {imageUrl ? (
-                <img
-                    src={imageUrl}
-                    alt={alt}
-                    className="size-full object-cover"
-                />
-            ) : null}
+            <img
+                src={imageUrl || DEFAULT_COVER_IMAGE}
+                alt={alt}
+                className="size-full object-cover"
+            />
         </div>
     );
 }

--- a/apps/kvark/src/components/event-card.tsx
+++ b/apps/kvark/src/components/event-card.tsx
@@ -2,7 +2,6 @@ import { Link } from "@tanstack/react-router";
 import { CalendarDays, MapPin, UsersRound } from "lucide-react";
 
 import { ListCard } from "#/components/list-card";
-import { DEFAULT_EVENT_IMAGE } from "#/lib/event";
 
 export type EventCardProps = {
     slug: string;
@@ -46,7 +45,7 @@ export function EventCard({
         <ListCard
             render={<Link to="/arrangementer/$slug" params={{ slug }} />}
             title={title}
-            imageUrl={imageUrl || DEFAULT_EVENT_IMAGE}
+            imageUrl={imageUrl}
             imageBadge={organizer}
             meta={meta}
         />

--- a/apps/kvark/src/components/issue-card.tsx
+++ b/apps/kvark/src/components/issue-card.tsx
@@ -1,5 +1,7 @@
 import { Card, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
 
+import { DEFAULT_COVER_IMAGE } from "#/lib/image";
+
 export type IssueCardProps = {
     title: string;
     edition: string;
@@ -21,20 +23,12 @@ export function IssueCard({
              * so wrapping it in an aspect-ratio div left a band of card above
              * the image. The ratio goes on the image itself instead.
              */}
-            {coverUrl ? (
-                <img
-                    src={coverUrl}
-                    alt={title}
-                    className="aspect-[3/4] w-full object-cover"
-                    loading="lazy"
-                />
-            ) : (
-                <div
-                    data-slot="card-media"
-                    className="aspect-[3/4] w-full bg-muted"
-                    aria-hidden
-                />
-            )}
+            <img
+                src={coverUrl || DEFAULT_COVER_IMAGE}
+                alt={title}
+                className="aspect-[3/4] w-full object-cover"
+                loading="lazy"
+            />
             <CardHeader>
                 <CardTitle>{title}</CardTitle>
                 <p className="text-muted-foreground">{edition}</p>

--- a/apps/kvark/src/components/list-card.tsx
+++ b/apps/kvark/src/components/list-card.tsx
@@ -3,6 +3,8 @@ import { useRender } from "@tihlde/ui/hooks/use-render";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
+import { DEFAULT_COVER_IMAGE } from "#/lib/image";
+
 export type ListCardMetaRow = {
     icon: LucideIcon;
     text: ReactNode;
@@ -30,14 +32,17 @@ export function ListCard({
                 "flex flex-col gap-3 overflow-hidden rounded-2xl bg-card sm:flex-row sm:gap-3 sm:overflow-visible sm:bg-transparent sm:p-2 sm:transition-colors sm:hover:bg-muted/50",
             children: (
                 <>
-                    <div className="relative aspect-[16/7] w-full shrink-0 overflow-hidden rounded-t-2xl bg-muted sm:w-52 sm:rounded-lg">
-                        {imageUrl ? (
-                            <img
-                                src={imageUrl}
-                                alt=""
-                                className="size-full object-cover"
-                            />
-                        ) : null}
+                    {/*
+                     * `self-start` keeps the media at its 16/7 ratio: as a
+                     * flex child it would otherwise stretch to the row height,
+                     * making covers taller on cards with two-line titles.
+                     */}
+                    <div className="relative aspect-[16/7] w-full shrink-0 overflow-hidden rounded-t-2xl bg-muted sm:w-52 sm:self-start sm:rounded-lg">
+                        <img
+                            src={imageUrl || DEFAULT_COVER_IMAGE}
+                            alt=""
+                            className="size-full object-cover"
+                        />
                         {imageBadge ? (
                             <Badge className="absolute right-2 bottom-2">
                                 {imageBadge}

--- a/apps/kvark/src/components/news-card.tsx
+++ b/apps/kvark/src/components/news-card.tsx
@@ -7,6 +7,8 @@ import {
     CardTitle,
 } from "@tihlde/ui/ui/card";
 
+import { DEFAULT_COVER_IMAGE } from "#/lib/image";
+
 export type NewsCardProps = {
     slug: string;
     title: string;
@@ -32,19 +34,11 @@ export function NewsCard({
              * the top corners only for an `img:first-child`, so a ratio wrapper
              * leaves a strip of card above the image. The ratio goes here.
              */}
-            {imageUrl ? (
-                <img
-                    src={imageUrl}
-                    alt=""
-                    className="aspect-[16/7] w-full object-cover"
-                />
-            ) : (
-                <div
-                    data-slot="card-media"
-                    className="aspect-[16/7] w-full bg-muted"
-                    aria-hidden
-                />
-            )}
+            <img
+                src={imageUrl || DEFAULT_COVER_IMAGE}
+                alt=""
+                className="aspect-[16/7] w-full object-cover"
+            />
             <CardHeader>
                 <CardTitle>{title}</CardTitle>
                 <CardDescription>{publishedAt}</CardDescription>

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -1,11 +1,6 @@
 import { format } from "date-fns";
 import { nb } from "date-fns/locale";
 
-/**
- * Fallback cover image used for events and activities without their own image.
- */
-export const DEFAULT_EVENT_IMAGE = "/browser-icons/cover-image.jpg";
-
 // -- Shared display types (previously in mock/events) --
 
 export type EventRegistrationState =

--- a/apps/kvark/src/lib/image.ts
+++ b/apps/kvark/src/lib/image.ts
@@ -1,0 +1,5 @@
+/**
+ * Fallback TIHLDE cover image, used everywhere content is missing its own
+ * image (event/job/news cards, detail heroes, Töddel covers).
+ */
+export const DEFAULT_COVER_IMAGE = "/browser-icons/cover-image.jpg";

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -31,7 +31,6 @@ import { IconActionButton } from "#/components/icon-action-button";
 import { ShareButton } from "#/components/share-button";
 import { buildGoogleCalendarUrl } from "#/lib/calendar-url";
 import {
-    DEFAULT_EVENT_IMAGE,
     deriveRegistrationState,
     formatEventDate,
     formatEventPrice,
@@ -109,7 +108,7 @@ function EventDetailPage() {
                     </Button>
                 </div>
             }
-            hero={<DetailHero imageUrl={event.image || DEFAULT_EVENT_IMAGE} />}
+            hero={<DetailHero imageUrl={event.image ?? undefined} />}
             header={
                 <>
                     <div className="flex items-center justify-between gap-2">


### PR DESCRIPTION
## Hva

To relaterte kort-fikser i Kvark.

### 1. Ulik høyde på cover-bildene
Cover-boksen i `ListCard` er et flex-barn, så den ble strukket til radhøyden og overstyrte `aspect-[16/7]`. Kort med to-linjers tittel eller en ekstra meta-rad fikk derfor høyere bilde enn resten. `sm:self-start` låser den til 16/7.

Målt i preview etter endringen: alle cover-bokser på `/arrangementer` og forsiden er nøyaktig `208x91` px — før varierte de med tittellengden.

### 2. TIHLDE-cover brukes overalt bilde mangler
Konstanten er flyttet til `src/lib/image.ts` som `DEFAULT_COVER_IMAGE` og tatt i bruk der det før ble rendret en tom grå boks:

- `list-card.tsx` — arrangement- og stillingskort (annonser hadde ingen fallback før)
- `news-card.tsx`
- `issue-card.tsx` — Töddel-forsider
- `detail-hero.tsx` — detaljsider for arrangement, nyhet og annonse (fallbacken lå tidligere bare i arrangement-ruten)

## Verifisering

- Kjørt i preview mot lokal API: 9 av 17 arrangementer viser nå TIHLDE-coveret i stedet for grå boks, og alle cover-bokser måler likt.
- `bun run typecheck` OK, `oxlint` uten treff i endrede filer, `oxfmt --check apps/kvark/src` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)