### PR TITLE
feat(forside): vis «Min profil» i hero når brukeren er logget inn

### DIFF
--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { Button } from "@tihlde/ui/ui/button";
 import { EventCalendar } from "@tihlde/ui/complex/event-calendar";
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import { Plus } from "lucide-react";
 import { Suspense } from "react";
 
+import { authQueryOptions } from "#/api/auth";
 import { getEventsQuery } from "#/api/queries/events";
 import { EventCard } from "#/components/event-card";
 import { NewsCard, type NewsCardProps } from "#/components/news-card";
@@ -154,19 +155,41 @@ function Hero() {
                     cybersikkerhet, Digital forretningsutvikling, Digital
                     transformasjon og Informasjonsbehandling ved NTNU.
                 </p>
-                <div className="flex flex-wrap items-center justify-center gap-2">
-                    <Button
-                        size="lg"
-                        nativeButton={false}
-                        render={<Link to="/login" />}
-                    >
-                        Logg inn
-                    </Button>
-                    <Button size="lg" variant="outline">
-                        Opprett bruker
-                    </Button>
-                </div>
+                <HeroActions />
             </section>
+        </div>
+    );
+}
+
+function HeroActions() {
+    const { data: session } = useQuery(authQueryOptions);
+
+    if (session?.user) {
+        return (
+            <div className="flex flex-wrap items-center justify-center gap-2">
+                <Button
+                    size="lg"
+                    nativeButton={false}
+                    render={<Link to="/profil/$id" params={{ id: "me" }} />}
+                >
+                    Min profil
+                </Button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-wrap items-center justify-center gap-2">
+            <Button
+                size="lg"
+                nativeButton={false}
+                render={<Link to="/login" />}
+            >
+                Logg inn
+            </Button>
+            <Button size="lg" variant="outline">
+                Opprett bruker
+            </Button>
         </div>
     );
 }


### PR DESCRIPTION
## Hva

Hero-seksjonen på forsiden viste alltid «Logg inn» og «Opprett bruker», også for innloggede brukere. Nå leser en ny `HeroActions`-komponent sesjonen via `authQueryOptions` og viser i stedet én «Min profil»-knapp (lenke til `/profil/me`) når brukeren er logget inn.

## Hvorfor

Innloggede brukere skal ikke bli bedt om å logge inn eller opprette bruker på forsiden.

## Verdt å vite

- Navbar-avataren håndterte allerede innlogget tilstand — dette gjelder kun hero-knappene.
- Utlogget tilstand er uendret.
- Verifisert i browser mot lokal API: utlogget viser de gamle knappene; etter innlogging viser heroen «Min profil», og klikk lander på profilsiden. `bun run typecheck` grønt for hele monorepoet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)