### PR TITLE
fix(ui): reserver scrollbar-gutter så tab-bytte ikke forskyver layout

### DIFF
--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -170,6 +170,10 @@
     }
     html {
         @apply font-sans;
+        /* Reserve space for the vertical scrollbar so centered layouts
+         * don't shift horizontally when content height changes (e.g.
+         * switching between short and tall tabs). */
+        scrollbar-gutter: stable;
     }
 }
 


### PR DESCRIPTION
## Problem
På gruppesiden (og alle andre sider med tabs) forskjøv hele layouten seg horisontalt når man byttet mellom korte og lange tabs — f.eks. Om → Medlemmer/Bøter på index-gruppa i prod. Det så ut som siden "glitchet".

## Årsak
Sideinnholdet ligger i en sentrert `container mx-auto`. Tabs med langt innhold gir vertikal scrollbar, korte tabs gjør ikke. Scrollbaren stjeler ~15px viewport-bredde, så containeren re-sentreres ved hvert bytte.

## Fix
`scrollbar-gutter: stable` på `html` i `@tihlde/ui` sine base-styles. Plassen til scrollbaren reserveres alltid, så bredden er konstant uavhengig av innholdshøyde. Global fix — dekker gruppesider, profilside, admin og alt annet med tabs.

## Verifisering
Målt i browser på `/grupper/index` gjennom alle seks tabs: `scrollHeight` varierer 736px → 72 440px (scrollbar av/på), men `clientWidth` (1265px) og x-posisjon for header/nav er identisk på alle. `bun run format` passerer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)