### PR TITLE
feat(lepton-migration): import users from Lepton's export endpoint

### DIFF
--- a/packages/lepton-migration/data/.gitignore
+++ b/packages/lepton-migration/data/.gitignore
@@ -1,0 +1,3 @@
+# The user export holds personal data for ~1700 members and must never be
+# committed. It is refetched from Lepton's export endpoint on demand.
+lepton-users.json

--- a/packages/lepton-migration/fetch-lepton-users.ts
+++ b/packages/lepton-migration/fetch-lepton-users.ts
@@ -1,0 +1,51 @@
+/**
+ * Fetches the user export from Lepton into a local JSON cache.
+ *
+ * Lepton exposes `GET /migration/photon-user-export/` (superuser-gated) because
+ * Photon has no direct access to its database. This pulls that once and caches
+ * it, so `import-users.ts` can run and re-run without hitting Lepton again.
+ *
+ * The auth token is read from the LEPTON_TOKEN environment variable and sent in
+ * the X-Csrf-Token header — never passed on the command line, so it stays out
+ * of shell history and process listings.
+ *
+ * Usage: LEPTON_TOKEN=$(cat path/to/token) bun fetch-lepton-users.ts
+ */
+const BASE = process.env.LEPTON_API ?? "https://api.tihlde.org";
+const TOKEN = process.env.LEPTON_TOKEN;
+
+if (!TOKEN) {
+    console.error(
+        "LEPTON_TOKEN må være satt, f.eks. LEPTON_TOKEN=$(cat .lepton-token) bun fetch-lepton-users.ts",
+    );
+    process.exit(1);
+}
+
+const main = async () => {
+    const res = await fetch(`${BASE}/migration/photon-user-export/`, {
+        headers: {
+            "X-Csrf-Token": TOKEN,
+            "User-Agent": "photon-user-import/1.0 (TIHLDE)",
+        },
+    });
+
+    if (!res.ok) {
+        const body = await res.text();
+        console.error(`Lepton svarte ${res.status}: ${body.slice(0, 200)}`);
+        if (res.status === 401 || res.status === 403) {
+            console.error(
+                "Sjekk at tokenet tilhører en superbruker i HS/Index.",
+            );
+        }
+        process.exit(1);
+    }
+
+    const data = (await res.json()) as { count: number; users: unknown[] };
+    const out = `${import.meta.dir}/data/lepton-users.json`;
+    await Bun.write(out, JSON.stringify(data, null, 2));
+
+    console.log(`Hentet ${data.count} brukere → ${out}`);
+};
+
+await main();
+process.exit(0);

--- a/packages/lepton-migration/import-users.ts
+++ b/packages/lepton-migration/import-users.ts
@@ -1,0 +1,175 @@
+/**
+ * Imports users from Lepton's export into Photon, ahead of the full migration.
+ *
+ * Reads the cache written by `fetch-lepton-users.ts` and, for each Lepton user,
+ * either adopts an existing Photon account with the same email or creates a new
+ * one. The Lepton user_id is stored as `username`, which is how
+ * `backfill-contact-persons.ts` and the eventual MySQL migration resolve
+ * members back to their rows.
+ *
+ * Scope is deliberately just the accounts: allergies, bio and settings are left
+ * to the full migration, which processes every user (created or adopted) and
+ * fills them in with ON CONFLICT DO NOTHING.
+ *
+ * Idempotent. Without --commit it only reports what it would do (read-only),
+ * because better-auth's createUser writes immediately and cannot be wrapped in
+ * a rollback. With --commit it creates and adopts.
+ *
+ * Usage: DATABASE_URL=... [AUTH_SECRET=...] bun import-users.ts [--commit]
+ */
+import { createAuth, drizzleAdapter } from "@photon/auth";
+import { createDb, schema } from "@photon/db";
+import { ConsoleEmailService } from "@photon/core/services/email";
+import { InMemoryCache } from "@photon/core/services/cache";
+import { eq } from "drizzle-orm";
+
+const commit = process.argv.includes("--commit");
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+    console.error("DATABASE_URL må være satt");
+    process.exit(1);
+}
+
+type LeptonUser = {
+    user_id: string;
+    first_name: string;
+    last_name: string;
+    email: string;
+    is_superuser: boolean;
+};
+
+const main = async () => {
+    const { users } = (await Bun.file(
+        `${import.meta.dir}/data/lepton-users.json`,
+    ).json()) as { users: LeptonUser[] };
+
+    console.log(`${users.length} brukere i eksporten\n`);
+
+    const db = createDb({ connectionString });
+
+    // Only the commit path needs an auth instance: a dry run is read-only.
+    // No redis, no queue, no outbound mail — an in-memory cache and a console
+    // mailer are enough to create accounts, and nothing here sends email. The
+    // secret only signs sessions, which this never creates, so any non-empty
+    // value works; it never touches the created rows.
+    const auth = commit
+        ? createAuth({
+              isDevMode: false,
+              secret:
+                  process.env.AUTH_SECRET ||
+                  crypto.randomUUID() + crypto.randomUUID(),
+              services: {
+                  database: drizzleAdapter(db, { provider: "pg", schema }),
+                  db,
+                  cache: new InMemoryCache(),
+                  email: new ConsoleEmailService(),
+              },
+              oauth: { pages: { consent: "/consent", login: "/login" } },
+              urls: {
+                  backend: "https://photon.tihlde.org",
+                  frontend: "https://new.tihlde.org",
+                  additionalTrusted: [],
+                  basePath: "/api/auth",
+              },
+              DANGEROUSLY_SET_INSECURE_HASHING_ALGORITHM: false,
+          })
+        : null;
+
+    // Dedupe by email, keeping the first — the same rule the full migration
+    // uses, so both agree on which duplicate wins.
+    const seen = new Set<string>();
+    const unique: LeptonUser[] = [];
+    let duplicates = 0;
+    for (const u of users) {
+        const email = u.email.trim().toLowerCase();
+        if (!email) continue;
+        if (seen.has(email)) {
+            duplicates++;
+            continue;
+        }
+        seen.add(email);
+        unique.push(u);
+    }
+
+    const existing = await db
+        .select({
+            id: schema.user.id,
+            email: schema.user.email,
+            username: schema.user.username,
+        })
+        .from(schema.user);
+    const existingByEmail = new Map(
+        existing.map((r) => [r.email.trim().toLowerCase(), r]),
+    );
+
+    let created = 0;
+    let adopted = 0;
+    let failed = 0;
+
+    for (const u of unique) {
+        const email = u.email.trim().toLowerCase();
+        const match = existingByEmail.get(email);
+
+        if (match) {
+            adopted++;
+            if (commit && match.username !== u.user_id) {
+                await db
+                    .update(schema.user)
+                    .set({
+                        username: u.user_id,
+                        displayUsername: u.user_id,
+                    })
+                    .where(eq(schema.user.id, match.id));
+            }
+            continue;
+        }
+
+        if (!commit) {
+            created++; // would create
+            continue;
+        }
+
+        try {
+            const placeholder = crypto.randomUUID() + crypto.randomUUID();
+            const result = await auth!.api.createUser({
+                body: {
+                    email: u.email.trim(),
+                    password: placeholder,
+                    name: `${u.first_name} ${u.last_name}`.trim(),
+                    role: u.is_superuser ? "admin" : "user",
+                    data: {
+                        username: u.user_id,
+                        displayUsername: u.user_id,
+                    },
+                },
+            });
+            if (result?.user?.id) {
+                created++;
+            } else {
+                failed++;
+                console.warn(`  createUser ga ingen id: ${u.user_id}`);
+            }
+        } catch (err) {
+            failed++;
+            console.warn(`  createUser feilet: ${u.user_id}`, err);
+        }
+
+        if ((created + failed) % 100 === 0) {
+            console.log(`  ${created} opprettet, ${adopted} adoptert...`);
+        }
+    }
+
+    console.log();
+    console.log(commit ? "=== KJØRT ===" : "=== TØRRKJØRING (read-only) ===");
+    console.log(`unike e-poster:     ${unique.length}`);
+    console.log(`duplikate e-poster: ${duplicates}`);
+    console.log(
+        commit ? `opprettet: ${created}` : `ville opprettet: ${created}`,
+    );
+    console.log(`adoptert (fantes):  ${adopted}`);
+    if (failed) console.log(`FEILET:             ${failed}`);
+};
+
+await main();
+process.exit(0);

--- a/packages/lepton-migration/import-users.ts
+++ b/packages/lepton-migration/import-users.ts
@@ -18,6 +18,7 @@
  * Usage: DATABASE_URL=... [AUTH_SECRET=...] bun import-users.ts [--commit]
  */
 import { createAuth, drizzleAdapter } from "@photon/auth";
+import { slugifyText } from "@photon/core/slug";
 import { createDb, schema } from "@photon/db";
 import { ConsoleEmailService } from "@photon/core/services/email";
 import { InMemoryCache } from "@photon/core/services/cache";
@@ -103,6 +104,46 @@ const main = async () => {
         existing.map((r) => [r.email.trim().toLowerCase(), r]),
     );
 
+    // Usernames must be unique. Seed with what the database already holds so a
+    // sanitized legacy id cannot collide with a real one — Sunniva has both a
+    // proper `sunnho` account and a legacy `sunnhø` duplicate, and the second
+    // must become sunnho.2 rather than fail. Deduplicating the human being is
+    // a judgement call left to TIHLDE, not something an import decides.
+    const takenUsernames = new Set(
+        existing.map((r) => r.username?.toLowerCase()).filter(Boolean),
+    );
+    const uniqueUsername = (base: string): string => {
+        let candidate = base;
+        let n = 1;
+        while (takenUsernames.has(candidate.toLowerCase())) {
+            n += 1;
+            candidate = `${base}.${n}`;
+        }
+        takenUsernames.add(candidate.toLowerCase());
+        return candidate;
+    };
+
+    /**
+     * Better Auth only accepts usernames matching [a-zA-Z0-9_.]{3,}. Seven
+     * legacy Lepton ids break that rule — full names with spaces and ø/æ,
+     * one-letter ids, hyphens. For them the username cannot be a join key
+     * anywhere (the eventual MySQL migration's createUser enforces the same
+     * rule), so email carries the identity and the username just has to be
+     * valid and unique. Falls back to the email local part when the id itself
+     * sanitizes to nothing usable.
+     */
+    const usernameFor = (u: LeptonUser): string => {
+        const id = (u.user_id || "").trim();
+        if (/^[a-zA-Z0-9_.]{3,}$/.test(id)) return id;
+
+        const fromId = slugifyText(id).replace(/-/g, ".");
+        if (fromId.length >= 3) return fromId;
+
+        const local = u.email.split("@")[0] ?? "";
+        const fromEmail = slugifyText(local).replace(/-/g, ".");
+        return fromEmail.length >= 3 ? fromEmail : `legacy.${fromId || "user"}`;
+    };
+
     let created = 0;
     let adopted = 0;
     let failed = 0;
@@ -110,15 +151,25 @@ const main = async () => {
     for (const u of unique) {
         const email = u.email.trim().toLowerCase();
         const match = existingByEmail.get(email);
+        // An adopted account keeps its slot in the taken-set via the seed; a
+        // new one must claim a free name.
+        const username = match
+            ? usernameFor(u)
+            : uniqueUsername(usernameFor(u));
+        if (username !== u.user_id) {
+            console.log(
+                `  LEGACY brukernavn ${JSON.stringify(u.user_id)} -> ${username}`,
+            );
+        }
 
         if (match) {
             adopted++;
-            if (commit && match.username !== u.user_id) {
+            if (commit && match.username !== username) {
                 await db
                     .update(schema.user)
                     .set({
-                        username: u.user_id,
-                        displayUsername: u.user_id,
+                        username,
+                        displayUsername: username,
                     })
                     .where(eq(schema.user.id, match.id));
             }
@@ -139,8 +190,8 @@ const main = async () => {
                     name: `${u.first_name} ${u.last_name}`.trim(),
                     role: u.is_superuser ? "admin" : "user",
                     data: {
-                        username: u.user_id,
-                        displayUsername: u.user_id,
+                        username,
+                        displayUsername: username,
                     },
                 },
             });


### PR DESCRIPTION
Bringer brukere fra Lepton til Photon **nå**, uten å vente på den fulle MySQL-migreringen. Bruker det superbruker-gatede endepunktet fra [TIHLDE/Lepton#998](https://github.com/TIHLDE/Lepton/pull/998), som er live på Lepton prod.

## To steg

**`fetch-lepton-users.ts`** henter eksporten til en lokal cache. Tokenet leses fra `LEPTON_TOKEN` (sendes som `X-Csrf-Token`), aldri på kommandolinjen — holdes ute av shell-historikk.

```bash
LEPTON_TOKEN=$(cat .lepton-token) bun fetch-lepton-users.ts
```

**`import-users.ts`** leser cachen og, per bruker, enten adopterer en eksisterende Photon-konto med samme e-post eller oppretter en ny. Lepton-`user_id` lagres som `username` — nøkkelen både `backfill-contact-persons.ts` og den fulle migreringen kobler medlemmer på.

```bash
DATABASE_URL=... bun import-users.ts            # tørrkjøring (read-only)
DATABASE_URL=... [AUTH_SECRET=...] bun import-users.ts --commit
```

## Omfang

Kun kontoene. Allergier, bio og innstillinger overlates til den fulle migreringen, som prosesserer alle brukere (opprettet eller adoptert) og fyller dem inn med `ON CONFLICT DO NOTHING`.

## Design

Tørrkjøring er read-only og trenger verken auth-instans eller secret — better-auths `createUser` skriver umiddelbart og kan ikke rulles tilbake, så tørrkjøringen rapporterer tall i stedet for å late som den skriver. Commit-stien bygger auth med in-memory cache og console-mailer: ingen redis, ingen kø, ingen utgående e-post. Signeringssecreten rører aldri de opprettede radene (ingen sesjon lages), så en hvilken som helst ikke-tom verdi funker.

## Verifisert mot en kopi av prod-skjemaet

| test | resultat |
|---|---|
| tørrkjøring | 2 unike, 1 duplikat hoppet over, 1 ville opprettet, 1 adoptert |
| commit | ny bruker opprettet **med auth_account-rad** (kan logge inn via Feide), eksisterende adoptert med rollen beholdt |
| kjørt på nytt | 0 opprettet, 2 adoptert — idempotent |
| adoptert bruker med avvikende username | rettet tilbake til Lepton-`user_id` |

## ⚠️ Sidefunn: den fulle migreringen er ødelagt

`src/index.ts` typechecker ikke lenger mot main — `createAuth`-signaturen er endret og `@photon/core/cache` er flyttet. **Den vil ikke kjøre som den står**, og trenger en egen fiks før MySQL-migreringen. Pakken har ingen typecheck-script, så det har ligget uoppdaget. Egen sak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)