### PR TITLE
fix(auth): scope session cookie to shared parent domain so SSR sees the session

### DIFF
--- a/apps/api/src/test/auth/shared-parent-domain.test.ts
+++ b/apps/api/src/test/auth/shared-parent-domain.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { sharedParentDomain } from "@photon/auth";
+
+/**
+ * The session cookie must be scoped to the parent domain shared by the
+ * frontend and the API so that SSR on the frontend receives it and can
+ * forward it. See `crossSubDomainCookies` in @photon/auth.
+ */
+describe("sharedParentDomain", () => {
+    it("finds the parent when the API is a subdomain of the frontend", () => {
+        expect(
+            sharedParentDomain(
+                "https://tihlde.org",
+                "https://photon.tihlde.org",
+            ),
+        ).toBe("tihlde.org");
+    });
+
+    it("finds the parent when both are sibling subdomains", () => {
+        expect(
+            sharedParentDomain(
+                "https://kvark.tihlde.org",
+                "https://photon.tihlde.org",
+            ),
+        ).toBe("tihlde.org");
+    });
+
+    it("returns undefined for identical hosts (localhost dev)", () => {
+        expect(
+            sharedParentDomain(
+                "http://localhost:3000",
+                "http://localhost:4000",
+            ),
+        ).toBeUndefined();
+    });
+
+    it("returns undefined for unrelated hosts", () => {
+        expect(
+            sharedParentDomain(
+                "https://kvark.vercel.app",
+                "https://photon.tihlde.org",
+            ),
+        ).toBeUndefined();
+    });
+
+    it("never widens the cookie to a bare TLD", () => {
+        expect(
+            sharedParentDomain("https://tihlde.org", "https://ntnu.org"),
+        ).toBeUndefined();
+    });
+});

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -51,6 +51,33 @@ const isFeideConfigured = Boolean(
 const STUD_NTNU_EMAIL_PATTERN =
     /^([a-z0-9]+(?:[._-][a-z0-9]+)*)@stud\.ntnu\.no$/;
 
+/**
+ * Longest domain suffix shared by two URLs' hostnames, or undefined when the
+ * hosts are identical (host-only cookies already reach both) or share fewer
+ * than two labels (never widen a cookie to a bare TLD or unrelated hosts).
+ * `https://tihlde.org` + `https://photon.tihlde.org` -> `tihlde.org`.
+ */
+export function sharedParentDomain(a: string, b: string): string | undefined {
+    const hostA = new URL(a).hostname;
+    const hostB = new URL(b).hostname;
+    if (hostA === hostB) return undefined;
+
+    const labelsA = hostA.split(".");
+    const labelsB = hostB.split(".");
+    const shared: string[] = [];
+    while (
+        labelsA.length > 0 &&
+        labelsB.length > 0 &&
+        labelsA.at(-1) === labelsB.at(-1)
+    ) {
+        shared.unshift(labelsA.pop() as string);
+        labelsB.pop();
+    }
+
+    if (shared.length < 2) return undefined;
+    return shared.join(".");
+}
+
 export interface CreateAuthOptions {
     isDevMode?: boolean;
 
@@ -104,6 +131,22 @@ export function createAuth(options: CreateAuthOptions) {
             "AUTH_SECRET must be set in production; refusing to start with an unsigned auth instance",
         );
     }
+
+    /**
+     * The frontend server-renders auth-guarded routes and must forward the
+     * session cookie to the API. That only works if the browser sends the
+     * cookie to the frontend host too — i.e. the cookie is scoped to the
+     * shared parent domain (tihlde.org for tihlde.org + photon.tihlde.org),
+     * not host-only for the API. Without this, a hard refresh on a guarded
+     * page SSRs with no cookie and bounces a logged-in user to /login.
+     *
+     * Derived from the configured URLs so localhost dev (same hostname on
+     * both sides — host-only cookies already work) stays untouched.
+     */
+    const cookieDomain = sharedParentDomain(
+        options.urls.frontend,
+        options.urls.backend,
+    );
 
     return betterAuth({
         appName: "Photon, TIHLDE Backend",
@@ -174,7 +217,9 @@ export function createAuth(options: CreateAuthOptions) {
         advanced: {
             cookiePrefix: "tihlde",
             useSecureCookies: isProd,
-            crossSubDomainCookies: { enabled: false },
+            crossSubDomainCookies: cookieDomain
+                ? { enabled: true, domain: cookieDomain }
+                : { enabled: false },
             defaultCookieAttributes: {
                 httpOnly: true,
                 sameSite: "lax",


### PR DESCRIPTION
## Problem

A hard refresh on an auth-guarded route (e.g. `/admin/*`) in prod redirects logged-in users to `/login`.

The guard (`authClientWithRedirect` in `apps/kvark/src/api/auth.ts`) runs during SSR on the frontend host (`tihlde.org`), which forwards the incoming request's cookies to `photon.tihlde.org/api/auth/get-session`. But with `crossSubDomainCookies: { enabled: false }`, the session cookie is host-only for `photon.tihlde.org` — the browser never sends it to `tihlde.org`, so SSR sees a definitive "no session" and throws the login redirect. Client-side navigation works because the browser talks to the API directly.

Dev never reproduces this because both servers run on `localhost` (cookies ignore ports).

## Fix

- New `sharedParentDomain(frontendUrl, backendUrl)` in `@photon/auth`: derives the longest shared domain suffix (`tihlde.org` + `photon.tihlde.org` → `tihlde.org`), returns `undefined` for identical hosts and refuses to widen to a bare TLD.
- `crossSubDomainCookies` is enabled with that domain when one exists, scoping the session cookie to `.tihlde.org` so the frontend SSR server receives and can forward it. Localhost dev and unrelated hosts keep host-only cookies (unchanged behavior).

## Verified

- `bun run typecheck` — all packages pass
- New unit tests for the domain derivation (5/5)
- Existing auth integration tests (`apps/api/src/test/auth`) — 10/10 pass

## Reviewer notes

- Sessions created before deploy still carry the old host-only cookie; it is replaced with the domain-scoped one on the next session-cookie refresh (cookie cache is 5 min) or sign-in. Worst case a user re-logs in once.
- The cookie becomes visible to all `*.tihlde.org` subdomains — intended, since the frontend must forward it, but worth noting if untrusted apps are ever hosted on subdomains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)