### PR TITLE
feat(nav): Søknader-lenke til utlegg.tihlde.org under For Medlemmer

### DIFF
--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -129,6 +129,13 @@ function AppLayout() {
                                   },
                                   {
                                       kind: "external",
+                                      label: "Søknader",
+                                      href: "https://utlegg.tihlde.org",
+                                      description:
+                                          "Send inn utlegg og søknader til TIHLDE",
+                                  },
+                                  {
+                                      kind: "external",
                                       label: "Kontres",
                                       href: "https://new-kontres.tihlde.org",
                                       description:


### PR DESCRIPTION
## Hva

Legger til en ekstern lenke **Søknader** i «For Medlemmer»-dropdownen i navigasjonen, som peker til https://utlegg.tihlde.org (åpnes i ny fane med ekstern-lenke-ikon).

## Hvorfor

Medlemmer skal enkelt finne utleggs-/søknadsportalen fra hovednavigasjonen.

## Verifisering

- `typecheck`, `oxlint` og `oxfmt` passerer
- Verifisert i browser-preview at lenken rendres i dropdownen med riktig `href` og `target="_blank"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)