### PR TITLE
fix(kvark): stop theme from flipping on navigation

### DIFF
--- a/apps/kvark/src/integrations/theme.tsx
+++ b/apps/kvark/src/integrations/theme.tsx
@@ -30,14 +30,41 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     const [mounted, setMounted] = useState(false);
 
     useEffect(() => {
+        // The inline script in __root.tsx applied the theme class before
+        // hydration — adopt it as the source of truth for React state.
         setTheme(readTheme());
         setMounted(true);
     }, []);
 
+    // The class on <html> is derived from state, never toggled ad hoc. This
+    // re-applies it after anything outside our control (e.g. React recovering
+    // from a hydration error re-renders <html> and drops attributes it does
+    // not own) has wiped it.
+    useEffect(() => {
+        if (!mounted) {
+            return;
+        }
+        const root = document.documentElement;
+        root.classList.toggle("dark", theme === "dark");
+
+        // Guard against external wipes between renders: if the class list is
+        // mutated to disagree with state, restore it.
+        const observer = new MutationObserver(() => {
+            const hasDark = root.classList.contains("dark");
+            if (hasDark !== (theme === "dark")) {
+                root.classList.toggle("dark", theme === "dark");
+            }
+        });
+        observer.observe(root, {
+            attributes: true,
+            attributeFilter: ["class"],
+        });
+        return () => observer.disconnect();
+    }, [theme, mounted]);
+
     const toggleTheme = useCallback(() => {
         setTheme((prev) => {
             const next = prev === "dark" ? "light" : "dark";
-            document.documentElement.classList.toggle("dark", next === "dark");
             window.localStorage.setItem(THEME_STORAGE_KEY, next);
             return next;
         });


### PR DESCRIPTION
## What

Fixes the bug where the site's theme would switch by itself (dark → light) when navigating between pages, without touching the theme toggle.

## Why

The `dark` class on `<html>` was applied once by the inline init script in `__root.tsx` and toggled ad hoc by the theme switcher — it lived entirely outside React's knowledge (`<html>` is rendered with no `className` prop). When React 19 recovers from a hydration error it re-renders `<html>` and strips attributes it doesn't own, wiping the class. Nothing ever re-applied it, so the theme silently flipped to light until the user toggled twice.

## How

`ThemeProvider` (`apps/kvark/src/integrations/theme.tsx`) now owns the class:

- The `dark` class on `<html>` is **derived from React state** via an effect instead of being toggled directly
- A `MutationObserver` on the `class` attribute restores the class immediately if anything external (React recovery renders, third-party scripts) removes it
- `toggleTheme` just updates state + localStorage; the DOM follows

The inline pre-hydration init script is unchanged, so there is still no flash of the wrong theme on load.

## Verified

- `bun run typecheck` (9/9 packages), oxlint, oxfmt pass
- In the browser (dev server from this branch): OS-dark loads dark and survives SPA navigation and full reloads; simulating the wipe (`document.documentElement.removeAttribute('class')`) restores `dark` within a tick while preserving foreign classes; toggle works both ways and persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)