### PR TITLE
feat(roller): rydd i roller-siden og koble ministerverv til gruppeleder

### DIFF
--- a/apps/api/src/db/seed/org.ts
+++ b/apps/api/src/db/seed/org.ts
@@ -29,7 +29,7 @@ export default async ({ db }: AppContext) => {
             description:
                 'Beta er en prosjektbasert komité, med selvvalgte prosjekter, og forslag fra _dere_ (send inn ønsker vha. spørreskjemaer). Prosjektene skal i både stor og liten skala bidra til å forbedre linjeforeningen. Vi har i det siste jobbet med å forbedre opptaksprosessen, SoMe-retningslinjer, interessegrupper og intern struktur. \n\nI IT-verden er "Beta" et velkjent begrep som representerer en forbedret versjon eller testversjon før den endelige lanseringen av et produkt.\n\nHar du lyst til å bidra litt _ekstra_ i TIHLDE, søk Beta! Hvis du har noen ideer til prosjekter legg det inn på \n[prosjektforslagsiden vår](https://www.notion.so/tihlde/199eea18864180e087a9c2afff74bedf?v=199eea1886418001b8e5000c485dfbe6&pvs=4)',
             contact_email: "betaleder@tihlde.org",
-            type: "COMMITTEE",
+            type: "SUBGROUP",
             fine_info: "",
             fines_activated: 0,
         },
@@ -203,6 +203,12 @@ export default async ({ db }: AppContext) => {
             name: "Næringslivsminister",
             description: "Leder av Næringsliv og Kurs",
             permissions: [],
+        },
+        {
+            name: "Innovasjonsminister",
+            description: "Leder av Beta",
+            permissions: [],
+            linkedGroupSlug: "beta",
         },
     ];
 

--- a/apps/api/src/db/seed/rbac.ts
+++ b/apps/api/src/db/seed/rbac.ts
@@ -13,7 +13,6 @@ import type { AppContext } from "~/lib/ctx";
  *              role management, API keys, OAuth clients and payment refunds.
  *              Those powers come from HS titles (AU → roles:*, Sosialminister
  *              → refund) instead. Auto-assigned via the hs group's roleId.
- * - moderator: limited helper role.
  * - member:    baseline for ACTIVE students, synced by the Feide hook
  *              (syncBaselineRoles). Can participate: view + register for
  *              events, view content, propose fines (group permissionMode
@@ -38,29 +37,29 @@ export default async ({ db }: AppContext) => {
     ] as const;
     const HS_EXCLUDED = new Set(["root", "events:payments:refund"]);
 
-    // Root role - highest in hierarchy (position 6)
+    // Root role - highest in hierarchy (position 5)
     await db
         .insert(schema.role)
         .values({
             name: "root",
             description: "System administrator with full access",
-            position: 6, // Manually set ONLY for seeding - highest number = highest role
+            position: 5, // Manually set ONLY for seeding - highest number = highest role
             permissions: Array.from(PERMISSIONS),
         })
         .onConflictDoNothing();
 
-    // Admin role - second highest (position 5)
+    // Admin role - second highest (position 4)
     await db
         .insert(schema.role)
         .values({
             name: "admin",
             description: "Administrator with most permissions",
-            position: 5, // Just below root
+            position: 4, // Just below root
             permissions: Array.from(PERMISSIONS).filter((p) => p !== "root"),
         })
         .onConflictDoNothing();
 
-    // Hovedstyret role (position 4)
+    // Hovedstyret role (position 3)
     // Auto-assigned to members of the "hs" group via group.roleId. Broad
     // content/ops access; role management and refunds come from HS titles.
     await db
@@ -69,7 +68,7 @@ export default async ({ db }: AppContext) => {
             name: "hs",
             description:
                 "Hovedstyret — all content/ops permissions; role management and refunds are granted via HS titles",
-            position: 4, // Below admin, above moderator
+            position: 3, // Below admin
             permissions: Array.from(PERMISSIONS).filter(
                 (p) =>
                     !HS_EXCLUDED.has(p) &&
@@ -77,22 +76,6 @@ export default async ({ db }: AppContext) => {
                         p.startsWith(prefix),
                     ),
             ),
-        })
-        .onConflictDoNothing();
-
-    // Moderator role (position 3)
-    await db
-        .insert(schema.role)
-        .values({
-            name: "moderator",
-            description: "Moderator with limited permissions",
-            position: 3, // Below hs
-            permissions: [
-                "events:view",
-                "events:create",
-                "users:view",
-                "roles:view",
-            ],
         })
         .onConflictDoNothing();
 

--- a/apps/api/src/routes/groups/positions/assign.ts
+++ b/apps/api/src/routes/groups/positions/assign.ts
@@ -46,6 +46,15 @@ export const assignPositionRoute = route().post(
             throw new HTTPException(404, { message: "Position not found" });
         }
 
+        // Linked leader-verv follow the linked subgroup's leadership and are
+        // synced automatically — they must never be assigned by hand here.
+        if (position.linkedGroupSlug) {
+            throw new HTTPException(409, {
+                message:
+                    "This position is held automatically by the linked group's leader and cannot be assigned manually. Change the group's leader on the group page instead.",
+            });
+        }
+
         if (!(await canAssignPosition(ctx, user.id, position))) {
             throw new HTTPException(403, {
                 message: "Not authorized to assign this position",

--- a/apps/api/src/routes/groups/positions/list.ts
+++ b/apps/api/src/routes/groups/positions/list.ts
@@ -61,6 +61,7 @@ export const listPositionsRoute = route().get(
                 description: position.description,
                 permissions: position.permissions,
                 scope: position.scope,
+                linkedGroupSlug: position.linkedGroupSlug,
                 holder: position.holder
                     ? {
                           userId: position.holder.user.id,

--- a/apps/api/src/routes/groups/positions/schema.ts
+++ b/apps/api/src/routes/groups/positions/schema.ts
@@ -83,6 +83,10 @@ export const positionSchema = Schema(
         description: z.string().nullable(),
         permissions: z.array(z.string()),
         scope: z.enum(["group", "global"]),
+        linkedGroupSlug: z.string().nullable().meta({
+            description:
+                "If set, this position is held automatically by the leader of the given subgroup and cannot be assigned manually.",
+        }),
         holder: positionHolderSchema.nullable().meta({
             description: "The single holder of this position, if assigned",
         }),

--- a/apps/api/src/routes/groups/positions/unassign.ts
+++ b/apps/api/src/routes/groups/positions/unassign.ts
@@ -23,6 +23,11 @@ export const unassignPositionRoute = route().delete(
         })
         .forbidden({ description: "Not authorized to manage this position" })
         .notFound({ description: "Position not found" })
+        .response({
+            statusCode: 409,
+            description:
+                "Position is managed automatically from group leadership",
+        })
         .build(),
     requireAuth,
     async (c) => {
@@ -36,6 +41,15 @@ export const unassignPositionRoute = route().delete(
         const position = await getPosition(ctx, positionId);
         if (!position || position.groupSlug !== groupSlug) {
             throw new HTTPException(404, { message: "Position not found" });
+        }
+
+        // Linked leader-verv follow the linked subgroup's leadership and are
+        // synced automatically — they must never be unassigned by hand here.
+        if (position.linkedGroupSlug) {
+            throw new HTTPException(409, {
+                message:
+                    "This position is held automatically by the linked group's leader and cannot be changed manually. Change the group's leader on the group page instead.",
+            });
         }
 
         if (!(await canAssignPosition(ctx, user.id, position))) {

--- a/apps/api/src/test/groups/positions.test.ts
+++ b/apps/api/src/test/groups/positions.test.ts
@@ -500,6 +500,71 @@ describe("group positions", () => {
         );
 
         integrationTest(
+            "linked leader-verv cannot be assigned or unassigned manually",
+            async ({ ctx }) => {
+                const leader = await ctx.utils.createTestUser();
+                const outsider = await ctx.utils.createTestUser();
+                // Actor holds root — so a 409 proves the guard blocks the
+                // linked verv, not a missing permission.
+                const admin = await ctx.utils.createTestUser();
+                await ctx.utils.giveUserPermissions(admin, ["root"]);
+                const client = await ctx.utils.clientForUser(admin);
+
+                await ctx.utils.createTestGroup({
+                    slug: "hs",
+                    name: "Hovedstyret",
+                    type: "board",
+                });
+                const subgroup = await ctx.utils.createTestGroup({
+                    type: "subgroup",
+                    name: "Låstgruppen",
+                });
+
+                // Becoming leader auto-creates the linked verv in HS.
+                await addUserToGroup(ctx, leader.id, subgroup.slug, "leader");
+
+                const [position] = await ctx.db
+                    .select()
+                    .from(schema.groupPosition)
+                    .where(
+                        eq(schema.groupPosition.linkedGroupSlug, subgroup.slug),
+                    );
+                expect(position).toBeDefined();
+
+                // Manual assignment to someone else is rejected.
+                const assignResponse = await client.api.groups[
+                    ":groupSlug"
+                ].positions[":positionId"].holders.$post({
+                    param: { groupSlug: "hs", positionId: position!.id },
+                    json: { userId: outsider.id },
+                });
+                expect(assignResponse.status).toBe(409);
+
+                // Manual unassignment of the auto-assigned leader is rejected.
+                const unassignResponse = await client.api.groups[
+                    ":groupSlug"
+                ].positions[":positionId"].holders[":userId"].$delete({
+                    param: {
+                        groupSlug: "hs",
+                        positionId: position!.id,
+                        userId: leader.id,
+                    },
+                });
+                expect(unassignResponse.status).toBe(409);
+
+                // The verv still belongs to the group leader.
+                const [holder] = await ctx.db
+                    .select()
+                    .from(schema.groupPositionHolder)
+                    .where(
+                        eq(schema.groupPositionHolder.positionId, position!.id),
+                    );
+                expect(holder?.userId).toBe(leader.id);
+            },
+            500_000,
+        );
+
+        integrationTest(
             "leadership change moves the verv and prunes the old leader from HS",
             async ({ ctx }) => {
                 const oldLeader = await ctx.utils.createTestUser();

--- a/apps/kvark/src/routes/admin/roller.tsx
+++ b/apps/kvark/src/routes/admin/roller.tsx
@@ -156,7 +156,8 @@ function HolderChip({
 }: {
     name: string | null;
     image: string | null;
-    onRemove: () => void;
+    /** Omit to render a non-removable chip (e.g. auto-managed holders). */
+    onRemove?: () => void;
 }) {
     return (
         <Badge variant="secondary" className="gap-1.5 py-1 pl-1">
@@ -165,14 +166,16 @@ function HolderChip({
                 <AvatarFallback>{initials(name ?? "?")}</AvatarFallback>
             </Avatar>
             {name}
-            <button
-                type="button"
-                aria-label={`Fjern ${name}`}
-                onClick={onRemove}
-                className="cursor-pointer"
-            >
-                <XIcon className="size-3" />
-            </button>
+            {onRemove ? (
+                <button
+                    type="button"
+                    aria-label={`Fjern ${name}`}
+                    onClick={onRemove}
+                    className="cursor-pointer"
+                >
+                    <XIcon className="size-3" />
+                </button>
+            ) : null}
         </Badge>
     );
 }
@@ -312,7 +315,12 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                                             <span className="font-medium">
                                                 {position.name}
                                             </span>
-                                            {position.scope === "global" ? (
+                                            {position.linkedGroupSlug ? (
+                                                <span className="text-xs text-muted-foreground">
+                                                    Følger lederen av «
+                                                    {position.linkedGroupSlug}»
+                                                </span>
+                                            ) : position.scope === "global" ? (
                                                 <span className="text-xs text-muted-foreground">
                                                     Gjelder hele TIHLDE
                                                 </span>
@@ -321,7 +329,30 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                                     </TableCell>
                                     <TableCell>
                                         <div className="flex flex-wrap items-center gap-2">
-                                            {position.holder ? (
+                                            {position.linkedGroupSlug ? (
+                                                // Auto-managed: holder follows the
+                                                // linked group's leader — not
+                                                // assignable from here.
+                                                position.holder ? (
+                                                    <HolderChip
+                                                        key={
+                                                            position.holder
+                                                                .userId
+                                                        }
+                                                        name={
+                                                            position.holder.name
+                                                        }
+                                                        image={
+                                                            position.holder
+                                                                .image
+                                                        }
+                                                    />
+                                                ) : (
+                                                    <span className="text-sm text-muted-foreground">
+                                                        Settes av gruppens leder
+                                                    </span>
+                                                )
+                                            ) : position.holder ? (
                                                 <HolderChip
                                                     key={position.holder.userId}
                                                     name={position.holder.name}
@@ -542,9 +573,21 @@ function PositionDialog({
 // Roller (global RBAC roles)
 // =============================================================================
 
+/**
+ * Roles that are managed automatically and must not be assigned by hand here:
+ * - `member` is the Feide baseline synced to every active student, so it would
+ *   list every user and isn't something you hand out from this page.
+ * - `moderator` is retired — nobody should hold it.
+ */
+const HIDDEN_ROLE_NAMES = new Set(["member", "moderator"]);
+
 function RolesSection() {
     const { data: roles, isPending, error } = useQuery(getRolesQuery());
     const [createOpen, setCreateOpen] = useState(false);
+
+    const visibleRoles = (roles ?? []).filter(
+        (role) => !HIDDEN_ROLE_NAMES.has(role.name),
+    );
 
     if (isPending) {
         return (
@@ -595,7 +638,7 @@ function RolesSection() {
                             </TableRow>
                         </TableHeader>
                         <TableBody>
-                            {(roles ?? []).map((role) => (
+                            {visibleRoles.map((role) => (
                                 <RoleRow key={role.id} role={role} />
                             ))}
                         </TableBody>

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3251,6 +3251,8 @@ export interface components {
             permissions: string[];
             /** @enum {string} */
             scope: "group" | "global";
+            /** @description If set, this position is held automatically by the leader of the given subgroup and cannot be assigned manually. */
+            linkedGroupSlug: string | null;
             /** @description The single holder of this position, if assigned */
             holder: components["schemas"]["GroupPositionHolder"] | null;
             createdAt: string;
@@ -7159,6 +7161,13 @@ export interface operations {
             };
             /** @description Not Found - Position not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Position is managed automatically from group leadership */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Hva og hvorfor

Rydder opp i admin-dashens **roller-side** (`/admin/roller`) og gjør ministervervene i Hovedstyret styrt av faktisk gruppeledelse.

### Roller-fanen
- **Skjuler `member` og `moderator`.** `member` er Feide-baseline som synkes til alle aktive studenter — den ville listet *alle* brukere og skal ikke deles ut herfra. `moderator` er pensjonert, ingen skal ha den.
- **Fjerner `moderator`-rollen fra RBAC-seeden** og gjør rolleposisjonene sammenhengende igjen (root 5 → alumni 1).

> ⚠️ `member` beholdes i DB (baseline) — den skjules kun i UI. `moderator`-*raden* ligger fortsatt i prod-DB (nå skjult); kan slettes helt via «Slett» på rollen ved behov.

### Verv-fanen / HS
- **Legger til `Innovasjonsminister`** som HS-verv.
- **Gjør Beta til undergruppe** (`SUBGROUP`) og kobler vervet via `linkedGroupSlug: "beta"`, slik at beta-lederen automatisk får HS-sete + vervet (samme mønster som Teknologiminister ↔ Index).
- **Koblede leder-verv styres nå kun av gruppeledelsen** — hvem som er leder endres på gruppesiden, ikke her:
  - **Backend:** `assign`/`unassign` avviser koblede verv med `409`.
  - **API:** positions-responsen eksponerer `linkedGroupSlug` (+ regenerert SDK).
  - **Frontend:** holderen vises uten fjern-knapp, eller «Settes av gruppens leder» — ingen manuell tildeling.

### Test
- Ny integrasjonstest: koblet leder-verv kan verken tildeles eller fjernes manuelt (begge gir `409`), og holderen forblir gruppelederen.

## For reviewer
- **Ingen DB-migrering** — `linked_group_slug`-kolonnen finnes allerede; endringene er seed-data + serialisering.
- **Prod-effekt:** seed-endringer treffer bare ferske DB-er. I prod må `Innovasjonsminister` + beta-som-subgroup enten re-seedes eller settes manuelt. Skjuling av member/moderator og 409-guarden virker umiddelbart.
- Beskrivelsen på beta-gruppa omtaler den fortsatt som «komité» i markdown — ikke rørt (kun `type` endret).

## Verifisert
- `bun run typecheck` ✅ (9/9), `oxlint` rent på endrede filer, `oxfmt` kjørt.
- Integrasjonstesten er lagt til og typechecker, men **ikke kjørt** her (krever Docker/testcontainers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)