### PR TITLE
feat(ui): horizontal group page tabs with sliding active indicator

### DIFF
--- a/apps/kvark/src/components/detail-layout.tsx
+++ b/apps/kvark/src/components/detail-layout.tsx
@@ -1,6 +1,5 @@
-import { Button } from "@tihlde/ui/ui/button";
-import { Separator } from "@tihlde/ui/ui/separator";
-import { Fragment, type ReactNode } from "react";
+import { Tabs, TabsIndicator, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
+import type { ReactNode } from "react";
 
 type NavItem<K extends string> = {
     key: K;
@@ -17,9 +16,7 @@ export function DetailLayout({ header, children }: DetailLayoutProps) {
     return (
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
             {header}
-            <div className="grid gap-6 md:grid-cols-[16rem_1fr]">
-                {children}
-            </div>
+            {children}
         </div>
     );
 }
@@ -66,74 +63,36 @@ type DetailLayoutNavProps<K extends string> = {
     sections: NavItem<K>[][];
     active: K;
     onSelect: (key: K) => void;
-    desktopFooter?: ReactNode;
 };
 
 export function DetailLayoutNav<K extends string>({
     sections,
     active,
     onSelect,
-    desktopFooter,
 }: DetailLayoutNavProps<K>) {
     const flatItems = sections.flat();
 
     return (
-        <>
-            <nav className="-mx-4 min-w-0 overflow-x-auto px-4 [scrollbar-width:none] md:hidden [&::-webkit-scrollbar]:hidden">
-                <ul className="flex w-max gap-2">
+        <nav className="-mx-4 min-w-0 overflow-x-auto px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            <Tabs
+                value={active}
+                onValueChange={(value) => onSelect(value as K)}
+            >
+                <TabsList>
+                    <TabsIndicator />
                     {flatItems.map((item) => (
-                        <li key={item.key} className="shrink-0">
-                            <Button
-                                variant={
-                                    active === item.key ? "default" : "ghost"
-                                }
-                                size="sm"
-                                onClick={() => onSelect(item.key)}
-                            >
-                                {item.icon}
-                                {item.label}
-                            </Button>
-                        </li>
+                        <TabsTrigger
+                            key={item.key}
+                            value={item.key}
+                            className="px-3"
+                        >
+                            {item.icon}
+                            {item.label}
+                        </TabsTrigger>
                     ))}
-                </ul>
-            </nav>
-
-            <aside className="hidden md:block">
-                <nav className="flex flex-col gap-2">
-                    {sections.map((items, index) => (
-                        <Fragment key={index}>
-                            {index > 0 ? <Separator className="my-2" /> : null}
-                            <ul className="flex flex-col gap-1">
-                                {items.map((item) => (
-                                    <li key={item.key}>
-                                        <Button
-                                            variant={
-                                                active === item.key
-                                                    ? "default"
-                                                    : "ghost"
-                                            }
-                                            className="w-full justify-start"
-                                            onClick={() => onSelect(item.key)}
-                                        >
-                                            {item.icon}
-                                            <span className="flex-1 text-left">
-                                                {item.label}
-                                            </span>
-                                        </Button>
-                                    </li>
-                                ))}
-                            </ul>
-                        </Fragment>
-                    ))}
-                    {desktopFooter ? (
-                        <>
-                            <Separator className="my-2" />
-                            {desktopFooter}
-                        </>
-                    ) : null}
-                </nav>
-            </aside>
-        </>
+                </TabsList>
+            </Tabs>
+        </nav>
     );
 }
 

--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -22,7 +22,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-    "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+    "group/tabs-list relative inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
     {
         variants: {
             variant: {
@@ -59,7 +59,22 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
                 "relative inline-flex h-[calc(100%-1px)] flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
                 "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
                 "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+                "group-has-data-[slot=tabs-indicator]/tabs-list:data-active:bg-transparent group-has-data-[slot=tabs-indicator]/tabs-list:data-active:shadow-none dark:group-has-data-[slot=tabs-indicator]/tabs-list:data-active:border-transparent dark:group-has-data-[slot=tabs-indicator]/tabs-list:data-active:bg-transparent",
                 "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function TabsIndicator({ className, ...props }: TabsPrimitive.Indicator.Props) {
+    return (
+        <TabsPrimitive.Indicator
+            data-slot="tabs-indicator"
+            renderBeforeHydration
+            className={cn(
+                "absolute top-0 left-0 h-[var(--active-tab-height)] w-[var(--active-tab-width)] translate-x-[var(--active-tab-left)] translate-y-[var(--active-tab-top)] rounded-md bg-background shadow-sm transition-[translate,width,height] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] dark:border dark:border-input dark:bg-input/30",
                 className,
             )}
             {...props}
@@ -77,4 +92,11 @@ function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
     );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };
+export {
+    Tabs,
+    TabsList,
+    TabsTrigger,
+    TabsIndicator,
+    TabsContent,
+    tabsListVariants,
+};


### PR DESCRIPTION
## What

Replaces the vertical sidebar nav on the group detail page (`/grupper/$slug`) with a horizontal tab row where the active tab is a pill that slides smoothly between selections.

- **`@tihlde/ui` tabs**: new `TabsIndicator` component built on Base UI's `Tabs.Indicator` — an absolutely positioned pill that CSS-transitions (300ms) along the `--active-tab-left/width/height` vars. No animation library needed. When an indicator is present in a `TabsList`, the triggers' own active background/shadow is suppressed automatically (via `group-has-data-[slot=tabs-indicator]`), so only the pill animates. Existing `Tabs` usages without an indicator are visually unchanged.
- **kvark `DetailLayoutNav`**: now renders one horizontal `Tabs` row (scrollable on small screens) instead of the mobile button row + desktop sidebar. `DetailLayout` drops the `16rem` sidebar grid column so tab content fills the full width.

## Why

The group page tabs were stacked vertically in a sidebar; this matches the requested horizontal layout with a smooth sliding active-tab animation.

## Reviewer notes

- Animation is pure CSS on Base UI's indicator position vars — verified in browser: clicking tabs slides the pill and switches content, no console errors.
- `bun run typecheck` and `bun run format` pass; remaining lint warnings are pre-existing in `apps/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)