### PR TITLE
feat(kvark): skjul admin-knapper utenfor dashboard for ikke-admins

### DIFF
--- a/apps/kvark/src/components/command-menu.tsx
+++ b/apps/kvark/src/components/command-menu.tsx
@@ -21,7 +21,9 @@ import {
     User,
     Users,
 } from "lucide-react";
-import { useCallback, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+
+import { useIsAdmin } from "#/hooks/use-permission";
 
 type CommandAction =
     | { kind: "navigate"; link: LinkOptions }
@@ -40,6 +42,8 @@ type CommandEntry = {
 type CommandSection = {
     heading: string;
     items: CommandEntry[];
+    /** Only shown to admins. The section is hidden entirely otherwise. */
+    requiresAdmin?: boolean;
 };
 
 const SECTIONS: CommandSection[] = [
@@ -105,6 +109,7 @@ const SECTIONS: CommandSection[] = [
     },
     {
         heading: "Administrasjon",
+        requiresAdmin: true,
         items: [
             {
                 id: "dashboard",
@@ -120,6 +125,12 @@ const SECTIONS: CommandSection[] = [
 export function CommandMenu() {
     const [open, setOpen] = useState(false);
     const navigate = useNavigate();
+    const isAdmin = useIsAdmin();
+
+    const sections = useMemo(
+        () => SECTIONS.filter((section) => !section.requiresAdmin || isAdmin),
+        [isAdmin],
+    );
 
     useHotkey("Mod+K", () => {
         setOpen((prev) => !prev);
@@ -145,7 +156,7 @@ export function CommandMenu() {
                 <CommandInput placeholder="Søk etter en side eller handling..." />
                 <CommandList>
                     <CommandEmpty>Ingen treff.</CommandEmpty>
-                    {SECTIONS.map((section, index) => (
+                    {sections.map((section, index) => (
                         <SectionBlock
                             key={section.heading}
                             section={section}

--- a/apps/kvark/src/hooks/use-permission.ts
+++ b/apps/kvark/src/hooks/use-permission.ts
@@ -1,0 +1,72 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { authQueryOptions, sessionHasPermission } from "#/api/auth";
+
+/**
+ * Whether the current session holds `required` globally.
+ *
+ * This gates the UI only — the API enforces the same permissions server-side,
+ * so this is purely cosmetic. See {@link sessionHasPermission}: `"root"` grants
+ * everything and a scoped grant does NOT satisfy a global check.
+ */
+export function usePermission(required: string | string[]): boolean {
+    const { data: session } = useQuery(authQueryOptions);
+    return sessionHasPermission(session?.permissions, required);
+}
+
+/**
+ * Permissions that grant access to at least one section of the admin
+ * dashboard. Holding any of these (or `"root"`) makes a user an "admin" for
+ * the purpose of showing admin entry points that live outside the dashboard
+ * (e.g. the "Admin" links in the command menu and profile nav).
+ *
+ * View-only permissions are intentionally excluded — regular members hold
+ * those, and they are not admins.
+ */
+export const ADMIN_DASHBOARD_PERMISSIONS = [
+    "roles:create",
+    "roles:update",
+    "roles:delete",
+    "roles:assign",
+    "users:create",
+    "users:update",
+    "users:delete",
+    "users:manage",
+    "events:create",
+    "events:update",
+    "events:delete",
+    "events:manage",
+    "groups:create",
+    "groups:update",
+    "groups:delete",
+    "groups:manage",
+    "fines:create",
+    "fines:update",
+    "fines:delete",
+    "fines:manage",
+    "forms:create",
+    "forms:update",
+    "forms:delete",
+    "forms:manage",
+    "news:create",
+    "news:update",
+    "news:delete",
+    "news:manage",
+    "jobs:create",
+    "jobs:update",
+    "jobs:delete",
+    "jobs:manage",
+    "banners:create",
+    "banners:update",
+    "banners:delete",
+    "banners:manage",
+] as const;
+
+/**
+ * Whether the current user is an admin, i.e. holds any management permission
+ * across the admin dashboard sections (or `"root"`). Use this to decide
+ * whether to show admin entry points outside the dashboard.
+ */
+export function useIsAdmin(): boolean {
+    return usePermission(ADMIN_DASHBOARD_PERMISSIONS as unknown as string[]);
+}

--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -8,6 +8,7 @@ import { Plus } from "lucide-react";
 import { Suspense } from "react";
 
 import { authQueryOptions } from "#/api/auth";
+import { usePermission } from "#/hooks/use-permission";
 import { getEventsQuery } from "#/api/queries/events";
 import { getVisibleBannersQuery } from "#/api/queries/banners";
 import { EventCard } from "#/components/event-card";
@@ -54,6 +55,10 @@ const NEWS: NewsCardProps[] = [
 ];
 
 function Home() {
+    // Admin-only shortcuts — the API enforces these permissions server-side too.
+    const canCreateEvent = usePermission("events:create");
+    const canCreateNews = usePermission("news:create");
+
     return (
         <>
             {/* Preloaded in the route loader, so the fallback never flashes. */}
@@ -66,7 +71,9 @@ function Home() {
             <section className="container mx-auto w-full px-4 py-8">
                 <SectionHeader
                     title="Arrangementer"
-                    actionLabel="Nytt arrangement"
+                    actionLabel={
+                        canCreateEvent ? "Nytt arrangement" : undefined
+                    }
                 />
                 <Suspense fallback={<EventsSkeleton />}>
                     <EventsSection />
@@ -74,7 +81,10 @@ function Home() {
             </section>
 
             <section className="container mx-auto w-full px-4 py-8">
-                <SectionHeader title="Nyheter" actionLabel="Ny nyhet" />
+                <SectionHeader
+                    title="Nyheter"
+                    actionLabel={canCreateNews ? "Ny nyhet" : undefined}
+                />
                 <div className="mt-4 grid gap-4 md:grid-cols-2">
                     {NEWS.map((item) => (
                         // TODO: replace with a unique id field once wired up to the backend

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -28,6 +28,7 @@ import {
     logoutUser,
 } from "#/api/auth";
 import { updateUserSettingsMutation } from "#/api/queries/user";
+import { useIsAdmin } from "#/hooks/use-permission";
 import { EditBioDialog } from "#/components/edit-bio-dialog";
 import { MembershipQrDialog } from "#/components/membership-qr-dialog";
 import {
@@ -69,6 +70,7 @@ function RouteComponent() {
     const navigate = useNavigate();
 
     const { data: session } = useQuery(authQueryOptions);
+    const isAdmin = useIsAdmin();
     const updateSettings = useMutation(updateUserSettingsMutation);
 
     const settings = session?.user.settings;
@@ -134,16 +136,21 @@ function RouteComponent() {
                 },
             ],
         },
-        {
-            id: "secondary",
-            items: [
-                {
-                    label: "Admin",
-                    icon: ShieldCheck,
-                    link: linkOptions({ to: "/admin" }),
-                },
-            ],
-        },
+        // Admin entry point — only for admins. The API still enforces access.
+        ...(isAdmin
+            ? [
+                  {
+                      id: "secondary",
+                      items: [
+                          {
+                              label: "Admin",
+                              icon: ShieldCheck,
+                              link: linkOptions({ to: "/admin" }),
+                          },
+                      ],
+                  },
+              ]
+            : []),
     ];
 
     return (


### PR DESCRIPTION
## Hva

Admin-relaterte knapper og lenker som vises **utenfor** selve admin-dashbordet var delvis synlige for alle brukere. Denne PR-en gater dem bak en tillatelsessjekk, slik at kun admins ser dem.

## Endringer

- **Ny gjenbrukbar hook** `apps/kvark/src/hooks/use-permission.ts`
  - `usePermission(required)` — leser sesjonen og bruker samme `sessionHasPermission` som resten av appen.
  - `useIsAdmin()` — sann hvis brukeren har en hvilken som helst administrasjons-tillatelse (create/update/delete/manage/assign) på tvers av dashboard-domenene, eller `root`. View-tillatelser er bevisst utelatt siden vanlige medlemmer har dem.
- **Forsiden** (`_app/index.tsx`): «Nytt arrangement» krever `events:create`, «Ny nyhet» krever `news:create`.
- **Kommandomeny (Cmd+K)** (`command-menu.tsx`): «Administrasjon»-seksjonen med «Admin Dashboard» er merket `requiresAdmin` og filtreres bort for ikke-admins (var tidligere synlig for alle).
- **Profilsiden** (`profil/$id.tsx`): «Admin»-lenken i sidemenyen inkluderes kun for admins (var tidligere synlig for alle innloggede).

## Ikke endret (bevisst)

- Knappene på arrangement-detalj (rediger, «Se alle påmeldte») og gruppesidene («Gi bot», «Legg til medlem», «Nytt spørreskjema», lover) var **allerede** gatet korrekt via `isAdmin`/`canManage`.
- Selve admin-dashbordet (`/admin`) og knappene inne i det er utenfor scope («som ikke er admin-dashboard»).

## For reviewer

- Dette er **UI-gating** — API-et håndhever de samme tillatelsene serverside uansett (`sessionHasPermission` speiler `hasPermission` i `@photon/auth/rbac`).
- Forsidens «Nytt arrangement»/«Ny nyhet»-knapper er fortsatt funksjonelle placeholders uten onClick/lenke i dag; kun synligheten er endret, ikke oppførselen.
- `useIsAdmin` bruker global tillatelsessjekk, så en gruppeleder med kun scoped grants (f.eks. `events:create@group:fotball`) regnes ikke som admin for de globale dashboard-lenkene. Gruppeledere beholder sine handlinger på gruppesidene via eksisterende `canManage`.

## Verifisering

- `bun run typecheck` ✅
- `bun run lint` (rent for kvark-filene) ✅
- `bun run format:fix` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)