### PR TITLE
fix(kvark): stop transient session-check failures from logging users out

### DIFF
--- a/apps/kvark/src/api/auth.ts
+++ b/apps/kvark/src/api/auth.ts
@@ -41,16 +41,13 @@ export const getAuthSession = createIsomorphicFn()
 export const authQueryOptions = queryOptions({
     queryKey: ["auth"],
     staleTime: 1000 * 60 * 2, // 2 minutes we want to check this frequently
-    async queryFn() {
-        try {
-            return await getAuthSession();
-        } catch (error) {
-            if (error instanceof AuthError) {
-                return undefined;
-            }
-            throw error;
-        }
-    },
+    // A failed session check (network hiccup, API 5xx) is NOT the same as
+    // being logged out — getAuthSession only resolves to null when the
+    // backend definitively says there is no session. Let errors throw so
+    // React Query retries and keeps the previous session in cache instead
+    // of silently caching "logged out".
+    retry: 2,
+    queryFn: () => getAuthSession(),
 });
 
 /**
@@ -59,14 +56,14 @@ export const authQueryOptions = queryOptions({
  */
 export async function authClient() {
     try {
-        const auth = await getQueryClient().ensureQueryData(authQueryOptions);
-        if (auth == null) {
-            invalidateAuth();
-        }
-        return auth;
+        return await getQueryClient().ensureQueryData(authQueryOptions);
     } catch {
-        invalidateAuth();
-        return undefined;
+        // The session check itself failed (after retries). Fall back to the
+        // last known session rather than treating the user as logged out —
+        // redirecting an authenticated user to /login on a transient error
+        // is worse than briefly trusting stale auth state. The API still
+        // enforces permissions server-side on every request.
+        return getQueryClient().getQueryData(authQueryOptions.queryKey);
     }
 }
 


### PR DESCRIPTION
## What

Fixes intermittent redirects to `/login` for users who are already authenticated.

## Why

In `apps/kvark/src/api/auth.ts`, **any** error from the session check — including transient network failures, timeouts, and API 5xx responses — was treated the same as "not logged in":

- `authQueryOptions.queryFn` caught `AuthError` and returned `undefined` as a *successful* result, so React Query never retried and cached the logged-out state
- `authClient()` caught everything and returned `undefined`, so `authClientWithRedirect` threw a redirect to `/login`

One failed `getSession` request while navigating to a protected route was enough to bounce a user with a fully valid cookie to the login page — hence the intermittent behavior.

## How

- Let session-check errors throw, with `retry: 2`, so React Query retries and keeps the previous session in cache on a failed background refetch
- If the check still fails after retries, `authClient()` falls back to the last known cached session instead of treating the user as logged out (the API still enforces permissions server-side on every request)
- A definitive logged-out response (`session.data === null`, no error) still redirects exactly as before

## Verified

- `bun run typecheck` and `bun run lint` pass (only pre-existing warnings in unrelated files)
- In the browser against the local stack: login works, protected route (`/qr-koder`) loads while authenticated, and after sign-out navigating there correctly redirects to `/login?redirectTo=%2Fqr-koder` with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)