### PR TITLE
feat(ui): konsistent glideanimasjon på alle tabs

### DIFF
--- a/apps/kvark/src/components/detail-layout.tsx
+++ b/apps/kvark/src/components/detail-layout.tsx
@@ -1,4 +1,4 @@
-import { Tabs, TabsIndicator, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
+import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import type { ReactNode } from "react";
 
 type NavItem<K extends string> = {
@@ -79,7 +79,6 @@ export function DetailLayoutNav<K extends string>({
                 onValueChange={(value) => onSelect(value as K)}
             >
                 <TabsList>
-                    <TabsIndicator />
                     {flatItems.map((item) => (
                         <TabsTrigger
                             key={item.key}

--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -39,6 +39,7 @@ const tabsListVariants = cva(
 function TabsList({
     className,
     variant = "default",
+    children,
     ...props
 }: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
     return (
@@ -47,7 +48,10 @@ function TabsList({
             data-variant={variant}
             className={cn(tabsListVariants({ variant }), className)}
             {...props}
-        />
+        >
+            {variant === "default" ? <TabsIndicator /> : null}
+            {children}
+        </TabsPrimitive.List>
     );
 }
 


### PR DESCRIPTION
## Hva

`TabsList` i `@tihlde/ui` rendrer nå `<TabsIndicator />` automatisk (for `default`-varianten), og den manuelle indikatoren i `detail-layout.tsx` er fjernet.

## Hvorfor

Alle tabs på siden brukte allerede den delte `Tabs`-komponenten, men bare gruppesidens hovednavigasjon la til `<TabsIndicator />` — komponenten som gir den glidende pill-animasjonen. Gruppeoversikten, forsiden, arrangementer, bøter-fanene, filtrene og admin-sidene byttet derfor aktiv fane uten animasjon. Nå får alle tab-lister samme animasjon uten at hvert kallsted må huske indikatoren.

## Verifisert

- Nettleser: indikatoren glir på `/grupper` (Liste/Hierarki) og på gruppesiden `/grupper/index` har alle fire tab-lister (hovednav, bøter-visning, begge filtrene) nøyaktig én indikator som ligger piksel-perfekt over aktiv fane.
- `typecheck`, `lint` og `format` passerer (kun eksisterende warnings i urelaterte API-filer).

## For reviewer

`line`-varianten av `TabsList` får ikke auto-indikator (den bruker understrek-styling i stedet) — varianten er ikke i bruk noe sted i dag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)