### PR TITLE
fix: verify Vipps webhook signatures

### DIFF
--- a/apps/api/src/lib/vipps.ts
+++ b/apps/api/src/lib/vipps.ts
@@ -1,4 +1,6 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { Client, type GetPaymentResponse } from "@vippsmobilepay/sdk";
+import type { Context } from "hono";
 import { getRedis } from "./cache";
 import { env } from "./env";
 
@@ -263,4 +265,122 @@ async function getWebhookSecret() {
     return webhook.secret;
 }
 
-export async function verifyVippsWebhookRequest() {}
+/**
+ * The raw parts of an incoming request needed to verify a Vipps webhook.
+ *
+ * Vipps signs each callback with an HMAC-SHA256 signature over the request
+ * method, path, host, date and a hash of the raw body. See
+ * https://developer.vippsmobilepay.com/docs/APIs/webhooks-api/request-authentication/
+ */
+export interface VippsWebhookRequestParts {
+    /** HTTP method, e.g. "POST". */
+    method: string;
+    /** Path and query string of the request, e.g. "/api/event/payment/webhook". */
+    pathAndQuery: string;
+    /** The `Host` header value the request was sent to. */
+    host: string;
+    /** The `x-ms-date` (or `date`) header value. */
+    date: string;
+    /** The `x-ms-content-sha256` header value (base64 SHA-256 of the body). */
+    contentSha256: string;
+    /** The `Authorization` header value. */
+    authorization: string;
+    /** The raw, unparsed request body. */
+    rawBody: string;
+}
+
+/**
+ * Constant-time comparison of two UTF-8 strings that never throws on length
+ * mismatch (which `timingSafeEqual` would).
+ */
+function safeStringEqual(a: string, b: string): boolean {
+    const bufferA = Buffer.from(a, "utf-8");
+    const bufferB = Buffer.from(b, "utf-8");
+
+    if (bufferA.length !== bufferB.length) {
+        return false;
+    }
+
+    return timingSafeEqual(bufferA, bufferB);
+}
+
+/**
+ * Extracts the `Signature` value from a Vipps `Authorization` header of the form
+ * `HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=<base64>`.
+ */
+function parseAuthorizationSignature(authorization: string): string | null {
+    if (!authorization.startsWith("HMAC-SHA256 ")) {
+        return null;
+    }
+
+    const match = authorization.match(/Signature=([^&\s]+)/);
+    return match?.[1] ?? null;
+}
+
+/**
+ * Verifies the authenticity of a Vipps webhook request from its raw parts.
+ *
+ * Recomputes the content hash and HMAC-SHA256 signature using the shared webhook
+ * secret and compares them, in constant time, against the values Vipps sent.
+ *
+ * @returns `true` if the request is authentic, `false` otherwise.
+ */
+export function verifyVippsWebhookSignature(
+    parts: VippsWebhookRequestParts,
+    secret: string,
+): boolean {
+    const providedSignature = parseAuthorizationSignature(parts.authorization);
+
+    if (!providedSignature || !parts.contentSha256 || !parts.date) {
+        return false;
+    }
+
+    // Verify the body has not been tampered with: base64(sha256(rawBody)) must
+    // match the x-ms-content-sha256 header.
+    const computedContentHash = createHash("sha256")
+        .update(parts.rawBody, "utf-8")
+        .digest("base64");
+
+    if (!safeStringEqual(computedContentHash, parts.contentSha256)) {
+        return false;
+    }
+
+    // Rebuild the string Vipps signed and recompute the HMAC-SHA256 signature.
+    const stringToSign = `${parts.method}\n${parts.pathAndQuery}\n${parts.date};${parts.host};${computedContentHash}`;
+
+    const expectedSignature = createHmac("sha256", secret)
+        .update(stringToSign, "utf-8")
+        .digest("base64");
+
+    return safeStringEqual(expectedSignature, providedSignature);
+}
+
+/**
+ * Verifies an incoming Vipps webhook request from the Hono context.
+ *
+ * The raw body must be read (e.g. via `c.req.text()`) before parsing it as JSON,
+ * because the body can only be consumed once and the raw bytes are required to
+ * recompute the content hash.
+ *
+ * @returns `true` if the request is authentic, `false` otherwise.
+ */
+export async function verifyVippsWebhookRequest(
+    c: Context,
+    rawBody: string,
+): Promise<boolean> {
+    const secret = await getWebhookSecret();
+    const url = new URL(c.req.url);
+
+    return verifyVippsWebhookSignature(
+        {
+            method: c.req.method,
+            pathAndQuery: url.pathname + url.search,
+            host: c.req.header("host") ?? url.host,
+            date: c.req.header("x-ms-date") ?? c.req.header("date") ?? "",
+            contentSha256: c.req.header("x-ms-content-sha256") ?? "",
+            authorization: c.req.header("authorization") ?? "",
+            rawBody,
+        },
+        secret,
+    );
+}

--- a/apps/api/src/routes/event/payment/webhook.ts
+++ b/apps/api/src/routes/event/payment/webhook.ts
@@ -3,7 +3,10 @@ import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "../../../lib/route";
-import { getPaymentDetails } from "../../../lib/vipps";
+import {
+    getPaymentDetails,
+    verifyVippsWebhookRequest,
+} from "../../../lib/vipps";
 
 /**
  * For documentation, please visit https://developer.vippsmobilepay.com/docs/APIs/webhooks-api/events/#epayment-api-event-types
@@ -38,10 +41,26 @@ export const paymentWebhookRoute = route().post(
             description: "Webhook processed successfully",
         })
         .badRequest({ description: "Invalid webhook payload" })
+        .response({
+            statusCode: 401,
+            description: "Invalid webhook signature",
+        })
         .notFound({ description: "Payment not found" })
         .build(),
     async (c) => {
-        const body = (await c.req.json()) as WebhookPayload;
+        // Read the raw body BEFORE parsing: the signature is computed over the
+        // raw bytes, and the body can only be consumed once.
+        const rawBody = await c.req.text();
+
+        // Reject any request that is not authentically signed by Vipps.
+        const isAuthentic = await verifyVippsWebhookRequest(c, rawBody);
+        if (!isAuthentic) {
+            throw new HTTPException(401, {
+                message: "Invalid webhook signature",
+            });
+        }
+
+        const body = JSON.parse(rawBody) as WebhookPayload;
         const { db } = c.get("ctx");
 
         // Vipps webhook payload structure

--- a/apps/api/src/test/event/vipps-webhook.test.ts
+++ b/apps/api/src/test/event/vipps-webhook.test.ts
@@ -1,0 +1,125 @@
+import { createHash, createHmac } from "node:crypto";
+import {
+    type VippsWebhookRequestParts,
+    verifyVippsWebhookSignature,
+} from "~/lib/vipps";
+import { describe, expect, it } from "vitest";
+
+const SECRET = "super-secret-webhook-key";
+
+/**
+ * Builds a set of request parts signed exactly the way Vipps signs webhook
+ * callbacks, so we can assert the verifier accepts genuine requests and rejects
+ * tampered ones.
+ * See https://developer.vippsmobilepay.com/docs/APIs/webhooks-api/request-authentication/
+ */
+function signRequest(
+    body: string,
+    overrides: Partial<Omit<VippsWebhookRequestParts, "rawBody">> = {},
+): VippsWebhookRequestParts {
+    const method = overrides.method ?? "POST";
+    const pathAndQuery = overrides.pathAndQuery ?? "/api/event/payment/webhook";
+    const host = overrides.host ?? "api.tihlde.org";
+    const date = overrides.date ?? "Thu, 30 Mar 2023 08:38:32 GMT";
+
+    const contentSha256 = createHash("sha256")
+        .update(body, "utf-8")
+        .digest("base64");
+
+    const stringToSign = `${method}\n${pathAndQuery}\n${date};${host};${contentSha256}`;
+    const signature = createHmac("sha256", SECRET)
+        .update(stringToSign, "utf-8")
+        .digest("base64");
+
+    return {
+        method,
+        pathAndQuery,
+        host,
+        date,
+        contentSha256: overrides.contentSha256 ?? contentSha256,
+        authorization:
+            overrides.authorization ??
+            `HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=${signature}`,
+        rawBody: body,
+    };
+}
+
+describe("verifyVippsWebhookSignature", () => {
+    const body = JSON.stringify({
+        reference: "payment-123",
+        name: "AUTHORIZED",
+        success: true,
+    });
+
+    it("accepts a request with a valid signature", () => {
+        const parts = signRequest(body);
+        expect(verifyVippsWebhookSignature(parts, SECRET)).toBe(true);
+    });
+
+    it("rejects a request signed with a different secret", () => {
+        const parts = signRequest(body);
+        expect(verifyVippsWebhookSignature(parts, "wrong-secret")).toBe(false);
+    });
+
+    it("rejects a request whose body was tampered with after signing", () => {
+        const parts = signRequest(body);
+        const tampered: VippsWebhookRequestParts = {
+            ...parts,
+            rawBody: body.replace("payment-123", "payment-999"),
+        };
+        expect(verifyVippsWebhookSignature(tampered, SECRET)).toBe(false);
+    });
+
+    it("rejects a request whose content hash does not match the body", () => {
+        const parts = signRequest(body);
+        const tampered: VippsWebhookRequestParts = {
+            ...parts,
+            contentSha256: createHash("sha256")
+                .update("some other body", "utf-8")
+                .digest("base64"),
+        };
+        expect(verifyVippsWebhookSignature(tampered, SECRET)).toBe(false);
+    });
+
+    it("rejects a request whose signed method or path differs", () => {
+        const parts = signRequest(body);
+        expect(
+            verifyVippsWebhookSignature(
+                { ...parts, pathAndQuery: "/api/event/payment/other" },
+                SECRET,
+            ),
+        ).toBe(false);
+        expect(
+            verifyVippsWebhookSignature({ ...parts, method: "GET" }, SECRET),
+        ).toBe(false);
+    });
+
+    it("rejects a request with a malformed Authorization header", () => {
+        const parts = signRequest(body);
+        expect(
+            verifyVippsWebhookSignature(
+                { ...parts, authorization: "Bearer some-token" },
+                SECRET,
+            ),
+        ).toBe(false);
+        expect(
+            verifyVippsWebhookSignature(
+                { ...parts, authorization: "" },
+                SECRET,
+            ),
+        ).toBe(false);
+    });
+
+    it("rejects a request missing the content hash or date headers", () => {
+        const parts = signRequest(body);
+        expect(
+            verifyVippsWebhookSignature(
+                { ...parts, contentSha256: "" },
+                SECRET,
+            ),
+        ).toBe(false);
+        expect(
+            verifyVippsWebhookSignature({ ...parts, date: "" }, SECRET),
+        ).toBe(false);
+    });
+});

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -5274,6 +5274,13 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Invalid webhook signature */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Not Found - Payment not found */
             404: {
                 headers: {


### PR DESCRIPTION
## Hva

Betalingswebhooken (`/api/event/payment/webhook`) behandlet tidligere **enhver** POSTet payload uten autentisering — hvem som helst kunne forfalske en forespørsel og endre betalingsstatus. Denne PR-en implementerer signaturverifisering per [Vipps webhooks-API request-authentication-spec](https://developer.vippsmobilepay.com/docs/APIs/webhooks-api/request-authentication/).

### Endringer
- **`apps/api/src/lib/vipps.ts`**: erstattet den tomme `verifyVippsWebhookRequest`-stubben med:
  - `verifyVippsWebhookSignature(parts, secret)` — ren funksjon som (1) regner ut `base64(sha256(rawBody))` og sjekker mot `x-ms-content-sha256`, (2) bygger string-to-sign `METHOD\npath\ndate;host;contentHash`, (3) regner ut `base64(HMAC-SHA256(secret, stringToSign))` og sammenligner mot `Signature=` fra `Authorization`-headeren. All sammenligning i konstant tid (`timingSafeEqual` med trygg lengdesjekk).
  - `verifyVippsWebhookRequest(c, rawBody)` — Hono-wrapper som henter hemmeligheten via eksisterende `getWebhookSecret()`.
- **`apps/api/src/routes/event/payment/webhook.ts`**: leser rå body med `c.req.text()` **før** parsing, verifierer signaturen helt øverst, kaster `HTTPException(401)` ved ugyldig signatur, og parser deretter med `JSON.parse`. La til 401 i OpenAPI-responsene.
- **`apps/api/src/test/event/vipps-webhook.test.ts`**: ny enhetstest (7 caser).
- **`packages/sdk/src/generated/openapi.ts`**: regenerert (401-respons på webhook-ruten).

## Verifisert
- `bun run typecheck` ✅
- `bun run build` ✅ (4/4 tasks)
- `bun run lint:fix` / `format:fix` ✅ — ingen advarsler i endrede filer
- Enhetstest ✅ 7/7: gyldig signatur aksepteres; feil hemmelighet, tuklet body, feil content-hash, endret method/path, malformert/tom `Authorization`, og manglende content-hash/dato avvises. Testen signerer med ekte `node:crypto` og speiler Vipps-algoritmen.

> Merk: i `VIPPS_TEST_MODE` er hemmeligheten `"test"`, så verifisering er aktiv også lokalt (ingen bypass — bevisst, siden dette er en sikkerhetsfiks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)