### PR TITLE
fix(kvark): norske gruppetyper på medlemskap-kort, skjul TIHLDE

### DIFF
--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -67,6 +67,29 @@ export type Form = {
 type ApiGroupForm = GroupFormList[number];
 
 /**
+ * Norske visningsnavn for gruppetyper. Databasen lagrer typen som UPPERCASE
+ * (f.eks. "SUBGROUP"); i grensesnittet vil vi vise norske ord.
+ */
+const GROUP_TYPE_LABELS: Record<string, string> = {
+    SUBGROUP: "Undergruppe",
+    COMMITTEE: "Komité",
+    BOARD: "Styre",
+    INTERESTGROUP: "Interessegruppe",
+    STUDYYEAR: "Klassetrinn",
+    STUDY: "Studie",
+    TIHLDE: "TIHLDE",
+    PRIVATE: "Privat",
+};
+
+/** Norsk visningsnavn for en gruppetype fra databasen (f.eks. "SUBGROUP"). */
+export function groupTypeLabel(type: string): string {
+    return (
+        GROUP_TYPE_LABELS[type] ??
+        type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
+    );
+}
+
+/**
  * Format an ISO timestamp as a Norwegian long date, e.g. "tor. 30. apr. 2026".
  */
 export function formatGroupDate(iso: string): string {

--- a/apps/kvark/src/routes/_app/profil/$id/medlemskap.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/medlemskap.tsx
@@ -1,4 +1,5 @@
 import { authQueryOptions } from "#/api/auth";
+import { groupTypeLabel } from "#/lib/group";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
@@ -21,9 +22,11 @@ function RouteComponent() {
     const { data: session } = useQuery(authQueryOptions);
     const groups = session?.groups ?? [];
     // study/studyyear er avledede grupper (projeksjon av Feide-data) og vises
-    // ved profilbildet, ikke i medlemskapslisten. Typen er UPPERCASE i DB.
+    // ved profilbildet, ikke i medlemskapslisten. TIHLDE er ingen gruppe man
+    // melder seg inn i – alle er med – så den skal heller ikke vises her.
+    // Typen er UPPERCASE i DB.
     const memberships = groups.filter(
-        (g) => !["study", "studyyear"].includes(g.type.toLowerCase()),
+        (g) => !["study", "studyyear", "tihlde"].includes(g.type.toLowerCase()),
     );
 
     if (memberships.length === 0) {
@@ -66,7 +69,7 @@ function RouteComponent() {
                                 {group.name}
                             </span>
                             <span className="truncate text-sm text-muted-foreground">
-                                {group.type}
+                                {groupTypeLabel(group.type)}
                             </span>
                         </div>
                         <Badge

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -35,6 +35,7 @@ import {
 } from "#/api/queries/contracts";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { groupTypeLabel } from "#/lib/group";
 
 export const Route = createFileRoute("/admin/grupper")({
     component: GrupperAdminPage,
@@ -53,25 +54,6 @@ const GROUP_TYPE_TABS = [
 ] as const;
 
 type TabType = (typeof GROUP_TYPE_TABS)[number]["type"];
-
-const GROUP_TYPE_LABELS: Record<string, string> = {
-    SUBGROUP: "Undergruppe",
-    COMMITTEE: "Komité",
-    BOARD: "Styre",
-    INTERESTGROUP: "Interessegruppe",
-    STUDYYEAR: "Klassetrinn",
-    STUDY: "Studie",
-    TIHLDE: "TIHLDE",
-    PRIVATE: "Privat",
-};
-
-/** Norsk visningsnavn for en gruppetype fra databasen (f.eks. "SUBGROUP"). */
-function groupTypeLabel(type: string): string {
-    return (
-        GROUP_TYPE_LABELS[type] ??
-        type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
-    );
-}
 
 function GrupperAdminPage() {
     const { data: allGroups } = useSuspenseQuery(getGroupsQuery(0));


### PR DESCRIPTION
## Hva

Medlemskap-kortene på profilsiden viste den rå UPPERCASE-typen fra databasen (`SUBGROUP`, `BOARD`, `COMMITTEE`, …) i stedet for norske ord. I tillegg ble TIHLDE-gruppen vist som et eget medlemskap – men det er ingen gruppe man melder seg inn i, alle er med i TIHLDE.

## Endringer

- **Norske gruppetyper:** Løftet den eksisterende `GROUP_TYPE_LABELS` / `groupTypeLabel`-mappingen ut av `admin/grupper.tsx` til delte `lib/group.ts`, og bruker `groupTypeLabel(group.type)` på medlemskap-kortene. Kortene viser nå **Undergruppe**, **Styre**, **Komité**, **Interessegruppe** osv.
- **Skjul TIHLDE:** La `tihlde` til filteret i `medlemskap.tsx`, ved siden av de avledede `study`/`studyyear`-gruppene, så TIHLDE ikke lenger vises som et medlemskort.
- **Fjernet duplisering:** `admin/grupper.tsx` importerer nå den delte `groupTypeLabel` i stedet for sin egen kopi.

## Verifisering

- `bun run typecheck` ✅
- `bun run lint` / `bun run format` ✅ (kun urelaterte, eksisterende warnings i `apps/api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)