### PR TITLE
feat(lepton-migration): consume Lepton's table export instead of MySQL

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -205,6 +205,7 @@
       },
       "devDependencies": {
         "@photon/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "typescript": "catalog:",
       },

--- a/packages/lepton-migration/data/.gitignore
+++ b/packages/lepton-migration/data/.gitignore
@@ -2,3 +2,7 @@
 # committed. It is refetched from Lepton's export endpoint on demand.
 lepton-users.json
 lepton-memberships.json
+
+# Table dumps from the photon-table-export endpoint: registrations, fines,
+# payments and form answers for real members. Refetch on demand.
+tables/

--- a/packages/lepton-migration/fetch-lepton-tables.ts
+++ b/packages/lepton-migration/fetch-lepton-tables.ts
@@ -1,0 +1,139 @@
+/**
+ * Fetches every migration table from Lepton into a local JSON cache.
+ *
+ * Lepton exposes `GET /migration/photon-table-export/` (superuser-gated,
+ * paged) because Photon has no direct access to its MySQL database. This
+ * pulls each table the migration pipeline reads and caches it under
+ * `data/tables/<table>.json` as an array of row objects — the shape
+ * `src/mysql.ts` serves back to the phases when LEPTON_TABLES_DIR is set,
+ * standing in for a live MySQL connection.
+ *
+ * The auth token is read from the LEPTON_TOKEN environment variable and sent
+ * in the X-Csrf-Token header — never passed on the command line, so it stays
+ * out of shell history and process listings.
+ *
+ * Usage: LEPTON_TOKEN=$(cat path/to/token) bun fetch-lepton-tables.ts [table...]
+ */
+const BASE = process.env.LEPTON_API ?? "https://api.tihlde.org";
+const TOKEN = process.env.LEPTON_TOKEN;
+const PAGE_SIZE = 1000;
+
+/** Mirrors ALLOWED_TABLES in Lepton's photon_table_export view. */
+const TABLES = [
+    "career_jobpost",
+    "communication_notification",
+    "content_category",
+    "content_event",
+    "content_event_favorite_users",
+    "content_news",
+    "content_prioritypool",
+    "content_prioritypool_groups",
+    "content_registration",
+    "content_strike",
+    "content_user",
+    "django_content_type",
+    "emoji_reaction",
+    "forms_answer",
+    "forms_answer_selected_options",
+    "forms_eventform",
+    "forms_field",
+    "forms_form",
+    "forms_groupform",
+    "forms_option",
+    "forms_submission",
+    "group_fine",
+    "group_group",
+    "group_membership",
+    "payment_order",
+    "payment_paidevent",
+];
+
+if (!TOKEN) {
+    console.error(
+        "LEPTON_TOKEN må være satt, f.eks. LEPTON_TOKEN=$(cat .lepton-token) bun fetch-lepton-tables.ts",
+    );
+    process.exit(1);
+}
+
+type ExportPage = {
+    table: string;
+    count: number;
+    offset: number;
+    limit: number;
+    columns: string[];
+    rows: unknown[][];
+};
+
+async function fetchTable(table: string): Promise<Record<string, unknown>[]> {
+    const rows: Record<string, unknown>[] = [];
+    let offset = 0;
+    let total = Infinity;
+
+    while (offset < total) {
+        const res = await fetch(
+            `${BASE}/migration/photon-table-export/?table=${table}&offset=${offset}&limit=${PAGE_SIZE}`,
+            {
+                headers: {
+                    "X-Csrf-Token": TOKEN!,
+                    "User-Agent": "photon-table-import/1.0 (TIHLDE)",
+                },
+            },
+        );
+
+        if (!res.ok) {
+            const body = await res.text();
+            console.error(
+                `Lepton svarte ${res.status} for ${table}: ${body.slice(0, 200)}`,
+            );
+            if (res.status === 401 || res.status === 403) {
+                console.error(
+                    "Sjekk at tokenet tilhører en superbruker i HS/Index.",
+                );
+            }
+            process.exit(1);
+        }
+
+        const page = (await res.json()) as ExportPage;
+        total = page.count;
+
+        for (const row of page.rows) {
+            rows.push(
+                Object.fromEntries(
+                    page.columns.map((column, i) => [column, row[i]]),
+                ),
+            );
+        }
+
+        offset += page.rows.length;
+        // A short page before the reported total means rows moved under us —
+        // stop rather than looping on a stale count.
+        if (page.rows.length < Math.min(PAGE_SIZE, total - page.offset)) break;
+    }
+
+    if (rows.length !== total) {
+        console.warn(
+            `  ${table}: Lepton oppga ${total} rader, fikk ${rows.length}`,
+        );
+    }
+    return rows;
+}
+
+const requested = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+const targets = requested.length > 0 ? requested : TABLES;
+
+for (const table of targets) {
+    if (!TABLES.includes(table)) {
+        console.error(`Ukjent tabell: ${table}`);
+        process.exit(1);
+    }
+}
+
+const outDir = `${import.meta.dir}/data/tables`;
+
+for (const table of targets) {
+    const rows = await fetchTable(table);
+    await Bun.write(`${outDir}/${table}.json`, JSON.stringify(rows));
+    console.log(`${table}: ${rows.length} rader → data/tables/${table}.json`);
+}
+
+process.exit(0);

--- a/packages/lepton-migration/package.json
+++ b/packages/lepton-migration/package.json
@@ -6,7 +6,8 @@
     "type": "module",
     "scripts": {
         "migrate": "bun src/index.ts",
-        "verify": "bun src/index.ts --verify-only"
+        "verify": "bun src/index.ts --verify-only",
+        "typecheck": "tsc --noEmit"
     },
     "dependencies": {
         "@photon/auth": "workspace:*",
@@ -18,6 +19,7 @@
     },
     "devDependencies": {
         "@photon/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "typescript": "catalog:"
     }

--- a/packages/lepton-migration/src/index.ts
+++ b/packages/lepton-migration/src/index.ts
@@ -5,18 +5,23 @@
  *
  * Usage:
  *   bun src/index.ts --mysql-url="mysql://root:pass@localhost:3306/lepton" [options]
+ *   bun src/index.ts --mysql-url="json:./data/tables" [options]
+ *
+ * The json: form reads the table dumps fetched by fetch-lepton-tables.ts from
+ * Lepton's superuser-gated export endpoint — the mode used against prod,
+ * where no MySQL access exists.
  *
  * Options:
- *   --mysql-url   MySQL connection URL (required, or set MYSQL_URL env)
+ *   --mysql-url   MySQL connection URL or json:<dir> (required, or MYSQL_URL env)
  *   --phase       Run only a specific phase (e.g. --phase=users)
  *   --force       Truncate target tables before inserting
  *   --verify-only Run only verification (no migration)
  */
-import { createDb } from "@photon/db";
-import { createAuth } from "@photon/auth";
+import { createDb, schema } from "@photon/db";
+import { createAuth, drizzleAdapter } from "@photon/auth";
 import { env } from "@photon/core/env";
-import { QueueManager, createRedisClient } from "@photon/core/cache";
-import { createEmailTransporter } from "@photon/email";
+import { InMemoryCache } from "@photon/core/services/cache";
+import { ConsoleEmailService } from "@photon/core/services";
 import { connectMySQL, closeMySQL } from "./mysql";
 import { skippedUsers, userIdMap, eventIdMap, newsIdMap } from "./mappings";
 
@@ -115,14 +120,31 @@ async function main() {
         return;
     }
 
-    // Create auth instance for user migration
-    const redis = await createRedisClient(env.REDIS_URL);
-    const queue = new QueueManager(env.REDIS_URL);
-    const mailer = createEmailTransporter();
-    const auth = createAuth(
-        { db, redis, mailer, queue, bucket: null as any },
-        { isDev: true },
-    );
+    // Auth instance for the user phase. The migration never sends email and
+    // needs no shared cache, so in-memory/console services suffice.
+    const auth = createAuth({
+        isDevMode: env.NODE_ENV === "development" || env.NODE_ENV === "test",
+        secret: env.AUTH_SECRET,
+        services: {
+            database: drizzleAdapter(db, { provider: "pg", schema }),
+            db,
+            cache: new InMemoryCache(),
+            email: new ConsoleEmailService(),
+        },
+        oauth: {
+            pages: {
+                consent: "/consent",
+                login: "/login",
+            },
+        },
+        urls: {
+            backend: env.ROOT_URL,
+            frontend: env.WEBSITE_URL,
+            additionalTrusted: [env.ROOT_URL, env.WEBSITE_URL],
+            basePath: "/api/auth",
+        },
+        DANGEROUSLY_SET_INSECURE_HASHING_ALGORITHM: false,
+    });
 
     const startTime = Date.now();
 

--- a/packages/lepton-migration/src/mysql.ts
+++ b/packages/lepton-migration/src/mysql.ts
@@ -1,28 +1,84 @@
 /**
- * MySQL connection helper using mysql2/promise for async queries.
+ * Data source for the migration phases.
+ *
+ * Two modes behind the same `query()` interface:
+ *
+ * - A real MySQL connection (mysql2/promise), when a `mysql://` url is given.
+ * - A JSON directory (`json:<dir>`), holding one `<table>.json` per table as
+ *   fetched by `fetch-lepton-tables.ts` from Lepton's superuser-gated export
+ *   endpoint. Photon has no access to Lepton's database in production, so
+ *   this is the mode the real migration runs in.
+ *
+ * The phases only ever run `SELECT * FROM <table>` (plus one column
+ * projection), so JSON mode resolves the table name from the FROM clause and
+ * returns the cached rows. Timestamps arrive as ISO-8601 strings and are
+ * revived to Date objects, matching what mysql2 returns with
+ * `dateStrings: false`; naive datetimes are UTC (Django stores UTC), so a
+ * missing offset gets a Z rather than being read in local time.
  */
 import mysql from "mysql2/promise";
 
-let connection: mysql.Connection;
+let connection: mysql.Connection | null = null;
+let tablesDir: string | null = null;
 
-export async function connectMySQL(url: string): Promise<mysql.Connection> {
+const DATETIME_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const HAS_OFFSET_PATTERN = /(Z|[+-]\d{2}:?\d{2})$/;
+
+function reviveDates(row: Record<string, unknown>): Record<string, unknown> {
+    for (const [key, value] of Object.entries(row)) {
+        if (typeof value !== "string") continue;
+        if (DATETIME_PATTERN.test(value)) {
+            row[key] = new Date(
+                HAS_OFFSET_PATTERN.test(value) ? value : `${value}Z`,
+            );
+        } else if (DATE_PATTERN.test(value)) {
+            row[key] = new Date(`${value}T00:00:00Z`);
+        }
+    }
+    return row;
+}
+
+export async function connectMySQL(url: string): Promise<void> {
+    if (url.startsWith("json:")) {
+        tablesDir = url.slice("json:".length);
+        console.log(`Reading Lepton tables from ${tablesDir} (JSON export)`);
+        return;
+    }
+
     connection = await mysql.createConnection({
         uri: url,
         timezone: "+00:00",
         dateStrings: false,
     });
     console.log("Connected to MySQL (Lepton)");
-    return connection;
 }
 
 export async function query<T = Record<string, unknown>>(
     sql: string,
 ): Promise<T[]> {
-    const [rows] = await connection.query(sql);
+    if (tablesDir) {
+        const table = sql.match(/FROM\s+([a-z_]+)/i)?.[1];
+        if (!table) {
+            throw new Error(`JSON mode cannot resolve a table from: ${sql}`);
+        }
+        const file = Bun.file(`${tablesDir}/${table}.json`);
+        if (!(await file.exists())) {
+            throw new Error(
+                `${tablesDir}/${table}.json missing — run fetch-lepton-tables.ts first`,
+            );
+        }
+        const rows = (await file.json()) as Record<string, unknown>[];
+        return rows.map(reviveDates) as T[];
+    }
+
+    const [rows] = await connection!.query(sql);
     return rows as T[];
 }
 
 export async function closeMySQL(): Promise<void> {
-    await connection.end();
-    console.log("MySQL connection closed");
+    if (connection) {
+        await connection.end();
+        console.log("MySQL connection closed");
+    }
 }

--- a/packages/lepton-migration/tsconfig.json
+++ b/packages/lepton-migration/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "@photon/tsconfig/node/bundler.json",
     "compilerOptions": {
         "outDir": "./dist",
-        "strict": true
+        "strict": true,
+        "types": ["node", "bun"]
     },
     "include": ["src"],
     "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Hva

Gjør at hele den eksisterende migrasjonspipelinen (fase 01–14: registreringer, prikker, betalinger, forms, favoritter, reaksjoner, varsler …) kan kjøre mot prod **uten MySQL-tilgang**, via det nye superadmin-gatede tabelleksport-endepunktet i Lepton ([TIHLDE/Lepton#1000](https://github.com/TIHLDE/Lepton/pull/1000)).

- **`fetch-lepton-tables.ts`**: pager alle 26 tabellene ned til `data/tables/<tabell>.json` (token via `LEPTON_TOKEN`-env, aldri på kommandolinjen)
- **`src/mysql.ts`**: `query()` får en `json:<dir>`-modus — samme grensesnitt, leser dumpene, reviver ISO-timestamps til `Date` (naive tolkes som UTC, som mysql2-oppsettet gjorde). Alle fasene kjører uendret.
- **`src/index.ts`**: reparert mot dagens `createAuth`-signatur og service-oppsett (hadde råtnet uten typecheck)
- **`typecheck`-script** lagt til i pakken så det ikke råtner stille igjen
- `data/.gitignore` dekker `tables/` — dumpene inneholder PII

## Verifisert

- `bun run typecheck` grønt (pakken er nå med, 9 tasks)
- Shim smoke-testet: datetime/date-strenger → `Date` (UTC), strenger/tall/null urørt, manglende tabellfil gir tydelig feil, kolonneprojeksjon-spørringen løses
- Fetch-skriptet nekter å kjøre uten `LEPTON_TOKEN`

## Kjøreplan (etter at begge PR-er er ute)

1. Deploy Lepton-endepunktet (dev → master)
2. `LEPTON_TOKEN=... bun fetch-lepton-tables.ts`
3. `MYSQL_URL="json:./data/tables" bun src/index.ts --phase=<fase>` mot prod, fase for fase
4. Fjern begge migrasjonsendepunktene i Lepton + roter tokenet

🤖 Generated with [Claude Code](https://claude.com/claude-code)