### PR TITLE
fix(hs): backfill-skriptet kjører med db-only kontekst (virker i prod)

### DIFF
--- a/apps/api/src/db/backfill-hs-subgroup-leaders.ts
+++ b/apps/api/src/db/backfill-hs-subgroup-leaders.ts
@@ -27,9 +27,10 @@
  * Run against the target database (uses env.DATABASE_URL):
  *   cd apps/api && bun run src/db/backfill-hs-subgroup-leaders.ts
  */
-import { type DbSchema, schema } from "@photon/db";
+import { createDb, type DbSchema, schema } from "@photon/db";
 import { and, eq, type InferSelectModel } from "drizzle-orm";
-import { createAppContext } from "~/lib/ctx";
+import type { AppContext } from "~/lib/ctx";
+import { env } from "~/lib/env";
 import {
     HS_GROUP_SLUG,
     isSubgroupType,
@@ -59,7 +60,7 @@ const MINISTER_BY_NORMALIZED_NAME = new Map(
     ]),
 );
 
-type Ctx = Awaited<ReturnType<typeof createAppContext>>;
+type Ctx = AppContext;
 type Group = InferSelectModel<DbSchema["group"]>;
 
 /**
@@ -109,7 +110,11 @@ async function ensureLinkedMinisterVerv(
 }
 
 async function main() {
-    const ctx = await createAppContext();
+    // Backfill only touches the DB; a minimal db-only context avoids the
+    // auth/redis/bucket wiring that createAppContext refuses to build in
+    // production. Only `db` is read by the code paths below.
+    const db = createDb({ connectionString: env.DATABASE_URL });
+    const ctx = { db } as unknown as AppContext;
 
     const groups = await ctx.db.select().from(schema.group);
     const subgroups = groups.filter((group) => isSubgroupType(group.type));

--- a/apps/api/src/db/backfill-hs-subgroup-leaders.ts
+++ b/apps/api/src/db/backfill-hs-subgroup-leaders.ts
@@ -50,6 +50,15 @@ const MINISTER_BY_SUBGROUP_NAME: Record<string, string> = {
     "Næringsliv og Kurs": "Næringslivsminister",
 };
 
+/** Match resiliently: ignore surrounding whitespace and letter case. */
+const normalizeName = (name: string) => name.trim().toLowerCase();
+const MINISTER_BY_NORMALIZED_NAME = new Map(
+    Object.entries(MINISTER_BY_SUBGROUP_NAME).map(([name, minister]) => [
+        normalizeName(name),
+        minister,
+    ]),
+);
+
 type Ctx = Awaited<ReturnType<typeof createAppContext>>;
 type Group = InferSelectModel<DbSchema["group"]>;
 
@@ -107,7 +116,9 @@ async function main() {
 
     // Step 1: link the named minister-verv for each known subgroup.
     for (const group of subgroups) {
-        const ministerName = MINISTER_BY_SUBGROUP_NAME[group.name];
+        const ministerName = MINISTER_BY_NORMALIZED_NAME.get(
+            normalizeName(group.name),
+        );
         if (!ministerName) {
             console.log(
                 `⚠️  ${group.slug} ("${group.name}"): no minister mapping — leader will get a generic "Leder av …" verv`,


### PR DESCRIPTION
Følger opp #262. Backfill-skriptet brukte `createAppContext()`, som bygger auth/redis/bucket og **nekter å starte i produksjon** (`AUTH_SECRET must be set in production`). Skriptet kunne derfor ikke kjøres mot prod.

## Fix
Backfillen rører kun DB-en, og hele kall-kjeden (`syncSubgroupLeaderIntoHs` → `addUserToGroup` → `getRoleById`/`assignUserRole`) tar `DbCtx` (`{ db }`). Bytter derfor til en minimal db-only kontekst via `createDb(...)`, samme mønster som `import-group-logos.ts`.

## Kjørt mot prod ✅
Verifisert etter kjøring — alle seks undergruppers ministerverv er koblet, har holder, og hver holder er nå HS-medlem:

| verv | linked_slug | holder | i HS |
|---|---|---|---|
| Innovasjonsminister | beta | ✅ | ✅ |
| Kontorminister | kontkom | ✅ | ✅ |
| Næringslivsminister | nok | ✅ | ✅ |
| Promoteringsminister | promo | ✅ | ✅ |
| Sosialminister | sosialen | ✅ | ✅ |
| Teknologiminister | index | ✅ | ✅ |

(Innovasjons-, Promoterings-, Næringslivs- og Kontorminister ble opprettet; Teknologi-/Sosialminister koblet — de andre fantes fra før.)

## Verifisert
- `bun run typecheck` ✅ (`@photon/api`), `oxlint` rent, `oxfmt` kjørt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)