### PR TITLE
fix(fines): show user names instead of user IDs in bøter UI

### DIFF
--- a/apps/api/src/routes/groups/fines/get.ts
+++ b/apps/api/src/routes/groups/fines/get.ts
@@ -40,12 +40,27 @@ export const getFineRoute = route().get(
             });
         }
 
-        const fine = await db
-            .select()
-            .from(schema.fine)
-            .where(eq(schema.fine.id, fineId))
-            .limit(1)
-            .then((res) => res[0]);
+        // Include public user info (name/image) so the UI can display names
+        // instead of user IDs
+        const fine = await db.query.fine.findFirst({
+            where: eq(schema.fine.id, fineId),
+            with: {
+                user: {
+                    columns: {
+                        id: true,
+                        name: true,
+                        image: true,
+                    },
+                },
+                createdByUser: {
+                    columns: {
+                        id: true,
+                        name: true,
+                        image: true,
+                    },
+                },
+            },
+        });
 
         if (!fine) {
             throw new HTTPException(404, {

--- a/apps/api/src/routes/groups/fines/list.ts
+++ b/apps/api/src/routes/groups/fines/list.ts
@@ -89,11 +89,28 @@ export const listFinesRoute = route().get(
             conditions.push(eq(schema.fine.status, statusFilter));
         }
 
-        const fines = await db
-            .select()
-            .from(schema.fine)
-            .where(and(...conditions))
-            .orderBy(desc(schema.fine.createdAt));
+        // Include public user info (name/image) so the UI can display names
+        // instead of user IDs
+        const fines = await db.query.fine.findMany({
+            where: and(...conditions),
+            orderBy: desc(schema.fine.createdAt),
+            with: {
+                user: {
+                    columns: {
+                        id: true,
+                        name: true,
+                        image: true,
+                    },
+                },
+                createdByUser: {
+                    columns: {
+                        id: true,
+                        name: true,
+                        image: true,
+                    },
+                },
+            },
+        });
 
         return c.json(fines);
     },

--- a/apps/api/src/routes/groups/fines/schema.ts
+++ b/apps/api/src/routes/groups/fines/schema.ts
@@ -84,6 +84,31 @@ export const fineSchema = Schema(
             .meta({ description: "Payment timestamp" }),
         createdAt: z.string().meta({ description: "Creation timestamp" }),
         updatedAt: z.string().meta({ description: "Last update timestamp" }),
+        user: z
+            .object({
+                id: z.string().meta({ description: "User ID" }),
+                name: z.string().meta({ description: "User display name" }),
+                image: z
+                    .string()
+                    .nullable()
+                    .meta({ description: "User profile image URL" }),
+            })
+            .meta({
+                description: "Public user info for the fined user",
+            }),
+        createdByUser: z
+            .object({
+                id: z.string().meta({ description: "User ID" }),
+                name: z.string().meta({ description: "User display name" }),
+                image: z
+                    .string()
+                    .nullable()
+                    .meta({ description: "User profile image URL" }),
+            })
+            .nullable()
+            .meta({
+                description: "Public user info for the fine creator",
+            }),
     }),
 );
 

--- a/apps/kvark/src/components/group-fines-tab.tsx
+++ b/apps/kvark/src/components/group-fines-tab.tsx
@@ -1,4 +1,4 @@
-import { Avatar, AvatarFallback } from "@tihlde/ui/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
 import { Card } from "@tihlde/ui/ui/card";
 import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import { ChevronRight } from "lucide-react";
@@ -46,9 +46,9 @@ export function GroupFinesTab({ fines, memberCount }: GroupFinesTabProps) {
     const grouped = useMemo(() => {
         const map = new Map<string, Fine[]>();
         for (const fine of filtered) {
-            const list = map.get(fine.user) ?? [];
+            const list = map.get(fine.userId) ?? [];
             list.push(fine);
-            map.set(fine.user, list);
+            map.set(fine.userId, list);
         }
         return map;
     }, [filtered]);
@@ -144,8 +144,8 @@ export function GroupFinesTab({ fines, memberCount }: GroupFinesTabProps) {
                     </ul>
                 ) : (
                     <ul className="flex flex-col gap-2">
-                        {Array.from(grouped.entries()).map(([user, list]) => (
-                            <li key={user}>
+                        {Array.from(grouped.entries()).map(([userId, list]) => (
+                            <li key={userId}>
                                 <Card
                                     size="sm"
                                     className="flex-row items-center gap-3 px-3 py-2 cursor-pointer"
@@ -158,13 +158,19 @@ export function GroupFinesTab({ fines, memberCount }: GroupFinesTabProps) {
                                     }}
                                 >
                                     <Avatar className="size-10">
+                                        {list[0]?.userImage ? (
+                                            <AvatarImage
+                                                src={list[0].userImage}
+                                                alt={list[0].user}
+                                            />
+                                        ) : null}
                                         <AvatarFallback>
-                                            {initials(user)}
+                                            {initials(list[0]?.user ?? "")}
                                         </AvatarFallback>
                                     </Avatar>
                                     <div className="flex min-w-0 flex-1 flex-col">
                                         <span className="truncate font-medium">
-                                            {user}
+                                            {list[0]?.user}
                                         </span>
                                         <span className="truncate text-sm text-muted-foreground">
                                             {list.length} bøter

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -35,7 +35,9 @@ export type Member = {
 
 export type Fine = {
     id: string;
+    userId: string;
     user: string;
+    userImage?: string;
     paragraph: string;
     title: string;
     amount: number;
@@ -95,7 +97,7 @@ export function mapGroup(group: ApiGroup, leader?: string): Group {
 export function mapMember(member: ApiGroupMember): Member {
     return {
         id: member.userId,
-        name: member.user?.name ?? member.userId,
+        name: member.user?.name ?? "Ukjent bruker",
         image: member.user?.image ?? undefined,
         role: member.role,
         joined: formatGroupDate(member.createdAt),
@@ -110,13 +112,15 @@ export function mapMember(member: ApiGroupMember): Member {
 export function mapFine(fine: ApiFine): Fine {
     return {
         id: fine.id,
-        user: fine.userId,
+        userId: fine.userId,
+        user: fine.user?.name ?? "Ukjent bruker",
+        userImage: fine.user?.image ?? undefined,
         paragraph: "",
         title: fine.reason,
         amount: fine.amount,
         approved: fine.status === "approved" || fine.status === "paid",
         paid: fine.status === "paid",
-        createdBy: fine.createdByUserId ?? "",
+        createdBy: fine.createdByUser?.name ?? "",
         date: fine.createdAt ? formatGroupDate(fine.createdAt) : "",
         reason: fine.reason,
     };

--- a/packages/db/src/schema/org.ts
+++ b/packages/db/src/schema/org.ts
@@ -182,6 +182,19 @@ export const fine = pgTable("fine", {
     ...timestamps,
 });
 
+export const fineRelations = relations(fine, ({ one }) => ({
+    user: one(user, {
+        fields: [fine.userId],
+        references: [user.id],
+        relationName: "fineUser",
+    }),
+    createdByUser: one(user, {
+        fields: [fine.createdByUserId],
+        references: [user.id],
+        relationName: "fineCreatedByUser",
+    }),
+}));
+
 /**
  * Where a signature is drawn on the contract PDF.
  *

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2407,6 +2407,24 @@ export interface components {
             createdAt: string;
             /** @description Last update timestamp */
             updatedAt: string;
+            /** @description Public user info for the fined user */
+            user: {
+                /** @description User ID */
+                id: string;
+                /** @description User display name */
+                name: string;
+                /** @description User profile image URL */
+                image: string | null;
+            };
+            /** @description Public user info for the fine creator */
+            createdByUser: {
+                /** @description User ID */
+                id: string;
+                /** @description User display name */
+                name: string;
+                /** @description User profile image URL */
+                image: string | null;
+            } | null;
         };
         FineList: components["schemas"]["Fine"][];
         CreateFine: {


### PR DESCRIPTION
## What

The bøter (fines) UI rendered raw user IDs everywhere a person should be named — fine rows, the per-member cards, and the fine detail dialog ("Opprettet av"). This PR makes the UI show display names (and avatar images) instead, so user IDs never appear in the UI.

## Why

The `GET /groups/:slug/fines` and `GET /groups/:slug/fines/:id` endpoints only returned `userId`/`createdByUserId`, and the frontend mapped those IDs straight into the display layer (`mapFine` set `user: fine.userId`).

## How

- **DB**: added `fineRelations` in `packages/db/src/schema/org.ts` (fine → user, fine → createdByUser)
- **API**: list/get fines now use `db.query.fine` with the user relations and return public user info (`id`/`name`/`image`) for the fined user and the fine creator; OpenAPI schema updated
- **SDK**: regenerated types
- **Frontend (kvark)**: `mapFine` maps `fine.user.name` (fallback "Ukjent bruker", never the ID); the dialog's "Opprettet av" shows the creator's name; the "Per medlem" view groups by `userId` (so two members with the same name don't merge) while displaying name + avatar image. Same no-ID fallback applied to `mapMember`.

## Verified

- All 21 fines integration tests pass; typecheck, lint, and format green
- Ran the API + kvark from this branch against the seeded dev DB and checked in the browser: fine rows, per-member cards, and the dialog all show names — no IDs anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)