### PR TITLE
feat(admin): felles heading-stil, norske gruppetyper, medlemstall og tabs på gruppesiden

### DIFF
--- a/apps/api/src/routes/groups/list.ts
+++ b/apps/api/src/routes/groups/list.ts
@@ -1,5 +1,5 @@
 import { schema } from "@photon/db";
-import { asc, eq, ilike, or } from "drizzle-orm";
+import { asc, count, eq, ilike, or } from "drizzle-orm";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { groupListSchema } from "./schema";
@@ -46,6 +46,23 @@ export const listRoute = route().get(
             orderBy: [asc(schema.group.name)],
         });
 
-        return c.json(groups);
+        // Fetch member counts in one aggregated query instead of per group
+        const memberCounts = await db
+            .select({
+                groupSlug: schema.groupMembership.groupSlug,
+                memberCount: count(),
+            })
+            .from(schema.groupMembership)
+            .groupBy(schema.groupMembership.groupSlug);
+        const countBySlug = new Map(
+            memberCounts.map((row) => [row.groupSlug, row.memberCount]),
+        );
+
+        return c.json(
+            groups.map((group) => ({
+                ...group,
+                memberCount: countBySlug.get(group.slug) ?? 0,
+            })),
+        );
     },
 );

--- a/apps/api/src/routes/groups/schema.ts
+++ b/apps/api/src/routes/groups/schema.ts
@@ -157,7 +157,19 @@ export const groupSchema = Schema(
     }),
 );
 
-export const groupListSchema = Schema("GroupList", z.array(groupSchema));
+export const groupWithMemberCountSchema = Schema(
+    "GroupWithMemberCount",
+    groupSchema.extend({
+        memberCount: z
+            .number()
+            .meta({ description: "Number of members in the group" }),
+    }),
+);
+
+export const groupListSchema = Schema(
+    "GroupList",
+    z.array(groupWithMemberCountSchema),
+);
 
 const membershipSchema = z.object({
     role: z.enum(["member", "leader"]),

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -20,11 +20,12 @@ import {
     TableRow,
 } from "@tihlde/ui/ui/table";
 import type {
-    Group,
     GroupSignatureList,
     GroupSignatureMember,
+    GroupWithMemberCount,
 } from "@tihlde/sdk";
-import { CheckCircle2, XCircle } from "lucide-react";
+import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
+import { CheckCircle2, UsersIcon, XCircle } from "lucide-react";
 import { useState } from "react";
 
 import { getGroupsQuery, updateGroupMutation } from "#/api/queries/groups";
@@ -32,6 +33,8 @@ import {
     getGroupSignaturesQuery,
     revokeSignatureMutation,
 } from "#/api/queries/contracts";
+import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminPageHeader } from "#/components/admin-page-header";
 
 export const Route = createFileRoute("/admin/grupper")({
     component: GrupperAdminPage,
@@ -42,43 +45,80 @@ export const Route = createFileRoute("/admin/grupper")({
 // Kontraktsignering gjelder kun verv (undergrupper, komiteer, styrer,
 // interessegrupper). Automatisk genererte grupper (klassetrinn, studier,
 // TIHLDE) og private bøtelag skal ikke administreres her.
-const HIDDEN_GROUP_TYPES = new Set<Group["type"]>([
-    "STUDYYEAR",
-    "STUDY",
-    "TIHLDE",
-    "PRIVATE",
-]);
+const GROUP_TYPE_TABS = [
+    { type: "SUBGROUP", label: "Undergrupper" },
+    { type: "COMMITTEE", label: "Komiteer" },
+    { type: "BOARD", label: "Styrer" },
+    { type: "INTERESTGROUP", label: "Interessegrupper" },
+] as const;
+
+type TabType = (typeof GROUP_TYPE_TABS)[number]["type"];
+
+const GROUP_TYPE_LABELS: Record<string, string> = {
+    SUBGROUP: "Undergruppe",
+    COMMITTEE: "Komité",
+    BOARD: "Styre",
+    INTERESTGROUP: "Interessegruppe",
+    STUDYYEAR: "Klassetrinn",
+    STUDY: "Studie",
+    TIHLDE: "TIHLDE",
+    PRIVATE: "Privat",
+};
+
+/** Norsk visningsnavn for en gruppetype fra databasen (f.eks. "SUBGROUP"). */
+function groupTypeLabel(type: string): string {
+    return (
+        GROUP_TYPE_LABELS[type] ??
+        type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
+    );
+}
 
 function GrupperAdminPage() {
     const { data: allGroups } = useSuspenseQuery(getGroupsQuery(0));
-    const groups = allGroups.filter(
-        (group) => !HIDDEN_GROUP_TYPES.has(group.type),
-    );
+    const [tab, setTab] = useState<TabType>("SUBGROUP");
     const [expandedSlug, setExpandedSlug] = useState<string | null>(null);
+
+    const groups = allGroups.filter((group) => group.type === tab);
 
     return (
         <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
-            <div className="flex flex-col gap-1">
-                <h1>Grupper – kontraktinnstillinger</h1>
-                <p>
-                    Administrer kontraktsignering per gruppe og se
-                    signeringsstatus for medlemmer.
-                </p>
-            </div>
-            <div className="flex flex-col gap-4">
-                {groups.map((group) => (
-                    <GroupCard
-                        key={group.slug}
-                        group={group}
-                        expanded={expandedSlug === group.slug}
-                        onToggle={() =>
-                            setExpandedSlug(
-                                expandedSlug === group.slug ? null : group.slug,
-                            )
-                        }
-                    />
-                ))}
-            </div>
+            <AdminPageHeader
+                title="Grupper – kontraktinnstillinger"
+                description="Administrer kontraktsignering per gruppe og se signeringsstatus for medlemmer."
+            />
+            <Tabs value={tab} onValueChange={(v) => setTab(v as TabType)}>
+                <TabsList>
+                    {GROUP_TYPE_TABS.map(({ type, label }) => (
+                        <TabsTrigger key={type} value={type}>
+                            {label}
+                        </TabsTrigger>
+                    ))}
+                </TabsList>
+            </Tabs>
+            {groups.length === 0 ? (
+                <AdminEmptyState
+                    icon={UsersIcon}
+                    title="Ingen grupper"
+                    description="Fant ingen grupper av denne typen."
+                />
+            ) : (
+                <div className="flex flex-col gap-4">
+                    {groups.map((group) => (
+                        <GroupCard
+                            key={group.slug}
+                            group={group}
+                            expanded={expandedSlug === group.slug}
+                            onToggle={() =>
+                                setExpandedSlug(
+                                    expandedSlug === group.slug
+                                        ? null
+                                        : group.slug,
+                                )
+                            }
+                        />
+                    ))}
+                </div>
+            )}
         </div>
     );
 }
@@ -88,7 +128,7 @@ function GroupCard({
     expanded,
     onToggle,
 }: {
-    group: Group;
+    group: GroupWithMemberCount;
     expanded: boolean;
     onToggle: () => void;
 }) {
@@ -110,7 +150,8 @@ function GroupCard({
                     <div className="flex flex-col gap-1">
                         <CardTitle>{group.name}</CardTitle>
                         <CardDescription>
-                            {group.slug} · {group.type}
+                            {groupTypeLabel(group.type)} · {group.memberCount}{" "}
+                            {group.memberCount === 1 ? "medlem" : "medlemmer"}
                         </CardDescription>
                     </div>
                     <div className="flex items-center gap-2">

--- a/apps/kvark/src/routes/admin/opptak.tsx
+++ b/apps/kvark/src/routes/admin/opptak.tsx
@@ -27,6 +27,7 @@ import { CheckCircle2, Upload, XCircle, Zap } from "lucide-react";
 import { Suspense, lazy, useEffect, useState } from "react";
 
 import { uploadAssetMutation } from "#/api/queries/assets";
+import { AdminPageHeader } from "#/components/admin-page-header";
 import {
     activateContractMutation,
     createContractMutation,
@@ -51,10 +52,10 @@ function OpptakAdminPage() {
 
     return (
         <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
-            <div className="flex flex-col gap-1">
-                <h1>Kontraktstyring</h1>
-                <p>Last opp og administrer frivillighetskontrakter.</p>
-            </div>
+            <AdminPageHeader
+                title="Kontraktstyring"
+                description="Last opp og administrer frivillighetskontrakter."
+            />
             <UploadContractCard />
             <ContractListCard
                 contracts={contracts}

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2753,7 +2753,7 @@ export interface components {
             /** @description Whether notification should be marked as read */
             isRead: boolean;
         };
-        Group: {
+        GroupWithMemberCount: {
             /** @description Group slug */
             slug: string;
             /** @description Group image URL */
@@ -2778,8 +2778,10 @@ export interface components {
             createdAt: string;
             /** @description Last update timestamp */
             updatedAt: string;
+            /** @description Number of members in the group */
+            memberCount: number;
         };
-        GroupList: components["schemas"]["Group"][];
+        GroupList: components["schemas"]["GroupWithMemberCount"][];
         MyGroup: {
             /** @description Group slug */
             slug: string;
@@ -2813,6 +2815,32 @@ export interface components {
             };
         };
         MyGroupList: components["schemas"]["MyGroup"][];
+        Group: {
+            /** @description Group slug */
+            slug: string;
+            /** @description Group image URL */
+            imageUrl: string | null;
+            /** @description Group name */
+            name: string;
+            /** @description Group description */
+            description: string | null;
+            /** @description Group contact email */
+            contactEmail: string | null;
+            /** @description Group type */
+            type: string;
+            /** @description Group fines info */
+            finesInfo: string;
+            /** @description Group fines activated */
+            finesActivated: boolean;
+            /** @description Group fines admin ID */
+            finesAdminId: string | null;
+            /** @description Whether contract signing is required */
+            contractSigningRequired: boolean;
+            /** @description Creation timestamp */
+            createdAt: string;
+            /** @description Last update timestamp */
+            updatedAt: string;
+        };
         CreateGroup: {
             /** @description Unique group slug identifier */
             slug: string;

--- a/packages/sdk/src/generated/schemas.ts
+++ b/packages/sdk/src/generated/schemas.ts
@@ -88,6 +88,7 @@ export type GroupPositionList = Schemas["GroupPositionList"];
 export type GroupPositionMessage = Schemas["GroupPositionMessage"];
 export type GroupSignatureList = Schemas["GroupSignatureList"];
 export type GroupSignatureMember = Schemas["GroupSignatureMember"];
+export type GroupWithMemberCount = Schemas["GroupWithMemberCount"];
 export type HTTPAppException = Schemas["HTTPAppException"];
 export type JobDetail = Schemas["JobDetail"];
 export type JobList = Schemas["JobList"];


### PR DESCRIPTION
## Hva

- **Opptak- og gruppesidene** i admin bruker nå `AdminPageHeader` slik som resten av admin-sidene (samme heading-stil og subheader).
- **Gruppesiden**:
  - Viser norsk gruppetype med stor forbokstav (f.eks. `SUBGROUP` → «Undergruppe») i stedet for rå DB-verdi.
  - Slug er fjernet fra kortet; antall medlemmer vises i stedet («Undergruppe · 34 medlemmer», entall «1 medlem»).
  - Tabs under subheader for å velge gruppetype: Undergrupper / Komiteer / Styrer / Interessegrupper (samme `Tabs`-mønster som roller-siden). Tom tab viser `AdminEmptyState`.
- **Backend**: `GET /api/groups` returnerer nå `memberCount` per gruppe via ett aggregert count-query (nytt `GroupWithMemberCount`-skjema, ingen N+1). SDK regenerert.

## Hvorfor

Admin-sidene for opptak og grupper hadde egne, avvikende headere, og gruppesiden viste slug og DB-enum direkte — lite brukervennlig for admins.

## For reviewer

- `GroupWithMemberCount` utvider `Group`, så eksisterende konsumenter av gruppelisten er bakoverkompatible.
- Verifisert lokalt i nettleser mot lokal API: tabs, norske labels og medlemstall stemmer med databasen.
- `bun run typecheck`, lint og format grønt; `groups.test.ts` 18/18 passert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)