### PR TITLE
fix(kvark): rendre ekte QR-kode i medlemsbevis

### DIFF
--- a/apps/kvark/src/components/membership-qr-dialog.tsx
+++ b/apps/kvark/src/components/membership-qr-dialog.tsx
@@ -6,18 +6,24 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@tihlde/ui/ui/dialog";
+import { QRCode } from "@tihlde/ui/ui/qr-code";
 import { QrCode } from "lucide-react";
 
 type MembershipQrDialogProps = {
     name: string;
+    /**
+     * Bruker-id-en som skannes ved innsjekk på arrangementer. Uten den finnes
+     * det ikke noe gyldig medlemsbevis, så knappen deaktiveres.
+     */
+    userId?: string;
 };
 
-export function MembershipQrDialog({ name }: MembershipQrDialogProps) {
+export function MembershipQrDialog({ name, userId }: MembershipQrDialogProps) {
     return (
         <Dialog>
             <DialogTrigger
                 render={
-                    <Button variant="outline">
+                    <Button variant="outline" disabled={!userId}>
                         <QrCode />
                         Medlemsbevis
                     </Button>
@@ -28,10 +34,10 @@ export function MembershipQrDialog({ name }: MembershipQrDialogProps) {
                     <DialogTitle>Medlemsbevis</DialogTitle>
                 </DialogHeader>
                 <div className="flex flex-col items-center gap-4">
+                    {userId ? (
+                        <QRCode className="w-full max-w-xs" value={userId} />
+                    ) : null}
                     <p className="text-base font-medium">{name}</p>
-                    <div className="flex aspect-square w-full max-w-xs items-center justify-center rounded-md bg-muted">
-                        <QrCode className="size-32 text-muted-foreground" />
-                    </div>
                 </div>
             </DialogContent>
         </Dialog>

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -162,7 +162,10 @@ function RouteComponent() {
                 onAddLink={() => setBioOpen(true)}
                 actions={
                     <>
-                        <MembershipQrDialog name={user.name} />
+                        <MembershipQrDialog
+                            name={user.name}
+                            userId={session?.user.id}
+                        />
                         <Button onClick={() => setBioOpen(true)}>
                             <Pencil />
                             Rediger bio


### PR DESCRIPTION
## Hva

Medlemsbevis-dialogen på profilsiden viste bare et statisk `QrCode`-ikon i en grå boks — ingen faktisk QR-kode, så beviset var ubrukelig ved innsjekk på arrangementer.

- `membership-qr-dialog.tsx`: bytter placeholder-ikonet med den ekte `QRCode`-komponenten fra `@tihlde/ui` (qrcode.react), med navnet under koden — samme oppsett som `QRButton` i gamle Kvark. Knappen deaktiveres hvis bruker-id mangler.
- `routes/_app/profil/$id.tsx`: sender `session.user.id` inn som QR-verdi.

## Hvorfor den id-en

Gamle Kvark kodet `user.user_id`. I Photon er ekvivalenten bruker-id-en som `PATCH /:eventId/registration/:userId/attendance` bruker ved innsjekk, altså `session.user.id`.

## Verifisert

- `bun run typecheck --filter=kvark` grønn. `bun run lint` viser bare eksisterende warnings i `apps/api`, ingen nye.
- Kjørte dev-serveren lokalt, logget inn mot lokal API og åpnet dialogen på `/profil/meg` — QR-koden rendres på hvit plate med navnet under.

## For reviewer

- App-badgene fra gamle Kvark («også tilgjengelig i TIHLDE-appen») er ikke tatt med — de bilde-assetene finnes ikke i denne appen ennå.
- Uavhengig funn: `apps/kvark/src/routeTree.gen.ts` regenereres med en ekstra `declare module`-blokk hver gang dev-serveren kjører. Den er holdt utenfor denne PR-en, men bør enten committes eller ignoreres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)