### PR TITLE
feat(groups): include public user info in group members list

### DIFF
--- a/apps/api/src/routes/groups/members/list.ts
+++ b/apps/api/src/routes/groups/members/list.ts
@@ -38,11 +38,19 @@ export const listMembersRoute = route().get(
             });
         }
 
-        // Get members
-        const members = await db
-            .select()
-            .from(schema.groupMembership)
-            .where(eq(schema.groupMembership.groupSlug, groupSlug));
+        // Get members with their public user info (name/image for display)
+        const members = await db.query.groupMembership.findMany({
+            where: eq(schema.groupMembership.groupSlug, groupSlug),
+            with: {
+                user: {
+                    columns: {
+                        id: true,
+                        name: true,
+                        image: true,
+                    },
+                },
+            },
+        });
 
         return c.json(members);
     },

--- a/apps/api/src/routes/groups/schema.ts
+++ b/apps/api/src/routes/groups/schema.ts
@@ -186,6 +186,16 @@ export const memberSchema = Schema(
         updatedAt: z
             .string()
             .meta({ description: "Membership update timestamp" }),
+        user: z
+            .object({
+                id: z.string().meta({ description: "User ID" }),
+                name: z.string().meta({ description: "User display name" }),
+                image: z
+                    .string()
+                    .nullable()
+                    .meta({ description: "User profile image URL" }),
+            })
+            .meta({ description: "Public user info for the member" }),
     }),
 );
 

--- a/apps/api/src/test/groups/members.test.ts
+++ b/apps/api/src/test/groups/members.test.ts
@@ -407,6 +407,20 @@ describe("group members", () => {
                 const userIds = json.map((m) => m.userId);
                 expect(userIds).toContain(member1.user.id);
                 expect(userIds).toContain(member2.user.id);
+
+                // Each member includes public user info for display
+                const m1 = json.find((m) => m.userId === member1.user.id);
+                const m2 = json.find((m) => m.userId === member2.user.id);
+                expect(m1?.user).toMatchObject({
+                    id: member1.user.id,
+                    name: "Member 1",
+                });
+                expect(m2?.user).toMatchObject({
+                    id: member2.user.id,
+                    name: "Member 2",
+                });
+                // No sensitive fields leak through the user relation
+                expect(m1?.user).not.toHaveProperty("email");
             },
             500_000,
         );

--- a/apps/kvark/src/components/group-member-row.tsx
+++ b/apps/kvark/src/components/group-member-row.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Avatar, AvatarFallback } from "@tihlde/ui/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
 import { Badge } from "@tihlde/ui/ui/badge";
 import { Button } from "@tihlde/ui/ui/button";
 import { Card } from "@tihlde/ui/ui/card";
@@ -40,6 +40,9 @@ export function GroupMemberRow({
                 className="flex min-w-0 flex-1 items-center gap-3"
             >
                 <Avatar className="size-10">
+                    {member.image ? (
+                        <AvatarImage src={member.image} alt={member.name} />
+                    ) : null}
                     <AvatarFallback>{initials(member.name)}</AvatarFallback>
                 </Avatar>
                 <div className="flex min-w-0 flex-1 flex-col">

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -89,13 +89,14 @@ export function mapGroup(group: ApiGroup, leader?: string): Group {
 
 /**
  * Map an API group membership to a display member.
- * The members endpoint only exposes `userId` (no name/image lookup exists),
- * so the userId is used as the display identifier.
+ * The members endpoint includes public user info (name/image); fall back to
+ * the userId if the user relation is missing for some reason.
  */
 export function mapMember(member: ApiGroupMember): Member {
     return {
         id: member.userId,
-        name: member.userId,
+        name: member.user?.name ?? member.userId,
+        image: member.user?.image ?? undefined,
         role: member.role,
         joined: formatGroupDate(member.createdAt),
     };

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2425,6 +2425,15 @@ export interface components {
             createdAt: string;
             /** @description Membership update timestamp */
             updatedAt: string;
+            /** @description Public user info for the member */
+            user: {
+                /** @description User ID */
+                id: string;
+                /** @description User display name */
+                name: string;
+                /** @description User profile image URL */
+                image: string | null;
+            };
         };
         GroupMemberList: components["schemas"]["GroupMember"][];
         GroupMembership: {


### PR DESCRIPTION
## Hva

`GET /api/groups/{groupSlug}/members` returnerte kun rå medlemskapsrader (`userId`, `groupSlug`, `role`, timestamps), så gruppesider i prod viste rå bruker-ID-er som navn etter at 6256 medlemskap ble importert fra Lepton.

Endepunktet embedder nå `user: { id, name, image }` per medlem via drizzle-relasjonen — samme mønster og samme trygge kolonnesett (ingen e-post) som event-registreringslisten.

## Endringer

- **API**: `groups/members/list.ts` bruker `db.query.groupMembership.findMany` med `with: { user: { columns: { id, name, image } } }`
- **OpenAPI**: `GroupMember`-skjemaet utvidet med `user`-objektet
- **SDK**: regenerert (`bun run codegen`)
- **Kvark**: `mapMember` bruker `user.name`/`user.image` (fallback til userId); `GroupMemberRow` viser `AvatarImage` når bilde finnes. Leder-navnet i headeren fikses automatisk siden det hentes fra medlemslisten.
- **Test**: `members.test.ts` asserter at `user.name`/`user.id` følger med og at `email` ikke lekker

## Verifisert

- `bun run typecheck` (4/4 pakker), lint og format rene
- 17/17 integrasjonstester passert (Testcontainers, ekte Postgres)
- Live mot dev-DB: uautentisert kall returnerer navn, ingen e-post
- Browser: `/grupper/index` viser ekte navn for leder og alle 28 medlemmer

🤖 Generated with [Claude Code](https://claude.com/claude-code)