### PR TITLE
feat: Feide som hovedvalg for innlogging og registrering

### DIFF
--- a/apps/kvark/.env.example
+++ b/apps/kvark/.env.example
@@ -5,5 +5,3 @@ VITE_API_URL=http://localhost:4000/
 # Optional analytics
 VITE_POSTHOG_KEY=phc_xxx
 
-# Set to "true" to show the "Logg inn med Feide" button (backend Feide client must be configured too)
-VITE_FEIDE_ENABLED=false

--- a/apps/kvark/src/env.ts
+++ b/apps/kvark/src/env.ts
@@ -14,16 +14,6 @@ export const env = createEnv({
 
     client: {
         VITE_APP_TITLE: z.string().min(1).optional(),
-        /**
-         * Set to "true" to show the "Logg inn med Feide" button. Kept off by
-         * default so the button never appears before the backend Feide client
-         * is registered and its credentials are in place — clicking it then
-         * would only produce a Dataporten error.
-         */
-        VITE_FEIDE_ENABLED: z
-            .string()
-            .optional()
-            .transform((v) => v === "true"),
     },
 
     /**

--- a/apps/kvark/src/routes/_auth/login.tsx
+++ b/apps/kvark/src/routes/_auth/login.tsx
@@ -2,6 +2,7 @@ import { Link, createFileRoute } from "@tanstack/react-router";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { z } from "zod";
+import { Button } from "@tihlde/ui/ui/button";
 import {
     Card,
     CardContent,
@@ -20,7 +21,6 @@ import {
 } from "#/api/auth";
 import { FeideSignInButton } from "#/components/feide-sign-in-button";
 import { OrDivider } from "#/components/or-divider";
-import { env } from "#/env";
 import { formHandlers, useAppForm } from "#/hooks/form";
 
 // Keep extra search params (sig, exp, client_id, scope…) so the
@@ -45,6 +45,9 @@ function LoginPage() {
     const { redirectTo } = Route.useSearch();
 
     const [feideLoading, setFeideLoading] = useState(false);
+    // Feide is the primary path, so the username/password form stays collapsed
+    // behind a "Kan du ikke bruke Feide?" link.
+    const [showPasswordForm, setShowPasswordForm] = useState(false);
 
     async function handleFeideSignIn() {
         setFeideLoading(true);
@@ -91,83 +94,98 @@ function LoginPage() {
             <CardHeader>
                 <CardTitle>Logg inn</CardTitle>
                 <CardDescription>
-                    Velkommen tilbake. Logg inn på kontoen din.
+                    Velkommen tilbake. Logg inn med Feide.
                 </CardDescription>
             </CardHeader>
-            <form {...formHandlers(form)} className="flex flex-col gap-4">
-                <CardContent className="flex flex-col gap-5">
-                    <FieldGroup>
-                        <form.AppField name="username">
-                            {(field) => (
-                                <field.InputField
-                                    label="Brukernavn"
-                                    type="text"
-                                    autoComplete="username"
-                                    required
-                                />
-                            )}
-                        </form.AppField>
-                        <div className="flex flex-col gap-2">
-                            <form.AppField name="password">
+
+            <CardContent className="flex flex-col gap-4">
+                <FeideSignInButton
+                    variant="default"
+                    onSignIn={handleFeideSignIn}
+                    loading={feideLoading}
+                />
+                {!showPasswordForm && (
+                    <Button
+                        type="button"
+                        variant="link"
+                        className="mx-auto"
+                        onClick={() => setShowPasswordForm(true)}
+                    >
+                        Kan du ikke bruke Feide?
+                    </Button>
+                )}
+            </CardContent>
+
+            {showPasswordForm && (
+                <form {...formHandlers(form)} className="flex flex-col gap-4">
+                    <div className="px-6">
+                        <OrDivider label="eller logg inn med brukernavn" />
+                    </div>
+                    <CardContent className="flex flex-col gap-5">
+                        <FieldGroup>
+                            <form.AppField name="username">
                                 {(field) => (
-                                    <field.PasswordField
-                                        label="Passord"
-                                        autoComplete="current-password"
+                                    <field.InputField
+                                        label="Brukernavn"
+                                        type="text"
+                                        autoComplete="username"
                                         required
                                     />
                                 )}
                             </form.AppField>
-                            <div className="flex justify-end">
-                                <Link
-                                    to="/forgot-password"
-                                    className="text-sm text-muted-foreground underline underline-offset-4"
-                                >
-                                    Glemt passord?
-                                </Link>
+                            <div className="flex flex-col gap-2">
+                                <form.AppField name="password">
+                                    {(field) => (
+                                        <field.PasswordField
+                                            label="Passord"
+                                            autoComplete="current-password"
+                                            required
+                                        />
+                                    )}
+                                </form.AppField>
+                                <div className="flex justify-end">
+                                    <Link
+                                        to="/forgot-password"
+                                        className="text-sm text-muted-foreground underline underline-offset-4"
+                                    >
+                                        Glemt passord?
+                                    </Link>
+                                </div>
                             </div>
-                        </div>
-                    </FieldGroup>
+                        </FieldGroup>
 
-                    <form.AppForm>
-                        <form.FormErrors />
-                    </form.AppForm>
+                        <form.AppForm>
+                            <form.FormErrors />
+                        </form.AppForm>
 
-                    <form.AppForm>
-                        <form.SubmitButton
-                            className="w-full"
-                            loading={
-                                <>
-                                    <Spinner />
-                                    <span>Logger inn...</span>
-                                </>
-                            }
-                        >
-                            Logg inn
-                        </form.SubmitButton>
-                    </form.AppForm>
+                        <form.AppForm>
+                            <form.SubmitButton
+                                className="w-full"
+                                loading={
+                                    <>
+                                        <Spinner />
+                                        <span>Logger inn...</span>
+                                    </>
+                                }
+                            >
+                                Logg inn
+                            </form.SubmitButton>
+                        </form.AppForm>
+                    </CardContent>
+                </form>
+            )}
 
-                    {env.VITE_FEIDE_ENABLED && (
-                        <>
-                            <OrDivider />
-                            <FeideSignInButton
-                                onSignIn={handleFeideSignIn}
-                                loading={feideLoading}
-                            />
-                        </>
-                    )}
-                </CardContent>
-                <CardFooter className="justify-center">
-                    <p className="text-sm text-muted-foreground">
-                        Har du ikke konto?{" "}
-                        <Link
-                            to="/register"
-                            className="underline underline-offset-4"
-                        >
-                            Opprett bruker
-                        </Link>
-                    </p>
-                </CardFooter>
-            </form>
+            <CardFooter className="justify-center">
+                <p className="text-sm text-muted-foreground">
+                    Har du ikke konto?{" "}
+                    <Link
+                        to="/register"
+                        className="underline underline-offset-4"
+                    >
+                        Opprett bruker
+                    </Link>
+                </p>
+            </CardFooter>
         </Card>
     );
 }

--- a/apps/kvark/src/routes/_auth/register.tsx
+++ b/apps/kvark/src/routes/_auth/register.tsx
@@ -22,7 +22,6 @@ import {
 } from "#/api/auth";
 import { FeideSignInButton } from "#/components/feide-sign-in-button";
 import { OrDivider } from "#/components/or-divider";
-import { env } from "#/env";
 import { formHandlers, useAppForm } from "#/hooks/form";
 
 export const Route = createFileRoute("/_auth/register")({
@@ -64,10 +63,9 @@ function RegisterPage() {
     const navigate = useNavigate();
 
     const [feideLoading, setFeideLoading] = useState(false);
-    // When Feide is the primary path, the email/password form stays collapsed
-    // behind a "Kan du ikke bruke Feide?" link. When Feide is off entirely the
-    // form is the only option, so show it straight away.
-    const [showEmailForm, setShowEmailForm] = useState(!env.VITE_FEIDE_ENABLED);
+    // Feide is the primary path, so the email/password form stays collapsed
+    // behind a "Kan du ikke bruke Feide?" link.
+    const [showEmailForm, setShowEmailForm] = useState(false);
 
     async function handleFeideSignIn() {
         setFeideLoading(true);
@@ -141,47 +139,39 @@ function RegisterPage() {
         }
     }
 
-    const feideEnabled = env.VITE_FEIDE_ENABLED;
-
     return (
         <Card>
             <CardHeader>
                 <CardTitle>Opprett bruker</CardTitle>
                 <CardDescription>
-                    {feideEnabled
-                        ? "Registrer deg med Feide for å delta på arrangementer."
-                        : "Opprett en konto for å delta på arrangementer."}
+                    Registrer deg med Feide for å delta på arrangementer.
                 </CardDescription>
             </CardHeader>
 
-            {feideEnabled && (
-                <CardContent className="flex flex-col gap-4">
-                    <FeideSignInButton
-                        variant="default"
-                        label="Registrer med Feide"
-                        onSignIn={handleFeideSignIn}
-                        loading={feideLoading}
-                    />
-                    {!showEmailForm && (
-                        <Button
-                            type="button"
-                            variant="link"
-                            className="mx-auto"
-                            onClick={() => setShowEmailForm(true)}
-                        >
-                            Kan du ikke bruke Feide?
-                        </Button>
-                    )}
-                </CardContent>
-            )}
+            <CardContent className="flex flex-col gap-4">
+                <FeideSignInButton
+                    variant="default"
+                    label="Registrer med Feide"
+                    onSignIn={handleFeideSignIn}
+                    loading={feideLoading}
+                />
+                {!showEmailForm && (
+                    <Button
+                        type="button"
+                        variant="link"
+                        className="mx-auto"
+                        onClick={() => setShowEmailForm(true)}
+                    >
+                        Kan du ikke bruke Feide?
+                    </Button>
+                )}
+            </CardContent>
 
             {showEmailForm && (
                 <form {...formHandlers(form)} className="flex flex-col gap-4">
-                    {feideEnabled && (
-                        <div className="px-6">
-                            <OrDivider label="eller registrer med e-post" />
-                        </div>
-                    )}
+                    <div className="px-6">
+                        <OrDivider label="eller registrer med e-post" />
+                    </div>
                     <CardContent className="flex flex-col gap-5">
                         <FieldGroup>
                             <form.AppField name="name">


### PR DESCRIPTION
## Hva

Feide-innlogging vises ikke i UI-et i dag: knappen lå bak feature-flagget `VITE_FEIDE_ENABLED`, som står `false` både i `.env.example` og i deployen. Denne PR-en fjerner flagget helt og gjør Feide til primærvalget.

- **`/login`**: «Logg inn med Feide» er nå primærknappen. Brukernavn/passord-skjemaet ligger kollapset bak «Kan du ikke bruke Feide?», og folder ut under en «eller logg inn med brukernavn»-divider. Samme mønster som registreringssiden allerede brukte.
- **`/register`**: Feide-først-layouten som allerede lå i koden er nå ubetinget (ikke lenger avhengig av flagget).
- **`env.ts` / `.env.example`**: `VITE_FEIDE_ENABLED` fjernet.

## Verifisert

- `bun run typecheck` grønn (9/9 tasks), `bun run format:fix` kjørt, `bun run lint` uten nye warnings i endrede filer.
- Kjørt dev-server og sjekket begge sidene i browser: Feide er primær-CTA, «Kan du ikke bruke Feide?» folder ut skjemaet, ingen konsollfeil (kun nettverksfeil mot API-et som ikke kjørte lokalt).

## Merk før merge

`FEIDE_CLIENT_ID` / `FEIDE_CLIENT_SECRET` er tomme i `.env.prod`. Frem til Feide-klienten er registrert hos Dataporten og credentials er på plass, vil et klikk på knappen gi en Dataporten-feil. Deploy-en bør altså vente på backend-credentials — eller merges bevisst med den kjente konsekvensen.

Vercel-prosjektet kan også ha `VITE_FEIDE_ENABLED` satt som env-variabel; den er nå ubrukt og kan slettes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)