### PR TITLE
fix(auth): restore card spacing and refresh login/register UX

### DIFF
--- a/apps/kvark/src/components/or-divider.tsx
+++ b/apps/kvark/src/components/or-divider.tsx
@@ -1,0 +1,15 @@
+import { Separator } from "@tihlde/ui/ui/separator";
+
+/**
+ * Horizontal divider with a small label in the middle, used to separate
+ * primary and alternative actions (e.g. password login vs. Feide).
+ */
+export function OrDivider({ label = "eller" }: { label?: string }) {
+    return (
+        <div className="flex items-center gap-3">
+            <Separator className="flex-1" />
+            <span className="text-xs text-muted-foreground">{label}</span>
+            <Separator className="flex-1" />
+        </div>
+    );
+}

--- a/apps/kvark/src/routes/_auth.tsx
+++ b/apps/kvark/src/routes/_auth.tsx
@@ -1,15 +1,25 @@
 import { Link, Outlet, createFileRoute } from "@tanstack/react-router";
 
+import { TihldeLogo } from "#/components/icons/tihlde";
+
 export const Route = createFileRoute("/_auth")({ component: AuthLayout });
 
 function AuthLayout() {
     return (
         <div className="flex min-h-screen flex-col items-center justify-center gap-8 px-4 py-12">
-            <Link to="/" className="flex items-center gap-2">
-                <div className="size-10 rounded-md bg-muted" aria-hidden />
-                <span className="text-lg">TIHLDE</span>
+            <Link
+                to="/"
+                className="flex items-center gap-1"
+                style={{ color: "var(--color-logo, currentColor)" }}
+            >
+                <div className="size-14">
+                    <TihldeLogo />
+                </div>
+                <span className="text-3xl font-stretch-condensed font-extrabold">
+                    TIHLDE
+                </span>
             </Link>
-            <div className="w-full max-w-sm">
+            <div className="w-full max-w-md">
                 <Outlet />
             </div>
         </div>

--- a/apps/kvark/src/routes/_auth/forgot-password.tsx
+++ b/apps/kvark/src/routes/_auth/forgot-password.tsx
@@ -83,8 +83,8 @@ function ForgotPasswordPage() {
                     tilbakestille passordet.
                 </CardDescription>
             </CardHeader>
-            <form {...formHandlers(form)}>
-                <CardContent>
+            <form {...formHandlers(form)} className="flex flex-col gap-4">
+                <CardContent className="flex flex-col gap-5">
                     <FieldGroup>
                         <form.AppField name="email">
                             {(field) => (
@@ -101,8 +101,7 @@ function ForgotPasswordPage() {
                     <form.AppForm>
                         <form.FormErrors />
                     </form.AppForm>
-                </CardContent>
-                <CardFooter className="flex flex-col gap-3">
+
                     <form.AppForm>
                         <form.SubmitButton
                             className="w-full"
@@ -116,6 +115,8 @@ function ForgotPasswordPage() {
                             Send lenke
                         </form.SubmitButton>
                     </form.AppForm>
+                </CardContent>
+                <CardFooter className="justify-center">
                     <p className="text-sm text-muted-foreground">
                         <Link
                             to="/login"

--- a/apps/kvark/src/routes/_auth/login.tsx
+++ b/apps/kvark/src/routes/_auth/login.tsx
@@ -19,6 +19,7 @@ import {
     signInWithFeide,
 } from "#/api/auth";
 import { FeideSignInButton } from "#/components/feide-sign-in-button";
+import { OrDivider } from "#/components/or-divider";
 import { env } from "#/env";
 import { formHandlers, useAppForm } from "#/hooks/form";
 
@@ -93,8 +94,8 @@ function LoginPage() {
                     Velkommen tilbake. Logg inn på kontoen din.
                 </CardDescription>
             </CardHeader>
-            <form {...formHandlers(form)}>
-                <CardContent>
+            <form {...formHandlers(form)} className="flex flex-col gap-4">
+                <CardContent className="flex flex-col gap-5">
                     <FieldGroup>
                         <form.AppField name="username">
                             {(field) => (
@@ -106,22 +107,31 @@ function LoginPage() {
                                 />
                             )}
                         </form.AppField>
-                        <form.AppField name="password">
-                            {(field) => (
-                                <field.PasswordField
-                                    label="Passord"
-                                    autoComplete="current-password"
-                                    required
-                                />
-                            )}
-                        </form.AppField>
+                        <div className="flex flex-col gap-2">
+                            <form.AppField name="password">
+                                {(field) => (
+                                    <field.PasswordField
+                                        label="Passord"
+                                        autoComplete="current-password"
+                                        required
+                                    />
+                                )}
+                            </form.AppField>
+                            <div className="flex justify-end">
+                                <Link
+                                    to="/forgot-password"
+                                    className="text-sm text-muted-foreground underline underline-offset-4"
+                                >
+                                    Glemt passord?
+                                </Link>
+                            </div>
+                        </div>
                     </FieldGroup>
 
                     <form.AppForm>
                         <form.FormErrors />
                     </form.AppForm>
-                </CardContent>
-                <CardFooter className="flex flex-col gap-3">
+
                     <form.AppForm>
                         <form.SubmitButton
                             className="w-full"
@@ -135,12 +145,18 @@ function LoginPage() {
                             Logg inn
                         </form.SubmitButton>
                     </form.AppForm>
+
                     {env.VITE_FEIDE_ENABLED && (
-                        <FeideSignInButton
-                            onSignIn={handleFeideSignIn}
-                            loading={feideLoading}
-                        />
+                        <>
+                            <OrDivider />
+                            <FeideSignInButton
+                                onSignIn={handleFeideSignIn}
+                                loading={feideLoading}
+                            />
+                        </>
                     )}
+                </CardContent>
+                <CardFooter className="justify-center">
                     <p className="text-sm text-muted-foreground">
                         Har du ikke konto?{" "}
                         <Link
@@ -148,14 +164,6 @@ function LoginPage() {
                             className="underline underline-offset-4"
                         >
                             Opprett bruker
-                        </Link>
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                        <Link
-                            to="/forgot-password"
-                            className="underline underline-offset-4"
-                        >
-                            Glemt passord?
                         </Link>
                     </p>
                 </CardFooter>

--- a/apps/kvark/src/routes/_auth/register.tsx
+++ b/apps/kvark/src/routes/_auth/register.tsx
@@ -20,6 +20,7 @@ import {
     signUpEmailMutationOptions,
 } from "#/api/auth";
 import { FeideSignInButton } from "#/components/feide-sign-in-button";
+import { OrDivider } from "#/components/or-divider";
 import { env } from "#/env";
 import { formHandlers, useAppForm } from "#/hooks/form";
 
@@ -143,8 +144,8 @@ function RegisterPage() {
                     Opprett en konto for å delta på arrangementer.
                 </CardDescription>
             </CardHeader>
-            <form {...formHandlers(form)}>
-                <CardContent>
+            <form {...formHandlers(form)} className="flex flex-col gap-4">
+                <CardContent className="flex flex-col gap-5">
                     <FieldGroup>
                         <form.AppField name="name">
                             {(field) => (
@@ -189,8 +190,7 @@ function RegisterPage() {
                     <form.AppForm>
                         <form.FormErrors />
                     </form.AppForm>
-                </CardContent>
-                <CardFooter className="flex flex-col gap-3">
+
                     <form.AppForm>
                         <form.SubmitButton
                             className="w-full"
@@ -204,12 +204,18 @@ function RegisterPage() {
                             Opprett bruker
                         </form.SubmitButton>
                     </form.AppForm>
+
                     {env.VITE_FEIDE_ENABLED && (
-                        <FeideSignInButton
-                            onSignIn={handleFeideSignIn}
-                            loading={feideLoading}
-                        />
+                        <>
+                            <OrDivider />
+                            <FeideSignInButton
+                                onSignIn={handleFeideSignIn}
+                                loading={feideLoading}
+                            />
+                        </>
                     )}
+                </CardContent>
+                <CardFooter className="justify-center">
                     <p className="text-sm text-muted-foreground">
                         Har du allerede konto?{" "}
                         <Link

--- a/apps/kvark/src/routes/_auth/reset-password.tsx
+++ b/apps/kvark/src/routes/_auth/reset-password.tsx
@@ -118,8 +118,8 @@ function ResetPasswordPage() {
                     Velg et nytt passord for kontoen din.
                 </CardDescription>
             </CardHeader>
-            <form {...formHandlers(form)}>
-                <CardContent>
+            <form {...formHandlers(form)} className="flex flex-col gap-4">
+                <CardContent className="flex flex-col gap-5">
                     <FieldGroup>
                         <form.AppField name="password">
                             {(field) => (
@@ -146,10 +146,10 @@ function ResetPasswordPage() {
                     <form.AppForm>
                         <form.FormErrors />
                     </form.AppForm>
-                </CardContent>
-                <CardFooter className="flex flex-col gap-3">
+
                     <form.AppForm>
                         <form.SubmitButton
+                            className="w-full"
                             loading={
                                 <>
                                     <Spinner />
@@ -160,6 +160,8 @@ function ResetPasswordPage() {
                             Sett nytt passord
                         </form.SubmitButton>
                     </form.AppForm>
+                </CardContent>
+                <CardFooter className="justify-center">
                     <p className="text-sm text-muted-foreground">
                         <Link
                             to="/login"


### PR DESCRIPTION
## Hva

Frisker opp login-siden og resten av auth-flyten (login, register, glemt/tilbakestill passord).

## Hvorfor

Passord-feltet så «croppet» ut og kortet var veldig komprimert: `<form>`-elementet wrappet `CardContent` + `CardFooter`, så Card-ens `gap-4` aldri gjaldt inne i skjemaet — den muted footeren lå klint oppå passord-feltet. I tillegg viste auth-layouten en grå placeholder-boks i stedet for TIHLDE-logoen.

## Endringer

- `flex flex-col gap-4` på skjemaet i alle fire auth-sider, så kortets rytme gjenopprettes
- Ekte `TihldeLogo` i auth-layouten, lagt ut som hero-en på forsiden (ikon + ordmerke side om side)
- «Glemt passord?» flyttet opp som høyrejustert lenke rett under passord-feltet
- Submit-knappen inn i kortinnholdet; footeren holder nå én sentrert sekundærlenke
- Feide-knappen skilt fra skjemaet med en gjenbrukbar «eller»-divider (`or-divider.tsx`)
- Auth-kortet utvidet fra `max-w-sm` til `max-w-md`

## Verifisering

- `bun run typecheck`, `bun run lint`, `bun run format` passerer
- Visuelt verifisert i browser-preview (login + register), ingen console-feil
- Feide-knappen er ikke synlig lokalt (`VITE_FEIDE_ENABLED` av), men divider + knapp rendres når flagget er på

🤖 Generated with [Claude Code](https://claude.com/claude-code)