### PR TITLE
fix(admin): skjul auto-genererte og private grupper fra kontraktinnstillinger

### DIFF
--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -39,8 +39,21 @@ export const Route = createFileRoute("/admin/grupper")({
         context.queryClient.ensureQueryData(getGroupsQuery(0)),
 });
 
+// Kontraktsignering gjelder kun verv (undergrupper, komiteer, styrer,
+// interessegrupper). Automatisk genererte grupper (klassetrinn, studier,
+// TIHLDE) og private bøtelag skal ikke administreres her.
+const HIDDEN_GROUP_TYPES = new Set<Group["type"]>([
+    "STUDYYEAR",
+    "STUDY",
+    "TIHLDE",
+    "PRIVATE",
+]);
+
 function GrupperAdminPage() {
-    const { data: groups } = useSuspenseQuery(getGroupsQuery(0));
+    const { data: allGroups } = useSuspenseQuery(getGroupsQuery(0));
+    const groups = allGroups.filter(
+        (group) => !HIDDEN_GROUP_TYPES.has(group.type),
+    );
     const [expandedSlug, setExpandedSlug] = useState<string | null>(null);
 
     return (


### PR DESCRIPTION
## Hva

Filtrerer bort gruppetypene `STUDYYEAR`, `STUDY`, `TIHLDE` og `PRIVATE` fra grupper-siden i admin-panelet (`/admin/grupper`).

## Hvorfor

Siden viste alle grupper, inkludert auto-genererte grupper (klassetrinn 2017–2025, studieprogrammene og TIHLDE-gruppen) og private bøtelag. Kontraktsignering gjelder kun verv — undergrupper, komiteer, styrer og interessegrupper — så de andre typene skal ikke administreres her.

## Verifisert

- Browser-preview mot lokal dev-API: før viste listen 2017–2025, alle studier, TIHLDE og ett privat bøtelag; etter viser den kun COMMITTEE/SUBGROUP/BOARD/INTERESTGROUP.
- `typecheck` passerer.

Merk: API-et returnerer gruppetyper i store bokstaver (`"STUDYYEAR"` osv.), så filteret er typet mot `Group["type"]` fra SDK-en.

🤖 Generated with [Claude Code](https://claude.com/claude-code)