### PR TITLE
feat(profil): vis studieprogram/klasse ved profilbildet, skjul study/studyyear i medlemskap

### DIFF
--- a/apps/kvark/src/lib/utils.ts
+++ b/apps/kvark/src/lib/utils.ts
@@ -27,3 +27,49 @@ export function initials(name: string): string {
         .join("")
         .toUpperCase();
 }
+
+/**
+ * Beregn hvilket klassetrinn en student er på ut fra oppstartsåret (kull).
+ * Det norske studieåret starter i august, så fra og med august teller man ett
+ * trinn opp. Måned er 0-indeksert, så `>= 7` betyr august og senere.
+ * Returnerer det rå tallet (ingen cap) — la kalleren bestemme gyldig intervall.
+ */
+export function computeClassYear(startYear: number, now = new Date()): number {
+    return now.getFullYear() - startYear + (now.getMonth() >= 7 ? 1 : 0);
+}
+
+type StudyGroupLike = { name: string; type: string };
+
+/**
+ * Avled studieprogram og klassetrinn fra brukerens gruppemedlemskap.
+ * `study`- og `studyyear`-gruppene er en projeksjon av Feide-dataene; typen
+ * lagres i UPPERCASE i databasen, så sammenlign case-insensitivt.
+ *
+ * Klassetrinn vises bare når det havner i intervallet 1–5 (bachelor 3 + master
+ * 2). Utenfor dette (typisk alumni, siden medlemskap aldri fjernes) utelates
+ * `classYear` slik at kun programnavnet vises. Vi kan ikke skille bachelor fra
+ * master ut fra `session.groups`, så 1–5 er den pragmatiske grensen.
+ */
+export function deriveStudy(
+    groups: readonly StudyGroupLike[],
+    now = new Date(),
+): { programme?: string; classYear?: number } {
+    const programme = groups.find(
+        (g) => g.type.toLowerCase() === "study",
+    )?.name;
+
+    const startYears = groups
+        .filter((g) => g.type.toLowerCase() === "studyyear")
+        .map((g) => Number.parseInt(g.name, 10))
+        .filter((year) => Number.isFinite(year));
+
+    let classYear: number | undefined;
+    if (startYears.length > 0) {
+        const computed = computeClassYear(Math.max(...startYears), now);
+        if (computed >= 1 && computed <= 5) {
+            classYear = computed;
+        }
+    }
+
+    return { programme, classYear };
+}

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -35,6 +35,7 @@ import {
     type ProfileHeaderUser,
     type ProfileLink,
 } from "#/components/profile-header";
+import { deriveStudy } from "#/lib/utils";
 
 export const Route = createFileRoute("/_app/profil/$id")({
     component: RouteComponent,
@@ -71,10 +72,16 @@ function RouteComponent() {
     const updateSettings = useMutation(updateUserSettingsMutation);
 
     const settings = session?.user.settings;
+    const { programme, classYear } = deriveStudy(session?.groups ?? []);
+    const studyLabel =
+        [programme, classYear ? `${classYear}. klasse` : null]
+            .filter(Boolean)
+            .join(" · ") || undefined;
     const user: ProfileHeaderUser = {
         name: session?.user.name ?? "",
         email: session?.user.email ?? "",
         avatarUrl: settings?.imageUrl ?? session?.user.image ?? undefined,
+        programme: studyLabel,
         links: buildProfileLinks(settings?.githubUrl, settings?.linkedinUrl),
     };
 

--- a/apps/kvark/src/routes/_app/profil/$id/medlemskap.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/medlemskap.tsx
@@ -20,8 +20,13 @@ export const Route = createFileRoute("/_app/profil/$id/medlemskap")({
 function RouteComponent() {
     const { data: session } = useQuery(authQueryOptions);
     const groups = session?.groups ?? [];
+    // study/studyyear er avledede grupper (projeksjon av Feide-data) og vises
+    // ved profilbildet, ikke i medlemskapslisten. Typen er UPPERCASE i DB.
+    const memberships = groups.filter(
+        (g) => !["study", "studyyear"].includes(g.type.toLowerCase()),
+    );
 
-    if (groups.length === 0) {
+    if (memberships.length === 0) {
         return (
             <Empty>
                 <EmptyHeader>
@@ -39,7 +44,7 @@ function RouteComponent() {
 
     return (
         <ul className="flex flex-col gap-3">
-            {groups.map((group) => (
+            {memberships.map((group) => (
                 <li key={group.slug}>
                     <Card
                         size="sm"


### PR DESCRIPTION
## Hva

Under **Medlemskap**-taben på profilen skal ikke TIHLDE-studieprogram og kull vises som medlemskap. De hører hjemme ved profilbildet/brukernavnet, som del av brukerens identitet.

- **Skjuler `study`/`studyyear`** (case-insensitivt) fra medlemskapslisten på `/profil/$id/medlemskap`.
- **Viser studieprogram + "N. klasse"** i profilheaderens undertittel (f.eks. "Dataingeniør · 3. klasse"), avledet fra `session.groups`.
- Ny ren util `deriveStudy` / `computeClassYear` i `apps/kvark/src/lib/utils.ts`.

## Hvorfor

`study` og `studyyear` er bevisst modellert som **avledede gruppemedlemskap** (en projeksjon av Feide-data) — ikke ekte klubb-/verv-medlemskap. De må ikke fjernes fra backend: 252 av 273 prioritetspooler for arrangementspåmelding peker på nettopp disse gruppetypene. Derfor er dette **rent en frontend-/visningsendring**; backend og `session.groups` er uendret.

## Detaljer for reviewer

- **Ingen endring i `profile-header.tsx`** — `programme`-feltet var allerede koblet inn i undertittelen (mobil + desktop), men aldri populert. Containeren (`$id.tsx`) bygger nå den sammensatte strengen og holder komponenten "dum".
- **Klasseberegning:** norsk studieår starter i august (`getMonth() >= 7` teller ett trinn opp). Klasse vises kun i intervallet **1–5** (bachelor 3 + master 2); utenfor (typisk alumni, siden medlemskap er additive og aldri fjernes) vises kun programnavnet. Vi kan ikke skille bachelor/master fra `session.groups`, så 1–5 er den pragmatiske grensen.
- Ved flere kull-grupper velges nyeste år.

## Kjente begrensninger

- Alumni med mer enn 5 år siden oppstart viser kun programnavn (ingen klasse).
- Kobling study↔kull er ikke eksplisitt i `session.groups`; bruker nyeste kull + study-gruppens navn.

## Verifisering

- `bun run typecheck` ✅, `bun run lint` ✅, `oxfmt --check` ✅
- Klasse-formelen kjørt gjennom grensetilfeller (august-rollover, 1. klasse, alumni/fremtid → skjult) — alle PASS.
- ⚠️ Live visuell sjekk (innlogget bruker med study/studyyear-grupper) gjenstår — kunne ikke fullføre Feide-OAuth i automatisert miljø.

🤖 Generated with [Claude Code](https://claude.com/claude-code)