### PR TITLE
chore(kvark): add a working typecheck task to the frontend

### DIFF
--- a/apps/kvark/package.json
+++ b/apps/kvark/package.json
@@ -9,6 +9,7 @@
         "dev": "vite dev --port 3000",
         "build": "vite build",
         "preview": "vite preview",
+        "typecheck": "tsc --noEmit",
         "format": "oxfmt .",
         "lint": "oxlint .",
         "lint:fix": "oxlint --fix ."

--- a/apps/kvark/tsconfig.json
+++ b/apps/kvark/tsconfig.json
@@ -5,7 +5,11 @@
         "jsx": "react-jsx",
         "module": "ESNext",
         "paths": {
-            "#/*": ["./src/*"]
+            // Workspace packages (@tihlde/ui) are consumed as source, and their
+            // own `#/...` self-imports are resolved by this same map — tsconfig
+            // paths are program-wide, not per-package. Listing their src roots
+            // as fallbacks keeps cross-package type resolution working.
+            "#/*": ["./src/*", "../../packages/ui/src/*"]
         },
         "lib": ["ES2022", "DOM", "DOM.Iterable"],
         "types": ["vite/client"],

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,4 +1,8 @@
-import { betterAuth, BetterAuthOptions, DBAdapter } from "better-auth";
+import {
+    betterAuth,
+    type BetterAuthOptions,
+    type DBAdapter,
+} from "better-auth";
 import { APIError, createAuthMiddleware } from "better-auth/api";
 import {
     admin,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,4 +1,4 @@
-import { paths } from "./generated/openapi";
+import type { paths } from "./generated/openapi";
 
 type HTTPMethods =
     | "get"

--- a/packages/ui/src/components/ui/scroll-area.tsx
+++ b/packages/ui/src/components/ui/scroll-area.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as React from "react";
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
 
 import { cn } from "#/lib/utils";


### PR DESCRIPTION
## What

`apps/kvark` had no `typecheck` script, so `bun run typecheck` at the repo root ran **7** tasks and never type-checked the frontend — type errors in `apps/kvark` only showed up at runtime. It now runs **8** and includes `kvark:typecheck`.

## Why it wasn't just "add a script"

Running `tsc --noEmit` in `apps/kvark` reported ~700 errors, nearly all bogus:

```
../../packages/ui/src/components/ui/dialog.tsx(5,24): error TS2307:
  Cannot find module '#/components/ui/button' or its corresponding type declarations.
```

tsconfig `paths` are **program-wide, not per-package**. `@tihlde/ui` is consumed as source (its `exports` point at raw `.ts`/`.tsx`), so ui's files land in kvark's program — and kvark's `"#/*": ["./src/*"]` was applied to them too, sending ui's own `#/...` self-imports into kvark's `src/`, where they don't exist. The cascade of `TS7006 implicitly has an 'any' type` errors was downstream of that: unresolved modules type as `any`.

## The fix

`"#/*": ["./src/*", "../../packages/ui/src/*"]` — tsc tries mappings in order, so kvark's own `#/...` still resolves first and ui's fall through to ui's src.

**Reviewer note on the one shared path:** `lib/utils.ts` exists in both trees, so ui's `#/lib/utils` resolves to kvark's copy. I checked — kvark's is a strict superset of ui's (same `cn`, plus `nameToSlug`/`groupHref`/`initials`), so nothing is mistyped. The tradeoff is that a future kvark file could shadow a ui internal module; the alternative was renaming ui's `#/` alias to something unique, which meant churning 59 files in the shared UI package. I went with the two-line change and a comment in the tsconfig explaining why. Happy to do the rename instead if you'd rather have the stronger guarantee.

## Real errors this uncovered

kvark's config is stricter than these packages' own, so three genuine issues surfaced:

- `packages/auth/src/index.ts` — `BetterAuthOptions`, `DBAdapter` need `type` imports (`verbatimModuleSyntax`)
- `packages/sdk/src/types.ts` — same for `paths`
- `packages/ui/src/components/ui/scroll-area.tsx` — unused `React` import (`noUnusedLocals`)

## turbo.json

No change needed. The generic `"typecheck": { "dependsOn": ["^typecheck", "^build"] }` picks kvark up automatically, and `^build` already builds `@tihlde/sdk` (which generates `src/generated/openapi.ts`) before kvark type-checks.

## Route generation

Not added, despite `src/routeTree.gen.ts` being plugin-generated. It's committed and not gitignored, so `tsc --noEmit` works standalone; the TanStack install here ships no `tsr` CLI; and running `vite build` regenerates the file with reordered-but-identical imports, which would make the script dirty the working tree on every run. Trailing caveat: adding a route without running `vite dev` means typecheck sees a stale tree — same as today.

## Verification

- `bun run typecheck` → 8/8 pass (kvark included)
- `bun run build` → 4/4 pass (confirms vite's `resolve.tsconfigPaths` handles the new array)
- `bun run lint` → no new warnings
- `bun run format` → clean for all touched files (one pre-existing unrelated issue in `.github/workflows/deploy.yml`, left alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)