### PR TITLE
fix(auth): e-postlenker sender brukeren til nettsiden (WEBSITE_URL), ikke API-et

### DIFF
--- a/apps/api/src/test/auth/frontend-callback.test.ts
+++ b/apps/api/src/test/auth/frontend-callback.test.ts
@@ -1,0 +1,50 @@
+import { withFrontendCallback } from "@photon/auth";
+import { describe, expect, it } from "vitest";
+
+const FRONTEND = "https://tihlde.org";
+
+describe("withFrontendCallback", () => {
+    it("rewrites the default relative callbackURL to the frontend", () => {
+        const url =
+            "https://photon.tihlde.org/api/auth/verify-email?token=abc&callbackURL=%2F";
+        const result = new URL(withFrontendCallback(url, FRONTEND));
+        expect(result.searchParams.get("callbackURL")).toBe(
+            "https://tihlde.org/",
+        );
+        // The action link itself still points at the backend (it must —
+        // that's where the token is verified)
+        expect(result.origin).toBe("https://photon.tihlde.org");
+        expect(result.searchParams.get("token")).toBe("abc");
+    });
+
+    it("rewrites relative paths against the frontend, keeping the path", () => {
+        const url =
+            "https://photon.tihlde.org/api/auth/verify-email?token=abc&callbackURL=%2Fprofil";
+        const result = new URL(withFrontendCallback(url, FRONTEND));
+        expect(result.searchParams.get("callbackURL")).toBe(
+            "https://tihlde.org/profil",
+        );
+    });
+
+    it("adds a frontend callbackURL when none is present", () => {
+        const url = "https://photon.tihlde.org/api/auth/verify-email?token=abc";
+        const result = new URL(withFrontendCallback(url, FRONTEND));
+        expect(result.searchParams.get("callbackURL")).toBe(
+            "https://tihlde.org/",
+        );
+    });
+
+    it("leaves absolute callback URLs untouched", () => {
+        const url =
+            "https://photon.tihlde.org/api/auth/reset-password/tok123?callbackURL=https%3A%2F%2Ftihlde.org%2Freset-password";
+        const result = new URL(withFrontendCallback(url, FRONTEND));
+        expect(result.searchParams.get("callbackURL")).toBe(
+            "https://tihlde.org/reset-password",
+        );
+        expect(result.pathname).toBe("/api/auth/reset-password/tok123");
+    });
+
+    it("returns invalid URLs unchanged", () => {
+        expect(withFrontendCallback("not-a-url", FRONTEND)).toBe("not-a-url");
+    });
+});

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -90,6 +90,37 @@ export interface CreateAuthOptions {
     DANGEROUSLY_SET_INSECURE_HASHING_ALGORITHM: boolean;
 }
 
+/**
+ * Point an auth action link's redirect back at the FRONTEND (WEBSITE_URL).
+ *
+ * Better Auth builds action URLs against its own baseURL (the backend) and
+ * defaults `callbackURL` to "/" — a RELATIVE path that resolves against the
+ * backend host when the user clicks the link, landing them on the API
+ * (photon.tihlde.org) instead of the website. Rewrites relative callback
+ * URLs to absolute frontend ones; absolute callbacks (e.g. the frontend's
+ * own redirectTo for password resets) pass through untouched.
+ *
+ * Exported for testing.
+ */
+export function withFrontendCallback(
+    rawUrl: string,
+    frontendOrigin: string,
+): string {
+    try {
+        const url = new URL(rawUrl);
+        const callback = url.searchParams.get("callbackURL") ?? "/";
+        if (callback.startsWith("/")) {
+            url.searchParams.set(
+                "callbackURL",
+                new URL(callback, frontendOrigin).toString(),
+            );
+        }
+        return url.toString();
+    } catch {
+        return rawUrl;
+    }
+}
+
 export function createAuth(options: CreateAuthOptions) {
     const isProd = options.isDevMode !== true;
 
@@ -135,7 +166,7 @@ export function createAuth(options: CreateAuthOptions) {
             async sendResetPassword({ user: u, url }) {
                 await options.services.email.sendPasswordResetMail({
                     to: u.email,
-                    url,
+                    url: withFrontendCallback(url, options.urls.frontend),
                 });
             },
             ...(options.DANGEROUSLY_SET_INSECURE_HASHING_ALGORITHM && !isProd
@@ -159,7 +190,7 @@ export function createAuth(options: CreateAuthOptions) {
             sendVerificationEmail: async ({ user: u, url }) => {
                 await options.services.email.sendVerifyEmailMail({
                     to: u.email,
-                    url,
+                    url: withFrontendCallback(url, options.urls.frontend),
                 });
             },
         },


### PR DESCRIPTION
## Problem

Verifiserings- og tilbakestillingslenker i e-poster sendte brukeren til `photon.tihlde.org` etter fullført handling. Better Auth bygger lenkene mot sin egen `baseURL` (backenden) og defaulter `callbackURL` til `/` — en *relativ* sti som løses mot API-hosten når brukeren klikker.

## Fiks

Ny `withFrontendCallback(url, frontend)` i `packages/auth`: skriver om relative `callbackURL`-verdier til absolutte mot `WEBSITE_URL` før e-posten sendes. Brukes i både `sendResetPassword` og `sendVerificationEmail`.

- Selve handlingslenka går fortsatt via backenden (der token valideres) — det er *redirecten etterpå* som nå peker på nettsiden.
- Absolutte callbacks (f.eks. frontendens egen `redirectTo` ved passord-reset) røres ikke.
- Når `WEBSITE_URL` senere endres til `tihlde.org`, følger e-postene automatisk.

## Verifisert

- 5 nye enhetstester for URL-omskrivingen (`frontend-callback.test.ts`), alle grønne.
- Reell verifisering mot lokal dev: registrerte en bruker og inspiserte den faktiske e-posten — `callbackURL` peker nå på `WEBSITE_URL` (frontend) i stedet for å være relativ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)