### PR TITLE
feat(register): Feide som primært registreringsvalg

### DIFF
--- a/apps/kvark/src/components/feide-sign-in-button.tsx
+++ b/apps/kvark/src/components/feide-sign-in-button.tsx
@@ -5,6 +5,13 @@ export type FeideSignInButtonProps = {
     onSignIn: () => void;
     loading?: boolean;
     disabled?: boolean;
+    /**
+     * Button emphasis. Defaults to "outline" so login keeps Feide as a
+     * secondary action; register passes "default" to make it the primary CTA.
+     */
+    variant?: "default" | "outline";
+    /** Overrides the resting label, e.g. "Registrer med Feide". */
+    label?: string;
 };
 
 /**
@@ -15,11 +22,13 @@ export function FeideSignInButton({
     onSignIn,
     loading = false,
     disabled = false,
+    variant = "outline",
+    label = "Logg inn med Feide",
 }: FeideSignInButtonProps) {
     return (
         <Button
             type="button"
-            variant="outline"
+            variant={variant}
             className="w-full"
             onClick={onSignIn}
             disabled={disabled || loading}
@@ -30,7 +39,7 @@ export function FeideSignInButton({
                     <span>Sender deg til Feide...</span>
                 </>
             ) : (
-                <span>Logg inn med Feide</span>
+                <span>{label}</span>
             )}
         </Button>
     );

--- a/apps/kvark/src/routes/_auth/register.tsx
+++ b/apps/kvark/src/routes/_auth/register.tsx
@@ -1,6 +1,7 @@
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useMutation } from "@tanstack/react-query";
 import { z } from "zod";
+import { Button } from "@tihlde/ui/ui/button";
 import {
     Card,
     CardContent,
@@ -63,6 +64,10 @@ function RegisterPage() {
     const navigate = useNavigate();
 
     const [feideLoading, setFeideLoading] = useState(false);
+    // When Feide is the primary path, the email/password form stays collapsed
+    // behind a "Kan du ikke bruke Feide?" link. When Feide is off entirely the
+    // form is the only option, so show it straight away.
+    const [showEmailForm, setShowEmailForm] = useState(!env.VITE_FEIDE_ENABLED);
 
     async function handleFeideSignIn() {
         setFeideLoading(true);
@@ -136,97 +141,118 @@ function RegisterPage() {
         }
     }
 
+    const feideEnabled = env.VITE_FEIDE_ENABLED;
+
     return (
         <Card>
             <CardHeader>
                 <CardTitle>Opprett bruker</CardTitle>
                 <CardDescription>
-                    Opprett en konto for å delta på arrangementer.
+                    {feideEnabled
+                        ? "Registrer deg med Feide for å delta på arrangementer."
+                        : "Opprett en konto for å delta på arrangementer."}
                 </CardDescription>
             </CardHeader>
-            <form {...formHandlers(form)} className="flex flex-col gap-4">
-                <CardContent className="flex flex-col gap-5">
-                    <FieldGroup>
-                        <form.AppField name="name">
-                            {(field) => (
-                                <field.InputField
-                                    label="Navn"
-                                    autoComplete="name"
-                                    required
-                                />
-                            )}
-                        </form.AppField>
-                        <form.AppField name="email">
-                            {(field) => (
-                                <field.InputField
-                                    label="E-post"
-                                    type="email"
-                                    autoComplete="email"
-                                    description="Bruk din @stud.ntnu.no-adresse. Brukernavnet ditt blir det som står før @."
-                                    required
-                                />
-                            )}
-                        </form.AppField>
-                        <form.AppField name="password">
-                            {(field) => (
-                                <field.PasswordField
-                                    label="Passord"
-                                    autoComplete="new-password"
-                                    required
-                                />
-                            )}
-                        </form.AppField>
-                        <form.AppField name="confirmPassword">
-                            {(field) => (
-                                <field.PasswordField
-                                    label="Bekreft passord"
-                                    autoComplete="new-password"
-                                    required
-                                />
-                            )}
-                        </form.AppField>
-                    </FieldGroup>
 
-                    <form.AppForm>
-                        <form.FormErrors />
-                    </form.AppForm>
-
-                    <form.AppForm>
-                        <form.SubmitButton
-                            className="w-full"
-                            loading={
-                                <>
-                                    <Spinner />
-                                    <span>Oppretter...</span>
-                                </>
-                            }
+            {feideEnabled && (
+                <CardContent className="flex flex-col gap-4">
+                    <FeideSignInButton
+                        variant="default"
+                        label="Registrer med Feide"
+                        onSignIn={handleFeideSignIn}
+                        loading={feideLoading}
+                    />
+                    {!showEmailForm && (
+                        <Button
+                            type="button"
+                            variant="link"
+                            className="mx-auto"
+                            onClick={() => setShowEmailForm(true)}
                         >
-                            Opprett bruker
-                        </form.SubmitButton>
-                    </form.AppForm>
-
-                    {env.VITE_FEIDE_ENABLED && (
-                        <>
-                            <OrDivider />
-                            <FeideSignInButton
-                                onSignIn={handleFeideSignIn}
-                                loading={feideLoading}
-                            />
-                        </>
+                            Kan du ikke bruke Feide?
+                        </Button>
                     )}
                 </CardContent>
-                <CardFooter className="justify-center">
-                    <p className="text-sm text-muted-foreground">
-                        Har du allerede konto?{" "}
-                        <Link
-                            to="/login"
-                            className="underline underline-offset-4"
-                        >
-                            Logg inn
-                        </Link>
-                    </p>
-                </CardFooter>
-            </form>
+            )}
+
+            {showEmailForm && (
+                <form {...formHandlers(form)} className="flex flex-col gap-4">
+                    {feideEnabled && (
+                        <div className="px-6">
+                            <OrDivider label="eller registrer med e-post" />
+                        </div>
+                    )}
+                    <CardContent className="flex flex-col gap-5">
+                        <FieldGroup>
+                            <form.AppField name="name">
+                                {(field) => (
+                                    <field.InputField
+                                        label="Navn"
+                                        autoComplete="name"
+                                        required
+                                    />
+                                )}
+                            </form.AppField>
+                            <form.AppField name="email">
+                                {(field) => (
+                                    <field.InputField
+                                        label="E-post"
+                                        type="email"
+                                        autoComplete="email"
+                                        description="Bruk din @stud.ntnu.no-adresse. Brukernavnet ditt blir det som står før @."
+                                        required
+                                    />
+                                )}
+                            </form.AppField>
+                            <form.AppField name="password">
+                                {(field) => (
+                                    <field.PasswordField
+                                        label="Passord"
+                                        autoComplete="new-password"
+                                        required
+                                    />
+                                )}
+                            </form.AppField>
+                            <form.AppField name="confirmPassword">
+                                {(field) => (
+                                    <field.PasswordField
+                                        label="Bekreft passord"
+                                        autoComplete="new-password"
+                                        required
+                                    />
+                                )}
+                            </form.AppField>
+                        </FieldGroup>
+
+                        <form.AppForm>
+                            <form.FormErrors />
+                        </form.AppForm>
+
+                        <form.AppForm>
+                            <form.SubmitButton
+                                className="w-full"
+                                loading={
+                                    <>
+                                        <Spinner />
+                                        <span>Oppretter...</span>
+                                    </>
+                                }
+                            >
+                                Opprett bruker
+                            </form.SubmitButton>
+                        </form.AppForm>
+                    </CardContent>
+                </form>
+            )}
+
+            <CardFooter className="justify-center">
+                <p className="text-sm text-muted-foreground">
+                    Har du allerede konto?{" "}
+                    <Link to="/login" className="underline underline-offset-4">
+                        Logg inn
+                    </Link>
+                </p>
+            </CardFooter>
         </Card>
     );
 }


### PR DESCRIPTION
## Hva

Gjør **Feide til standard registreringsalternativ** på `/register`. E-post/passord blir en fallback for de som ikke kan bruke Feide.

- **`VITE_FEIDE_ENABLED=true`:** tydelig primær «Registrer med Feide»-CTA øverst + diskré «Kan du ikke bruke Feide?»-lenke. E-post/passord-skjemaet er skjult til lenka klikkes, da folder det seg ut under en «eller registrer med e-post»-divider.
- **Flagget av (dagens default):** uendret e-post-first-layout, ingen Feide-knapp. Sikkerhetsnettet består, så en ukonfigurert backend-Feide-klient gir ikke en ødelagt knapp.
- **Login er urørt** — brukernavn/passord er fortsatt primær der.

## Endringer

- `apps/kvark/src/routes/_auth/register.tsx` — Feide-primær layout med utfoldbar e-post-fallback; footeren («Logg inn») flyttet ut så den alltid vises.
- `apps/kvark/src/components/feide-sign-in-button.tsx` — valgfri `variant` (default `outline`; register bruker `default`) og `label`-prop.

## Verifisert

- `tsc --noEmit` på kvark → exit 0
- `bun run build --filter=kvark` → ✓ built
- lint rene for endrede filer
- Browser-preview av begge tilstander (Feide-primær + utfoldet skjema, og fallback-layout); ingen konsollfeil fra registreringssiden

## Merk

For at Feide faktisk skal virke i et miljø kreves `FEIDE_CLIENT_ID` + `FEIDE_CLIENT_SECRET` i backend og `VITE_FEIDE_ENABLED=true` i kvark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)