### PR TITLE
feat(grupper): URL-driven tabs on group detail pages

### DIFF
--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
+import { z } from "zod";
 
 import { authQueryOptions } from "#/api/auth";
 import {
@@ -29,8 +30,23 @@ import { GROUP_NAV_ITEMS, type GroupNavKey } from "#/components/group-nav";
 import { GroupOmTab } from "#/components/group-om-tab";
 import { mapFine, mapForm, mapGroup, mapLaw, mapMember } from "#/lib/group";
 
+const searchSchema = z.object({
+    tab: z
+        .enum([
+            "om",
+            "medlemmer",
+            "arrangementer",
+            "boter",
+            "lovverk",
+            "sporreskjema",
+        ])
+        .default("om")
+        .catch("om"),
+});
+
 export const Route = createFileRoute("/_app/grupper/$slug")({
     component: GroupDetailPage,
+    validateSearch: searchSchema,
     loader: ({ context, params }) =>
         context.queryClient.ensureQueryData(getGroupBySlugQuery(params.slug)),
 });
@@ -39,8 +55,13 @@ const ADMIN_PERMISSIONS = ["groups:update", "groups:manage", "groups:delete"];
 
 function GroupDetailPage() {
     const { slug } = Route.useParams();
-    const [active, setActive] = useState<GroupNavKey>("om");
+    const { tab: active } = Route.useSearch();
+    const navigate = Route.useNavigate();
     const [fineDialogOpen, setFineDialogOpen] = useState(false);
+
+    function setActive(tab: GroupNavKey) {
+        navigate({ search: (prev) => ({ ...prev, tab }) });
+    }
 
     const { data: apiGroup } = useSuspenseQuery(getGroupBySlugQuery(slug));
     const { data: session } = useQuery(authQueryOptions);


### PR DESCRIPTION
## What
Tab switching on `/grupper/$slug` now writes a `?tab=` search param instead of using local component state.

## Why
The URL previously never changed when switching to Medlemmer, Bøter, Spørreskjema etc., so it was impossible to link directly to a specific tab (e.g. a group's spørreskjema).

## How
- Added a Zod `validateSearch` schema on the route (same pattern as the `visning` param on `/grupper`)
- `tab` is one of `om | medlemmer | arrangementer | boter | lovverk | sporreskjema`, defaults to `om`, and invalid values fall back to `om` via `.catch()`
- Nav selection calls `navigate({ search })`, so browser back/forward works between tabs

## Verified
- Clicking tabs updates the URL and renders the right content (checked in browser)
- Deep link `?tab=sporreskjema` opens the tab directly; `?tab=tullball` falls back to Om
- `bun run typecheck` passes, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)