### PR TITLE
feat: spørreskjema-siden og /ny-student portert fra Kvark

### DIFF
--- a/apps/api/src/routes/form/get.ts
+++ b/apps/api/src/routes/form/get.ts
@@ -52,13 +52,53 @@ export const getRoute = route().get(
             ? await userHasSubmitted(db, form.id, user.id)
             : false;
 
+        // A form is either standalone, attached to an event, or owned by a
+        // group. The client needs to know which, plus the owner's submission
+        // rules, to decide how to present and gate the form.
+        const eventForm = await db.query.formEventForm.findFirst({
+            where: eq(schema.formEventForm.formId, form.id),
+            with: { event: true },
+        });
+
+        const groupForm = eventForm
+            ? undefined
+            : await db.query.formGroupForm.findFirst({
+                  where: eq(schema.formGroupForm.formId, form.id),
+                  with: { group: true },
+              });
+
+        const resourceType = eventForm
+            ? "EventForm"
+            : groupForm
+              ? "GroupForm"
+              : "Form";
+
         return c.json({
             id: form.id,
             title: form.title,
             description: form.description,
             template: form.isTemplate,
-            resource_type: "Form",
+            resource_type: resourceType,
             viewer_has_answered: hasAnswered,
+            type: eventForm?.type ?? null,
+            event: eventForm
+                ? {
+                      id: eventForm.event.id,
+                      title: eventForm.event.title,
+                      slug: eventForm.event.slug,
+                      start_date: eventForm.event.start.toISOString(),
+                      location: eventForm.event.location,
+                  }
+                : null,
+            group: groupForm
+                ? {
+                      slug: groupForm.group.slug,
+                      name: groupForm.group.name,
+                  }
+                : null,
+            can_submit_multiple: groupForm?.canSubmitMultiple ?? null,
+            is_open_for_submissions: groupForm?.isOpenForSubmissions ?? null,
+            only_for_group_members: groupForm?.onlyForGroupMembers ?? null,
             website_url: `/sporreskjema/${form.id}/`,
             created_at: form.createdAt.toISOString(),
             updated_at: form.updatedAt.toISOString(),

--- a/apps/api/src/routes/form/schema.ts
+++ b/apps/api/src/routes/form/schema.ts
@@ -153,6 +153,19 @@ const formFieldResponseSchema = z.object({
 
 // ===== RESPONSE SCHEMAS =====
 
+const formEventContextSchema = z.object({
+    id: z.uuid(),
+    title: z.string(),
+    slug: z.string().nullable(),
+    start_date: z.string(),
+    location: z.string().nullable(),
+});
+
+const formGroupContextSchema = z.object({
+    slug: z.string(),
+    name: z.string(),
+});
+
 export const formDetailSchema = Schema(
     "FormDetail",
     z.object({
@@ -160,12 +173,20 @@ export const formDetailSchema = Schema(
         title: z.string(),
         description: z.string().nullable(),
         template: z.boolean(),
-        resource_type: z.string(),
+        resource_type: z.enum(["Form", "EventForm", "GroupForm"]),
         viewer_has_answered: z.boolean(),
         website_url: z.string(),
         created_at: z.string(),
         updated_at: z.string(),
         fields: z.array(formFieldResponseSchema),
+        // Only set when resource_type is "EventForm".
+        type: z.enum(["survey", "evaluation"]).nullable(),
+        event: formEventContextSchema.nullable(),
+        // Only set when resource_type is "GroupForm".
+        group: formGroupContextSchema.nullable(),
+        can_submit_multiple: z.boolean().nullable(),
+        is_open_for_submissions: z.boolean().nullable(),
+        only_for_group_members: z.boolean().nullable(),
     }),
 );
 

--- a/apps/api/src/test/form/forms.test.ts
+++ b/apps/api/src/test/form/forms.test.ts
@@ -238,6 +238,23 @@ describe("Forms System", () => {
             expect(groupForm.resource_type).toBe("GroupForm");
             expect(groupForm.fields).toBeDefined();
 
+            // The generic form detail endpoint resolves the owner too, so the
+            // /sporreskjema page can gate on the group's submission rules.
+            const groupFormDetailResponse = await leaderClient.api.forms[
+                ":id"
+            ].$get({
+                param: { id: groupForm.id! },
+            });
+
+            expect(groupFormDetailResponse.status).toBe(200);
+            const groupFormDetail = await groupFormDetailResponse.json();
+            expect(groupFormDetail.resource_type).toBe("GroupForm");
+            expect(groupFormDetail.group?.slug).toBe("index");
+            expect(groupFormDetail.can_submit_multiple).toBe(false);
+            expect(groupFormDetail.is_open_for_submissions).toBe(true);
+            expect(groupFormDetail.only_for_group_members).toBe(true);
+            expect(groupFormDetail.event).toBeNull();
+
             // Non-member cannot submit to member-only form
             const nonMemberSubmitResponse = await userClient.api.forms[
                 ":formId"

--- a/apps/kvark/src/components/group-admission-card.tsx
+++ b/apps/kvark/src/components/group-admission-card.tsx
@@ -36,6 +36,8 @@ type GroupAdmissionCardProps = {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     status: AdmissionStatus;
+    /** The admission form to answer, when the group has an open one. */
+    formId?: string;
 };
 
 /**
@@ -47,6 +49,7 @@ export function GroupAdmissionCard({
     open,
     onOpenChange,
     status,
+    formId,
 }: GroupAdmissionCardProps) {
     return (
         <Card size="sm" className="h-full">
@@ -69,7 +72,11 @@ export function GroupAdmissionCard({
                 </CollapsibleTrigger>
                 <CollapsibleContent>
                     <CardContent className="flex flex-col gap-2 px-0 pt-4">
-                        <AdmissionAction group={group} status={status} />
+                        <AdmissionAction
+                            group={group}
+                            status={status}
+                            formId={formId}
+                        />
                         <Button
                             variant="ghost"
                             className="w-full"
@@ -94,9 +101,11 @@ export function GroupAdmissionCard({
 function AdmissionAction({
     group,
     status,
+    formId,
 }: {
     group: AdmissionGroup;
     status: AdmissionStatus;
+    formId?: string;
 }) {
     switch (status) {
         case "unauthenticated":
@@ -137,10 +146,17 @@ function AdmissionAction({
                     className="w-full"
                     nativeButton={false}
                     render={
-                        <Link
-                            to="/grupper/$slug"
-                            params={{ slug: group.slug }}
-                        />
+                        formId ? (
+                            <Link
+                                to="/sporreskjema/$id"
+                                params={{ id: formId }}
+                            />
+                        ) : (
+                            <Link
+                                to="/grupper/$slug"
+                                params={{ slug: group.slug }}
+                            />
+                        )
                     }
                 >
                     Søk nå

--- a/apps/kvark/src/components/group-form-row.tsx
+++ b/apps/kvark/src/components/group-form-row.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
 import { Share2 } from "lucide-react";
@@ -26,7 +27,17 @@ export function GroupFormRow({ form }: GroupFormRowProps) {
                     <Button variant="outline" size="sm">
                         Administrer
                     </Button>
-                    <Button variant="outline" size="sm">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        nativeButton={false}
+                        render={
+                            <Link
+                                to="/sporreskjema/$id"
+                                params={{ id: form.id }}
+                            />
+                        }
+                    >
                         Svar på/se skjema
                     </Button>
                     <Button variant="outline" size="sm">

--- a/apps/kvark/src/routeTree.gen.ts
+++ b/apps/kvark/src/routeTree.gen.ts
@@ -9,176 +9,79 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as AdminRouteImport } from './routes/admin'
-import { Route as DevRouteImport } from './routes/_dev'
-import { Route as AuthRouteImport } from './routes/_auth'
 import { Route as AppRouteImport } from './routes/_app'
-import { Route as AdminIndexRouteImport } from './routes/admin/index'
+import { Route as AuthRouteImport } from './routes/_auth'
+import { Route as DevRouteImport } from './routes/_dev'
+import { Route as AdminRouteImport } from './routes/admin'
 import { Route as AppIndexRouteImport } from './routes/_app/index'
-import { Route as AdminPrikkerRouteImport } from './routes/admin/prikker'
-import { Route as AdminOpptakRouteImport } from './routes/admin/opptak'
-import { Route as AdminNyheterRouteImport } from './routes/admin/nyheter'
-import { Route as AdminGrupperRouteImport } from './routes/admin/grupper'
-import { Route as AdminBrukereRouteImport } from './routes/admin/brukere'
-import { Route as AdminBannereRouteImport } from './routes/admin/bannere'
-import { Route as AdminArrangementerRouteImport } from './routes/admin/arrangementer'
-import { Route as AdminAnnonserRouteImport } from './routes/admin/annonser'
-import { Route as AdminSuperAdminRouteImport } from './routes/admin/_super-admin'
-import { Route as DevFormTestRouteImport } from './routes/_dev/form-test'
-import { Route as AuthResetPasswordRouteImport } from './routes/_auth/reset-password'
-import { Route as AuthRegisterRouteImport } from './routes/_auth/register'
-import { Route as AuthLoginRouteImport } from './routes/_auth/login'
-import { Route as AuthForgotPasswordRouteImport } from './routes/_auth/forgot-password'
-import { Route as AppToddelRouteImport } from './routes/_app/toddel'
-import { Route as AppQrKoderRouteImport } from './routes/_app/qr-koder'
-import { Route as AppPersonvernRouteImport } from './routes/_app/personvern'
-import { Route as AppOpptakRouteImport } from './routes/_app/opptak'
-import { Route as AppKontraktRouteImport } from './routes/_app/kontrakt'
 import { Route as AppKokebokRouteImport } from './routes/_app/kokebok'
-import { Route as AppNyheterIndexRouteImport } from './routes/_app/nyheter.index'
-import { Route as AppGrupperIndexRouteImport } from './routes/_app/grupper.index'
-import { Route as AppGalleriIndexRouteImport } from './routes/_app/galleri.index'
-import { Route as AppBedriftIndexRouteImport } from './routes/_app/bedrift.index'
-import { Route as AppArrangementerIndexRouteImport } from './routes/_app/arrangementer.index'
+import { Route as AppKontraktRouteImport } from './routes/_app/kontrakt'
+import { Route as AppNyStudentRouteImport } from './routes/_app/ny-student'
+import { Route as AppOpptakRouteImport } from './routes/_app/opptak'
+import { Route as AppPersonvernRouteImport } from './routes/_app/personvern'
+import { Route as AppQrKoderRouteImport } from './routes/_app/qr-koder'
+import { Route as AppToddelRouteImport } from './routes/_app/toddel'
+import { Route as AuthForgotPasswordRouteImport } from './routes/_auth/forgot-password'
+import { Route as AuthLoginRouteImport } from './routes/_auth/login'
+import { Route as AuthRegisterRouteImport } from './routes/_auth/register'
+import { Route as AuthResetPasswordRouteImport } from './routes/_auth/reset-password'
+import { Route as DevFormTestRouteImport } from './routes/_dev/form-test'
+import { Route as AdminIndexRouteImport } from './routes/admin/index'
+import { Route as AdminSuperAdminRouteImport } from './routes/admin/_super-admin'
+import { Route as AdminAnnonserRouteImport } from './routes/admin/annonser'
+import { Route as AdminArrangementerRouteImport } from './routes/admin/arrangementer'
+import { Route as AdminBannereRouteImport } from './routes/admin/bannere'
+import { Route as AdminBrukereRouteImport } from './routes/admin/brukere'
+import { Route as AdminGrupperRouteImport } from './routes/admin/grupper'
+import { Route as AdminNyheterRouteImport } from './routes/admin/nyheter'
+import { Route as AdminOpptakRouteImport } from './routes/admin/opptak'
+import { Route as AdminPrikkerRouteImport } from './routes/admin/prikker'
 import { Route as AppAnnonserIndexRouteImport } from './routes/_app/annonser.index'
-import { Route as AdminSuperAdminOauthClientsRouteImport } from './routes/admin/_super-admin/oauth-clients'
-import { Route as AdminSuperAdminLogsRouteImport } from './routes/admin/_super-admin/logs'
-import { Route as AdminSuperAdminDatabaseRouteImport } from './routes/admin/_super-admin/database'
-import { Route as AdminSuperAdminApiKeysRouteImport } from './routes/admin/_super-admin/api-keys'
-import { Route as AuthOauthConsentRouteImport } from './routes/_auth/oauth/consent'
-import { Route as AppProfilIdRouteImport } from './routes/_app/profil/$id'
-import { Route as AppPlaygroundMarkdownRouteImport } from './routes/_app/playground.markdown'
-import { Route as AppNyheterSlugRouteImport } from './routes/_app/nyheter.$slug'
-import { Route as AppGrupperSlugRouteImport } from './routes/_app/grupper.$slug'
-import { Route as AppGalleriSlugRouteImport } from './routes/_app/galleri.$slug'
-import { Route as AppBedriftStudieneRouteImport } from './routes/_app/bedrift.studiene'
-import { Route as AppArrangementerSlugRouteImport } from './routes/_app/arrangementer.$slug'
 import { Route as AppAnnonserSlugRouteImport } from './routes/_app/annonser.$slug'
+import { Route as AppArrangementerIndexRouteImport } from './routes/_app/arrangementer.index'
+import { Route as AppArrangementerSlugRouteImport } from './routes/_app/arrangementer.$slug'
+import { Route as AppBedriftIndexRouteImport } from './routes/_app/bedrift.index'
+import { Route as AppBedriftStudieneRouteImport } from './routes/_app/bedrift.studiene'
+import { Route as AppGalleriIndexRouteImport } from './routes/_app/galleri.index'
+import { Route as AppGalleriSlugRouteImport } from './routes/_app/galleri.$slug'
+import { Route as AppGrupperIndexRouteImport } from './routes/_app/grupper.index'
+import { Route as AppGrupperSlugRouteImport } from './routes/_app/grupper.$slug'
+import { Route as AppNyheterIndexRouteImport } from './routes/_app/nyheter.index'
+import { Route as AppNyheterSlugRouteImport } from './routes/_app/nyheter.$slug'
+import { Route as AppPlaygroundMarkdownRouteImport } from './routes/_app/playground.markdown'
+import { Route as AppProfilIdRouteImport } from './routes/_app/profil/$id'
+import { Route as AppSporreskjemaIdRouteImport } from './routes/_app/sporreskjema.$id'
+import { Route as AuthOauthConsentRouteImport } from './routes/_auth/oauth/consent'
+import { Route as AdminSuperAdminApiKeysRouteImport } from './routes/admin/_super-admin/api-keys'
+import { Route as AdminSuperAdminDatabaseRouteImport } from './routes/admin/_super-admin/database'
+import { Route as AdminSuperAdminLogsRouteImport } from './routes/admin/_super-admin/logs'
+import { Route as AdminSuperAdminOauthClientsRouteImport } from './routes/admin/_super-admin/oauth-clients'
 import { Route as AppProfilIdIndexRouteImport } from './routes/_app/profil/$id/index'
-import { Route as AppProfilIdSporreskjemaerRouteImport } from './routes/_app/profil/$id/sporreskjemaer'
-import { Route as AppProfilIdPrikkerRouteImport } from './routes/_app/profil/$id/prikker'
-import { Route as AppProfilIdMedlemskapRouteImport } from './routes/_app/profil/$id/medlemskap'
 import { Route as AppProfilIdArrangementerRouteImport } from './routes/_app/profil/$id/arrangementer'
+import { Route as AppProfilIdMedlemskapRouteImport } from './routes/_app/profil/$id/medlemskap'
+import { Route as AppProfilIdPrikkerRouteImport } from './routes/_app/profil/$id/prikker'
+import { Route as AppProfilIdSporreskjemaerRouteImport } from './routes/_app/profil/$id/sporreskjemaer'
 
-const AdminRoute = AdminRouteImport.update({
-  id: '/admin',
-  path: '/admin',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DevRoute = DevRouteImport.update({
-  id: '/_dev',
+const AppRoute = AppRouteImport.update({
+  id: '/_app',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthRoute = AuthRouteImport.update({
   id: '/_auth',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AppRoute = AppRouteImport.update({
-  id: '/_app',
+const DevRoute = DevRouteImport.update({
+  id: '/_dev',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AdminIndexRoute = AdminIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => AdminRoute,
+const AdminRoute = AdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AppIndexRoute = AppIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => AppRoute,
-} as any)
-const AdminPrikkerRoute = AdminPrikkerRouteImport.update({
-  id: '/prikker',
-  path: '/prikker',
-  getParentRoute: () => AdminRoute,
-} as any)
-const AdminOpptakRoute = AdminOpptakRouteImport.update({
-  id: '/opptak',
-  path: '/opptak',
-  getParentRoute: () => AdminRoute,
-} as any)
-const AdminNyheterRoute = AdminNyheterRouteImport.update({
-  id: '/nyheter',
-  path: '/nyheter',
-  getParentRoute: () => AdminRoute,
-} as any)
-const AdminGrupperRoute = AdminGrupperRouteImport.update({
-  id: '/grupper',
-  path: '/grupper',
-  getParentRoute: () => AdminRoute,
-} as any)
-const AdminBrukereRoute = AdminBrukereRouteImport.update({
-  id: '/brukere',
-  path: '/brukere',
-  getParentRoute: () => AdminRoute,
-} as any)
-const AdminBannereRoute = AdminBannereRouteImport.update({
-  id: '/bannere',
-  path: '/bannere',
-  getParentRoute: () => AdminRoute,
-} as any)
-const AdminArrangementerRoute = AdminArrangementerRouteImport.update({
-  id: '/arrangementer',
-  path: '/arrangementer',
-  getParentRoute: () => AdminRoute,
-} as any)
-const AdminAnnonserRoute = AdminAnnonserRouteImport.update({
-  id: '/annonser',
-  path: '/annonser',
-  getParentRoute: () => AdminRoute,
-} as any)
-const AdminSuperAdminRoute = AdminSuperAdminRouteImport.update({
-  id: '/_super-admin',
-  getParentRoute: () => AdminRoute,
-} as any)
-const DevFormTestRoute = DevFormTestRouteImport.update({
-  id: '/form-test',
-  path: '/form-test',
-  getParentRoute: () => DevRoute,
-} as any)
-const AuthResetPasswordRoute = AuthResetPasswordRouteImport.update({
-  id: '/reset-password',
-  path: '/reset-password',
-  getParentRoute: () => AuthRoute,
-} as any)
-const AuthRegisterRoute = AuthRegisterRouteImport.update({
-  id: '/register',
-  path: '/register',
-  getParentRoute: () => AuthRoute,
-} as any)
-const AuthLoginRoute = AuthLoginRouteImport.update({
-  id: '/login',
-  path: '/login',
-  getParentRoute: () => AuthRoute,
-} as any)
-const AuthForgotPasswordRoute = AuthForgotPasswordRouteImport.update({
-  id: '/forgot-password',
-  path: '/forgot-password',
-  getParentRoute: () => AuthRoute,
-} as any)
-const AppToddelRoute = AppToddelRouteImport.update({
-  id: '/toddel',
-  path: '/toddel',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppQrKoderRoute = AppQrKoderRouteImport.update({
-  id: '/qr-koder',
-  path: '/qr-koder',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppPersonvernRoute = AppPersonvernRouteImport.update({
-  id: '/personvern',
-  path: '/personvern',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppOpptakRoute = AppOpptakRouteImport.update({
-  id: '/opptak',
-  path: '/opptak',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppKontraktRoute = AppKontraktRouteImport.update({
-  id: '/kontrakt',
-  path: '/kontrakt',
   getParentRoute: () => AppRoute,
 } as any)
 const AppKokebokRoute = AppKokebokRouteImport.update({
@@ -186,95 +89,113 @@ const AppKokebokRoute = AppKokebokRouteImport.update({
   path: '/kokebok',
   getParentRoute: () => AppRoute,
 } as any)
-const AppNyheterIndexRoute = AppNyheterIndexRouteImport.update({
-  id: '/nyheter/',
-  path: '/nyheter/',
+const AppKontraktRoute = AppKontraktRouteImport.update({
+  id: '/kontrakt',
+  path: '/kontrakt',
   getParentRoute: () => AppRoute,
 } as any)
-const AppGrupperIndexRoute = AppGrupperIndexRouteImport.update({
-  id: '/grupper/',
-  path: '/grupper/',
+const AppNyStudentRoute = AppNyStudentRouteImport.update({
+  id: '/ny-student',
+  path: '/ny-student',
   getParentRoute: () => AppRoute,
 } as any)
-const AppGalleriIndexRoute = AppGalleriIndexRouteImport.update({
-  id: '/galleri/',
-  path: '/galleri/',
+const AppOpptakRoute = AppOpptakRouteImport.update({
+  id: '/opptak',
+  path: '/opptak',
   getParentRoute: () => AppRoute,
 } as any)
-const AppBedriftIndexRoute = AppBedriftIndexRouteImport.update({
-  id: '/bedrift/',
-  path: '/bedrift/',
+const AppPersonvernRoute = AppPersonvernRouteImport.update({
+  id: '/personvern',
+  path: '/personvern',
   getParentRoute: () => AppRoute,
 } as any)
-const AppArrangementerIndexRoute = AppArrangementerIndexRouteImport.update({
-  id: '/arrangementer/',
-  path: '/arrangementer/',
+const AppQrKoderRoute = AppQrKoderRouteImport.update({
+  id: '/qr-koder',
+  path: '/qr-koder',
   getParentRoute: () => AppRoute,
+} as any)
+const AppToddelRoute = AppToddelRouteImport.update({
+  id: '/toddel',
+  path: '/toddel',
+  getParentRoute: () => AppRoute,
+} as any)
+const AuthForgotPasswordRoute = AuthForgotPasswordRouteImport.update({
+  id: '/forgot-password',
+  path: '/forgot-password',
+  getParentRoute: () => AuthRoute,
+} as any)
+const AuthLoginRoute = AuthLoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => AuthRoute,
+} as any)
+const AuthRegisterRoute = AuthRegisterRouteImport.update({
+  id: '/register',
+  path: '/register',
+  getParentRoute: () => AuthRoute,
+} as any)
+const AuthResetPasswordRoute = AuthResetPasswordRouteImport.update({
+  id: '/reset-password',
+  path: '/reset-password',
+  getParentRoute: () => AuthRoute,
+} as any)
+const DevFormTestRoute = DevFormTestRouteImport.update({
+  id: '/form-test',
+  path: '/form-test',
+  getParentRoute: () => DevRoute,
+} as any)
+const AdminIndexRoute = AdminIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminSuperAdminRoute = AdminSuperAdminRouteImport.update({
+  id: '/_super-admin',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminAnnonserRoute = AdminAnnonserRouteImport.update({
+  id: '/annonser',
+  path: '/annonser',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminArrangementerRoute = AdminArrangementerRouteImport.update({
+  id: '/arrangementer',
+  path: '/arrangementer',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminBannereRoute = AdminBannereRouteImport.update({
+  id: '/bannere',
+  path: '/bannere',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminBrukereRoute = AdminBrukereRouteImport.update({
+  id: '/brukere',
+  path: '/brukere',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminGrupperRoute = AdminGrupperRouteImport.update({
+  id: '/grupper',
+  path: '/grupper',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminNyheterRoute = AdminNyheterRouteImport.update({
+  id: '/nyheter',
+  path: '/nyheter',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminOpptakRoute = AdminOpptakRouteImport.update({
+  id: '/opptak',
+  path: '/opptak',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminPrikkerRoute = AdminPrikkerRouteImport.update({
+  id: '/prikker',
+  path: '/prikker',
+  getParentRoute: () => AdminRoute,
 } as any)
 const AppAnnonserIndexRoute = AppAnnonserIndexRouteImport.update({
   id: '/annonser/',
   path: '/annonser/',
-  getParentRoute: () => AppRoute,
-} as any)
-const AdminSuperAdminOauthClientsRoute =
-  AdminSuperAdminOauthClientsRouteImport.update({
-    id: '/oauth-clients',
-    path: '/oauth-clients',
-    getParentRoute: () => AdminSuperAdminRoute,
-  } as any)
-const AdminSuperAdminLogsRoute = AdminSuperAdminLogsRouteImport.update({
-  id: '/logs',
-  path: '/logs',
-  getParentRoute: () => AdminSuperAdminRoute,
-} as any)
-const AdminSuperAdminDatabaseRoute = AdminSuperAdminDatabaseRouteImport.update({
-  id: '/database',
-  path: '/database',
-  getParentRoute: () => AdminSuperAdminRoute,
-} as any)
-const AdminSuperAdminApiKeysRoute = AdminSuperAdminApiKeysRouteImport.update({
-  id: '/api-keys',
-  path: '/api-keys',
-  getParentRoute: () => AdminSuperAdminRoute,
-} as any)
-const AuthOauthConsentRoute = AuthOauthConsentRouteImport.update({
-  id: '/oauth/consent',
-  path: '/oauth/consent',
-  getParentRoute: () => AuthRoute,
-} as any)
-const AppProfilIdRoute = AppProfilIdRouteImport.update({
-  id: '/profil/$id',
-  path: '/profil/$id',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppPlaygroundMarkdownRoute = AppPlaygroundMarkdownRouteImport.update({
-  id: '/playground/markdown',
-  path: '/playground/markdown',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppNyheterSlugRoute = AppNyheterSlugRouteImport.update({
-  id: '/nyheter/$slug',
-  path: '/nyheter/$slug',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppGrupperSlugRoute = AppGrupperSlugRouteImport.update({
-  id: '/grupper/$slug',
-  path: '/grupper/$slug',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppGalleriSlugRoute = AppGalleriSlugRouteImport.update({
-  id: '/galleri/$slug',
-  path: '/galleri/$slug',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppBedriftStudieneRoute = AppBedriftStudieneRouteImport.update({
-  id: '/bedrift/studiene',
-  path: '/bedrift/studiene',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppArrangementerSlugRoute = AppArrangementerSlugRouteImport.update({
-  id: '/arrangementer/$slug',
-  path: '/arrangementer/$slug',
   getParentRoute: () => AppRoute,
 } as any)
 const AppAnnonserSlugRoute = AppAnnonserSlugRouteImport.update({
@@ -282,25 +203,100 @@ const AppAnnonserSlugRoute = AppAnnonserSlugRouteImport.update({
   path: '/annonser/$slug',
   getParentRoute: () => AppRoute,
 } as any)
+const AppArrangementerIndexRoute = AppArrangementerIndexRouteImport.update({
+  id: '/arrangementer/',
+  path: '/arrangementer/',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppArrangementerSlugRoute = AppArrangementerSlugRouteImport.update({
+  id: '/arrangementer/$slug',
+  path: '/arrangementer/$slug',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppBedriftIndexRoute = AppBedriftIndexRouteImport.update({
+  id: '/bedrift/',
+  path: '/bedrift/',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppBedriftStudieneRoute = AppBedriftStudieneRouteImport.update({
+  id: '/bedrift/studiene',
+  path: '/bedrift/studiene',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppGalleriIndexRoute = AppGalleriIndexRouteImport.update({
+  id: '/galleri/',
+  path: '/galleri/',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppGalleriSlugRoute = AppGalleriSlugRouteImport.update({
+  id: '/galleri/$slug',
+  path: '/galleri/$slug',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppGrupperIndexRoute = AppGrupperIndexRouteImport.update({
+  id: '/grupper/',
+  path: '/grupper/',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppGrupperSlugRoute = AppGrupperSlugRouteImport.update({
+  id: '/grupper/$slug',
+  path: '/grupper/$slug',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppNyheterIndexRoute = AppNyheterIndexRouteImport.update({
+  id: '/nyheter/',
+  path: '/nyheter/',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppNyheterSlugRoute = AppNyheterSlugRouteImport.update({
+  id: '/nyheter/$slug',
+  path: '/nyheter/$slug',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppPlaygroundMarkdownRoute = AppPlaygroundMarkdownRouteImport.update({
+  id: '/playground/markdown',
+  path: '/playground/markdown',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppProfilIdRoute = AppProfilIdRouteImport.update({
+  id: '/profil/$id',
+  path: '/profil/$id',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppSporreskjemaIdRoute = AppSporreskjemaIdRouteImport.update({
+  id: '/sporreskjema/$id',
+  path: '/sporreskjema/$id',
+  getParentRoute: () => AppRoute,
+} as any)
+const AuthOauthConsentRoute = AuthOauthConsentRouteImport.update({
+  id: '/oauth/consent',
+  path: '/oauth/consent',
+  getParentRoute: () => AuthRoute,
+} as any)
+const AdminSuperAdminApiKeysRoute = AdminSuperAdminApiKeysRouteImport.update({
+  id: '/api-keys',
+  path: '/api-keys',
+  getParentRoute: () => AdminSuperAdminRoute,
+} as any)
+const AdminSuperAdminDatabaseRoute = AdminSuperAdminDatabaseRouteImport.update({
+  id: '/database',
+  path: '/database',
+  getParentRoute: () => AdminSuperAdminRoute,
+} as any)
+const AdminSuperAdminLogsRoute = AdminSuperAdminLogsRouteImport.update({
+  id: '/logs',
+  path: '/logs',
+  getParentRoute: () => AdminSuperAdminRoute,
+} as any)
+const AdminSuperAdminOauthClientsRoute =
+  AdminSuperAdminOauthClientsRouteImport.update({
+    id: '/oauth-clients',
+    path: '/oauth-clients',
+    getParentRoute: () => AdminSuperAdminRoute,
+  } as any)
 const AppProfilIdIndexRoute = AppProfilIdIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => AppProfilIdRoute,
-} as any)
-const AppProfilIdSporreskjemaerRoute =
-  AppProfilIdSporreskjemaerRouteImport.update({
-    id: '/sporreskjemaer',
-    path: '/sporreskjemaer',
-    getParentRoute: () => AppProfilIdRoute,
-  } as any)
-const AppProfilIdPrikkerRoute = AppProfilIdPrikkerRouteImport.update({
-  id: '/prikker',
-  path: '/prikker',
-  getParentRoute: () => AppProfilIdRoute,
-} as any)
-const AppProfilIdMedlemskapRoute = AppProfilIdMedlemskapRouteImport.update({
-  id: '/medlemskap',
-  path: '/medlemskap',
   getParentRoute: () => AppProfilIdRoute,
 } as any)
 const AppProfilIdArrangementerRoute =
@@ -309,12 +305,29 @@ const AppProfilIdArrangementerRoute =
     path: '/arrangementer',
     getParentRoute: () => AppProfilIdRoute,
   } as any)
+const AppProfilIdMedlemskapRoute = AppProfilIdMedlemskapRouteImport.update({
+  id: '/medlemskap',
+  path: '/medlemskap',
+  getParentRoute: () => AppProfilIdRoute,
+} as any)
+const AppProfilIdPrikkerRoute = AppProfilIdPrikkerRouteImport.update({
+  id: '/prikker',
+  path: '/prikker',
+  getParentRoute: () => AppProfilIdRoute,
+} as any)
+const AppProfilIdSporreskjemaerRoute =
+  AppProfilIdSporreskjemaerRouteImport.update({
+    id: '/sporreskjemaer',
+    path: '/sporreskjemaer',
+    getParentRoute: () => AppProfilIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof AppIndexRoute
   '/admin': typeof AdminRouteWithChildren
   '/kokebok': typeof AppKokebokRoute
   '/kontrakt': typeof AppKontraktRoute
+  '/ny-student': typeof AppNyStudentRoute
   '/opptak': typeof AppOpptakRoute
   '/personvern': typeof AppPersonvernRoute
   '/qr-koder': typeof AppQrKoderRoute
@@ -341,6 +354,7 @@ export interface FileRoutesByFullPath {
   '/nyheter/$slug': typeof AppNyheterSlugRoute
   '/playground/markdown': typeof AppPlaygroundMarkdownRoute
   '/profil/$id': typeof AppProfilIdRouteWithChildren
+  '/sporreskjema/$id': typeof AppSporreskjemaIdRoute
   '/oauth/consent': typeof AuthOauthConsentRoute
   '/admin/api-keys': typeof AdminSuperAdminApiKeysRoute
   '/admin/database': typeof AdminSuperAdminDatabaseRoute
@@ -362,6 +376,7 @@ export interface FileRoutesByTo {
   '/': typeof AppIndexRoute
   '/kokebok': typeof AppKokebokRoute
   '/kontrakt': typeof AppKontraktRoute
+  '/ny-student': typeof AppNyStudentRoute
   '/opptak': typeof AppOpptakRoute
   '/personvern': typeof AppPersonvernRoute
   '/qr-koder': typeof AppQrKoderRoute
@@ -387,6 +402,7 @@ export interface FileRoutesByTo {
   '/grupper/$slug': typeof AppGrupperSlugRoute
   '/nyheter/$slug': typeof AppNyheterSlugRoute
   '/playground/markdown': typeof AppPlaygroundMarkdownRoute
+  '/sporreskjema/$id': typeof AppSporreskjemaIdRoute
   '/oauth/consent': typeof AuthOauthConsentRoute
   '/admin/api-keys': typeof AdminSuperAdminApiKeysRoute
   '/admin/database': typeof AdminSuperAdminDatabaseRoute
@@ -412,6 +428,7 @@ export interface FileRoutesById {
   '/admin': typeof AdminRouteWithChildren
   '/_app/kokebok': typeof AppKokebokRoute
   '/_app/kontrakt': typeof AppKontraktRoute
+  '/_app/ny-student': typeof AppNyStudentRoute
   '/_app/opptak': typeof AppOpptakRoute
   '/_app/personvern': typeof AppPersonvernRoute
   '/_app/qr-koder': typeof AppQrKoderRoute
@@ -440,6 +457,7 @@ export interface FileRoutesById {
   '/_app/nyheter/$slug': typeof AppNyheterSlugRoute
   '/_app/playground/markdown': typeof AppPlaygroundMarkdownRoute
   '/_app/profil/$id': typeof AppProfilIdRouteWithChildren
+  '/_app/sporreskjema/$id': typeof AppSporreskjemaIdRoute
   '/_auth/oauth/consent': typeof AuthOauthConsentRoute
   '/admin/_super-admin/api-keys': typeof AdminSuperAdminApiKeysRoute
   '/admin/_super-admin/database': typeof AdminSuperAdminDatabaseRoute
@@ -464,6 +482,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/kokebok'
     | '/kontrakt'
+    | '/ny-student'
     | '/opptak'
     | '/personvern'
     | '/qr-koder'
@@ -490,6 +509,7 @@ export interface FileRouteTypes {
     | '/nyheter/$slug'
     | '/playground/markdown'
     | '/profil/$id'
+    | '/sporreskjema/$id'
     | '/oauth/consent'
     | '/admin/api-keys'
     | '/admin/database'
@@ -511,6 +531,7 @@ export interface FileRouteTypes {
     | '/'
     | '/kokebok'
     | '/kontrakt'
+    | '/ny-student'
     | '/opptak'
     | '/personvern'
     | '/qr-koder'
@@ -536,6 +557,7 @@ export interface FileRouteTypes {
     | '/grupper/$slug'
     | '/nyheter/$slug'
     | '/playground/markdown'
+    | '/sporreskjema/$id'
     | '/oauth/consent'
     | '/admin/api-keys'
     | '/admin/database'
@@ -560,6 +582,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/_app/kokebok'
     | '/_app/kontrakt'
+    | '/_app/ny-student'
     | '/_app/opptak'
     | '/_app/personvern'
     | '/_app/qr-koder'
@@ -588,6 +611,7 @@ export interface FileRouteTypes {
     | '/_app/nyheter/$slug'
     | '/_app/playground/markdown'
     | '/_app/profil/$id'
+    | '/_app/sporreskjema/$id'
     | '/_auth/oauth/consent'
     | '/admin/_super-admin/api-keys'
     | '/admin/_super-admin/database'
@@ -615,18 +639,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/admin': {
-      id: '/admin'
-      path: '/admin'
-      fullPath: '/admin'
-      preLoaderRoute: typeof AdminRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_dev': {
-      id: '/_dev'
+    '/_app': {
+      id: '/_app'
       path: ''
       fullPath: '/'
-      preLoaderRoute: typeof DevRouteImport
+      preLoaderRoute: typeof AppRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_auth': {
@@ -636,158 +653,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_app': {
-      id: '/_app'
+    '/_dev': {
+      id: '/_dev'
       path: ''
       fullPath: '/'
-      preLoaderRoute: typeof AppRouteImport
+      preLoaderRoute: typeof DevRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/admin/': {
-      id: '/admin/'
-      path: '/'
-      fullPath: '/admin/'
-      preLoaderRoute: typeof AdminIndexRouteImport
-      parentRoute: typeof AdminRoute
+    '/admin': {
+      id: '/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AdminRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_app/': {
       id: '/_app/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof AppIndexRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/admin/prikker': {
-      id: '/admin/prikker'
-      path: '/prikker'
-      fullPath: '/admin/prikker'
-      preLoaderRoute: typeof AdminPrikkerRouteImport
-      parentRoute: typeof AdminRoute
-    }
-    '/admin/opptak': {
-      id: '/admin/opptak'
-      path: '/opptak'
-      fullPath: '/admin/opptak'
-      preLoaderRoute: typeof AdminOpptakRouteImport
-      parentRoute: typeof AdminRoute
-    }
-    '/admin/nyheter': {
-      id: '/admin/nyheter'
-      path: '/nyheter'
-      fullPath: '/admin/nyheter'
-      preLoaderRoute: typeof AdminNyheterRouteImport
-      parentRoute: typeof AdminRoute
-    }
-    '/admin/grupper': {
-      id: '/admin/grupper'
-      path: '/grupper'
-      fullPath: '/admin/grupper'
-      preLoaderRoute: typeof AdminGrupperRouteImport
-      parentRoute: typeof AdminRoute
-    }
-    '/admin/brukere': {
-      id: '/admin/brukere'
-      path: '/brukere'
-      fullPath: '/admin/brukere'
-      preLoaderRoute: typeof AdminBrukereRouteImport
-      parentRoute: typeof AdminRoute
-    }
-    '/admin/bannere': {
-      id: '/admin/bannere'
-      path: '/bannere'
-      fullPath: '/admin/bannere'
-      preLoaderRoute: typeof AdminBannereRouteImport
-      parentRoute: typeof AdminRoute
-    }
-    '/admin/arrangementer': {
-      id: '/admin/arrangementer'
-      path: '/arrangementer'
-      fullPath: '/admin/arrangementer'
-      preLoaderRoute: typeof AdminArrangementerRouteImport
-      parentRoute: typeof AdminRoute
-    }
-    '/admin/annonser': {
-      id: '/admin/annonser'
-      path: '/annonser'
-      fullPath: '/admin/annonser'
-      preLoaderRoute: typeof AdminAnnonserRouteImport
-      parentRoute: typeof AdminRoute
-    }
-    '/admin/_super-admin': {
-      id: '/admin/_super-admin'
-      path: ''
-      fullPath: '/admin'
-      preLoaderRoute: typeof AdminSuperAdminRouteImport
-      parentRoute: typeof AdminRoute
-    }
-    '/_dev/form-test': {
-      id: '/_dev/form-test'
-      path: '/form-test'
-      fullPath: '/form-test'
-      preLoaderRoute: typeof DevFormTestRouteImport
-      parentRoute: typeof DevRoute
-    }
-    '/_auth/reset-password': {
-      id: '/_auth/reset-password'
-      path: '/reset-password'
-      fullPath: '/reset-password'
-      preLoaderRoute: typeof AuthResetPasswordRouteImport
-      parentRoute: typeof AuthRoute
-    }
-    '/_auth/register': {
-      id: '/_auth/register'
-      path: '/register'
-      fullPath: '/register'
-      preLoaderRoute: typeof AuthRegisterRouteImport
-      parentRoute: typeof AuthRoute
-    }
-    '/_auth/login': {
-      id: '/_auth/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof AuthLoginRouteImport
-      parentRoute: typeof AuthRoute
-    }
-    '/_auth/forgot-password': {
-      id: '/_auth/forgot-password'
-      path: '/forgot-password'
-      fullPath: '/forgot-password'
-      preLoaderRoute: typeof AuthForgotPasswordRouteImport
-      parentRoute: typeof AuthRoute
-    }
-    '/_app/toddel': {
-      id: '/_app/toddel'
-      path: '/toddel'
-      fullPath: '/toddel'
-      preLoaderRoute: typeof AppToddelRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/qr-koder': {
-      id: '/_app/qr-koder'
-      path: '/qr-koder'
-      fullPath: '/qr-koder'
-      preLoaderRoute: typeof AppQrKoderRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/personvern': {
-      id: '/_app/personvern'
-      path: '/personvern'
-      fullPath: '/personvern'
-      preLoaderRoute: typeof AppPersonvernRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/opptak': {
-      id: '/_app/opptak'
-      path: '/opptak'
-      fullPath: '/opptak'
-      preLoaderRoute: typeof AppOpptakRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/kontrakt': {
-      id: '/_app/kontrakt'
-      path: '/kontrakt'
-      fullPath: '/kontrakt'
-      preLoaderRoute: typeof AppKontraktRouteImport
       parentRoute: typeof AppRoute
     }
     '/_app/kokebok': {
@@ -797,130 +681,158 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppKokebokRouteImport
       parentRoute: typeof AppRoute
     }
-    '/_app/nyheter/': {
-      id: '/_app/nyheter/'
-      path: '/nyheter'
-      fullPath: '/nyheter/'
-      preLoaderRoute: typeof AppNyheterIndexRouteImport
+    '/_app/kontrakt': {
+      id: '/_app/kontrakt'
+      path: '/kontrakt'
+      fullPath: '/kontrakt'
+      preLoaderRoute: typeof AppKontraktRouteImport
       parentRoute: typeof AppRoute
     }
-    '/_app/grupper/': {
-      id: '/_app/grupper/'
-      path: '/grupper'
-      fullPath: '/grupper/'
-      preLoaderRoute: typeof AppGrupperIndexRouteImport
+    '/_app/ny-student': {
+      id: '/_app/ny-student'
+      path: '/ny-student'
+      fullPath: '/ny-student'
+      preLoaderRoute: typeof AppNyStudentRouteImport
       parentRoute: typeof AppRoute
     }
-    '/_app/galleri/': {
-      id: '/_app/galleri/'
-      path: '/galleri'
-      fullPath: '/galleri/'
-      preLoaderRoute: typeof AppGalleriIndexRouteImport
+    '/_app/opptak': {
+      id: '/_app/opptak'
+      path: '/opptak'
+      fullPath: '/opptak'
+      preLoaderRoute: typeof AppOpptakRouteImport
       parentRoute: typeof AppRoute
     }
-    '/_app/bedrift/': {
-      id: '/_app/bedrift/'
-      path: '/bedrift'
-      fullPath: '/bedrift/'
-      preLoaderRoute: typeof AppBedriftIndexRouteImport
+    '/_app/personvern': {
+      id: '/_app/personvern'
+      path: '/personvern'
+      fullPath: '/personvern'
+      preLoaderRoute: typeof AppPersonvernRouteImport
       parentRoute: typeof AppRoute
     }
-    '/_app/arrangementer/': {
-      id: '/_app/arrangementer/'
+    '/_app/qr-koder': {
+      id: '/_app/qr-koder'
+      path: '/qr-koder'
+      fullPath: '/qr-koder'
+      preLoaderRoute: typeof AppQrKoderRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/toddel': {
+      id: '/_app/toddel'
+      path: '/toddel'
+      fullPath: '/toddel'
+      preLoaderRoute: typeof AppToddelRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_auth/forgot-password': {
+      id: '/_auth/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof AuthForgotPasswordRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/_auth/login': {
+      id: '/_auth/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof AuthLoginRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/_auth/register': {
+      id: '/_auth/register'
+      path: '/register'
+      fullPath: '/register'
+      preLoaderRoute: typeof AuthRegisterRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/_auth/reset-password': {
+      id: '/_auth/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof AuthResetPasswordRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/_dev/form-test': {
+      id: '/_dev/form-test'
+      path: '/form-test'
+      fullPath: '/form-test'
+      preLoaderRoute: typeof DevFormTestRouteImport
+      parentRoute: typeof DevRoute
+    }
+    '/admin/': {
+      id: '/admin/'
+      path: '/'
+      fullPath: '/admin/'
+      preLoaderRoute: typeof AdminIndexRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/_super-admin': {
+      id: '/admin/_super-admin'
+      path: ''
+      fullPath: '/admin'
+      preLoaderRoute: typeof AdminSuperAdminRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/annonser': {
+      id: '/admin/annonser'
+      path: '/annonser'
+      fullPath: '/admin/annonser'
+      preLoaderRoute: typeof AdminAnnonserRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/arrangementer': {
+      id: '/admin/arrangementer'
       path: '/arrangementer'
-      fullPath: '/arrangementer/'
-      preLoaderRoute: typeof AppArrangementerIndexRouteImport
-      parentRoute: typeof AppRoute
+      fullPath: '/admin/arrangementer'
+      preLoaderRoute: typeof AdminArrangementerRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/bannere': {
+      id: '/admin/bannere'
+      path: '/bannere'
+      fullPath: '/admin/bannere'
+      preLoaderRoute: typeof AdminBannereRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/brukere': {
+      id: '/admin/brukere'
+      path: '/brukere'
+      fullPath: '/admin/brukere'
+      preLoaderRoute: typeof AdminBrukereRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/grupper': {
+      id: '/admin/grupper'
+      path: '/grupper'
+      fullPath: '/admin/grupper'
+      preLoaderRoute: typeof AdminGrupperRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/nyheter': {
+      id: '/admin/nyheter'
+      path: '/nyheter'
+      fullPath: '/admin/nyheter'
+      preLoaderRoute: typeof AdminNyheterRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/opptak': {
+      id: '/admin/opptak'
+      path: '/opptak'
+      fullPath: '/admin/opptak'
+      preLoaderRoute: typeof AdminOpptakRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/prikker': {
+      id: '/admin/prikker'
+      path: '/prikker'
+      fullPath: '/admin/prikker'
+      preLoaderRoute: typeof AdminPrikkerRouteImport
+      parentRoute: typeof AdminRoute
     }
     '/_app/annonser/': {
       id: '/_app/annonser/'
       path: '/annonser'
       fullPath: '/annonser/'
       preLoaderRoute: typeof AppAnnonserIndexRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/admin/_super-admin/oauth-clients': {
-      id: '/admin/_super-admin/oauth-clients'
-      path: '/oauth-clients'
-      fullPath: '/admin/oauth-clients'
-      preLoaderRoute: typeof AdminSuperAdminOauthClientsRouteImport
-      parentRoute: typeof AdminSuperAdminRoute
-    }
-    '/admin/_super-admin/logs': {
-      id: '/admin/_super-admin/logs'
-      path: '/logs'
-      fullPath: '/admin/logs'
-      preLoaderRoute: typeof AdminSuperAdminLogsRouteImport
-      parentRoute: typeof AdminSuperAdminRoute
-    }
-    '/admin/_super-admin/database': {
-      id: '/admin/_super-admin/database'
-      path: '/database'
-      fullPath: '/admin/database'
-      preLoaderRoute: typeof AdminSuperAdminDatabaseRouteImport
-      parentRoute: typeof AdminSuperAdminRoute
-    }
-    '/admin/_super-admin/api-keys': {
-      id: '/admin/_super-admin/api-keys'
-      path: '/api-keys'
-      fullPath: '/admin/api-keys'
-      preLoaderRoute: typeof AdminSuperAdminApiKeysRouteImport
-      parentRoute: typeof AdminSuperAdminRoute
-    }
-    '/_auth/oauth/consent': {
-      id: '/_auth/oauth/consent'
-      path: '/oauth/consent'
-      fullPath: '/oauth/consent'
-      preLoaderRoute: typeof AuthOauthConsentRouteImport
-      parentRoute: typeof AuthRoute
-    }
-    '/_app/profil/$id': {
-      id: '/_app/profil/$id'
-      path: '/profil/$id'
-      fullPath: '/profil/$id'
-      preLoaderRoute: typeof AppProfilIdRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/playground/markdown': {
-      id: '/_app/playground/markdown'
-      path: '/playground/markdown'
-      fullPath: '/playground/markdown'
-      preLoaderRoute: typeof AppPlaygroundMarkdownRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/nyheter/$slug': {
-      id: '/_app/nyheter/$slug'
-      path: '/nyheter/$slug'
-      fullPath: '/nyheter/$slug'
-      preLoaderRoute: typeof AppNyheterSlugRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/grupper/$slug': {
-      id: '/_app/grupper/$slug'
-      path: '/grupper/$slug'
-      fullPath: '/grupper/$slug'
-      preLoaderRoute: typeof AppGrupperSlugRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/galleri/$slug': {
-      id: '/_app/galleri/$slug'
-      path: '/galleri/$slug'
-      fullPath: '/galleri/$slug'
-      preLoaderRoute: typeof AppGalleriSlugRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/bedrift/studiene': {
-      id: '/_app/bedrift/studiene'
-      path: '/bedrift/studiene'
-      fullPath: '/bedrift/studiene'
-      preLoaderRoute: typeof AppBedriftStudieneRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/arrangementer/$slug': {
-      id: '/_app/arrangementer/$slug'
-      path: '/arrangementer/$slug'
-      fullPath: '/arrangementer/$slug'
-      preLoaderRoute: typeof AppArrangementerSlugRouteImport
       parentRoute: typeof AppRoute
     }
     '/_app/annonser/$slug': {
@@ -930,6 +842,132 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppAnnonserSlugRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/arrangementer/': {
+      id: '/_app/arrangementer/'
+      path: '/arrangementer'
+      fullPath: '/arrangementer/'
+      preLoaderRoute: typeof AppArrangementerIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/arrangementer/$slug': {
+      id: '/_app/arrangementer/$slug'
+      path: '/arrangementer/$slug'
+      fullPath: '/arrangementer/$slug'
+      preLoaderRoute: typeof AppArrangementerSlugRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/bedrift/': {
+      id: '/_app/bedrift/'
+      path: '/bedrift'
+      fullPath: '/bedrift/'
+      preLoaderRoute: typeof AppBedriftIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/bedrift/studiene': {
+      id: '/_app/bedrift/studiene'
+      path: '/bedrift/studiene'
+      fullPath: '/bedrift/studiene'
+      preLoaderRoute: typeof AppBedriftStudieneRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/galleri/': {
+      id: '/_app/galleri/'
+      path: '/galleri'
+      fullPath: '/galleri/'
+      preLoaderRoute: typeof AppGalleriIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/galleri/$slug': {
+      id: '/_app/galleri/$slug'
+      path: '/galleri/$slug'
+      fullPath: '/galleri/$slug'
+      preLoaderRoute: typeof AppGalleriSlugRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/grupper/': {
+      id: '/_app/grupper/'
+      path: '/grupper'
+      fullPath: '/grupper/'
+      preLoaderRoute: typeof AppGrupperIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/grupper/$slug': {
+      id: '/_app/grupper/$slug'
+      path: '/grupper/$slug'
+      fullPath: '/grupper/$slug'
+      preLoaderRoute: typeof AppGrupperSlugRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/nyheter/': {
+      id: '/_app/nyheter/'
+      path: '/nyheter'
+      fullPath: '/nyheter/'
+      preLoaderRoute: typeof AppNyheterIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/nyheter/$slug': {
+      id: '/_app/nyheter/$slug'
+      path: '/nyheter/$slug'
+      fullPath: '/nyheter/$slug'
+      preLoaderRoute: typeof AppNyheterSlugRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/playground/markdown': {
+      id: '/_app/playground/markdown'
+      path: '/playground/markdown'
+      fullPath: '/playground/markdown'
+      preLoaderRoute: typeof AppPlaygroundMarkdownRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/profil/$id': {
+      id: '/_app/profil/$id'
+      path: '/profil/$id'
+      fullPath: '/profil/$id'
+      preLoaderRoute: typeof AppProfilIdRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/sporreskjema/$id': {
+      id: '/_app/sporreskjema/$id'
+      path: '/sporreskjema/$id'
+      fullPath: '/sporreskjema/$id'
+      preLoaderRoute: typeof AppSporreskjemaIdRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_auth/oauth/consent': {
+      id: '/_auth/oauth/consent'
+      path: '/oauth/consent'
+      fullPath: '/oauth/consent'
+      preLoaderRoute: typeof AuthOauthConsentRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/admin/_super-admin/api-keys': {
+      id: '/admin/_super-admin/api-keys'
+      path: '/api-keys'
+      fullPath: '/admin/api-keys'
+      preLoaderRoute: typeof AdminSuperAdminApiKeysRouteImport
+      parentRoute: typeof AdminSuperAdminRoute
+    }
+    '/admin/_super-admin/database': {
+      id: '/admin/_super-admin/database'
+      path: '/database'
+      fullPath: '/admin/database'
+      preLoaderRoute: typeof AdminSuperAdminDatabaseRouteImport
+      parentRoute: typeof AdminSuperAdminRoute
+    }
+    '/admin/_super-admin/logs': {
+      id: '/admin/_super-admin/logs'
+      path: '/logs'
+      fullPath: '/admin/logs'
+      preLoaderRoute: typeof AdminSuperAdminLogsRouteImport
+      parentRoute: typeof AdminSuperAdminRoute
+    }
+    '/admin/_super-admin/oauth-clients': {
+      id: '/admin/_super-admin/oauth-clients'
+      path: '/oauth-clients'
+      fullPath: '/admin/oauth-clients'
+      preLoaderRoute: typeof AdminSuperAdminOauthClientsRouteImport
+      parentRoute: typeof AdminSuperAdminRoute
+    }
     '/_app/profil/$id/': {
       id: '/_app/profil/$id/'
       path: '/'
@@ -937,18 +975,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProfilIdIndexRouteImport
       parentRoute: typeof AppProfilIdRoute
     }
-    '/_app/profil/$id/sporreskjemaer': {
-      id: '/_app/profil/$id/sporreskjemaer'
-      path: '/sporreskjemaer'
-      fullPath: '/profil/$id/sporreskjemaer'
-      preLoaderRoute: typeof AppProfilIdSporreskjemaerRouteImport
-      parentRoute: typeof AppProfilIdRoute
-    }
-    '/_app/profil/$id/prikker': {
-      id: '/_app/profil/$id/prikker'
-      path: '/prikker'
-      fullPath: '/profil/$id/prikker'
-      preLoaderRoute: typeof AppProfilIdPrikkerRouteImport
+    '/_app/profil/$id/arrangementer': {
+      id: '/_app/profil/$id/arrangementer'
+      path: '/arrangementer'
+      fullPath: '/profil/$id/arrangementer'
+      preLoaderRoute: typeof AppProfilIdArrangementerRouteImport
       parentRoute: typeof AppProfilIdRoute
     }
     '/_app/profil/$id/medlemskap': {
@@ -958,11 +989,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProfilIdMedlemskapRouteImport
       parentRoute: typeof AppProfilIdRoute
     }
-    '/_app/profil/$id/arrangementer': {
-      id: '/_app/profil/$id/arrangementer'
-      path: '/arrangementer'
-      fullPath: '/profil/$id/arrangementer'
-      preLoaderRoute: typeof AppProfilIdArrangementerRouteImport
+    '/_app/profil/$id/prikker': {
+      id: '/_app/profil/$id/prikker'
+      path: '/prikker'
+      fullPath: '/profil/$id/prikker'
+      preLoaderRoute: typeof AppProfilIdPrikkerRouteImport
+      parentRoute: typeof AppProfilIdRoute
+    }
+    '/_app/profil/$id/sporreskjemaer': {
+      id: '/_app/profil/$id/sporreskjemaer'
+      path: '/sporreskjemaer'
+      fullPath: '/profil/$id/sporreskjemaer'
+      preLoaderRoute: typeof AppProfilIdSporreskjemaerRouteImport
       parentRoute: typeof AppProfilIdRoute
     }
   }
@@ -991,6 +1029,7 @@ const AppProfilIdRouteWithChildren = AppProfilIdRoute._addFileChildren(
 interface AppRouteChildren {
   AppKokebokRoute: typeof AppKokebokRoute
   AppKontraktRoute: typeof AppKontraktRoute
+  AppNyStudentRoute: typeof AppNyStudentRoute
   AppOpptakRoute: typeof AppOpptakRoute
   AppPersonvernRoute: typeof AppPersonvernRoute
   AppQrKoderRoute: typeof AppQrKoderRoute
@@ -1004,6 +1043,7 @@ interface AppRouteChildren {
   AppNyheterSlugRoute: typeof AppNyheterSlugRoute
   AppPlaygroundMarkdownRoute: typeof AppPlaygroundMarkdownRoute
   AppProfilIdRoute: typeof AppProfilIdRouteWithChildren
+  AppSporreskjemaIdRoute: typeof AppSporreskjemaIdRoute
   AppAnnonserIndexRoute: typeof AppAnnonserIndexRoute
   AppArrangementerIndexRoute: typeof AppArrangementerIndexRoute
   AppBedriftIndexRoute: typeof AppBedriftIndexRoute
@@ -1015,6 +1055,7 @@ interface AppRouteChildren {
 const AppRouteChildren: AppRouteChildren = {
   AppKokebokRoute: AppKokebokRoute,
   AppKontraktRoute: AppKontraktRoute,
+  AppNyStudentRoute: AppNyStudentRoute,
   AppOpptakRoute: AppOpptakRoute,
   AppPersonvernRoute: AppPersonvernRoute,
   AppQrKoderRoute: AppQrKoderRoute,
@@ -1028,6 +1069,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppNyheterSlugRoute: AppNyheterSlugRoute,
   AppPlaygroundMarkdownRoute: AppPlaygroundMarkdownRoute,
   AppProfilIdRoute: AppProfilIdRouteWithChildren,
+  AppSporreskjemaIdRoute: AppSporreskjemaIdRoute,
   AppAnnonserIndexRoute: AppAnnonserIndexRoute,
   AppArrangementerIndexRoute: AppArrangementerIndexRoute,
   AppBedriftIndexRoute: AppBedriftIndexRoute,

--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -66,7 +66,7 @@ function AppLayout() {
                           {
                               kind: "internal",
                               label: "Ny student",
-                              link: linkOptions({ to: "/" }),
+                              link: linkOptions({ to: "/ny-student" }),
                           },
                       ]
                     : []),

--- a/apps/kvark/src/routes/_app/ny-student.tsx
+++ b/apps/kvark/src/routes/_app/ny-student.tsx
@@ -1,0 +1,293 @@
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { Link, createFileRoute } from "@tanstack/react-router";
+import { Button } from "@tihlde/ui/ui/button";
+import { Card, CardContent } from "@tihlde/ui/ui/card";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import { ArrowRight, AtSign, Facebook, Instagram, Users2 } from "lucide-react";
+import { Suspense, useMemo } from "react";
+
+import { authQueryOptions } from "#/api/auth";
+import { getGroupsQuery } from "#/api/queries/groups";
+import { getToddelIssuesQuery } from "#/api/queries/toddel";
+import {
+    type AdmissionGroup,
+    GroupAdmissionLinkCard,
+} from "#/components/group-admission-card";
+import { HeroSectionBackground } from "#/components/hero-section";
+
+export const Route = createFileRoute("/_app/ny-student")({
+    component: NewStudentPage,
+    loader: ({ context }) =>
+        context.queryClient.ensureQueryData(getGroupsQuery(0)),
+});
+
+const FADDERUKA_URL = "https://fadderuka.tihlde.org";
+const NEW_STUDENT_WIKI_URL = "https://wiki.tihlde.org/ny-student";
+
+const CONTACTS = [
+    { icon: AtSign, label: "hs@tihlde.org", href: "mailto:hs@tihlde.org" },
+    {
+        icon: AtSign,
+        label: "fadderkom@tihlde.org",
+        href: "mailto:fadderkom@tihlde.org",
+    },
+    {
+        icon: Instagram,
+        label: "@tihlde",
+        href: "https://www.instagram.com/tihlde/",
+    },
+    {
+        icon: Facebook,
+        label: "TIHLDE",
+        href: "https://www.facebook.com/tihlde/",
+    },
+] as const;
+
+type ApiGroup = {
+    name: string;
+    slug: string;
+    type: string;
+    contactEmail: string | null;
+    imageUrl: string | null;
+};
+
+function toGroups(groups: ApiGroup[], type: string): AdmissionGroup[] {
+    return groups
+        .filter((group) => group.type === type)
+        .map((group) => ({
+            name: group.name,
+            slug: group.slug,
+            email: group.contactEmail ?? undefined,
+            logoUrl: group.imageUrl ?? undefined,
+        }));
+}
+
+function NewStudentPage() {
+    const { data: session } = useQuery(authQueryOptions);
+    const isAuthenticated = Boolean(session);
+
+    return (
+        <div className="flex w-full flex-col items-center">
+            <section className="relative flex min-h-[60vh] w-full items-center justify-center overflow-hidden">
+                <HeroSectionBackground />
+                <div className="relative z-10 mx-auto flex max-w-3xl flex-col items-center gap-4 px-4 py-24 text-center">
+                    <h1 className="text-4xl md:text-6xl">
+                        Velkommen til linjeforeningen TIHLDE!
+                    </h1>
+                    <p className="text-muted-foreground">
+                        Her finner du nyttig info om hvordan linjeforeningen og
+                        fadderuka fungerer. Er du ny student kan du melde deg på
+                        fadderuka under. Du burde også lage deg en bruker om du
+                        ikke har gjort det allerede.
+                    </p>
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                        <Button
+                            nativeButton={false}
+                            render={
+                                <a
+                                    href={FADDERUKA_URL}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                />
+                            }
+                        >
+                            <Users2 />
+                            Meld meg på fadderuka
+                        </Button>
+                        <Button
+                            variant="outline"
+                            nativeButton={false}
+                            render={
+                                isAuthenticated ? (
+                                    <Link to="/opptak" />
+                                ) : (
+                                    <Link to="/register" />
+                                )
+                            }
+                        >
+                            {isAuthenticated ? "Søk verv" : "Opprett bruker"}
+                            <ArrowRight />
+                        </Button>
+                    </div>
+                </div>
+            </section>
+
+            <section className="container mx-auto flex max-w-5xl flex-col gap-4 px-4 py-16">
+                <p className="text-muted-foreground">
+                    Ditt første møte med TIHLDE
+                </p>
+                <h2 className="text-3xl md:text-5xl">Fadderuka</h2>
+                <p className="max-w-2xl text-muted-foreground">
+                    Fadderuka er en gyllen mulighet til å bli kjent med
+                    medstudenter og med linjeforeningen. Fadderuka varer fra uka
+                    før skolestart til en uke inn i semesteret. Meld deg på for
+                    å få plass!
+                </p>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                    <Button
+                        nativeButton={false}
+                        render={
+                            <a
+                                href={FADDERUKA_URL}
+                                target="_blank"
+                                rel="noreferrer"
+                            />
+                        }
+                    >
+                        Meld meg på!
+                    </Button>
+                    <Button
+                        variant="outline"
+                        nativeButton={false}
+                        render={<Link to="/arrangementer" />}
+                    >
+                        Hva skjer i fadderuka?
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        nativeButton={false}
+                        render={
+                            <a
+                                href={NEW_STUDENT_WIKI_URL}
+                                target="_blank"
+                                rel="noreferrer"
+                            />
+                        }
+                    >
+                        Les mer
+                        <ArrowRight />
+                    </Button>
+                </div>
+            </section>
+
+            <section className="container mx-auto flex max-w-4xl flex-col gap-2 px-4 py-16">
+                <p className="text-muted-foreground">Hva er egentlig TIHLDE?</p>
+                <p className="text-xl md:text-3xl">
+                    «TIHLDE (Trondheim IngeniørHøgskoles Linjeforening for
+                    Dannede EDBere) er linjeforeningen for bachelorstudiene
+                    Dataingeniør, Digital infrastruktur og cybersikkerhet,
+                    Digital forretningsutvikling, samt masterstudiet Digital
+                    transformasjon og det nettbaserte studiet
+                    Informasjonsbehandling.»
+                </p>
+            </section>
+
+            <section className="container mx-auto flex max-w-5xl flex-col gap-8 px-4 py-16">
+                <div className="flex flex-col gap-2 text-center">
+                    <h2 className="text-2xl md:text-4xl">
+                        TIHLDE er drevet av frivillige studenter — bli kjent med
+                        de forskjellige vervene
+                    </h2>
+                    <p className="mx-auto max-w-lg text-muted-foreground">
+                        Opptaksrunder skjer rett etter fadderuka. Du blir kalt
+                        inn på intervju ved å sende søknad.
+                    </p>
+                </div>
+                <Suspense fallback={<GroupSectionsSkeleton />}>
+                    <GroupSections />
+                </Suspense>
+            </section>
+
+            <Suspense fallback={null}>
+                <LatestToddelSection />
+            </Suspense>
+
+            <section className="container mx-auto flex max-w-5xl flex-col gap-8 px-4 py-16">
+                <h2 className="text-center text-2xl md:text-4xl">
+                    Har du flere spørsmål? Ta kontakt her
+                </h2>
+                <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+                    {CONTACTS.map((contact) => (
+                        <a
+                            key={contact.label}
+                            href={contact.href}
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            <Card size="sm" className="h-full">
+                                <CardContent className="flex flex-col items-center gap-4 py-8">
+                                    <contact.icon className="size-10" />
+                                    <p className="text-muted-foreground">
+                                        {contact.label}
+                                    </p>
+                                </CardContent>
+                            </Card>
+                        </a>
+                    ))}
+                </div>
+            </section>
+        </div>
+    );
+}
+
+function GroupSectionsSkeleton() {
+    return (
+        <div className="flex flex-col gap-4">
+            {Array.from({ length: 3 }, (_, index) => (
+                <Skeleton key={index} className="h-24 w-full" />
+            ))}
+        </div>
+    );
+}
+
+function GroupSections() {
+    const { data: apiGroups } = useSuspenseQuery(getGroupsQuery(0));
+
+    const sections = useMemo(() => {
+        const groups = apiGroups as ApiGroup[];
+        return [
+            { title: "Hovedorgan", groups: toGroups(groups, "BOARD") },
+            { title: "Undergrupper", groups: toGroups(groups, "SUBGROUP") },
+            { title: "Komitéer", groups: toGroups(groups, "COMMITTEE") },
+            {
+                title: "Interessegrupper",
+                groups: toGroups(groups, "INTERESTGROUP"),
+            },
+        ].filter((section) => section.groups.length > 0);
+    }, [apiGroups]);
+
+    return (
+        <div className="flex flex-col gap-10">
+            {sections.map((section) => (
+                <div key={section.title} className="flex flex-col gap-3">
+                    <h3 className="text-lg font-semibold">{section.title}</h3>
+                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                        {section.groups.map((group) => (
+                            <GroupAdmissionLinkCard
+                                key={group.slug}
+                                group={group}
+                            />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+/**
+ * The whole section is skipped when the archive has no cover to show — a
+ * heading with nothing under it reads as a broken page.
+ */
+function LatestToddelSection() {
+    const { data: issues } = useSuspenseQuery(getToddelIssuesQuery());
+    const latest = issues[0];
+
+    if (!latest?.imageUrl) return null;
+
+    return (
+        <section className="container mx-auto flex max-w-5xl flex-col gap-8 px-4 py-16">
+            <h2 className="text-center text-2xl md:text-4xl">
+                TIHLDEs avis heter TÖDDEL — les siste utgave her
+            </h2>
+            <Link to="/toddel" className="mx-auto w-full max-w-md">
+                <img
+                    src={latest.imageUrl}
+                    alt={latest.title}
+                    className="w-full"
+                    loading="lazy"
+                />
+            </Link>
+        </section>
+    );
+}

--- a/apps/kvark/src/routes/_app/opptak.tsx
+++ b/apps/kvark/src/routes/_app/opptak.tsx
@@ -190,20 +190,25 @@ function AdmissionCardContainer({
         enabled: open && isAuthenticated,
     });
 
+    const admissionForm = useMemo(
+        () => forms?.find((f) => f.title.toLowerCase().includes("opptak")),
+        [forms],
+    );
+
     const status = useMemo<AdmissionStatus>(() => {
         if (!isAuthenticated) return "unauthenticated";
         if (isLoading || !forms) return "loading";
 
-        const form = forms.find((f) =>
-            f.title.toLowerCase().includes("opptak"),
-        );
-        if (!form) return "missing";
-        if (!form.is_open_for_submissions) return "closed";
-        if (!form.can_submit_multiple && form.viewer_has_answered) {
+        if (!admissionForm) return "missing";
+        if (!admissionForm.is_open_for_submissions) return "closed";
+        if (
+            !admissionForm.can_submit_multiple &&
+            admissionForm.viewer_has_answered
+        ) {
             return "answered";
         }
         return "open";
-    }, [forms, isAuthenticated, isLoading]);
+    }, [admissionForm, forms, isAuthenticated, isLoading]);
 
     return (
         <GroupAdmissionCard
@@ -211,6 +216,7 @@ function AdmissionCardContainer({
             open={open}
             onOpenChange={setOpen}
             status={status}
+            formId={admissionForm?.id}
         />
     );
 }

--- a/apps/kvark/src/routes/_app/sporreskjema.$id.tsx
+++ b/apps/kvark/src/routes/_app/sporreskjema.$id.tsx
@@ -1,0 +1,358 @@
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { Link, createFileRoute } from "@tanstack/react-router";
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
+import { Button } from "@tihlde/ui/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@tihlde/ui/ui/card";
+import { FieldGroup } from "@tihlde/ui/ui/field";
+import { Separator } from "@tihlde/ui/ui/separator";
+import { Spinner } from "@tihlde/ui/ui/spinner";
+import { ArrowLeft, CheckCircle2, TriangleAlert } from "lucide-react";
+import type { FormDetail } from "@tihlde/sdk";
+import { z } from "zod";
+
+import { authClientWithRedirect } from "#/api/auth";
+import {
+    createSubmissionMutation,
+    getFormByIdQuery,
+} from "#/api/queries/forms";
+import { formHandlers, useAppForm } from "#/hooks/form";
+import { formatEventDate } from "#/lib/event";
+
+export const Route = createFileRoute("/_app/sporreskjema/$id")({
+    component: FormPage,
+    beforeLoad: ({ location }) => authClientWithRedirect(location.href),
+    loader: ({ context, params }) =>
+        context.queryClient.ensureQueryData(getFormByIdQuery(params.id)),
+});
+
+type FormField = FormDetail["fields"][number];
+
+const requiredText = z.string().min(1, { error: "Feltet er påkrevd" });
+const requiredChoice = z.string().min(1, { error: "Velg ett alternativ" });
+const requiredChoices = z
+    .array(z.string())
+    .min(1, { error: "Velg minst ett alternativ" });
+
+function byType(fields: FormField[], type: FormField["type"]) {
+    return fields.filter((field) => field.type === type);
+}
+
+function FormPage() {
+    const { id } = Route.useParams();
+    const { data: form } = useSuspenseQuery(getFormByIdQuery(id));
+
+    return (
+        <div className="container mx-auto flex max-w-3xl flex-col gap-6 px-4 py-12">
+            <Button
+                variant="outline"
+                className="self-start"
+                nativeButton={false}
+                render={<Link to="/" />}
+            >
+                <ArrowLeft />
+                Til forsiden
+            </Button>
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-2xl">
+                        {form.resource_type === "EventForm" &&
+                        form.type === "evaluation"
+                            ? "Evaluering"
+                            : form.title}
+                    </CardTitle>
+                    <CardDescription>
+                        <FormSubtitle form={form} />
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                    {form.description ? <p>{form.description}</p> : null}
+                    <Separator />
+                    <FormBody form={form} />
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+function FormSubtitle({ form }: { form: FormDetail }) {
+    if (form.resource_type === "EventForm" && form.event) {
+        return (
+            <>
+                Arrangøren av{" "}
+                <Link
+                    to="/arrangementer/$slug"
+                    params={{ slug: form.event.slug ?? form.event.id }}
+                >
+                    «{form.event.title}»
+                </Link>
+                {form.event.location
+                    ? `, som ble holdt ${formatEventDate(form.event.start_date)} på ${form.event.location}, `
+                    : `, som ble holdt ${formatEventDate(form.event.start_date)}, `}
+                ønsker at du svarer på følgende spørsmål:
+            </>
+        );
+    }
+
+    if (form.resource_type === "GroupForm" && form.group) {
+        return <>Spørreskjema fra {form.group.name}</>;
+    }
+
+    return null;
+}
+
+/**
+ * Decides whether the viewer may answer at all, and renders either the answer
+ * form or the reason they cannot.
+ */
+function FormBody({ form }: { form: FormDetail }) {
+    // Event surveys are answered as part of the registration flow on the event
+    // page — only evaluations are filled in here.
+    if (form.resource_type === "EventForm" && form.type !== "evaluation") {
+        return (
+            <Alert>
+                <TriangleAlert />
+                <AlertTitle>
+                    Dette skjemaet svarer du på ved påmelding
+                </AlertTitle>
+                <AlertDescription>
+                    Gå til arrangementet for å melde deg på og svare på
+                    spørsmålene.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    if (form.resource_type === "GroupForm" && !form.is_open_for_submissions) {
+        return (
+            <Alert>
+                <TriangleAlert />
+                <AlertTitle>Skjemaet er stengt</AlertTitle>
+                <AlertDescription>
+                    Spørreskjemaet er ikke åpent for innsending av svar akkurat
+                    nå.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    const canAnswerAgain =
+        form.resource_type === "GroupForm" && Boolean(form.can_submit_multiple);
+
+    if (form.viewer_has_answered && !canAnswerAgain) {
+        return <AlreadyAnswered />;
+    }
+
+    return <AnswerForm form={form} />;
+}
+
+function AlreadyAnswered() {
+    return (
+        <div className="flex flex-col gap-4">
+            <Alert>
+                <CheckCircle2 />
+                <AlertTitle>Du har allerede svart på dette skjemaet</AlertTitle>
+                <AlertDescription>Takk for svaret ditt!</AlertDescription>
+            </Alert>
+            <div className="flex flex-col gap-2 sm:flex-row">
+                <Button
+                    variant="outline"
+                    className="w-full"
+                    nativeButton={false}
+                    render={<Link to="/" />}
+                >
+                    Gå til forsiden
+                </Button>
+                <Button
+                    variant="outline"
+                    className="w-full"
+                    nativeButton={false}
+                    render={<Link to="/profil/$id" params={{ id: "me" }} />}
+                >
+                    Gå til profilen din
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+function AnswerForm({ form }: { form: FormDetail }) {
+    const submit = useMutation(createSubmissionMutation);
+
+    const textFields = byType(form.fields, "text_answer");
+    const singleFields = byType(form.fields, "single_select");
+    const multiFields = byType(form.fields, "multiple_select");
+
+    // Answers are keyed by field id and split by shape, so every field name
+    // stays a single, well-typed value instead of a union.
+    const answerForm = useAppForm({
+        defaultValues: {
+            texts: Object.fromEntries(
+                textFields.map((field) => [field.id, ""]),
+            ) as Record<string, string>,
+            choices: Object.fromEntries(
+                singleFields.map((field) => [field.id, ""]),
+            ) as Record<string, string>,
+            selections: Object.fromEntries(
+                multiFields.map((field) => [field.id, [] as string[]]),
+            ) as Record<string, string[]>,
+        },
+        async onSubmit({ value }) {
+            // Unanswered optional fields are left out entirely — the API
+            // requires each answer to carry either text or selected options.
+            const answers = [
+                ...textFields
+                    .filter((field) => value.texts[field.id]?.trim())
+                    .map((field) => ({
+                        field: { id: field.id },
+                        answer_text: value.texts[field.id] as string,
+                    })),
+                ...singleFields
+                    .filter((field) => value.choices[field.id])
+                    .map((field) => ({
+                        field: { id: field.id },
+                        selected_options: [
+                            { id: value.choices[field.id] as string },
+                        ],
+                    })),
+                ...multiFields
+                    .filter((field) => value.selections[field.id]?.length)
+                    .map((field) => ({
+                        field: { id: field.id },
+                        selected_options: (
+                            value.selections[field.id] as string[]
+                        ).map((optionId) => ({ id: optionId })),
+                    })),
+            ];
+
+            try {
+                await submit.mutateAsync({
+                    formId: form.id,
+                    data: { answers },
+                });
+            } catch {
+                // Surfaced through `submit.isError` below
+            }
+        },
+    });
+
+    if (submit.isSuccess) {
+        return (
+            <Alert>
+                <CheckCircle2 />
+                <AlertTitle>Svaret ditt er sendt inn</AlertTitle>
+                <AlertDescription>Takk for at du svarte!</AlertDescription>
+            </Alert>
+        );
+    }
+
+    return (
+        <form {...formHandlers(answerForm)} className="flex flex-col gap-6">
+            {submit.isError && (
+                <Alert variant="destructive">
+                    <TriangleAlert />
+                    <AlertTitle>Klarte ikke å sende inn svaret</AlertTitle>
+                    <AlertDescription>
+                        Prøv igjen om litt. Har du allerede svart, kan det hende
+                        skjemaet bare tar imot ett svar.
+                    </AlertDescription>
+                </Alert>
+            )}
+
+            <FieldGroup className="flex flex-col gap-6">
+                {form.fields.map((field) => {
+                    if (field.type === "text_answer") {
+                        return (
+                            <answerForm.AppField
+                                key={field.id}
+                                name={`texts.${field.id}`}
+                                validators={
+                                    field.required
+                                        ? { onDynamic: requiredText }
+                                        : undefined
+                                }
+                            >
+                                {(f) => (
+                                    <f.Field required={field.required}>
+                                        <f.Label>{field.title}</f.Label>
+                                        <f.Textarea
+                                            rows={3}
+                                            placeholder="Skriv svaret ditt her..."
+                                        />
+                                        <f.Error />
+                                    </f.Field>
+                                )}
+                            </answerForm.AppField>
+                        );
+                    }
+
+                    const options = field.options.map((option) => ({
+                        value: option.id,
+                        label: option.title,
+                    }));
+
+                    if (field.type === "single_select") {
+                        return (
+                            <answerForm.AppField
+                                key={field.id}
+                                name={`choices.${field.id}`}
+                                validators={
+                                    field.required
+                                        ? { onDynamic: requiredChoice }
+                                        : undefined
+                                }
+                            >
+                                {(f) => (
+                                    <f.Field required={field.required}>
+                                        <f.Label>{field.title}</f.Label>
+                                        <f.RadioGroup options={options} />
+                                        <f.Error />
+                                    </f.Field>
+                                )}
+                            </answerForm.AppField>
+                        );
+                    }
+
+                    return (
+                        <answerForm.AppField
+                            key={field.id}
+                            name={`selections.${field.id}`}
+                            validators={
+                                field.required
+                                    ? { onDynamic: requiredChoices }
+                                    : undefined
+                            }
+                        >
+                            {(f) => (
+                                <f.Field required={field.required}>
+                                    <f.Label>{field.title}</f.Label>
+                                    <f.CheckboxGroup options={options} />
+                                    <f.Error />
+                                </f.Field>
+                            )}
+                        </answerForm.AppField>
+                    );
+                })}
+            </FieldGroup>
+
+            <answerForm.AppForm>
+                <answerForm.SubmitButton
+                    className="w-full"
+                    loading={
+                        <>
+                            <Spinner />
+                            <span>Sender inn...</span>
+                        </>
+                    }
+                >
+                    Send inn
+                </answerForm.SubmitButton>
+            </answerForm.AppForm>
+        </form>
+    );
+}

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2012,7 +2012,8 @@ export interface components {
             title: string;
             description: string | null;
             template: boolean;
-            resource_type: string;
+            /** @enum {string} */
+            resource_type: "Form" | "EventForm" | "GroupForm";
             viewer_has_answered: boolean;
             website_url: string;
             created_at: string;
@@ -2032,6 +2033,22 @@ export interface components {
                     order: number;
                 }[];
             }[];
+            type: ("survey" | "evaluation") | null;
+            event: {
+                /** Format: uuid */
+                id: string;
+                title: string;
+                slug: string | null;
+                start_date: string;
+                location: string | null;
+            } | null;
+            group: {
+                slug: string;
+                name: string;
+            } | null;
+            can_submit_multiple: boolean | null;
+            is_open_for_submissions: boolean | null;
+            only_for_group_members: boolean | null;
         };
         UpdateFormResponse: {
             /** Format: uuid */


### PR DESCRIPTION
Porterer to sider til fra tihlde.org: spørreskjema-siden og «Ny student».

## Spørreskjema

`GET /api/forms/{id}` løste alltid `resource_type` til `"Form"`. Den slår nå opp eieren og returnerer konteksten klienten trenger for å gate skjemaet:

- `resource_type`: `"Form" | "EventForm" | "GroupForm"`
- `type` + `event` (id, tittel, slug, startdato, sted) for arrangementsskjemaer
- `group` + `can_submit_multiple` / `is_open_for_submissions` / `only_for_group_members` for gruppeskjemaer

Selve innsendingsreglene lå allerede ferdig i `lib/form/service.ts` og er urørt.

Ny side `/sporreskjema/$id` besvarer skjemaet med TanStack Form: `text_answer` → Textarea, `single_select` → RadioGroup, `multiple_select` → CheckboxGroup, påkrevd-validering per felt, og de fire tilstandene fra Kvark — svar, allerede svart, stengt gruppeskjema, og arrangementsskjema som besvares ved påmelding.

«Søk nå» på `/opptak` og «Svar på/se skjema» i gruppenes skjema-fane pekte på gruppesiden i mangel av et sted å gå. Begge går nå rett til skjemaet.

## Ny student

`/ny-student` gjenskapt fra Kvark på `@tihlde/ui`: hero, fadderuka-seksjon, «Hva er TIHLDE»-sitatet, gruppeoversikt fra API-et (hovedorgan/undergrupper/komitéer/interessegrupper), siste TÖDDEL og kontaktkortene. TÖDDEL-seksjonen skjuler seg selv når arkivet er tomt.

**Merk:** nav-lenken peker nå på `/ny-student`, men ligger fortsatt bak `isNewStudentTime = false` i `_app.tsx` — siden er ikke synlig i menyen før noen bestemmer hvordan det flagget skal styres.

## Verifisering

- Fylte ut og sendte inn et ekte gruppeskjema i nettleseren mot lokal API → `POST .../submissions` 201, og raden i dev-DB fikk 13 svar + 1 valgt alternativ, samme form som de Lepton-migrerte innsendingene. Testinnsendingen ble slettet etterpå.
- Tom innsending blokkeres med «Feltet er påkrevd» per felt.
- Stengt gruppeskjema, evaluering (med arrangementskontekst og dato/sted) og survey rendrer hver sin tilstand riktig.
- `bun run test`: 192/192, inkludert en ny assertion i `forms.test.ts` på gruppekonteksten i detail-responsen.
- `bun run typecheck`, `tsc --noEmit` i kvark og `vite build`: rene. `bun run lint`: kun de eksisterende warningene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)