### PR TITLE
refactor(kvark): fjern initial-firkanten i DetailIdentity

### DIFF
--- a/apps/kvark/src/components/detail-identity.tsx
+++ b/apps/kvark/src/components/detail-identity.tsx
@@ -12,11 +12,7 @@ export function DetailIdentity({ name, logoUrl }: DetailIdentityProps) {
                     src={logoUrl}
                     className="size-12 shrink-0 rounded-lg object-cover"
                 />
-            ) : (
-                <div className="flex size-12 shrink-0 items-center justify-center rounded-lg bg-muted text-sm font-medium">
-                    {name.slice(0, 2).toUpperCase()}
-                </div>
-            )}
+            ) : null}
             <span className="truncate font-medium">{name}</span>
         </div>
     );


### PR DESCRIPTION
## Hva

Fjerner initial-firkanten (to bokstaver) som `DetailIdentity` rendret som fallback når det ikke fantes en logo — f.eks. «BO»-boksen på Borg-stillingsannonsen.

Nå:
- Logo finnes → logoen vises som før.
- Ingen logo → kun navnet vises, uten firkanten.

## Hvorfor

Firkanten med initialer var uønsket visuelt. Annonser (`annonser.$slug`) sender aldri inn en logo, så der forsvinner firkanten helt; arrangementer (`arrangementer.$slug`) beholder logoen når arrangøren har bilde.

## For reviewer

- Endringen er i den delte komponenten `apps/kvark/src/components/detail-identity.tsx`, som brukes av både annonser- og arrangement-detaljsidene.
- `logoUrl`-propen beholdes; kun `else`-grenen med `name.slice(0, 2)` er fjernet.
- `bun run --filter kvark typecheck` grønt. Detaljsiden kunne ikke rendres visuelt lokalt fordi den henter fra prod-API-et som ikke er tilgjengelig fra sandkassen, men listesiden lastet fint og endringen er en ren JSX-fjerning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)