### PR TITLE
fix(kvark): vertikal profilheader og fungerende «Legg til lenke»

### DIFF
--- a/apps/kvark/src/components/edit-bio-dialog.tsx
+++ b/apps/kvark/src/components/edit-bio-dialog.tsx
@@ -35,10 +35,29 @@ type EditBioValues = z.infer<typeof editBioSchema>;
 type EditBioDialogProps = {
     defaultValues?: Partial<EditBioValues>;
     onSubmit?: (values: EditBioValues) => void | Promise<void>;
+    /**
+     * Styrt åpen-tilstand. Oppgis denne, skjules den innebygde
+     * «Rediger bio»-knappen og kalleren bestemmer når dialogen vises — slik
+     * kan flere knapper (f.eks. «Legg til lenke») åpne samme dialog.
+     */
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
 };
 
-export function EditBioDialog({ defaultValues, onSubmit }: EditBioDialogProps) {
-    const [open, setOpen] = useState(false);
+export function EditBioDialog({
+    defaultValues,
+    onSubmit,
+    open: controlledOpen,
+    onOpenChange,
+}: EditBioDialogProps) {
+    const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+    const isControlled = controlledOpen !== undefined;
+    const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+    function setOpen(next: boolean) {
+        if (!isControlled) setUncontrolledOpen(next);
+        onOpenChange?.(next);
+    }
 
     const form = useForm({
         defaultValues: {
@@ -55,14 +74,16 @@ export function EditBioDialog({ defaultValues, onSubmit }: EditBioDialogProps) {
 
     return (
         <Dialog open={open} onOpenChange={setOpen}>
-            <DialogTrigger
-                render={
-                    <Button>
-                        <Pencil />
-                        Rediger bio
-                    </Button>
-                }
-            />
+            {isControlled ? null : (
+                <DialogTrigger
+                    render={
+                        <Button>
+                            <Pencil />
+                            Rediger bio
+                        </Button>
+                    }
+                />
+            )}
             <DialogContent className="max-w-lg">
                 <DialogHeader>
                     <DialogTitle>Rediger bio</DialogTitle>

--- a/apps/kvark/src/components/profile-header.tsx
+++ b/apps/kvark/src/components/profile-header.tsx
@@ -1,6 +1,6 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
 import { Badge } from "@tihlde/ui/ui/badge";
-import { Github, Linkedin, Mail, Plus } from "lucide-react";
+import { Github, GraduationCap, Linkedin, Mail, Plus } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { DetailHeader } from "#/components/detail-layout";
@@ -13,7 +13,6 @@ export type ProfileLink = {
 
 export type ProfileHeaderUser = {
     name: string;
-    username?: string;
     email: string;
     programme?: string;
     avatarUrl?: string;
@@ -23,9 +22,15 @@ export type ProfileHeaderUser = {
 type ProfileHeaderProps = {
     user: ProfileHeaderUser;
     actions?: ReactNode;
+    /** Åpner dialogen der GitHub-/LinkedIn-lenker redigeres. */
+    onAddLink?: () => void;
 };
 
-export function ProfileHeader({ user, actions }: ProfileHeaderProps) {
+export function ProfileHeader({
+    user,
+    actions,
+    onAddLink,
+}: ProfileHeaderProps) {
     return (
         <DetailHeader
             avatar={
@@ -39,28 +44,24 @@ export function ProfileHeader({ user, actions }: ProfileHeaderProps) {
                 </Avatar>
             }
             title={
+                /* Navn, studie + klassetrinn og e-post stables vertikalt — én
+                   opplysning per linje, i stedet for å slås sammen på én rad. */
                 <div className="flex flex-col gap-1">
                     <h1 className="text-2xl">{user.name}</h1>
+                    {user.programme ? (
+                        <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                            <GraduationCap className="size-3.5 shrink-0" />
+                            {user.programme}
+                        </p>
+                    ) : null}
                     <a
                         href={`mailto:${user.email}`}
-                        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground md:hidden"
+                        className="flex w-fit items-center gap-1.5 text-sm text-muted-foreground"
                     >
-                        <Mail className="size-3.5" />
+                        <Mail className="size-3.5 shrink-0" />
                         {user.email}
                     </a>
                 </div>
-            }
-            subtitle={
-                <p className="text-sm text-muted-foreground">
-                    <span className="md:hidden">
-                        {user.programme ?? user.email}
-                    </span>
-                    <span className="hidden md:inline">
-                        {[user.username, user.email, user.programme]
-                            .filter(Boolean)
-                            .join(" · ")}
-                    </span>
-                </p>
             }
             badges={
                 <>
@@ -68,7 +69,7 @@ export function ProfileHeader({ user, actions }: ProfileHeaderProps) {
                         <Badge
                             key={link.kind}
                             variant="outline"
-                            className="hidden gap-1.5 md:flex"
+                            className="gap-1.5"
                         >
                             {link.kind === "github" ? <Github /> : <Linkedin />}
                             {link.label}
@@ -76,10 +77,11 @@ export function ProfileHeader({ user, actions }: ProfileHeaderProps) {
                     ))}
                     <Badge
                         variant="secondary"
-                        className="hidden gap-1.5 md:flex"
+                        className="gap-1.5"
+                        render={<button type="button" onClick={onAddLink} />}
                     >
                         <Plus />
-                        add link
+                        Legg til lenke
                     </Badge>
                 </>
             }

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -15,12 +15,13 @@ import {
     HelpCircle,
     LayoutGrid,
     LogOut,
+    Pencil,
     ShieldCheck,
     Ticket,
     UserCircle2,
     type LucideIcon,
 } from "lucide-react";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import {
     authClientWithRedirect,
     authQueryOptions,
@@ -72,6 +73,7 @@ function RouteComponent() {
     const { data: session } = useQuery(authQueryOptions);
     const isAdmin = useIsAdmin();
     const updateSettings = useMutation(updateUserSettingsMutation);
+    const [bioOpen, setBioOpen] = useState(false);
 
     const settings = session?.user.settings;
     const { programme, classYear } = deriveStudy(session?.groups ?? []);
@@ -157,30 +159,38 @@ function RouteComponent() {
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
             <ProfileHeader
                 user={user}
+                onAddLink={() => setBioOpen(true)}
                 actions={
                     <>
                         <MembershipQrDialog name={user.name} />
-                        <EditBioDialog
-                            defaultValues={{
-                                bio: settings?.bioDescription ?? "",
-                                github: settings?.githubUrl ?? "",
-                                linkedin: settings?.linkedinUrl ?? "",
-                            }}
-                            onSubmit={async (values) => {
-                                await updateSettings.mutateAsync({
-                                    data: {
-                                        bioDescription: values.bio || undefined,
-                                        githubUrl: values.github || undefined,
-                                        linkedinUrl:
-                                            values.linkedin || undefined,
-                                        allergies: settings?.allergies ?? [],
-                                    },
-                                });
-                                await invalidateAuth();
-                            }}
-                        />
+                        <Button onClick={() => setBioOpen(true)}>
+                            <Pencil />
+                            Rediger bio
+                        </Button>
                     </>
                 }
+            />
+            {/* Dialogen styres herfra slik at både «Rediger bio» og
+                «Legg til lenke» i headeren åpner den samme dialogen. */}
+            <EditBioDialog
+                open={bioOpen}
+                onOpenChange={setBioOpen}
+                defaultValues={{
+                    bio: settings?.bioDescription ?? "",
+                    github: settings?.githubUrl ?? "",
+                    linkedin: settings?.linkedinUrl ?? "",
+                }}
+                onSubmit={async (values) => {
+                    await updateSettings.mutateAsync({
+                        data: {
+                            bioDescription: values.bio || undefined,
+                            githubUrl: values.github || undefined,
+                            linkedinUrl: values.linkedin || undefined,
+                            allergies: settings?.allergies ?? [],
+                        },
+                    });
+                    await invalidateAuth();
+                }}
             />
             <div className="grid gap-6 md:grid-cols-[16rem_1fr]">
                 <ProfileNav navGroups={navGroups} onLogout={handleLogout} />


### PR DESCRIPTION
## Hva

To ting på profilsiden (`/profil/$id`):

**1. Vertikal stabling.** Headeren slo sammen opplysningene på én rad på desktop (`brukernavn · e-post · studie`). Nå stables de vertikalt — én opplysning per linje:

```
Mathias Strøm
🎓 Dataingeniør · 3. klasse
✉️ mathstr@tihlde.org
```

`subtitle`-blokken er fjernet; den duplisert e-posten på mobil og var kilden til rad-sammenslåingen på desktop.

**2. «add link» virket ikke, og var på engelsk.** Merkelappen var en død `<span>`. Den er nå «Legg til lenke» og rendres som en ekte `<button>` via `Badge` sin `render`-prop, så den er både klikkbar og tastaturnavigerbar. Den åpner bio-dialogen, som er der GitHub-/LinkedIn-lenkene faktisk redigeres.

For at én dialog skal kunne åpnes fra to knapper støtter `EditBioDialog` nå styrt åpen-tilstand (`open`/`onOpenChange`). Uten disse propene oppfører den seg nøyaktig som før, med sin egen «Rediger bio»-trigger.

## Detaljer

- Merkelappene vistes tidligere bare på desktop (`hidden md:flex`). De vises nå på alle skjermstørrelser — ellers ville «Legg til lenke» vært utilgjengelig på mobil.
- `username` er fjernet fra `ProfileHeaderUser`. Ruten satte det aldri, og eneste bruk var raden som nå er borte.
- Klassetrinnet («3. klasse») kommer fra `deriveStudy`, som allerede fantes i `#/lib/utils` — ingen ny logikk for dette.

## Verifisert

- `bun run typecheck` ✅
- `bunx oxlint apps/kvark/src` ✅ (ingen funn)
- `bun run format` ✅
- `bun run build --filter=kvark` ✅
- Rendret `ProfileHeader` med `renderToStaticMarkup` og sjekket faktisk output:
  - rekkefølge: `Mathias Strøm | Dataingeniør · 3. klasse | mathstr@tihlde.org | github | Legg til lenke`
  - «Legg til lenke» er et `<button type="button">`, ikke en span
  - «add link» finnes ikke lenger i output
  - `deriveStudy` med kull 2023 per 2026-07-25 → `3. klasse` ✅

**Ikke verifisert:** innlogget visuell sjekk i nettleser. Ruten er auth-beskyttet og kvark autentiserer mot prod (ingen lokal `.env`), så det krever innlogging med ekte brukerkonto. Verdt en rask manuell titt før merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)