### PR TITLE
feat(kvark): single live-preview markdown-boks i admin-skjemaer

### DIFF
--- a/apps/kvark/src/routes/admin/arrangementer.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.tsx
@@ -2,16 +2,10 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { MarkdownView, RichEditor } from "@tihlde/ui/complex/markdown";
+import { RichEditor } from "@tihlde/ui/complex/markdown";
 import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { Button } from "@tihlde/ui/ui/button";
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from "@tihlde/ui/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
 import { Checkbox } from "@tihlde/ui/ui/checkbox";
 import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
 import { Input } from "@tihlde/ui/ui/input";
@@ -126,8 +120,8 @@ function EventAdminPage() {
             <div className="flex flex-col gap-1">
                 <h1 className="text-3xl">Nytt arrangement</h1>
                 <p className="text-muted-foreground">
-                    Beskrivelsen lagres som markdown og rendres med samme
-                    direktiv-registret som redigeringen.
+                    Beskrivelsen lagres som markdown og formateringen vises
+                    direkte mens du skriver.
                 </p>
             </div>
 
@@ -303,21 +297,6 @@ function EventAdminPage() {
                                 />
                             </Field>
                         </FieldGroup>
-                    </CardContent>
-                </Card>
-
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Forhåndsvisning</CardTitle>
-                        <CardDescription>
-                            Slik blir beskrivelsen vist for medlemmer.
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <MarkdownView
-                            registry={richRegistry}
-                            source={description}
-                        />
                     </CardContent>
                 </Card>
 

--- a/apps/kvark/src/routes/admin/nyheter.tsx
+++ b/apps/kvark/src/routes/admin/nyheter.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { MarkdownView, RichEditor } from "@tihlde/ui/complex/markdown";
+import { RichEditor } from "@tihlde/ui/complex/markdown";
 import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { Button } from "@tihlde/ui/ui/button";
 import {
@@ -66,7 +66,7 @@ function NewsAdminPage() {
                 <h1 className="text-3xl">Ny nyhet</h1>
                 <p className="text-muted-foreground">
                     Skriv en nyhet i markdown-redigeringsverktøyet under.
-                    Forhåndsvisning til høyre.
+                    Formateringen vises direkte mens du skriver.
                 </p>
             </div>
 
@@ -118,18 +118,6 @@ function NewsAdminPage() {
                                 />
                             </Field>
                         </FieldGroup>
-                    </CardContent>
-                </Card>
-
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Forhåndsvisning</CardTitle>
-                        <CardDescription>
-                            Slik vises nyheten med rik-registret aktivert.
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <MarkdownView registry={richRegistry} source={body} />
                     </CardContent>
                 </Card>
 


### PR DESCRIPTION
## Hva

Admin-skjemaene **«Ny nyhet»** ([nyheter.tsx](apps/kvark/src/routes/admin/nyheter.tsx)) og **«Nytt arrangement»** ([arrangementer.tsx](apps/kvark/src/routes/admin/arrangementer.tsx)) viste to bokser for markdown:

1. En `RichEditor` — Tiptap WYSIWYG-editor som allerede rendrer formateringen live mens du skriver
2. Et eget **«Forhåndsvisning»**-kort med `MarkdownView` som rendret samme innhold på nytt

`RichEditor` **er** allerede en live-forhåndsvisning, så det andre kortet var overflødig.

## Hvorfor

Issue: legge til live-forhåndsvisning av markdown for admin — **kun én boks, ikke to** — slik det er i `texicon-repos/aarhonen`. I aarhonen er markdown-editoren en enkelt WYSIWYG-boks som selv er forhåndsvisningen. Photon sin `RichEditor` er allerede det samme mønsteret.

## Endringer

I begge admin-rutene:
- Fjernet det frittstående **«Forhåndsvisning»**-kortet (`MarkdownView`)
- Fjernet ubrukt `MarkdownView`-import (og ubrukt `CardDescription` i `arrangementer.tsx`)
- Oppdatert introteksten («Forhåndsvisning til høyre» → «Formateringen vises direkte mens du skriver»)

Netto: `6 insertions, 39 deletions`. Admin får nå én live-forhåndsvisnings-boks.

## Verifisering

- ✅ `bun run typecheck` (kvark) — passerer
- ✅ `bun run lint` + `bun run format` — rene; ingen funn i de endrede filene
- ✅ Bekreftet at `RichEditor` rendrer som én WYSIWYG-boks med verktøylinje og live formatering (overskrift, fet, tabell inline) på `/playground/markdown` — samme komponent som nå står alene i admin-skjemaene

**Ikke verifisert i nettleser:** selve innloggede admin-sidene. Riktig origin er 3001 (`WEBSITE_URL`), men port 3000 var opptatt av en urelatert app og seed-bruker-innlogging fullførte ikke gjennom browser-automatikk i denne worktreen — en miljø-/sesjonsbegrensning, ikke relatert til endringen. Endringen er ren JSX-fjerning som typechecker og linter rent, og den gjenværende editor-komponenten er verifisert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)