### PR TITLE
feat(auth): match first-time Feide logins to migrated accounts by username

### DIFF
--- a/apps/api/src/test/feide/migrated-username-match.test.ts
+++ b/apps/api/src/test/feide/migrated-username-match.test.ts
@@ -1,0 +1,120 @@
+import { feideUsernameOf, resolveMigratedEmail } from "@photon/auth/feide";
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+const USERID_SEC = "https://n.feide.no/claims/userid_sec";
+
+const profileFor = (username: string) => ({
+    sub: `feide-sub-${username}`,
+    name: "Test Person",
+    email: `${username}@stud.ntnu.no`,
+    [USERID_SEC]: [`feide:${username}@ntnu.no`],
+});
+
+describe("feideUsernameOf", () => {
+    it("extracts the local part of the feide principal", () => {
+        expect(
+            feideUsernameOf({ [USERID_SEC]: ["feide:mathstr@ntnu.no"] }),
+        ).toBe("mathstr");
+    });
+
+    it("skips non-feide identifiers and lowercases the result", () => {
+        expect(
+            feideUsernameOf({
+                [USERID_SEC]: ["nin:01010112345", "feide:MathStr@ntnu.no"],
+            }),
+        ).toBe("mathstr");
+    });
+
+    it("returns null when the claim is missing or has no feide entry", () => {
+        expect(feideUsernameOf({})).toBeNull();
+        expect(feideUsernameOf({ [USERID_SEC]: ["nin:010101"] })).toBeNull();
+    });
+});
+
+/**
+ * Most migrated members registered in Lepton with a personal address, so
+ * Better Auth's email-based OAuth matching would miss them and mint a second,
+ * empty account. These cover the username bridge that prevents that.
+ */
+describe("resolveMigratedEmail", () => {
+    integrationTest(
+        "returns the stored email for a migrated user without a Feide link",
+        async ({ ctx }) => {
+            // A migrated member: Lepton had a gmail address, and the import
+            // stored the Lepton user_id as username.
+            const user = await ctx.utils.createTestUser(
+                "personal-address@gmail.com",
+            );
+            await ctx.db
+                .update(schema.user)
+                .set({ username: "mathstr", displayUsername: "mathstr" })
+                .where(eq(schema.user.id, user.id));
+
+            const email = await resolveMigratedEmail(
+                ctx.db,
+                profileFor("mathstr"),
+            );
+
+            expect(email).toBe("personal-address@gmail.com");
+        },
+    );
+
+    integrationTest(
+        "returns null once the user already has a Feide link",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser(
+                "linked-user@gmail.com",
+            );
+            await ctx.db
+                .update(schema.user)
+                .set({ username: "linked", displayUsername: "linked" })
+                .where(eq(schema.user.id, user.id));
+            await ctx.db.insert(schema.account).values({
+                id: crypto.randomUUID(),
+                userId: user.id,
+                providerId: "feide",
+                accountId: "feide-sub-linked",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+
+            // From the second login on, the provider/sub pair identifies the
+            // user — and the guard is what keeps a hand-picked Lepton username
+            // from capturing someone else's NTNU username.
+            const email = await resolveMigratedEmail(
+                ctx.db,
+                profileFor("linked"),
+            );
+
+            expect(email).toBeNull();
+        },
+    );
+
+    integrationTest(
+        "returns null when no user carries the username",
+        async ({ ctx }) => {
+            const email = await resolveMigratedEmail(
+                ctx.db,
+                profileFor("ukjentbruker"),
+            );
+
+            expect(email).toBeNull();
+        },
+    );
+
+    integrationTest(
+        "returns null when the profile has no principal claim",
+        async ({ ctx }) => {
+            const email = await resolveMigratedEmail(ctx.db, {
+                sub: "feide-sub-x",
+                name: "Uten Claim",
+                email: "x@stud.ntnu.no",
+            });
+
+            expect(email).toBeNull();
+        },
+    );
+});

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -15,6 +15,7 @@ import {
     groupMembership,
     studyProgram,
     studyProgramMembership,
+    user,
 } from "@photon/db/schema";
 import { env } from "@photon/core/env";
 
@@ -68,6 +69,13 @@ interface OpenIDProfile {
      * Email address of the authenticated user. Requires the email attribute group.
      */
     email: string;
+    /**
+     * Secondary user identifiers, e.g. `["feide:mathstr@ntnu.no"]`. Requires
+     * the userid scope. The local part is the NTNU username — the same value
+     * Lepton stored as `user_id`, and therefore what the migration put in
+     * `username`.
+     */
+    "https://n.feide.no/claims/userid_sec"?: string[];
 }
 
 /**
@@ -104,7 +112,7 @@ interface FeideGroup {
  * flow cannot start. A conditional spread in the plugins array would instead
  * widen the tuple and silently drop inferred fields like `banned`.
  */
-export const feidePlugin = () =>
+export const feidePlugin = (db: NodePgDatabase<DbSchema>) =>
     genericOAuth({
         config:
             env.FEIDE_CLIENT_ID && env.FEIDE_CLIENT_SECRET
@@ -122,7 +130,7 @@ export const feidePlugin = () =>
                               "groups-edu",
                               "email",
                           ],
-                          getUserInfo,
+                          getUserInfo: createGetUserInfo(db),
                       },
                   ]
                 : [],
@@ -350,29 +358,108 @@ export function parseValidStudyPrograms(groups: FeideGroup[]): StudyProgram[] {
 }
 
 /**
- * Creates a User object from Feide OpenID profile
- * @param accessToken Access token with "openid" scope from Feide
+ * Extracts the NTNU username from a Feide profile: `feide:mathstr@ntnu.no`
+ * becomes `mathstr`. Identical to the rule Lepton used when it set `user_id`,
+ * which is what the migration stored as `username` — the whole point is that
+ * the two derive the same value. Exported for testing.
  */
-async function getUserInfo(tokens: OAuth2Tokens): Promise<OAuth2UserInfo> {
-    if (!tokens.accessToken) {
-        throw new Error("No access token provided");
+export function feideUsernameOf(profile: {
+    "https://n.feide.no/claims/userid_sec"?: string[];
+}): string | null {
+    for (const id of profile["https://n.feide.no/claims/userid_sec"] ?? []) {
+        if (id.startsWith("feide:")) {
+            const local = id.slice("feide:".length).split("@")[0];
+            if (local) return local.toLowerCase();
+        }
     }
-
-    const response = await fetch("https://auth.dataporten.no/openid/userinfo", {
-        headers: { Authorization: `Bearer ${tokens.accessToken}` },
-    });
-
-    if (!response.ok) {
-        throw new Error("Failed to fetch user info");
-    }
-
-    const profile = (await response.json()) as OpenIDProfile;
-
-    return {
-        id: profile.sub,
-        name: profile.name,
-        email: profile.email,
-        emailVerified: true,
-        image: undefined,
-    };
+    return null;
 }
+
+/**
+ * The email a migrated account should be resolved by, or null to use Feide's.
+ *
+ * Better Auth matches a first-time OAuth login to an existing user by email
+ * alone. Most migrated members (996 of 1686) registered in Lepton with a
+ * personal address, while Feide hands us their NTNU one — so the lookup misses
+ * and they would get a second, empty account while their history sits on the
+ * migrated one.
+ *
+ * Feide has already authenticated the NTNU username, and the migration stored
+ * exactly that as `username`. When it names a user with no Feide link yet,
+ * returning that user's stored email makes Better Auth's own email match land
+ * on the right account. Exported for testing.
+ *
+ * Only accounts without an existing Feide link are considered: after the first
+ * login the provider/sub pair identifies the user before email is consulted,
+ * and the guard closes the edge where an old hand-picked Lepton username
+ * happens to equal someone else's NTNU username.
+ */
+export async function resolveMigratedEmail(
+    db: NodePgDatabase<DbSchema>,
+    profile: OpenIDProfile,
+): Promise<string | null> {
+    const username = feideUsernameOf(profile);
+    if (!username) {
+        return null;
+    }
+
+    const [match] = await db
+        .select({ id: user.id, email: user.email })
+        .from(user)
+        .where(eq(user.username, username))
+        .limit(1);
+
+    if (!match) {
+        return null;
+    }
+
+    const [feideLink] = await db
+        .select({ id: account.id })
+        .from(account)
+        .where(
+            and(
+                eq(account.userId, match.id),
+                eq(account.providerId, FEIDE_PROVIDER_ID),
+            ),
+        )
+        .limit(1);
+
+    return feideLink ? null : match.email;
+}
+
+/**
+ * Creates the profile fetcher for the Feide provider.
+ *
+ * Needs the database because a first-time login may belong to a migrated
+ * member: see {@link resolveMigratedEmail}.
+ */
+const createGetUserInfo =
+    (db: NodePgDatabase<DbSchema>) =>
+    async (tokens: OAuth2Tokens): Promise<OAuth2UserInfo> => {
+        if (!tokens.accessToken) {
+            throw new Error("No access token provided");
+        }
+
+        const response = await fetch(
+            "https://auth.dataporten.no/openid/userinfo",
+            {
+                headers: { Authorization: `Bearer ${tokens.accessToken}` },
+            },
+        );
+
+        if (!response.ok) {
+            throw new Error("Failed to fetch user info");
+        }
+
+        const profile = (await response.json()) as OpenIDProfile;
+
+        const migratedEmail = await resolveMigratedEmail(db, profile);
+
+        return {
+            id: profile.sub,
+            name: profile.name,
+            email: migratedEmail ?? profile.email,
+            emailVerified: true,
+            image: undefined,
+        };
+    };

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -225,7 +225,7 @@ export function createAuth(options: CreateAuthOptions) {
             // Always present so the plugins tuple stays stable for `$Infer`;
             // the Feide provider itself is gated inside feidePlugin() on the
             // credentials being set.
-            feidePlugin(),
+            feidePlugin(options.services.db),
             username(),
             jwt({
                 // Recommended by better-auth docs when using with OAuth Provider plugin


### PR DESCRIPTION
Forarbeid til brukerimporten ([#194](https://github.com/TIHLDE/Photon/pull/194)). **Denne bør merges og deployes FØR brukerne importeres.**

## Problemet

Better Auth kobler en førstegangsinnlogging via OAuth til eksisterende bruker på **e-post alene**. Av de 1686 medlemmene fra Lepton har **996 en privat adresse** (gmail 623, hotmail 133, ...) — mens Feide leverer NTNU-adressen deres. Oppslaget bommer, de får en ny tom konto, og den migrerte historikken blir stående på den gamle.

## Løsningen

Feide har allerede autentisert NTNU-brukernavnet: `userid_sec`-claimet inneholder `feide:mathstr@ntnu.no`, og lokaldelen er identisk med det Lepton lagret som `user_id` — som importen lagrer som `username`. Ekstraksjonen bruker samme regel som Leptons egen `get_feide_user_info_from_jwt`.

Når det brukernavnet peker på en bruker **uten eksisterende Feide-kobling**, returnerer `getUserInfo` den brukerens lagrede e-post — så treffer Better Auths egen e-postmatch riktig konto og kobler den.

## Sikkerhet

- Principal kommer fra autentisert Dataporten-userinfo — Feide *er* autoritativ for NTNU-brukernavn
- Kun kontoer **uten** Feide-kobling vurderes. Fra andre innlogging identifiserer provider/sub-paret brukeren før e-post sjekkes — og guarden lukker kanten der et gammelt egenvalgt Lepton-brukernavn tilfeldigvis er en annens NTNU-brukernavn: når den ekte eieren har logget inn, er broen borte

## Verifisert

- 7 nye tester: principal-ekstraksjon (inkl. ikke-feide-identifikatorer og casing) og oppslaget mot ekte database — migrert bruker adopteres, koblet bruker gjør det ikke, ukjent brukernavn og manglende claim faller tilbake til Feides e-post
- Eksisterende feide- og auth-suiter: 18 tester grønne
- `bun run typecheck`: 8 av 8 pakker

## Rekkefølge

1. Merge + deploy denne
2. Kjør brukerimporten (#194)
3. Claim-flyt for de som likevel ikke matcher («Jeg har allerede bruker» + kode til kontoens *eksisterende* e-post) kommer som egen PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)