### PR TITLE
feat(groups): show group logos everywhere and import them into our bucket

### DIFF
--- a/apps/api/src/db/import-group-logos.ts
+++ b/apps/api/src/db/import-group-logos.ts
@@ -1,0 +1,96 @@
+/**
+ * One-shot backfill: copy group logos from Lepton's Azure blob storage into
+ * our own S3/MinIO bucket and rewrite `org_group.image_url` to point at the
+ * Photon asset route (`/api/assets/...`).
+ *
+ * Idempotent: groups whose image_url already points at `/api/assets/` are
+ * skipped, and re-runs overwrite the same keys.
+ *
+ * Run with:
+ *   cd apps/api && bun run src/db/import-group-logos.ts
+ */
+import { createDb, schema } from "@photon/db";
+import { eq, isNotNull } from "drizzle-orm";
+import { env } from "~/lib/env";
+import { createStorageClient } from "~/lib/storage";
+
+const EXTENSION_BY_CONTENT_TYPE: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+};
+
+function extensionFor(contentType: string | null, url: string): string {
+    if (contentType && EXTENSION_BY_CONTENT_TYPE[contentType]) {
+        return EXTENSION_BY_CONTENT_TYPE[contentType];
+    }
+    const pathExt = new URL(url).pathname.split(".").pop()?.toLowerCase();
+    if (pathExt && ["png", "jpg", "jpeg", "gif", "webp"].includes(pathExt)) {
+        return pathExt === "jpeg" ? "jpg" : pathExt;
+    }
+    return "png";
+}
+
+async function main() {
+    const db = createDb({ connectionString: env.DATABASE_URL });
+    const bucket = await createStorageClient({ db });
+
+    const groups = await db.query.group.findMany({
+        where: isNotNull(schema.group.imageUrl),
+    });
+
+    let imported = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    for (const group of groups) {
+        const sourceUrl = group.imageUrl;
+        if (!sourceUrl) continue;
+
+        if (sourceUrl.includes("/api/assets/")) {
+            skipped++;
+            continue;
+        }
+
+        try {
+            const response = await fetch(sourceUrl);
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+
+            const contentType = response.headers.get("content-type");
+            const buffer = Buffer.from(await response.arrayBuffer());
+            const ext = extensionFor(contentType, sourceUrl);
+            const key = `group-logos/${group.slug}.${ext}`;
+
+            await bucket.upload(key, buffer, {
+                originalFilename: `${group.slug}.${ext}`,
+                contentType:
+                    contentType ?? `image/${ext === "jpg" ? "jpeg" : ext}`,
+                visibility: "public",
+            });
+            // Promote so the staged-asset cleanup job never reaps the logo.
+            await bucket.promoteAsset(key);
+
+            const newUrl = `${env.ROOT_URL}/api/assets/${key}`;
+            await db
+                .update(schema.group)
+                .set({ imageUrl: newUrl })
+                .where(eq(schema.group.slug, group.slug));
+
+            imported++;
+            console.log(`✅ ${group.slug} → ${newUrl} (${buffer.length} B)`);
+        } catch (error) {
+            failed++;
+            console.error(`❌ ${group.slug}: ${sourceUrl}`, error);
+        }
+    }
+
+    console.log(
+        `\nDone. imported=${imported} skipped=${skipped} failed=${failed}`,
+    );
+    process.exit(failed > 0 ? 1 : 0);
+}
+
+await main();

--- a/apps/kvark/src/components/group-detail-header.tsx
+++ b/apps/kvark/src/components/group-detail-header.tsx
@@ -1,4 +1,4 @@
-import { Avatar, AvatarFallback } from "@tihlde/ui/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
 import { Badge } from "@tihlde/ui/ui/badge";
 import { Button } from "@tihlde/ui/ui/button";
 import { Crown, HandCoins, Mail } from "lucide-react";
@@ -23,6 +23,9 @@ export function GroupDetailHeader({
         <DetailHeader
             avatar={
                 <Avatar className="size-16 shrink-0 md:row-span-3 md:aspect-square md:h-full md:max-h-32 md:w-auto">
+                    {group.imageUrl ? (
+                        <AvatarImage src={group.imageUrl} alt={group.name} />
+                    ) : null}
                     <AvatarFallback className="text-2xl">
                         {initials(group.name)}
                     </AvatarFallback>

--- a/apps/kvark/src/routes/_app/grupper.index.tsx
+++ b/apps/kvark/src/routes/_app/grupper.index.tsx
@@ -57,6 +57,7 @@ type ApiGroup = {
     slug: string;
     type: string;
     contactEmail: string | null;
+    imageUrl: string | null;
 };
 
 function sectionFrom(
@@ -76,6 +77,7 @@ function sectionFrom(
                 name: g.name,
                 slug: g.slug,
                 email: g.contactEmail ?? undefined,
+                logoUrl: g.imageUrl ?? undefined,
             })),
     };
 }

--- a/apps/kvark/src/routes/_app/profil/$id/medlemskap.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/medlemskap.tsx
@@ -1,6 +1,7 @@
 import { authQueryOptions } from "#/api/auth";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
 import { Badge } from "@tihlde/ui/ui/badge";
 import { Card } from "@tihlde/ui/ui/card";
 import {
@@ -44,6 +45,17 @@ function RouteComponent() {
                         size="sm"
                         className="flex-row items-center gap-3 px-3"
                     >
+                        <Avatar className="size-10 shrink-0">
+                            {group.imageUrl ? (
+                                <AvatarImage
+                                    src={group.imageUrl}
+                                    alt={group.name}
+                                />
+                            ) : null}
+                            <AvatarFallback>
+                                {group.name.slice(0, 2).toUpperCase()}
+                            </AvatarFallback>
+                        </Avatar>
                         <div className="flex min-w-0 flex-1 flex-col">
                             <span className="truncate font-medium">
                                 {group.name}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -299,6 +299,7 @@ export function createAuth(options: CreateAuthOptions) {
                         slug: g.groupSlug,
                         name: g.group.name,
                         type: g.group.type,
+                        imageUrl: g.group.imageUrl,
                         role: g.role,
                     })),
                 };

--- a/packages/sdk/src/generated/session-types.ts
+++ b/packages/sdk/src/generated/session-types.ts
@@ -45,6 +45,7 @@ export type ExtendedSession = {
         slug: string;
         name: string;
         type: string;
+        imageUrl: string | null;
         role: "member" | "leader";
 
     }[];


### PR DESCRIPTION
## Hva

Gruppelogoer vises nå overalt der de skal, og logoene hentes fra vår egen bucket i stedet for Leptons Azure-blob.

### Backend
- **Nytt script** `apps/api/src/db/import-group-logos.ts`: laster ned hver gruppes logo fra Lepton (`leptonstoragepro...`), laster opp i S3/MinIO under `group-logos/<slug>.<ext>` og skriver om `org_group.image_url` til `{ROOT_URL}/api/assets/group-logos/...`. Idempotent (hopper over URL-er som allerede peker på `/api/assets/`), og promoterer asset-raden så staged-cleanup ikke sletter logoene.
- Session-gruppene fra `customSession` inkluderer nå `imageUrl` (+ regenererte SDK-typer).

### Frontend (kvark)
- **Gruppeoversikt** (`/grupper`): `sectionFrom` droppet `imageUrl` — nå mappes `logoUrl` inn, så både liste-, hierarki- og mobilvisning viser logo.
- **Gruppedetalj**: header-avataren viser logoen (før: kun initialer).
- **Profil → Medlemskap**: viser gruppe-avatar per medlemskap.
- Om-tab, ny-student, opptak og arrangement-arrangør brukte allerede `imageUrl` og får logoene automatisk.

## Kjøring mot prod

```bash
cd apps/api && bun run src/db/import-group-logos.ts
```
med prod `DATABASE_URL`/S3-creds og `ROOT_URL` satt til prod-API-et.

## Verifisert
- Script kjørt mot dev-DB: **36 importert, 0 feilet**; `GET /api/assets/group-logos/index.png` → 200 image/png fra bucketen
- Browser-verifisert: liste-, hierarki- og detaljvisning viser logoer; `get-session` returnerer `imageUrl` per gruppe
- `bun run typecheck` (8/8), `bun run lint`, `bun run format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)