### PR TITLE
feat(kvark): vis Ny student i navmenyen fra juni til og med august

### DIFF
--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -22,8 +22,9 @@ function AppLayout() {
         : null;
     const isAuthenticated = Boolean(currentUser);
 
-    // Mock this for now
-    const isNewStudentTime = false;
+    // Vis "Ny student" i navmenyen fra og med juni til og med august
+    const month = new Date().getMonth();
+    const isNewStudentTime = month >= 5 && month <= 7;
 
     const navItems = useMemo(
         () =>


### PR DESCRIPTION
## Hva

Erstatter det mockede `isNewStudentTime = false`-flagget i `apps/kvark/src/routes/_app.tsx` med en ekte datosjekk (`month >= 5 && month <= 7`), slik at **Ny student**-lenken vises nest til venstre i navmenyen (etter «Generelt») fra og med juni til og med august.

## Verifisering

- `bun run typecheck`, `lint` og `format` passerer
- Verifisert i nettleseren: navmenyen viser `Generelt | Ny student | Arrangementer | Wiki | Stillinger | For Bedrifter` med lenke til `/ny-student`

🤖 Generated with [Claude Code](https://claude.com/claude-code)