### PR TITLE
fix(kvark): vis arrangementsnavn i oppmøte-dropdown

### DIFF
--- a/apps/kvark/src/routes/admin/oppmote.tsx
+++ b/apps/kvark/src/routes/admin/oppmote.tsx
@@ -62,6 +62,14 @@ function AttendanceAdminPage() {
     const [eventId, setEventId] = useState<string | null>(
         events.items[0]?.id ?? null,
     );
+    const eventOptions = useMemo(
+        () =>
+            events.items.map((event) => ({
+                value: event.id,
+                label: event.title,
+            })),
+        [events.items],
+    );
 
     return (
         <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
@@ -83,14 +91,18 @@ function AttendanceAdminPage() {
 
             <Field className="sm:max-w-96">
                 <FieldLabel>Arrangement</FieldLabel>
-                <Select value={eventId ?? ""} onValueChange={setEventId}>
+                <Select
+                    items={eventOptions}
+                    value={eventId ?? ""}
+                    onValueChange={setEventId}
+                >
                     <SelectTrigger>
                         <SelectValue placeholder="Velg arrangement" />
                     </SelectTrigger>
                     <SelectContent>
-                        {events.items.map((event) => (
-                            <SelectItem key={event.id} value={event.id}>
-                                {event.title}
+                        {eventOptions.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                                {option.label}
                             </SelectItem>
                         ))}
                     </SelectContent>


### PR DESCRIPTION
## Hva

Dropdownen for arrangement på `/admin/oppmote` viste event-id-en (`b009533c-bb59-...`) i stedet for arrangementstittelen når siden lastet med et forhåndsvalgt arrangement.

## Hvorfor

`Select` i `@tihlde/ui` er bygget på Base UI, ikke Radix. Base UI sin `SelectValue` løser etiketten for den valgte verdien via `items`-propen på `Select`-roten. Uten `items` finnes det ingen mapping fra verdi til etikett, og triggeren faller tilbake til å rendre råverdien — altså id-en.

Oppmøte-siden var den eneste selecten i appen som manglet `items`. Alle andre (prikker, brukere, annonser, arrangementer, motetid, event-filters, admin-group-picker, form/field/select) sender den allerede.

## Endring

- Bygger `eventOptions` (`{ value: id, label: title }`) med `useMemo`
- Sender den som `items={eventOptions}` på `Select`, og bruker den til å rendre `SelectItem`-ene

Én fil endret: `apps/kvark/src/routes/admin/oppmote.tsx`.

## Verifisert

- `bun run typecheck` — 9/9 pakker OK
- `bun run build` — 4/4 OK
- `bun run format` — OK

Ikke verifisert visuelt i preview: `/admin/oppmote` krever innlogging som admin, og jeg logger ikke inn på vegne av brukeren. Fikset følger samme mønster som de øvrige selectene i appen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)