### PR TITLE
fix(kvark): start markdown-editorene i admin tomme

### DIFF
--- a/apps/kvark/src/routes/admin/arrangementer.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.tsx
@@ -32,15 +32,6 @@ export const Route = createFileRoute("/admin/arrangementer")({
         context.queryClient.ensureQueryData(getGroupsQuery(0)),
 });
 
-const INITIAL_DESCRIPTION = `# Arrangementsbeskrivelse
-
-Beskriv arrangementet med **markdown**.
-
-:::callout{type=warn title="Påmelding"}
-Husk å sjekke kapasitet og påmeldingsfrist før du publiserer.
-:::
-`;
-
 /** Date -> ISO string, or null when unset */
 function toIso(value: Date | null): string | null {
     if (!value) return null;
@@ -61,7 +52,7 @@ function EventAdminPage() {
     const { data: groups } = useSuspenseQuery(getGroupsQuery(0));
 
     const [title, setTitle] = useState("");
-    const [description, setDescription] = useState(INITIAL_DESCRIPTION);
+    const [description, setDescription] = useState("");
     const [categorySlug, setCategorySlug] = useState("");
     const [organizerGroupSlug, setOrganizerGroupSlug] = useState("");
     const [location, setLocation] = useState("");
@@ -127,7 +118,7 @@ function EventAdminPage() {
             {
                 onSuccess() {
                     setTitle("");
-                    setDescription(INITIAL_DESCRIPTION);
+                    setDescription("");
                     setCategorySlug("");
                     setOrganizerGroupSlug("");
                     setLocation("");

--- a/apps/kvark/src/routes/admin/nyheter.tsx
+++ b/apps/kvark/src/routes/admin/nyheter.tsx
@@ -24,18 +24,10 @@ export const Route = createFileRoute("/admin/nyheter")({
     component: NewsAdminPage,
 });
 
-const INITIAL_BODY = `:::callout{type=info title="Tip"}
-Use directives like callouts to highlight important information for readers.
-:::
-
-Add the body of the news article here using **markdown** and any directive
-exposed by the rich registry.
-`;
-
 function NewsAdminPage() {
     const [title, setTitle] = useState("");
     const [excerpt, setExcerpt] = useState("");
-    const [body, setBody] = useState(INITIAL_BODY);
+    const [body, setBody] = useState("");
 
     const createNews = useMutation(createNewsMutation);
 
@@ -54,7 +46,7 @@ function NewsAdminPage() {
                 onSuccess() {
                     setTitle("");
                     setExcerpt("");
-                    setBody(INITIAL_BODY);
+                    setBody("");
                 },
             },
         );


### PR DESCRIPTION
## Hva

Fjerner eksempelinnholdet som markdown-editorene i admin ble forhåndsutfylt med:

- `apps/kvark/src/routes/admin/nyheter.tsx` — `INITIAL_BODY` (en `:::callout{type=info title="Tip"}` + instruksjonstekst om markdown og directives)
- `apps/kvark/src/routes/admin/arrangementer.tsx` — `INITIAL_DESCRIPTION` (overskrift «Arrangementsbeskrivelse», markdown-tips og en påmeldings-callout)

Begge editorene starter nå på tom streng og nullstilles til `""` etter vellykket innsending.

## Hvorfor

Tipsene var utviklingsplassholdere. I praksis måtte de slettes manuelt hver gang, og hvis de ble glemt ble de lagret som en del av nyheten eller arrangementsbeskrivelsen.

## For reviewer

- Ingen endringer i `@tihlde/ui`-editoren selv (`RichEditor`) — kun startverdiene i de to admin-rutene.
- `_app/playground.markdown.tsx` er bevisst urørt: eksempelteksten der finnes for å demonstrere rendering av alle directives.
- Verifisert: `bun run typecheck` (9/9), `bun run build` (4/4) og `bun run format` passerer; `bun run lint` gir kun forhåndseksisterende warnings. Browser-sjekk ble ikke fullført — `/admin/nyheter` ligger bak innlogging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)