### PR TITLE
feat(admin): ryddig roller/verv-admin med navnebasert brukersøk

### DIFF
--- a/apps/api/src/routes/user/index.ts
+++ b/apps/api/src/routes/user/index.ts
@@ -1,7 +1,9 @@
 import { route } from "~/lib/route";
 import { allergyRoutes } from "./allergy";
 import { meRoutes } from "./me";
+import { searchUsersRoute } from "./search";
 
 export const userRoutes = route()
     .route("/me", meRoutes)
-    .route("/allergy", allergyRoutes);
+    .route("/allergy", allergyRoutes)
+    .route("/", searchUsersRoute);

--- a/apps/api/src/routes/user/search.ts
+++ b/apps/api/src/routes/user/search.ts
@@ -1,0 +1,74 @@
+import { schema } from "@photon/db";
+import { ilike, or } from "drizzle-orm";
+import { validator } from "hono-openapi";
+import z from "zod";
+import { Schema, describeRoute } from "~/lib/openapi";
+import { route } from "~/lib/route";
+import { requireAccess } from "~/middleware/access";
+import { requireAuth } from "~/middleware/auth";
+
+export const userSearchResultSchema = Schema(
+    "UserSearchResult",
+    z.array(
+        z.object({
+            id: z.string(),
+            name: z.string().nullable(),
+            username: z.string().nullable(),
+            image: z.string().nullable(),
+        }),
+    ),
+);
+
+export const searchUsersRoute = route().get(
+    "/search",
+    describeRoute({
+        tags: ["users"],
+        summary: "Search users",
+        operationId: "searchUsers",
+        description:
+            "Search users by name or username (case-insensitive substring). Used by admin UIs to assign roles and positions. Requires 'users:view' or 'roles:assign'.",
+    })
+        .schemaResponse({
+            statusCode: 200,
+            schema: userSearchResultSchema,
+            description: "Matching users",
+        })
+        .forbidden({ description: "Requires users:view or roles:assign" })
+        .build(),
+    requireAuth,
+    requireAccess({ permission: ["users:view", "roles:assign"] }),
+    validator(
+        "query",
+        z.object({
+            q: z
+                .string()
+                .min(2)
+                .max(100)
+                .meta({ description: "Search term (name or username)" }),
+        }),
+    ),
+    async (c) => {
+        const { db } = c.get("ctx");
+        const { q } = c.req.valid("query");
+
+        const pattern = `%${q.trim()}%`;
+        const users = await db
+            .select({
+                id: schema.user.id,
+                name: schema.user.name,
+                username: schema.user.username,
+                image: schema.user.image,
+            })
+            .from(schema.user)
+            .where(
+                or(
+                    ilike(schema.user.name, pattern),
+                    ilike(schema.user.username, pattern),
+                ),
+            )
+            .orderBy(schema.user.name)
+            .limit(10);
+
+        return c.json(users);
+    },
+);

--- a/apps/api/src/test/user-search.test.ts
+++ b/apps/api/src/test/user-search.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+describe("user search", () => {
+    integrationTest(
+        "finds users by name and by username, requires permission",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["users:view"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            const target = await ctx.auth.api.createUser({
+                body: {
+                    email: "searchme@test.com",
+                    name: "Kari Søketest",
+                    password: "test123!",
+                    data: { username: "karisoek" },
+                },
+            });
+
+            // By name fragment (case-insensitive)
+            const byName = await client.api.user.search.$get({
+                query: { q: "søketest" },
+            });
+            expect(byName.status).toBe(200);
+            const nameResults = await byName.json();
+            expect(nameResults.some((u) => u.id === target.user.id)).toBe(true);
+
+            // By username fragment
+            const byUsername = await client.api.user.search.$get({
+                query: { q: "karisoe" },
+            });
+            expect(byUsername.status).toBe(200);
+            const usernameResults = await byUsername.json();
+            expect(usernameResults.some((u) => u.id === target.user.id)).toBe(
+                true,
+            );
+
+            // Without permission → 403
+            const plain = await ctx.utils.createTestUser();
+            const plainClient = await ctx.utils.clientForUser(plain);
+            const forbidden = await plainClient.api.user.search.$get({
+                query: { q: "søketest" },
+            });
+            expect(forbidden.status).toBe(403);
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/api/queries/roles.ts
+++ b/apps/kvark/src/api/queries/roles.ts
@@ -10,7 +10,20 @@ import { apiClient } from "#/api/api-client";
 const RoleQueryKeys = {
     roles: ["roles"] as const,
     positions: ["groups", "positions"] as const,
+    userSearch: ["users", "search"] as const,
 } as const;
+
+// -- User search (for assigning roles/positions by name, not ID) --
+
+export const searchUsersQuery = (q: string) =>
+    queryOptions({
+        queryKey: [...RoleQueryKeys.userSearch, q],
+        queryFn: () =>
+            apiClient.get("/api/user/search", {
+                searchParams: { q },
+            }),
+        staleTime: 30_000,
+    });
 
 // -- Roles --
 

--- a/apps/kvark/src/components/user-search-combobox.tsx
+++ b/apps/kvark/src/components/user-search-combobox.tsx
@@ -1,0 +1,147 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
+import { Input } from "@tihlde/ui/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@tihlde/ui/ui/popover";
+import { ChevronDownIcon, XIcon } from "lucide-react";
+import { useState } from "react";
+
+import { initials } from "#/lib/utils";
+
+export type UserSearchOption = {
+    id: string;
+    name: string | null;
+    username?: string | null;
+    image: string | null;
+};
+
+type UserSearchComboboxProps = {
+    /** Currently selected/assigned user shown on the trigger, or null. */
+    holder: { name: string | null; image: string | null } | null;
+    query: string;
+    onQueryChange: (query: string) => void;
+    results: UserSearchOption[];
+    isSearching?: boolean;
+    onSelect: (user: UserSearchOption) => void;
+    /** When set, shows a remove action for the current holder. */
+    onRemove?: () => void;
+    onOpenChange?: (open: boolean) => void;
+    placeholder?: string;
+    emptyLabel?: string;
+};
+
+/**
+ * Popover combobox for picking a user by searching on name/username.
+ * Dumb component: the parent owns the query state and result fetching.
+ */
+export function UserSearchCombobox({
+    holder,
+    query,
+    onQueryChange,
+    results,
+    isSearching = false,
+    onSelect,
+    onRemove,
+    onOpenChange,
+    placeholder = "Søk på navn eller brukernavn…",
+    emptyLabel = "Ingen tildelt",
+}: UserSearchComboboxProps) {
+    const [open, setOpen] = useState(false);
+    const handleOpenChange = (next: boolean) => {
+        setOpen(next);
+        onOpenChange?.(next);
+    };
+
+    return (
+        <Popover open={open} onOpenChange={handleOpenChange}>
+            <PopoverTrigger className="flex cursor-pointer items-center gap-2">
+                {holder ? (
+                    <>
+                        <Avatar className="size-7">
+                            <AvatarImage src={holder.image ?? undefined} />
+                            <AvatarFallback>
+                                {initials(holder.name ?? "?")}
+                            </AvatarFallback>
+                        </Avatar>
+                        <span className="text-sm">{holder.name}</span>
+                    </>
+                ) : (
+                    <span className="text-sm text-muted-foreground">
+                        {emptyLabel}
+                    </span>
+                )}
+                <ChevronDownIcon className="size-4 opacity-60" />
+            </PopoverTrigger>
+            <PopoverContent
+                align="start"
+                sideOffset={4}
+                className="flex w-72 flex-col gap-2 p-2"
+            >
+                <Input
+                    value={query}
+                    onChange={(e) => onQueryChange(e.target.value)}
+                    placeholder={placeholder}
+                    autoFocus
+                />
+                {isSearching ? (
+                    <span className="px-1 text-xs text-muted-foreground">
+                        Søker…
+                    </span>
+                ) : null}
+                {!isSearching &&
+                query.trim().length >= 2 &&
+                results.length === 0 ? (
+                    <span className="px-1 text-xs text-muted-foreground">
+                        Ingen treff
+                    </span>
+                ) : null}
+                {results.length > 0 ? (
+                    <ul className="flex max-h-64 flex-col gap-1 overflow-y-auto">
+                        {results.map((user) => (
+                            <li key={user.id}>
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        onSelect(user);
+                                        handleOpenChange(false);
+                                    }}
+                                    className="flex w-full cursor-pointer items-center gap-2 p-1 text-left"
+                                >
+                                    <Avatar className="size-7">
+                                        <AvatarImage
+                                            src={user.image ?? undefined}
+                                        />
+                                        <AvatarFallback>
+                                            {initials(user.name ?? "?")}
+                                        </AvatarFallback>
+                                    </Avatar>
+                                    <span className="flex min-w-0 flex-col">
+                                        <span className="truncate text-sm font-medium">
+                                            {user.name}
+                                        </span>
+                                        {user.username ? (
+                                            <span className="truncate text-xs text-muted-foreground">
+                                                {user.username}
+                                            </span>
+                                        ) : null}
+                                    </span>
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                ) : null}
+                {holder && onRemove ? (
+                    <button
+                        type="button"
+                        onClick={() => {
+                            onRemove();
+                            handleOpenChange(false);
+                        }}
+                        className="flex w-full cursor-pointer items-center gap-2 p-1 text-left text-sm text-destructive"
+                    >
+                        <XIcon className="size-4" />
+                        Fjern {holder.name}
+                    </button>
+                ) : null}
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/apps/kvark/src/lib/permission-domains.ts
+++ b/apps/kvark/src/lib/permission-domains.ts
@@ -1,0 +1,87 @@
+import { PERMISSIONS } from "@photon/auth/rbac/registry";
+
+/**
+ * Domain-level view of the permission registry, for admin UIs.
+ *
+ * Instead of exposing all ~70 individual permissions as checkboxes, the UI
+ * shows one checkbox per domain ("Arrangementer", "Bøter", …). Toggling a
+ * domain grants/removes every permission registered under it — mirroring how
+ * aarhonen's role admin works.
+ */
+
+export type PermissionDomain = {
+    slug: string;
+    label: string;
+};
+
+/** Norwegian labels for the permission domains, in display order. */
+export const PERMISSION_DOMAINS: PermissionDomain[] = [
+    { slug: "events", label: "Arrangementer" },
+    { slug: "groups", label: "Grupper" },
+    { slug: "fines", label: "Bøter" },
+    { slug: "news", label: "Nyheter" },
+    { slug: "jobs", label: "Annonser" },
+    { slug: "forms", label: "Spørreskjema" },
+    { slug: "contracts", label: "Kontrakter" },
+    { slug: "users", label: "Brukere" },
+    { slug: "roles", label: "Roller" },
+    { slug: "api-keys", label: "API-nøkler" },
+    { slug: "oauth-clients", label: "OAuth-klienter" },
+];
+
+const DOMAIN_LABELS = new Map(PERMISSION_DOMAINS.map((d) => [d.slug, d.label]));
+
+/** Domain part of a permission, e.g. "events:registrations:view" → "events". */
+export function domainOf(permission: string): string {
+    const i = permission.indexOf(":");
+    return i === -1 ? permission : permission.slice(0, i);
+}
+
+/** Domain slugs covered by a permission list. */
+export function domainsOf(permissions: string[]): Set<string> {
+    return new Set(permissions.map(domainOf));
+}
+
+/**
+ * Every permission registered under a top-level domain, including nested ones
+ * (e.g. "events" → events:view, …, events:registrations:view, …). Derived
+ * from the auth registry so it stays in sync as permissions are added.
+ */
+export const PERMISSIONS_BY_DOMAIN: Record<string, readonly string[]> = (() => {
+    const map: Record<string, string[]> = {};
+    for (const perm of PERMISSIONS) {
+        const dom = domainOf(perm);
+        if (dom === perm) continue; // "root" has no domain
+        const bucket = map[dom] ?? [];
+        bucket.push(perm);
+        map[dom] = bucket;
+    }
+    return map;
+})();
+
+/** Toggle a whole domain on/off in a permission list. */
+export function toggleDomain(
+    current: string[],
+    domainSlug: string,
+    checked: boolean,
+): string[] {
+    const perms = PERMISSIONS_BY_DOMAIN[domainSlug] ?? [];
+    if (checked) {
+        const next = new Set(current);
+        for (const perm of perms) next.add(perm);
+        return [...next];
+    }
+    return current.filter((p) => domainOf(p) !== domainSlug);
+}
+
+/**
+ * Short human-readable summary of a permission list, e.g.
+ * "Arrangementer, Bøter" or "Full tilgang (root)".
+ */
+export function summarizePermissions(permissions: string[]): string {
+    if (permissions.includes("root")) return "Full tilgang (root)";
+    const domains = [...domainsOf(permissions)]
+        .map((d) => DOMAIN_LABELS.get(d) ?? d)
+        .sort((a, b) => a.localeCompare(b, "nb"));
+    return domains.length === 0 ? "Ingen tilganger" : domains.join(", ");
+}

--- a/apps/kvark/src/routes/admin/roller.tsx
+++ b/apps/kvark/src/routes/admin/roller.tsx
@@ -1,7 +1,7 @@
-import { PERMISSIONS } from "@photon/auth/rbac/registry";
 import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import type { GroupPosition, Role } from "@tihlde/sdk";
+import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
 import { Badge } from "@tihlde/ui/ui/badge";
 import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent } from "@tihlde/ui/ui/card";
@@ -13,15 +13,14 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@tihlde/ui/ui/dialog";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@tihlde/ui/ui/dropdown-menu";
 import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
 import { Input } from "@tihlde/ui/ui/input";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@tihlde/ui/ui/select";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import {
     Table,
@@ -32,15 +31,8 @@ import {
     TableRow,
 } from "@tihlde/ui/ui/table";
 import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
-import {
-    CrownIcon,
-    PlusIcon,
-    ShieldIcon,
-    Trash2,
-    UserPlusIcon,
-    XIcon,
-} from "lucide-react";
-import { useMemo, useState } from "react";
+import { MoreHorizontalIcon, PlusIcon, ShieldIcon, XIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
 import { getGroupMembersQuery, getGroupsQuery } from "#/api/queries/groups";
 import {
@@ -52,12 +44,26 @@ import {
     deleteRoleMutation,
     getGroupPositionsQuery,
     getRolesQuery,
+    searchUsersQuery,
     unassignPositionMutation,
     unassignRoleMutation,
+    updatePositionMutation,
+    updateRoleMutation,
 } from "#/api/queries/roles";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminGroupPicker } from "#/components/admin-group-picker";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import {
+    UserSearchCombobox,
+    type UserSearchOption,
+} from "#/components/user-search-combobox";
+import {
+    PERMISSION_DOMAINS,
+    domainsOf,
+    summarizePermissions,
+    toggleDomain,
+} from "#/lib/permission-domains";
+import { initials } from "#/lib/utils";
 
 export const Route = createFileRoute("/admin/roller")({
     component: RolesAdminPage,
@@ -67,96 +73,488 @@ export const Route = createFileRoute("/admin/roller")({
     },
 });
 
-type TabValue = "roller" | "verv";
+type TabValue = "verv" | "roller";
 
 function RolesAdminPage() {
-    const [tab, setTab] = useState<TabValue>("roller");
+    const [tab, setTab] = useState<TabValue>("verv");
 
     return (
         <div className="container mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8">
             <AdminPageHeader
                 title="Roller og verv"
-                description="Administrer globale roller, gruppeverv og hvem som holder dem."
+                description="Administrer verv i grupper og globale roller."
             />
 
             <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
                 <TabsList>
-                    <TabsTrigger value="roller">Roller</TabsTrigger>
                     <TabsTrigger value="verv">Verv</TabsTrigger>
+                    <TabsTrigger value="roller">Roller</TabsTrigger>
                 </TabsList>
             </Tabs>
 
-            {tab === "roller" ? <RolesSection /> : <PositionsSection />}
+            {tab === "verv" ? <PositionsSection /> : <RolesSection />}
         </div>
     );
 }
 
-// =============================================================================
-// Shared: permission picker
-// =============================================================================
-
-/** Group permissions by domain prefix for a scannable checkbox grid. */
-function usePermissionGroups() {
-    return useMemo(() => {
-        const groups = new Map<string, string[]>();
-        for (const permission of PERMISSIONS) {
-            const domain = permission.includes(":")
-                ? (permission.split(":")[0] ?? permission)
-                : permission;
-            const list = groups.get(domain) ?? [];
-            list.push(permission);
-            groups.set(domain, list);
-        }
-        return Array.from(groups.entries());
-    }, []);
+/** Debounce a string value (for search-as-you-type). */
+function useDebounced(value: string, delayMs = 200): string {
+    const [debounced, setDebounced] = useState(value);
+    useEffect(() => {
+        const timeout = window.setTimeout(
+            () => setDebounced(value.trim()),
+            delayMs,
+        );
+        return () => window.clearTimeout(timeout);
+    }, [value, delayMs]);
+    return debounced;
 }
 
-function PermissionPicker({
-    selected,
+// =============================================================================
+// Shared: domain-level permission checkboxes
+// =============================================================================
+
+function PermissionDomainCheckboxes({
+    value,
     onChange,
 }: {
-    selected: string[];
-    onChange: (permissions: string[]) => void;
+    value: string[];
+    onChange: (next: string[]) => void;
 }) {
-    const groups = usePermissionGroups();
+    const present = domainsOf(value);
+    const hasRoot = value.includes("root");
 
-    function toggle(permission: string, checked: boolean) {
-        onChange(
-            checked
-                ? [...selected, permission]
-                : selected.filter((p) => p !== permission),
+    return (
+        <div className="flex flex-col gap-2">
+            {hasRoot ? (
+                <p className="text-sm text-muted-foreground">
+                    Full tilgang (root) — har alle tilganger.
+                </p>
+            ) : null}
+            <div className="grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-3">
+                {PERMISSION_DOMAINS.map((domain) => {
+                    const checked = hasRoot || present.has(domain.slug);
+                    return (
+                        <label
+                            key={domain.slug}
+                            className="flex items-center gap-2"
+                        >
+                            <Checkbox
+                                checked={checked}
+                                disabled={hasRoot}
+                                onCheckedChange={(next) =>
+                                    onChange(
+                                        toggleDomain(
+                                            value,
+                                            domain.slug,
+                                            next === true,
+                                        ),
+                                    )
+                                }
+                            />
+                            <span className="text-sm">{domain.label}</span>
+                        </label>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function HolderChip({
+    name,
+    image,
+    onRemove,
+}: {
+    name: string | null;
+    image: string | null;
+    onRemove: () => void;
+}) {
+    return (
+        <Badge variant="secondary" className="gap-1.5 py-1 pl-1">
+            <Avatar className="size-5">
+                <AvatarImage src={image ?? undefined} />
+                <AvatarFallback>{initials(name ?? "?")}</AvatarFallback>
+            </Avatar>
+            {name}
+            <button
+                type="button"
+                aria-label={`Fjern ${name}`}
+                onClick={onRemove}
+                className="cursor-pointer"
+            >
+                <XIcon className="size-3" />
+            </button>
+        </Badge>
+    );
+}
+
+// =============================================================================
+// Verv (group positions)
+// =============================================================================
+
+function PositionsSection() {
+    const { data: groups } = useSuspenseQuery(getGroupsQuery(0));
+    const [groupSlug, setGroupSlug] = useState<string | null>(
+        groups.find((g) => g.slug === "hs")?.slug ?? groups[0]?.slug ?? null,
+    );
+    const [createOpen, setCreateOpen] = useState(false);
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                <Field className="sm:max-w-72">
+                    <FieldLabel>Gruppe</FieldLabel>
+                    <AdminGroupPicker
+                        groups={groups}
+                        value={groupSlug}
+                        onValueChange={setGroupSlug}
+                    />
+                </Field>
+                {groupSlug && (
+                    <Button onClick={() => setCreateOpen(true)}>
+                        <PlusIcon className="size-4" />
+                        Nytt verv
+                    </Button>
+                )}
+            </div>
+
+            {groupSlug ? <PositionsTable groupSlug={groupSlug} /> : null}
+
+            {groupSlug && (
+                <PositionDialog
+                    groupSlug={groupSlug}
+                    open={createOpen}
+                    onOpenChange={setCreateOpen}
+                    position={null}
+                />
+            )}
+        </div>
+    );
+}
+
+function PositionsTable({ groupSlug }: { groupSlug: string }) {
+    const { data: positions, isPending } = useQuery(
+        getGroupPositionsQuery(groupSlug),
+    );
+    const { data: members } = useQuery(getGroupMembersQuery(groupSlug, 0));
+    const remove = useMutation(deletePositionMutation);
+    const unassign = useMutation(unassignPositionMutation);
+    const assign = useMutation(assignPositionMutation);
+    const [editing, setEditing] = useState<GroupPosition | null>(null);
+    const [assignQuery, setAssignQuery] = useState("");
+    const [assignFor, setAssignFor] = useState<string | null>(null);
+
+    // Holder candidates come from the group's member list (positions require
+    // membership) — filtered client-side on name.
+    const memberOptions: UserSearchOption[] = useMemo(
+        () =>
+            (members ?? []).map((member) => ({
+                id: member.user?.id ?? member.userId,
+                name: member.user?.name ?? member.userId,
+                image: member.user?.image ?? null,
+            })),
+        [members],
+    );
+
+    const filteredOptions = useMemo(() => {
+        const q = assignQuery.trim().toLowerCase();
+        if (q.length < 1) return memberOptions.slice(0, 10);
+        return memberOptions
+            .filter((option) => (option.name ?? "").toLowerCase().includes(q))
+            .slice(0, 10);
+    }, [memberOptions, assignQuery]);
+
+    if (isPending) {
+        return (
+            <Card>
+                <CardContent className="flex flex-col gap-3">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                        <Skeleton key={index} className="h-10 w-full" />
+                    ))}
+                </CardContent>
+            </Card>
         );
     }
 
+    if (!positions || positions.length === 0) {
+        return (
+            <Card>
+                <CardContent>
+                    <AdminEmptyState
+                        icon={ShieldIcon}
+                        title="Ingen verv"
+                        description="Denne gruppen har ingen verv ennå. Opprett det første med «Nytt verv»."
+                    />
+                </CardContent>
+            </Card>
+        );
+    }
+
+    function handleDelete(position: GroupPosition) {
+        if (
+            window.confirm(
+                `Slette vervet «${position.name}»? Alle holdere mister tilgangene.`,
+            )
+        ) {
+            remove.mutate({ groupSlug, positionId: position.id });
+        }
+    }
+
     return (
-        <div className="flex max-h-72 flex-col gap-4 overflow-y-auto">
-            {groups.map(([domain, permissions]) => (
-                <div key={domain} className="flex flex-col gap-2">
-                    <span className="text-sm font-medium">{domain}</span>
-                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                        {permissions.map((permission) => (
-                            <label
-                                key={permission}
-                                className="flex items-center gap-2"
-                            >
-                                <Checkbox
-                                    checked={selected.includes(permission)}
-                                    onCheckedChange={(checked) =>
-                                        toggle(permission, checked === true)
-                                    }
-                                />
-                                <span className="text-sm">{permission}</span>
-                            </label>
-                        ))}
-                    </div>
-                </div>
-            ))}
-        </div>
+        <>
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead className="w-56">Verv</TableHead>
+                                <TableHead>Bruker</TableHead>
+                                <TableHead className="w-72">
+                                    Tilganger
+                                </TableHead>
+                                <TableHead className="w-12" />
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {positions.map((position) => (
+                                <TableRow key={position.id}>
+                                    <TableCell>
+                                        <div className="flex flex-col">
+                                            <span className="font-medium">
+                                                {position.name}
+                                            </span>
+                                            {position.scope === "global" ? (
+                                                <span className="text-xs text-muted-foreground">
+                                                    Gjelder hele TIHLDE
+                                                </span>
+                                            ) : null}
+                                        </div>
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            {position.holders.map((holder) => (
+                                                <HolderChip
+                                                    key={holder.userId}
+                                                    name={holder.name}
+                                                    image={holder.image}
+                                                    onRemove={() =>
+                                                        unassign.mutate({
+                                                            groupSlug,
+                                                            positionId:
+                                                                position.id,
+                                                            userId: holder.userId,
+                                                        })
+                                                    }
+                                                />
+                                            ))}
+                                            <UserSearchCombobox
+                                                holder={null}
+                                                emptyLabel={
+                                                    position.holders.length ===
+                                                    0
+                                                        ? "Ingen tildelt"
+                                                        : "Legg til"
+                                                }
+                                                query={
+                                                    assignFor === position.id
+                                                        ? assignQuery
+                                                        : ""
+                                                }
+                                                onQueryChange={setAssignQuery}
+                                                onOpenChange={(open) => {
+                                                    setAssignFor(
+                                                        open
+                                                            ? position.id
+                                                            : null,
+                                                    );
+                                                    setAssignQuery("");
+                                                }}
+                                                results={
+                                                    assignFor === position.id
+                                                        ? filteredOptions.filter(
+                                                              (option) =>
+                                                                  !position.holders.some(
+                                                                      (h) =>
+                                                                          h.userId ===
+                                                                          option.id,
+                                                                  ),
+                                                          )
+                                                        : []
+                                                }
+                                                onSelect={(user) =>
+                                                    assign.mutate({
+                                                        groupSlug,
+                                                        positionId: position.id,
+                                                        userId: user.id,
+                                                    })
+                                                }
+                                                placeholder="Søk blant gruppens medlemmer…"
+                                            />
+                                        </div>
+                                    </TableCell>
+                                    <TableCell className="text-sm text-muted-foreground">
+                                        {summarizePermissions(
+                                            position.permissions,
+                                        )}
+                                    </TableCell>
+                                    <TableCell>
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger
+                                                aria-label="Handlinger"
+                                                className="cursor-pointer"
+                                            >
+                                                <MoreHorizontalIcon className="size-4" />
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent align="end">
+                                                <DropdownMenuItem
+                                                    onClick={() =>
+                                                        setEditing(position)
+                                                    }
+                                                >
+                                                    Rediger
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem
+                                                    variant="destructive"
+                                                    onClick={() =>
+                                                        handleDelete(position)
+                                                    }
+                                                >
+                                                    Slett
+                                                </DropdownMenuItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+
+            {editing && (
+                <PositionDialog
+                    groupSlug={groupSlug}
+                    open={Boolean(editing)}
+                    onOpenChange={(open) => {
+                        if (!open) setEditing(null);
+                    }}
+                    position={editing}
+                />
+            )}
+        </>
+    );
+}
+
+/** Create (position=null) or edit a position. */
+function PositionDialog({
+    groupSlug,
+    open,
+    onOpenChange,
+    position,
+}: {
+    groupSlug: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    position: GroupPosition | null;
+}) {
+    const create = useMutation(createPositionMutation);
+    const update = useMutation(updatePositionMutation);
+    const [name, setName] = useState(position?.name ?? "");
+    const [scope, setScope] = useState<"group" | "global">(
+        position?.scope ?? "group",
+    );
+    const [permissions, setPermissions] = useState<string[]>(
+        position?.permissions ?? [],
+    );
+    const isPending = create.isPending || update.isPending;
+
+    function handleSubmit() {
+        const onSuccess = () => {
+            if (!position) {
+                setName("");
+                setScope("group");
+                setPermissions([]);
+            }
+            onOpenChange(false);
+        };
+        if (position) {
+            update.mutate(
+                {
+                    groupSlug,
+                    positionId: position.id,
+                    data: { name, permissions, scope },
+                },
+                { onSuccess },
+            );
+        } else {
+            create.mutate(
+                { groupSlug, data: { name, permissions, scope } },
+                { onSuccess },
+            );
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-xl">
+                <DialogHeader>
+                    <DialogTitle>
+                        {position ? `Rediger «${position.name}»` : "Nytt verv"}
+                    </DialogTitle>
+                </DialogHeader>
+                <FieldGroup>
+                    <Field>
+                        <FieldLabel>Navn</FieldLabel>
+                        <Input
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            placeholder="f.eks. Økonomiansvarlig"
+                        />
+                    </Field>
+                    <Field>
+                        <FieldLabel>Tilganger</FieldLabel>
+                        <PermissionDomainCheckboxes
+                            value={permissions}
+                            onChange={setPermissions}
+                        />
+                    </Field>
+                    <Field>
+                        <label className="flex items-center gap-2">
+                            <Checkbox
+                                checked={scope === "global"}
+                                onCheckedChange={(next) =>
+                                    setScope(next === true ? "global" : "group")
+                                }
+                            />
+                            <span className="text-sm">
+                                Gjelder hele TIHLDE (ikke bare denne gruppen) —
+                                krever rolle-administrasjonstilgang
+                            </span>
+                        </label>
+                    </Field>
+                </FieldGroup>
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Avbryt
+                    </Button>
+                    <Button
+                        disabled={!name || isPending}
+                        onClick={handleSubmit}
+                    >
+                        {position ? "Lagre" : "Opprett"}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
     );
 }
 
 // =============================================================================
-// Roles section
+// Roller (global RBAC roles)
 // =============================================================================
 
 function RolesSection() {
@@ -182,7 +580,7 @@ function RolesSection() {
                     <AdminEmptyState
                         icon={ShieldIcon}
                         title="Ingen tilgang"
-                        description="Du mangler tilgangen som kreves for å se roller (roles:view)."
+                        description="Du mangler tilgangen som kreves for å se roller."
                     />
                 </CardContent>
             </Card>
@@ -198,147 +596,201 @@ function RolesSection() {
                 </Button>
             </div>
 
-            <div className="flex flex-col gap-4">
-                {(roles ?? []).map((role) => (
-                    <RoleCard key={role.id} role={role} />
-                ))}
-            </div>
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead className="w-56">Rolle</TableHead>
+                                <TableHead>Brukere</TableHead>
+                                <TableHead className="w-72">
+                                    Tilganger
+                                </TableHead>
+                                <TableHead className="w-12" />
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {(roles ?? []).map((role) => (
+                                <RoleRow key={role.id} role={role} />
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
 
-            <CreateRoleDialog open={createOpen} onOpenChange={setCreateOpen} />
+            <RoleDialog
+                open={createOpen}
+                onOpenChange={setCreateOpen}
+                role={null}
+            />
         </div>
     );
 }
 
-function RoleCard({ role }: { role: Role }) {
+function RoleRow({ role }: { role: Role }) {
     const remove = useMutation(deleteRoleMutation);
     const unassign = useMutation(unassignRoleMutation);
-    const [assignOpen, setAssignOpen] = useState(false);
+    const assign = useMutation(assignRoleMutation);
+    const [editing, setEditing] = useState(false);
+    const [query, setQuery] = useState("");
+    const debouncedQuery = useDebounced(query);
+    const { data: searchResults, isFetching } = useQuery({
+        ...searchUsersQuery(debouncedQuery),
+        enabled: debouncedQuery.length >= 2,
+    });
 
     function handleDelete() {
         if (
             window.confirm(
-                `Slette rollen "${role.name}"? Alle tildelinger fjernes. Dette kan ikke angres.`,
+                `Slette rollen «${role.name}»? Alle tildelinger fjernes.`,
             )
         ) {
             remove.mutate({ roleId: role.id });
         }
     }
 
+    const assignable = (searchResults ?? []).filter(
+        (user) => !role.users.some((u) => u.userId === user.id),
+    );
+
     return (
-        <Card>
-            <CardContent className="flex flex-col gap-3">
-                <div className="flex flex-wrap items-center gap-2">
-                    <CrownIcon className="size-4" />
+        <TableRow>
+            <TableCell>
+                <div className="flex flex-col">
                     <span className="font-medium">{role.name}</span>
-                    <Badge variant="secondary">posisjon {role.position}</Badge>
-                    <Badge variant="outline">
-                        {role.permissions.length} tilganger
-                    </Badge>
-                    <div className="ml-auto flex gap-2">
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setAssignOpen(true)}
-                        >
-                            <UserPlusIcon className="size-4" />
-                            Tildel
-                        </Button>
-                        <Button
+                    {role.description ? (
+                        <span className="text-xs text-muted-foreground">
+                            {role.description}
+                        </span>
+                    ) : null}
+                </div>
+            </TableCell>
+            <TableCell>
+                <div className="flex flex-wrap items-center gap-2">
+                    {role.users.map((user) => (
+                        <HolderChip
+                            key={user.userId}
+                            name={user.name}
+                            image={user.image}
+                            onRemove={() =>
+                                unassign.mutate({
+                                    roleId: role.id,
+                                    userId: user.userId,
+                                })
+                            }
+                        />
+                    ))}
+                    <UserSearchCombobox
+                        holder={null}
+                        emptyLabel={
+                            role.users.length === 0
+                                ? "Ingen tildelt"
+                                : "Legg til"
+                        }
+                        query={query}
+                        onQueryChange={setQuery}
+                        results={assignable}
+                        isSearching={isFetching}
+                        onSelect={(user) =>
+                            assign.mutate({ roleId: role.id, userId: user.id })
+                        }
+                        onOpenChange={(open) => {
+                            if (!open) setQuery("");
+                        }}
+                    />
+                </div>
+            </TableCell>
+            <TableCell className="text-sm text-muted-foreground">
+                {summarizePermissions(role.permissions)}
+            </TableCell>
+            <TableCell>
+                <DropdownMenu>
+                    <DropdownMenuTrigger
+                        aria-label="Handlinger"
+                        className="cursor-pointer"
+                    >
+                        <MoreHorizontalIcon className="size-4" />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => setEditing(true)}>
+                            Rediger
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
                             variant="destructive"
-                            size="sm"
-                            disabled={remove.isPending}
                             onClick={handleDelete}
                         >
-                            <Trash2 className="size-4" />
                             Slett
-                        </Button>
-                    </div>
-                </div>
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </TableCell>
 
-                {role.description && (
-                    <p className="text-sm text-muted-foreground">
-                        {role.description}
-                    </p>
-                )}
-
-                <div className="flex flex-wrap gap-1">
-                    {role.permissions.map((permission) => (
-                        <Badge key={permission} variant="outline">
-                            {permission}
-                        </Badge>
-                    ))}
-                </div>
-
-                {role.users.length > 0 && (
-                    <div className="flex flex-wrap items-center gap-2">
-                        <span className="text-sm text-muted-foreground">
-                            Brukere:
-                        </span>
-                        {role.users.map((user) => (
-                            <Badge
-                                key={user.userId}
-                                variant="secondary"
-                                className="gap-1"
-                            >
-                                {user.name ?? user.userId}
-                                <button
-                                    type="button"
-                                    aria-label={`Fjern ${user.name ?? user.userId}`}
-                                    onClick={() =>
-                                        unassign.mutate({
-                                            roleId: role.id,
-                                            userId: user.userId,
-                                        })
-                                    }
-                                >
-                                    <XIcon className="size-3" />
-                                </button>
-                            </Badge>
-                        ))}
-                    </div>
-                )}
-            </CardContent>
-
-            <AssignRoleDialog
-                role={role}
-                open={assignOpen}
-                onOpenChange={setAssignOpen}
-            />
-        </Card>
+            {editing && (
+                <RoleDialog
+                    open={editing}
+                    onOpenChange={setEditing}
+                    role={role}
+                />
+            )}
+        </TableRow>
     );
 }
 
-function CreateRoleDialog({
+/** Create (role=null) or edit a role. */
+function RoleDialog({
     open,
     onOpenChange,
+    role,
 }: {
     open: boolean;
     onOpenChange: (open: boolean) => void;
+    role: Role | null;
 }) {
     const create = useMutation(createRoleMutation);
-    const [name, setName] = useState("");
-    const [description, setDescription] = useState("");
-    const [permissions, setPermissions] = useState<string[]>([]);
+    const update = useMutation(updateRoleMutation);
+    const [name, setName] = useState(role?.name ?? "");
+    const [description, setDescription] = useState(role?.description ?? "");
+    const [permissions, setPermissions] = useState<string[]>(
+        role?.permissions ?? [],
+    );
+    const isPending = create.isPending || update.isPending;
 
     function handleSubmit() {
-        create.mutate(
-            { data: { name, description, permissions } },
-            {
-                onSuccess: () => {
-                    setName("");
-                    setDescription("");
-                    setPermissions([]);
-                    onOpenChange(false);
+        const onSuccess = () => {
+            if (!role) {
+                setName("");
+                setDescription("");
+                setPermissions([]);
+            }
+            onOpenChange(false);
+        };
+        if (role) {
+            update.mutate(
+                {
+                    roleId: role.id,
+                    data: {
+                        name,
+                        description: description || null,
+                        permissions,
+                    },
                 },
-            },
-        );
+                { onSuccess },
+            );
+        } else {
+            create.mutate(
+                { data: { name, description, permissions } },
+                { onSuccess },
+            );
+        }
     }
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-2xl">
+            <DialogContent className="max-w-xl">
                 <DialogHeader>
-                    <DialogTitle>Ny rolle</DialogTitle>
+                    <DialogTitle>
+                        {role ? `Rediger «${role.name}»` : "Ny rolle"}
+                    </DialogTitle>
                 </DialogHeader>
                 <FieldGroup>
                     <Field>
@@ -358,8 +810,8 @@ function CreateRoleDialog({
                     </Field>
                     <Field>
                         <FieldLabel>Tilganger</FieldLabel>
-                        <PermissionPicker
-                            selected={permissions}
+                        <PermissionDomainCheckboxes
+                            value={permissions}
                             onChange={setPermissions}
                         />
                     </Field>
@@ -372,481 +824,10 @@ function CreateRoleDialog({
                         Avbryt
                     </Button>
                     <Button
-                        disabled={!name || create.isPending}
+                        disabled={!name || isPending}
                         onClick={handleSubmit}
                     >
-                        Opprett
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    );
-}
-
-function AssignRoleDialog({
-    role,
-    open,
-    onOpenChange,
-}: {
-    role: Role;
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-}) {
-    const assign = useMutation(assignRoleMutation);
-    const [userId, setUserId] = useState("");
-
-    function handleSubmit() {
-        assign.mutate(
-            { roleId: role.id, userId },
-            {
-                onSuccess: () => {
-                    setUserId("");
-                    onOpenChange(false);
-                },
-            },
-        );
-    }
-
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>Tildel «{role.name}»</DialogTitle>
-                </DialogHeader>
-                <FieldGroup>
-                    <Field>
-                        <FieldLabel>Bruker-ID</FieldLabel>
-                        <Input
-                            value={userId}
-                            onChange={(e) => setUserId(e.target.value)}
-                            placeholder="Bruker-ID"
-                        />
-                    </Field>
-                </FieldGroup>
-                <DialogFooter>
-                    <Button
-                        variant="outline"
-                        onClick={() => onOpenChange(false)}
-                    >
-                        Avbryt
-                    </Button>
-                    <Button
-                        disabled={!userId || assign.isPending}
-                        onClick={handleSubmit}
-                    >
-                        Tildel
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    );
-}
-
-// =============================================================================
-// Positions (verv) section
-// =============================================================================
-
-function PositionsSection() {
-    const { data: groups } = useSuspenseQuery(getGroupsQuery(0));
-    const [groupSlug, setGroupSlug] = useState<string | null>(
-        groups[0]?.slug ?? null,
-    );
-    const [createOpen, setCreateOpen] = useState(false);
-
-    return (
-        <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-                <Field className="sm:max-w-72">
-                    <FieldLabel>Gruppe</FieldLabel>
-                    <AdminGroupPicker
-                        groups={groups}
-                        value={groupSlug}
-                        onValueChange={setGroupSlug}
-                    />
-                </Field>
-                {groupSlug && (
-                    <Button onClick={() => setCreateOpen(true)}>
-                        <PlusIcon className="size-4" />
-                        Nytt verv
-                    </Button>
-                )}
-            </div>
-
-            {groupSlug ? (
-                <PositionsTable groupSlug={groupSlug} />
-            ) : (
-                <Card>
-                    <CardContent>
-                        <AdminEmptyState
-                            icon={ShieldIcon}
-                            title="Velg en gruppe"
-                            description="Velg en gruppe for å se og administrere verv."
-                        />
-                    </CardContent>
-                </Card>
-            )}
-
-            {groupSlug && (
-                <CreatePositionDialog
-                    groupSlug={groupSlug}
-                    open={createOpen}
-                    onOpenChange={setCreateOpen}
-                />
-            )}
-        </div>
-    );
-}
-
-function PositionsTable({ groupSlug }: { groupSlug: string }) {
-    const { data: positions, isPending } = useQuery(
-        getGroupPositionsQuery(groupSlug),
-    );
-    const remove = useMutation(deletePositionMutation);
-    const unassign = useMutation(unassignPositionMutation);
-    const [assignFor, setAssignFor] = useState<GroupPosition | null>(null);
-
-    if (isPending) {
-        return (
-            <Card>
-                <CardContent className="flex flex-col gap-3">
-                    {Array.from({ length: 3 }).map((_, index) => (
-                        <Skeleton key={index} className="h-10 w-full" />
-                    ))}
-                </CardContent>
-            </Card>
-        );
-    }
-
-    if (!positions || positions.length === 0) {
-        return (
-            <Card>
-                <CardContent>
-                    <AdminEmptyState
-                        icon={ShieldIcon}
-                        title="Ingen verv"
-                        description="Denne gruppen har ingen verv ennå."
-                    />
-                </CardContent>
-            </Card>
-        );
-    }
-
-    function handleDelete(position: GroupPosition) {
-        if (
-            window.confirm(
-                `Slette vervet "${position.name}"? Alle holdere mister tilgangene. Dette kan ikke angres.`,
-            )
-        ) {
-            remove.mutate({ groupSlug, positionId: position.id });
-        }
-    }
-
-    return (
-        <>
-            <Card>
-                <CardContent className="p-0">
-                    <Table>
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead>Verv</TableHead>
-                                <TableHead>Omfang</TableHead>
-                                <TableHead>Tilganger</TableHead>
-                                <TableHead>Holdere</TableHead>
-                                <TableHead className="text-right">
-                                    Handlinger
-                                </TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {positions.map((position) => (
-                                <TableRow key={position.id}>
-                                    <TableCell className="font-medium">
-                                        {position.name}
-                                    </TableCell>
-                                    <TableCell>
-                                        <Badge
-                                            variant={
-                                                position.scope === "global"
-                                                    ? "default"
-                                                    : "secondary"
-                                            }
-                                        >
-                                            {position.scope === "global"
-                                                ? "Global"
-                                                : "Gruppe"}
-                                        </Badge>
-                                    </TableCell>
-                                    <TableCell>
-                                        <div className="flex max-w-72 flex-wrap gap-1">
-                                            {position.permissions.map(
-                                                (permission) => (
-                                                    <Badge
-                                                        key={permission}
-                                                        variant="outline"
-                                                    >
-                                                        {permission}
-                                                    </Badge>
-                                                ),
-                                            )}
-                                        </div>
-                                    </TableCell>
-                                    <TableCell>
-                                        <div className="flex flex-wrap gap-1">
-                                            {position.holders.map((holder) => (
-                                                <Badge
-                                                    key={holder.userId}
-                                                    variant="secondary"
-                                                    className="gap-1"
-                                                >
-                                                    {holder.name ??
-                                                        holder.userId}
-                                                    <button
-                                                        type="button"
-                                                        aria-label={`Fjern ${holder.name ?? holder.userId}`}
-                                                        onClick={() =>
-                                                            unassign.mutate({
-                                                                groupSlug,
-                                                                positionId:
-                                                                    position.id,
-                                                                userId: holder.userId,
-                                                            })
-                                                        }
-                                                    >
-                                                        <XIcon className="size-3" />
-                                                    </button>
-                                                </Badge>
-                                            ))}
-                                        </div>
-                                    </TableCell>
-                                    <TableCell>
-                                        <div className="flex justify-end gap-2">
-                                            <Button
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() =>
-                                                    setAssignFor(position)
-                                                }
-                                            >
-                                                <UserPlusIcon className="size-4" />
-                                                Tildel
-                                            </Button>
-                                            <Button
-                                                variant="destructive"
-                                                size="sm"
-                                                disabled={remove.isPending}
-                                                onClick={() =>
-                                                    handleDelete(position)
-                                                }
-                                            >
-                                                <Trash2 className="size-4" />
-                                            </Button>
-                                        </div>
-                                    </TableCell>
-                                </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
-                </CardContent>
-            </Card>
-
-            {assignFor && (
-                <AssignPositionDialog
-                    groupSlug={groupSlug}
-                    position={assignFor}
-                    open={Boolean(assignFor)}
-                    onOpenChange={(open) => {
-                        if (!open) setAssignFor(null);
-                    }}
-                />
-            )}
-        </>
-    );
-}
-
-function CreatePositionDialog({
-    groupSlug,
-    open,
-    onOpenChange,
-}: {
-    groupSlug: string;
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-}) {
-    const create = useMutation(createPositionMutation);
-    const [name, setName] = useState("");
-    const [description, setDescription] = useState("");
-    const [scope, setScope] = useState<"group" | "global">("group");
-    const [permissions, setPermissions] = useState<string[]>([]);
-
-    function handleSubmit() {
-        create.mutate(
-            {
-                groupSlug,
-                data: { name, description, permissions, scope },
-            },
-            {
-                onSuccess: () => {
-                    setName("");
-                    setDescription("");
-                    setScope("group");
-                    setPermissions([]);
-                    onOpenChange(false);
-                },
-            },
-        );
-    }
-
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-2xl">
-                <DialogHeader>
-                    <DialogTitle>Nytt verv i {groupSlug}</DialogTitle>
-                </DialogHeader>
-                <FieldGroup>
-                    <Field>
-                        <FieldLabel>Navn</FieldLabel>
-                        <Input
-                            value={name}
-                            onChange={(e) => setName(e.target.value)}
-                            placeholder="f.eks. Økonomiansvarlig"
-                        />
-                    </Field>
-                    <Field>
-                        <FieldLabel>Beskrivelse</FieldLabel>
-                        <Input
-                            value={description}
-                            onChange={(e) => setDescription(e.target.value)}
-                        />
-                    </Field>
-                    <Field>
-                        <FieldLabel>Omfang</FieldLabel>
-                        <Select
-                            items={[
-                                { value: "group", label: "Gruppe" },
-                                { value: "global", label: "Global" },
-                            ]}
-                            value={scope}
-                            onValueChange={(value) => {
-                                if (value === "group" || value === "global") {
-                                    setScope(value);
-                                }
-                            }}
-                        >
-                            <SelectTrigger className="w-48">
-                                <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="group">
-                                    Gruppe (tilganger gjelder kun i gruppen)
-                                </SelectItem>
-                                <SelectItem value="global">
-                                    Global (krever roles:create)
-                                </SelectItem>
-                            </SelectContent>
-                        </Select>
-                    </Field>
-                    <Field>
-                        <FieldLabel>Tilganger</FieldLabel>
-                        <PermissionPicker
-                            selected={permissions}
-                            onChange={setPermissions}
-                        />
-                    </Field>
-                </FieldGroup>
-                <DialogFooter>
-                    <Button
-                        variant="outline"
-                        onClick={() => onOpenChange(false)}
-                    >
-                        Avbryt
-                    </Button>
-                    <Button
-                        disabled={!name || create.isPending}
-                        onClick={handleSubmit}
-                    >
-                        Opprett
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    );
-}
-
-function AssignPositionDialog({
-    groupSlug,
-    position,
-    open,
-    onOpenChange,
-}: {
-    groupSlug: string;
-    position: GroupPosition;
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-}) {
-    const assign = useMutation(assignPositionMutation);
-    const { data: members } = useQuery(getGroupMembersQuery(groupSlug, 0));
-    const [userId, setUserId] = useState<string | null>(null);
-
-    function handleSubmit() {
-        if (!userId) return;
-        assign.mutate(
-            { groupSlug, positionId: position.id, userId },
-            {
-                onSuccess: () => {
-                    setUserId(null);
-                    onOpenChange(false);
-                },
-            },
-        );
-    }
-
-    const items = (members ?? []).map((member) => ({
-        value: member.userId,
-        label: member.userId,
-    }));
-
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>Tildel «{position.name}»</DialogTitle>
-                </DialogHeader>
-                <FieldGroup>
-                    <Field>
-                        <FieldLabel>Gruppemedlem</FieldLabel>
-                        <Select
-                            items={items}
-                            value={userId ?? ""}
-                            onValueChange={(value) => setUserId(value || null)}
-                        >
-                            <SelectTrigger className="w-full">
-                                <SelectValue placeholder="Velg medlem" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {items.map((item) => (
-                                    <SelectItem
-                                        key={item.value}
-                                        value={item.value}
-                                    >
-                                        {item.label}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </Field>
-                </FieldGroup>
-                <DialogFooter>
-                    <Button
-                        variant="outline"
-                        onClick={() => onOpenChange(false)}
-                    >
-                        Avbryt
-                    </Button>
-                    <Button
-                        disabled={!userId || assign.isPending}
-                        onClick={handleSubmit}
-                    >
-                        Tildel
+                        {role ? "Lagre" : "Opprett"}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1452,6 +1452,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/user/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search users
+         * @description Search users by name or username (case-insensitive substring). Used by admin UIs to assign roles and positions. Requires 'users:view' or 'roles:assign'.
+         */
+        get: operations["searchUsers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -3418,6 +3438,12 @@ export interface components {
             description: string | null;
         };
         AllergyList: components["schemas"]["Allergy"][];
+        UserSearchResult: {
+            id: string;
+            name: string | null;
+            username: string | null;
+            image: string | null;
+        }[];
     };
     responses: never;
     parameters: never;
@@ -7471,6 +7497,45 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["AllergyList"];
                 };
+            };
+        };
+    };
+    searchUsers: {
+        parameters: {
+            query: {
+                /** @description Search term (name or username) */
+                q: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Matching users */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserSearchResult"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Forbidden - Requires users:view or roles:assign */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/sdk/src/generated/schemas.ts
+++ b/packages/sdk/src/generated/schemas.ts
@@ -132,6 +132,7 @@ export type UpdateRole = Schemas["UpdateRole"];
 export type UpdateUserSettings = Schemas["UpdateUserSettings"];
 export type UpdateUserSettingsInput = Schemas["UpdateUserSettingsInput"];
 export type UploadResponse = Schemas["UploadResponse"];
+export type UserSearchResult = Schemas["UserSearchResult"];
 export type UserSettings = Schemas["UserSettings"];
 export type UserSettingsBase = Schemas["UserSettingsBase"];
 export type ValidateApiKeyInput = Schemas["ValidateApiKeyInput"];


### PR DESCRIPTION
## Hva

Omskriving av `/admin/roller` etter mønster fra aarhonen sin rolleadmin — den forrige versjonen var kaotisk (permission-badge-vegger, rå bruker-ID-er, tildeling via ID-input).

- **Nytt endepunkt `GET /api/user/search?q=`**: søk på navn eller brukernavn (case-insensitivt), krever `users:view`/`roles:assign`. Med integrasjonstest.
- **Domene-grupperte tilganger**: én checkbox per domene («Arrangementer», «Bøter», …) i stedet for ~70 enkeltpermissions; lister vises som korte sammendrag («Arrangementer, Roller» / «Full tilgang (root)»).
- **Brukersøk-combobox**: roller tildeles ved å søke på navn/brukernavn (debounced serversøk); verv tildeles ved å søke i gruppens medlemsliste. Ingen bruker-ID-er noe sted.
- **Verv-fanen** er default og åpner på Hovedstyret; ryddige tabeller med holder-chips (avatar + navn + fjern) og ⋯-meny for rediger/slett.

## Verifisert

- Typecheck, lint, format grønne; ny test passerer (`user-search.test.ts`).
- Verifisert i browser mot lokal dev: medlemssøk med filtrering på verv, globalt navnesøk på roller, tildeling + fjerning ende-til-ende.

🤖 Generated with [Claude Code](https://claude.com/claude-code)