### PR TITLE
feat(hs): generisk backfill for undergruppeledere inn i HS

### DIFF
--- a/apps/api/src/db/backfill-hs-subgroup-leaders.ts
+++ b/apps/api/src/db/backfill-hs-subgroup-leaders.ts
@@ -1,0 +1,72 @@
+/**
+ * One-shot backfill: seat every CURRENT subgroup leader into Hovedstyret (HS)
+ * with their linked leader-verv.
+ *
+ * This is a catch-up for leaders who were already sitting BEFORE the mechanism
+ * existed — or before their group became a subgroup (e.g. Beta →
+ * Innovasjonsminister). The runtime already keeps HS in sync automatically on
+ * every subgroup leadership change (see `syncSubgroupLeaderIntoHs`, called from
+ * `addUserToGroup` / `updateGroupMemberRole`), so no code path needs this after
+ * the fact — it only backfills existing state.
+ *
+ * Generic: it applies to ALL groups of type "subgroup". New subgroups need no
+ * bespoke handling here; the rule is the same for every subgroup leader.
+ *
+ * Idempotent: `syncSubgroupLeaderIntoHs` adds the hs membership with
+ * onConflictDoNothing and replaces the verv holder, so re-runs are safe.
+ *
+ * NOTE on naming: a leader gets the *named* minister verv only if a position
+ * with `linkedGroupSlug = <subgroup>` already exists (e.g. the seeded
+ * Teknologiminister ↔ index, Innovasjonsminister ↔ beta). If none is linked
+ * yet, the sync creates a generic "Leder av <gruppe>" verv instead. Ensure the
+ * named verv (and the group's `type = SUBGROUP`) are in place first if you want
+ * the nice title.
+ *
+ * Run against the target database (uses env.DATABASE_URL):
+ *   cd apps/api && bun run src/db/backfill-hs-subgroup-leaders.ts
+ */
+import { schema } from "@photon/db";
+import { and, eq } from "drizzle-orm";
+import { createAppContext } from "~/lib/ctx";
+import { isSubgroupType, syncSubgroupLeaderIntoHs } from "~/lib/group";
+
+async function main() {
+    const ctx = await createAppContext();
+
+    const groups = await ctx.db.select().from(schema.group);
+    const subgroups = groups.filter((group) => isSubgroupType(group.type));
+
+    let seated = 0;
+    let skipped = 0;
+
+    for (const group of subgroups) {
+        const leaders = await ctx.db
+            .select({ userId: schema.groupMembership.userId })
+            .from(schema.groupMembership)
+            .where(
+                and(
+                    eq(schema.groupMembership.groupSlug, group.slug),
+                    eq(schema.groupMembership.role, "leader"),
+                ),
+            );
+
+        if (leaders.length === 0) {
+            console.log(`• ${group.slug}: no leader — skipped`);
+            skipped++;
+            continue;
+        }
+
+        for (const { userId } of leaders) {
+            await syncSubgroupLeaderIntoHs(ctx, userId, group);
+            seated++;
+            console.log(`✅ ${group.slug}: seated ${userId} into HS`);
+        }
+    }
+
+    console.log(
+        `\nDone. subgroups=${subgroups.length} seated=${seated} skipped=${skipped}`,
+    );
+    process.exit(0);
+}
+
+await main();

--- a/apps/api/src/db/backfill-hs-subgroup-leaders.ts
+++ b/apps/api/src/db/backfill-hs-subgroup-leaders.ts
@@ -1,34 +1,103 @@
 /**
- * One-shot backfill: seat every CURRENT subgroup leader into Hovedstyret (HS)
- * with their linked leader-verv.
+ * One-shot backfill: wire every subgroup's leadership to Hovedstyret (HS).
  *
- * This is a catch-up for leaders who were already sitting BEFORE the mechanism
- * existed — or before their group became a subgroup (e.g. Beta →
- * Innovasjonsminister). The runtime already keeps HS in sync automatically on
- * every subgroup leadership change (see `syncSubgroupLeaderIntoHs`, called from
- * `addUserToGroup` / `updateGroupMemberRole`), so no code path needs this after
- * the fact — it only backfills existing state.
+ * The runtime already keeps HS in sync automatically on every subgroup
+ * leadership change (see `syncSubgroupLeaderIntoHs`, called from
+ * `addUserToGroup` / `updateGroupMemberRole`). This script only backfills
+ * EXISTING state: it links each subgroup's minister-verv and seats whoever is
+ * currently leader — a catch-up for leaders who were already sitting before the
+ * mechanism existed.
  *
- * Generic: it applies to ALL groups of type "subgroup". New subgroups need no
- * bespoke handling here; the rule is the same for every subgroup leader.
+ * Two idempotent steps, run in order:
+ *   1. Link each subgroup's named minister-verv (Teknologiminister,
+ *      Innovasjonsminister, …) to the subgroup via `linkedGroupSlug`, creating
+ *      the verv in HS if it's missing. This makes the leader inherit the NAMED
+ *      title instead of a generic "Leder av <gruppe>".
+ *   2. Seat every current subgroup leader into HS with that verv.
  *
- * Idempotent: `syncSubgroupLeaderIntoHs` adds the hs membership with
- * onConflictDoNothing and replaces the verv holder, so re-runs are safe.
+ * Generic where it can be: step 2 covers ALL `type = "subgroup"` groups, so new
+ * subgroups need no bespoke handling. Step 1 needs the org-specific verv name
+ * per subgroup — the six TIHLDE subgroups (see /opptak "Undergrupper"). Subgroup
+ * slugs are read from the DB at runtime, so this makes no assumption about them.
  *
- * NOTE on naming: a leader gets the *named* minister verv only if a position
- * with `linkedGroupSlug = <subgroup>` already exists (e.g. the seeded
- * Teknologiminister ↔ index, Innovasjonsminister ↔ beta). If none is linked
- * yet, the sync creates a generic "Leder av <gruppe>" verv instead. Ensure the
- * named verv (and the group's `type = SUBGROUP`) are in place first if you want
- * the nice title.
+ * Idempotent: linking checks for an existing link first, and
+ * `syncSubgroupLeaderIntoHs` adds the hs membership with onConflictDoNothing and
+ * replaces the verv holder — so re-runs are safe.
  *
  * Run against the target database (uses env.DATABASE_URL):
  *   cd apps/api && bun run src/db/backfill-hs-subgroup-leaders.ts
  */
-import { schema } from "@photon/db";
-import { and, eq } from "drizzle-orm";
+import { type DbSchema, schema } from "@photon/db";
+import { and, eq, type InferSelectModel } from "drizzle-orm";
 import { createAppContext } from "~/lib/ctx";
-import { isSubgroupType, syncSubgroupLeaderIntoHs } from "~/lib/group";
+import {
+    HS_GROUP_SLUG,
+    isSubgroupType,
+    syncSubgroupLeaderIntoHs,
+} from "~/lib/group";
+
+/**
+ * Subgroup display name → the HS minister-verv its leader should hold. These are
+ * the six TIHLDE subgroups. Matched on `group.name` (stable and human-visible);
+ * the slug is taken from the matched group row, not assumed here.
+ */
+const MINISTER_BY_SUBGROUP_NAME: Record<string, string> = {
+    Index: "Teknologiminister",
+    Beta: "Innovasjonsminister",
+    Sosialen: "Sosialminister",
+    Promo: "Promoteringsminister",
+    "Kiosk og Kontor": "Kontorminister",
+    "Næringsliv og Kurs": "Næringslivsminister",
+};
+
+type Ctx = Awaited<ReturnType<typeof createAppContext>>;
+type Group = InferSelectModel<DbSchema["group"]>;
+
+/**
+ * Ensure the subgroup's named minister-verv exists in HS and is linked to it.
+ * No-op if some verv is already linked to this subgroup (idempotent).
+ */
+async function ensureLinkedMinisterVerv(
+    ctx: Ctx,
+    group: Group,
+    ministerName: string,
+): Promise<void> {
+    const [alreadyLinked] = await ctx.db
+        .select({ id: schema.groupPosition.id })
+        .from(schema.groupPosition)
+        .where(eq(schema.groupPosition.linkedGroupSlug, group.slug))
+        .limit(1);
+    if (alreadyLinked) return;
+
+    const [existing] = await ctx.db
+        .select({ id: schema.groupPosition.id })
+        .from(schema.groupPosition)
+        .where(
+            and(
+                eq(schema.groupPosition.groupSlug, HS_GROUP_SLUG),
+                eq(schema.groupPosition.name, ministerName),
+            ),
+        )
+        .limit(1);
+
+    if (existing) {
+        await ctx.db
+            .update(schema.groupPosition)
+            .set({ linkedGroupSlug: group.slug })
+            .where(eq(schema.groupPosition.id, existing.id));
+        console.log(`🔗 linked "${ministerName}" → ${group.slug}`);
+    } else {
+        await ctx.db.insert(schema.groupPosition).values({
+            groupSlug: HS_GROUP_SLUG,
+            name: ministerName,
+            description: `Leder av ${group.name}`,
+            permissions: [],
+            scope: "global",
+            linkedGroupSlug: group.slug,
+        });
+        console.log(`➕ created "${ministerName}" linked → ${group.slug}`);
+    }
+}
 
 async function main() {
     const ctx = await createAppContext();
@@ -36,9 +105,21 @@ async function main() {
     const groups = await ctx.db.select().from(schema.group);
     const subgroups = groups.filter((group) => isSubgroupType(group.type));
 
+    // Step 1: link the named minister-verv for each known subgroup.
+    for (const group of subgroups) {
+        const ministerName = MINISTER_BY_SUBGROUP_NAME[group.name];
+        if (!ministerName) {
+            console.log(
+                `⚠️  ${group.slug} ("${group.name}"): no minister mapping — leader will get a generic "Leder av …" verv`,
+            );
+            continue;
+        }
+        await ensureLinkedMinisterVerv(ctx, group, ministerName);
+    }
+
+    // Step 2: seat every current subgroup leader into HS with their verv.
     let seated = 0;
     let skipped = 0;
-
     for (const group of subgroups) {
         const leaders = await ctx.db
             .select({ userId: schema.groupMembership.userId })

--- a/apps/api/src/lib/group/index.ts
+++ b/apps/api/src/lib/group/index.ts
@@ -343,7 +343,7 @@ async function getLinkedLeaderPosition(ctx: AppContext, groupSlug: string) {
  * the linked leader-verv (replacing any previous holder — a verv has exactly
  * one holder, and leadership is the source of truth for this one).
  */
-async function syncSubgroupLeaderIntoHs(
+export async function syncSubgroupLeaderIntoHs(
     ctx: AppContext,
     userId: string,
     group: InferSelectModel<DbSchema["group"]>,


### PR DESCRIPTION
Følger opp #261 (roller-siden + auto-kobling av ministerverv).

## Hva og hvorfor

Runtime-logikken (`syncSubgroupLeaderIntoHs`) synker allerede HS automatisk hver gang undergruppe-lederskap endres (via `addUserToGroup` / `updateGroupMemberRole`), og er **felles for alle undergrupper**. Men den kjører ikke retroaktivt for ledere som allerede *sitter*, og de eksisterende minister-vervene i prod er ikke koblet til undergruppene sine ennå.

Denne PR-en legger til et **idempotent engangsskript** (`apps/api/src/db/backfill-hs-subgroup-leaders.ts`) med to steg:

1. **Kobler** hver undergruppes navngitte ministerverv til gruppa via `linkedGroupSlug` — gjenbruker det eksisterende vervet (Teknologiminister, Promoteringsminister, …), eller oppretter det i HS om det mangler (f.eks. Innovasjonsminister). Da arver lederen den *fine tittelen* i stedet for et generisk «Leder av \<gruppe\>».
2. **Seter** hver nåværende undergruppeleder inn i HS med vervet sitt.

Kjøres manuelt mot `env.DATABASE_URL` (samme mønster som `import-group-logos`):
```bash
cd apps/api && bun run src/db/backfill-hs-subgroup-leaders.ts
```

## Detaljer
- Eksporterer `syncSubgroupLeaderIntoHs` fra `~/lib/group`.
- De seks TIHLDE-undergruppene matches på **gruppenavn** (Index, Beta, Sosialen, Promo, Kiosk og Kontor, Næringsliv og Kurs); **slug leses fra DB ved kjøretid**, så ingenting hardkodes om slug-ene.
- **Idempotent:** kobling hopper over hvis et verv allerede peker på undergruppa; `syncSubgroupLeaderIntoHs` legger til HS-medlemskap med `onConflictDoNothing` og erstatter verv-holderen. Trygt å re-kjøre.
- Steg 2 er generisk for alle `type = SUBGROUP`; en undergruppe uten navn-mapping logges og lederen får et generisk «Leder av …»-verv.

## Verifisert
- `bun run typecheck` ✅ (`@photon/api`), `oxlint` rent, `oxfmt` kjørt.
- Synk-logikken har integrasjonstester (inkl. guard-testen fra #261). Skriptet er **ikke** kjørt mot en live DB her.

🤖 Generated with [Claude Code](https://claude.com/claude-code)