### PR TITLE
feat(kvark): nyhetskort på forsiden i 3 kolonner

### DIFF
--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -85,7 +85,7 @@ function Home() {
                     title="Nyheter"
                     actionLabel={canCreateNews ? "Ny nyhet" : undefined}
                 />
-                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                     {NEWS.map((item) => (
                         // TODO: replace with a unique id field once wired up to the backend
                         <NewsCard key={item.title} {...item} />


### PR DESCRIPTION
## Hva

Endrer nyhets-gridden på forsiden fra 2 til 3 kolonner.

Før: `md:grid-cols-2` (maks 2 kolonner)
Nå: `sm:grid-cols-2 lg:grid-cols-3` — 1 kolonne på mobil, 2 på nettbrett, 3 på desktop.

## Hvorfor

Ønsket tettere/bredere visning av nyheter på forsiden.

## Verifisert

- Kjørte dev-serveren og bekreftet at grid-containeren gjengir 3 kolonner ved 1280px viewport (`grid-template-columns: 400px 400px 400px`).
- Endringen er kun layout-Tailwind, i tråd med `apps/kvark/CLAUDE.md`.

## Merknad til reviewer

Nyheter-seksjonen har foreløpig bare 2 hardkodede nyhetskort (det finnes en TODO om å koble mot backend), så inntil flere nyheter kommer vises to kort i en tre-kolonners rad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)