### PR TITLE
feat(lepton-migration): import group memberships from Lepton

### DIFF
--- a/packages/lepton-migration/data/.gitignore
+++ b/packages/lepton-migration/data/.gitignore
@@ -1,3 +1,4 @@
 # The user export holds personal data for ~1700 members and must never be
 # committed. It is refetched from Lepton's export endpoint on demand.
 lepton-users.json
+lepton-memberships.json

--- a/packages/lepton-migration/fetch-lepton-memberships.ts
+++ b/packages/lepton-migration/fetch-lepton-memberships.ts
@@ -1,0 +1,106 @@
+/**
+ * Fetches every group's memberships from Lepton into a local JSON cache.
+ *
+ * Walks the groups already imported into Photon and pulls
+ * `/groups/<slug>/memberships/` for each, paginated. Requires the same
+ * superuser token as the user export, read from LEPTON_TOKEN and sent as
+ * X-Csrf-Token — never on the command line.
+ *
+ * Usage: LEPTON_TOKEN=$(cat ...) bun fetch-lepton-memberships.ts
+ */
+const BASE = process.env.LEPTON_API ?? "https://api.tihlde.org";
+const TOKEN = process.env.LEPTON_TOKEN;
+const DELAY_MS = 120;
+
+if (!TOKEN) {
+    console.error("LEPTON_TOKEN må være satt");
+    process.exit(1);
+}
+
+type LeptonMembership = {
+    user: { user_id: string; email: string };
+    group: { slug: string } | string;
+    membership_type: string;
+    created_at: string;
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const get = async (path: string) => {
+    const res = await fetch(`${BASE}${path}`, {
+        headers: {
+            "X-Csrf-Token": TOKEN,
+            "User-Agent": "photon-membership-import/1.0 (TIHLDE)",
+        },
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+        throw new Error(`${path} -> ${res.status}`);
+    }
+    return (await res.json()) as {
+        count: number;
+        next: number | null;
+        results: LeptonMembership[];
+    };
+};
+
+const main = async () => {
+    const groups = (await Bun.file(
+        `${import.meta.dir}/../../packages/lepton-migration/data/lepton-groups.json`,
+    )
+        .json()
+        .catch(() => null)) as { slug: string }[] | null;
+
+    // The group list is small and public — fetch it fresh rather than
+    // depending on an older cache existing.
+    let slugs: string[];
+    if (groups) {
+        slugs = groups.map((g) => g.slug);
+    } else {
+        // /groups/ returns a plain array, not a paginated envelope.
+        const res = await fetch(`${BASE}/groups/`, {
+            headers: { "User-Agent": "photon-membership-import/1.0" },
+        });
+        if (!res.ok) {
+            throw new Error(`/groups/ -> ${res.status}`);
+        }
+        const data = (await res.json()) as
+            | { slug: string }[]
+            | { results: { slug: string }[] };
+        slugs = (Array.isArray(data) ? data : data.results).map((g) => g.slug);
+    }
+
+    console.log(`${slugs.length} grupper å hente medlemskap for`);
+
+    const memberships: Record<string, LeptonMembership[]> = {};
+    let total = 0;
+
+    for (const slug of slugs) {
+        const rows: LeptonMembership[] = [];
+        let page = 1;
+        while (true) {
+            const data = await get(
+                `/groups/${slug}/memberships/?page=${page}`,
+            ).catch((e) => {
+                console.warn(`  ${slug}: ${e.message}`);
+                return null;
+            });
+            if (!data) break;
+            rows.push(...data.results);
+            if (!data.next) break;
+            page++;
+            await sleep(DELAY_MS);
+        }
+        memberships[slug] = rows;
+        total += rows.length;
+        if (rows.length > 0) console.log(`  ${slug}: ${rows.length}`);
+        await sleep(DELAY_MS);
+    }
+
+    const out = `${import.meta.dir}/data/lepton-memberships.json`;
+    await Bun.write(out, JSON.stringify(memberships, null, 2));
+    console.log(`\n${total} medlemskap i ${slugs.length} grupper → ${out}`);
+};
+
+await main();
+process.exit(0);

--- a/packages/lepton-migration/import-memberships.ts
+++ b/packages/lepton-migration/import-memberships.ts
@@ -1,0 +1,138 @@
+/**
+ * Imports group memberships from Lepton's export into Photon.
+ *
+ * Reads the cache written by `fetch-lepton-memberships.ts` and inserts
+ * `org_group_membership` rows. Users and groups must already be imported —
+ * this only draws the edges between them.
+ *
+ * Members are resolved by *email*, not username: seven legacy Lepton ids were
+ * sanitized during the user import ("sunnhø" became sunnho.2), so the email is
+ * the one key guaranteed to agree between the two systems. The Lepton user_id
+ * is translated to an email via the user export cache.
+ *
+ * Idempotent: ON CONFLICT DO NOTHING on the (user, group) pair, and a re-run
+ * reports zero new rows. Without --commit nothing is written.
+ *
+ * Usage: DATABASE_URL=... bun import-memberships.ts [--commit]
+ */
+import { createDb, schema } from "@photon/db";
+
+const commit = process.argv.includes("--commit");
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+    console.error("DATABASE_URL må være satt");
+    process.exit(1);
+}
+
+type LeptonMembership = {
+    user: { user_id: string; email: string };
+    group: { slug: string } | string;
+    membership_type: string;
+    created_at: string;
+};
+
+const ROLE_MAP: Record<string, "member" | "leader"> = {
+    MEMBER: "member",
+    LEADER: "leader",
+};
+
+const main = async () => {
+    const memberships = (await Bun.file(
+        `${import.meta.dir}/data/lepton-memberships.json`,
+    ).json()) as Record<string, LeptonMembership[]>;
+
+    const { users } = (await Bun.file(
+        `${import.meta.dir}/data/lepton-users.json`,
+    ).json()) as { users: { user_id: string; email: string }[] };
+
+    // lepton user_id -> email, from the same export the user import ran on.
+    const emailByLeptonId = new Map(
+        users.map((u) => [u.user_id, u.email.trim().toLowerCase()]),
+    );
+
+    const db = createDb({ connectionString });
+
+    const photonUsers = await db
+        .select({ id: schema.user.id, email: schema.user.email })
+        .from(schema.user);
+    const userIdByEmail = new Map(
+        photonUsers.map((u) => [u.email.trim().toLowerCase(), u.id]),
+    );
+
+    const knownGroups = new Set(
+        (await db.select({ slug: schema.group.slug }).from(schema.group)).map(
+            (g) => g.slug,
+        ),
+    );
+
+    const rows: (typeof schema.groupMembership.$inferInsert)[] = [];
+    let unknownUser = 0;
+    let unknownGroup = 0;
+    let unknownRole = 0;
+
+    for (const [slug, list] of Object.entries(memberships)) {
+        if (!knownGroups.has(slug)) {
+            if (list.length > 0) {
+                unknownGroup += list.length;
+                console.warn(`  gruppe finnes ikke i Photon: ${slug}`);
+            }
+            continue;
+        }
+
+        for (const m of list) {
+            const email =
+                emailByLeptonId.get(m.user.user_id) ??
+                m.user.email?.trim().toLowerCase();
+            const userId = email ? userIdByEmail.get(email) : undefined;
+            if (!userId) {
+                unknownUser++;
+                console.warn(
+                    `  medlem uten Photon-bruker: ${m.user.user_id} i ${slug}`,
+                );
+                continue;
+            }
+
+            const role = ROLE_MAP[m.membership_type];
+            if (!role) {
+                unknownRole++;
+                console.warn(
+                    `  ukjent membership_type ${m.membership_type} for ${m.user.user_id} i ${slug}`,
+                );
+                continue;
+            }
+
+            rows.push({ userId, groupSlug: slug, role });
+        }
+    }
+
+    console.log(`${rows.length} medlemskap klare til innsetting`);
+
+    let inserted = 0;
+    if (commit && rows.length > 0) {
+        for (let i = 0; i < rows.length; i += 500) {
+            const batch = rows.slice(i, i + 500);
+            const result = await db
+                .insert(schema.groupMembership)
+                .values(batch)
+                .onConflictDoNothing()
+                .returning({ userId: schema.groupMembership.userId });
+            inserted += result.length;
+        }
+    }
+
+    console.log();
+    console.log(commit ? "=== KJØRT ===" : "=== TØRRKJØRING (read-only) ===");
+    console.log(`klare:            ${rows.length}`);
+    console.log(
+        commit
+            ? `satt inn:         ${inserted}`
+            : "satt inn:         0 (tørrkjøring)",
+    );
+    console.log(`bruker mangler:   ${unknownUser}`);
+    console.log(`gruppe mangler:   ${unknownGroup}`);
+    console.log(`ukjent rolle:     ${unknownRole}`);
+};
+
+await main();
+process.exit(0);


### PR DESCRIPTION
Basert på `dev` denne gangen — endringen er allerede kjørt mot prod, så ingenting haster til `main`; den følger neste ordinære promotering.

## Hva

Brukere og grupper var importert hver for seg, men **koblingene** manglet — `org_group_membership` hadde 6 håndlagde rader, og alle gruppesider så tomme ut. Dette henter kantene: **6256 medlemskap på tvers av alle 58 grupper**, per gruppe fra Leptons autentiserte memberships-endepunkt.

## Design

- **Oppslag på e-post, ikke brukernavn** — sju legacy-id-er ble renvasket under brukerimporten (`sunnhø` → `sunnho.2`), så e-post er eneste nøkkel som garantert stemmer i begge systemer
- `MEMBER`/`LEADER` → `member`/`leader`-enumen
- `ON CONFLICT DO NOTHING` på (bruker, gruppe) — gjenkjøring gir null
- Medlemskaps-cachen står på PII-gitignore-listen sammen med bruker-eksporten

## Kjørt mot prod (etter full generalprøve på kopi)

```
klare:      6256
satt inn:   6246    (4 kilde-duplikater kollapser korrekt, 6 eksisterende hoppes over)
index:        26 medlemmer
grupper med medlemmer:  58 av 58
gjenkjøring:   0
```

Én eksisterende rad beholdt gammel rolle gjennom conflict-skippet (Index-leder sto som medlem) og ble rettet manuelt.

## ⚠️ Avdekket følgefeil

`GET /api/groups/{slug}/members` returnerer kun `userId` — ingen navn eller bilde — så gruppesidene viser rå ID-er nå som det finnes medlemmer å vise. Egen sak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)