### PR TITLE
feat: lagre bedriftshenvendelser som søknader

### DIFF
--- a/apps/api/src/lib/application/access.ts
+++ b/apps/api/src/lib/application/access.ts
@@ -8,10 +8,11 @@ import type { AppContext } from "~/lib/ctx";
 /**
  * Who may see and handle which søknad type.
  *
- * The four types land on different desks — utlegg with the Finansminister,
- * idrettslagsstøtte with IdKom, saker til HS with Hovedstyret — so each has
- * its own permission pair. `applications:view` / `applications:manage` are
- * the all-types grants held by root and admin.
+ * The types land on different desks — utlegg with the Finansminister,
+ * idrettslagsstøtte with IdKom, saker til HS with Hovedstyret,
+ * bedriftshenvendelser with the Næringslivsminister — so each has its own
+ * permission pair. `applications:view` / `applications:manage` are the
+ * all-types grants held by root and admin.
  */
 const permissionsByType: Record<
     ApplicationType,
@@ -32,6 +33,10 @@ const permissionsByType: Record<
     hs_case: {
         view: ["applications:view", "applications:hs-case:view"],
         manage: ["applications:manage", "applications:hs-case:manage"],
+    },
+    company_contact: {
+        view: ["applications:view", "applications:company-contact:view"],
+        manage: ["applications:manage", "applications:company-contact:manage"],
     },
 };
 

--- a/apps/api/src/lib/application/labels.ts
+++ b/apps/api/src/lib/application/labels.ts
@@ -16,6 +16,7 @@ export const applicationTypeLabels: Record<ApplicationType, string> = {
     support: "Søknad om støtte",
     sports_support: "Søknad om støtte til idrettslag",
     hs_case: "Sak til HS",
+    company_contact: "Henvendelse fra bedrift",
 };
 
 export const applicationStatusLabels: Record<ApplicationStatus, string> = {

--- a/apps/api/src/lib/application/pdf/index.tsx
+++ b/apps/api/src/lib/application/pdf/index.tsx
@@ -125,6 +125,13 @@ export async function renderApplicationPdf(
                 />,
             );
         }
+
+        // Bedriftshenvendelser are an inbox item, not a document that gets
+        // signed or filed — there is nothing a PDF would add.
+        case "company_contact":
+            throw new Error(
+                `Application ${application.id} is a company contact enquiry and has no PDF`,
+            );
     }
 }
 

--- a/apps/api/src/lib/application/recipients.ts
+++ b/apps/api/src/lib/application/recipients.ts
@@ -11,6 +11,10 @@ const recipientsByType: Record<ApplicationType, string[]> = {
     support: ["finansminister@tihlde.org", "hs@tihlde.org"],
     sports_support: ["idkomleder@tihlde.org", "idkom@tihlde.org"],
     hs_case: ["hs@tihlde.org"],
+    // Listed for completeness — bedriftshenvendelser are mailed by
+    // routes/company/contact.ts, which uses the configurable
+    // COMPANY_CONTACT_EMAIL instead of going through this table.
+    company_contact: ["naeringslivsminister@tihlde.org"],
 };
 
 export function recipientsFor(type: ApplicationType): string[] {

--- a/apps/api/src/lib/application/service.ts
+++ b/apps/api/src/lib/application/service.ts
@@ -11,6 +11,7 @@ const applicationWith = {
     expense: { with: { group: { columns: { slug: true, name: true } } } },
     support: { with: { group: { columns: { slug: true, name: true } } } },
     hsCase: true,
+    companyContact: true,
     attachments: true,
     submittedBy: { columns: { id: true, name: true } },
     handledBy: { columns: { id: true, name: true } },

--- a/apps/api/src/lib/application/types.ts
+++ b/apps/api/src/lib/application/types.ts
@@ -16,8 +16,9 @@ export type ApplicationSupportDetail = schema.ApplicationSupport & {
 
 /**
  * A søknad with everything needed to render it — the detail row for its type
- * plus attachments. Exactly one of `expense` / `support` / `hsCase` is set,
- * decided by `type`; the others come back null from the relational query.
+ * plus attachments. Exactly one of `expense` / `support` / `hsCase` /
+ * `companyContact` is set, decided by `type`; the others come back null from
+ * the relational query.
  *
  * This is the shape returned by `findApplicationById` / `listApplications` in
  * ./service.ts, and consumed by the PDF renderer and the serializers.
@@ -26,6 +27,7 @@ export type ApplicationWithDetails = schema.Application & {
     expense: ApplicationExpenseDetail | null;
     support: ApplicationSupportDetail | null;
     hsCase: schema.ApplicationHsCase | null;
+    companyContact: schema.ApplicationCompanyContact | null;
     attachments: schema.ApplicationAttachment[];
     submittedBy: { id: string; name: string } | null;
     handledBy: { id: string; name: string } | null;

--- a/apps/api/src/routes/application/files.ts
+++ b/apps/api/src/routes/application/files.ts
@@ -156,6 +156,14 @@ export const regeneratePdfRoute = route().post(
             );
         }
 
+        // Bedriftshenvendelser never had a PDF to begin with, so this would
+        // fail deep inside the renderer instead of saying why.
+        if (application.type === "company_contact") {
+            throw HTTPAppException.BadRequest(
+                "Bedriftshenvendelser har ingen PDF",
+            );
+        }
+
         const pdfAssetKey = await generateApplicationPdf(ctx, application);
         return c.json({ pdfAssetKey }, 200);
     },

--- a/apps/api/src/routes/application/notify.ts
+++ b/apps/api/src/routes/application/notify.ts
@@ -12,6 +12,7 @@ const handlerLabels: Record<ApplicationWithDetails["type"], string> = {
     support: "Finansminister og Hovedstyret",
     sports_support: "IdKom",
     hs_case: "Hovedstyret",
+    company_contact: "Næringslivsminister",
 };
 
 const headlines: Record<ApplicationWithDetails["type"], string> = {
@@ -19,6 +20,7 @@ const headlines: Record<ApplicationWithDetails["type"], string> = {
     support: "Ny søknad om støtte",
     sports_support: "Ny søknad om støtte til idrettslag",
     hs_case: "Ny sak meldt inn til HS",
+    company_contact: "Ny henvendelse fra bedrift",
 };
 
 const logoUrl = () => `${env.WEBSITE_URL}/logo512.png`;

--- a/apps/api/src/routes/application/schema.ts
+++ b/apps/api/src/routes/application/schema.ts
@@ -278,6 +278,14 @@ export const applicationDetailSchema = Schema(
                 recommendation: z.string().nullable(),
             })
             .nullable(),
+        companyContact: z
+            .object({
+                company: z.string(),
+                eventTypes: z.array(z.string()),
+                semesters: z.array(z.string()),
+                comment: z.string().nullable(),
+            })
+            .nullable(),
     }),
 );
 

--- a/apps/api/src/routes/application/serialize.ts
+++ b/apps/api/src/routes/application/serialize.ts
@@ -14,6 +14,7 @@ import type { ApplicationWithDetails } from "~/lib/application/types";
  */
 function buildTitle(application: ApplicationWithDetails): string {
     if (application.hsCase) return application.hsCase.caseName;
+    if (application.companyContact) return application.companyContact.company;
     if (application.expense) {
         return `${application.expense.group.name} – ${formatNok(application.expense.amountNok)}`;
     }
@@ -123,6 +124,14 @@ export function serializeApplicationDetail(
                   recommendation: application.hsCase.recommendation,
               }
             : null,
+        companyContact: application.companyContact
+            ? {
+                  company: application.companyContact.company,
+                  eventTypes: application.companyContact.eventTypes,
+                  semesters: application.companyContact.semesters,
+                  comment: application.companyContact.comment,
+              }
+            : null,
     };
 }
 
@@ -158,6 +167,20 @@ export function buildEmailDetails(
             {
                 label: "Type",
                 value: applicationCaseTypeLabels[application.hsCase.caseType],
+            },
+        ];
+    }
+
+    if (application.companyContact) {
+        return [
+            { label: "Bedrift", value: application.companyContact.company },
+            {
+                label: "Arrangementer",
+                value: application.companyContact.eventTypes.join(", "),
+            },
+            {
+                label: "Semester",
+                value: application.companyContact.semesters.join(", "),
             },
         ];
     }

--- a/apps/api/src/routes/application/update-status.ts
+++ b/apps/api/src/routes/application/update-status.ts
@@ -66,6 +66,11 @@ export const updateStatusRoute = route().patch(
         const isDecision =
             body.status === "approved" || body.status === "rejected";
 
+        // A bedrift is not a submitter with a "Mine søknader" page, and an
+        // automated "Henvendelse fra bedrift er avslått" would be the wrong
+        // way to answer one. The Næringslivsminister replies by email.
+        const notifiesSubmitter = existing.type !== "company_contact";
+
         await ctx.db
             .update(schema.application)
             .set({
@@ -83,7 +88,11 @@ export const updateStatusRoute = route().patch(
         if (!updated) throw HTTPAppException.NotFound("Søknad");
 
         // Only final decisions are worth an email; "under behandling" is noise.
-        if (isDecision && body.status !== existing.status) {
+        if (
+            notifiesSubmitter &&
+            isDecision &&
+            body.status !== existing.status
+        ) {
             await notifyApplicationDecided(ctx, logger, updated, {
                 approved: body.status === "approved",
                 statusLabel: applicationStatusLabels[body.status],

--- a/apps/api/src/routes/company/contact.ts
+++ b/apps/api/src/routes/company/contact.ts
@@ -1,3 +1,4 @@
+import { schema } from "@photon/db";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { env } from "~/lib/env";
@@ -30,7 +31,7 @@ export const contactRoute = route().post(
         summary: "Submit company contact form",
         operationId: "submitCompanyContact",
         description:
-            "Public endpoint used by the company landing page. Emails the submission to TIHLDE's business contact. Rate limited per client.",
+            "Public endpoint used by the company landing page. Stores the enquiry as an application so the Næringslivsminister can handle it in /admin/soknader, and emails it to TIHLDE's business contact. Rate limited per client.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -46,7 +47,8 @@ export const contactRoute = route().post(
     validator("json", companyContactSchema),
     async (c) => {
         const body = c.req.valid("json");
-        const { cache, email } = c.get("ctx");
+        const { cache, db, email } = c.get("ctx");
+        const logger = c.get("logger");
 
         const key = rateLimitKey(
             clientIp(c.req.header("x-forwarded-for")),
@@ -65,24 +67,61 @@ export const contactRoute = route().post(
             RATE_LIMIT_WINDOW_SECONDS,
         );
 
-        await email.sendEmailTemplate(
-            {
-                from: env.MAIL_FROM,
-                to: env.COMPANY_CONTACT_EMAIL,
-                subject: `Bedrift: ${body.company} – Ny kontaktforespørsel`,
-                replyTo: body.contactEmail,
-            },
-            "CompanyContactEmail",
-            {
-                company: body.company,
+        // Store first: the database is the system of record, so an enquiry
+        // must survive a mail outage. The submitter is external, hence no
+        // submittedById — the signature says where it came from instead.
+        const [stored] = await db
+            .insert(schema.application)
+            .values({
+                type: "company_contact",
                 contactName: body.contactName,
                 contactEmail: body.contactEmail,
-                eventTypes: body.eventTypes,
-                semesters: body.semesters,
-                comment: body.comment || undefined,
-                logoUrl: `${env.WEBSITE_URL}/logo512.png`,
-            },
-        );
+                signature: `${body.company} (innsendt via tihlde.org/bedrift)`,
+            })
+            .returning({ id: schema.application.id });
+
+        if (!stored) {
+            throw new HTTPException(500, {
+                message: "Kunne ikke lagre henvendelsen",
+            });
+        }
+
+        await db.insert(schema.applicationCompanyContact).values({
+            applicationId: stored.id,
+            company: body.company,
+            eventTypes: body.eventTypes,
+            semesters: body.semesters,
+            comment: body.comment || null,
+        });
+
+        // Non-fatal from here on: the enquiry is already saved and visible in
+        // /admin/soknader, so a mail failure must not tell the company their
+        // submission was lost.
+        try {
+            await email.sendEmailTemplate(
+                {
+                    from: env.MAIL_FROM,
+                    to: env.COMPANY_CONTACT_EMAIL,
+                    subject: `Bedrift: ${body.company} – Ny kontaktforespørsel`,
+                    replyTo: body.contactEmail,
+                },
+                "CompanyContactEmail",
+                {
+                    company: body.company,
+                    contactName: body.contactName,
+                    contactEmail: body.contactEmail,
+                    eventTypes: body.eventTypes,
+                    semesters: body.semesters,
+                    comment: body.comment || undefined,
+                    logoUrl: `${env.WEBSITE_URL}/logo512.png`,
+                },
+            );
+        } catch (error) {
+            logger.error(
+                { err: error, applicationId: stored.id },
+                "Failed to queue company contact email",
+            );
+        }
 
         return c.json(
             {

--- a/apps/api/src/test/application/company-contact.test.ts
+++ b/apps/api/src/test/application/company-contact.test.ts
@@ -1,0 +1,172 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import type { IntegrationTestContext } from "~/test/config/integration";
+import { integrationTest } from "~/test/config/integration";
+
+const SUBMISSION = {
+    company: "Testbedrift AS",
+    contactName: "Kari Nordmann",
+    contactEmail: "kari@testbedrift.no",
+    eventTypes: ["Bedriftspresentasjon", "Kurs/workshop"],
+    semesters: ["Høst 2026"],
+    comment: "Vi ønsker kontakt om høstsemesteret.",
+};
+
+/**
+ * The public form is unauthenticated, so each submission needs a distinct
+ * client IP — otherwise the shared rate-limit bucket makes later tests fail
+ * for the wrong reason.
+ */
+function publicClient(ctx: IntegrationTestContext, ip: string) {
+    return ctx.utils.client({ "x-forwarded-for": ip });
+}
+
+describe("Henvendelser fra bedrift", () => {
+    integrationTest(
+        "the public form stores the enquiry as an application",
+        async ({ ctx }) => {
+            const response = await publicClient(
+                ctx,
+                "203.0.113.10",
+            ).api.company.contact.$post({ json: SUBMISSION });
+
+            expect(response.status).toBe(200);
+
+            const stored = await ctx.db.query.application.findFirst({
+                where: eq(schema.application.type, "company_contact"),
+                with: { companyContact: true },
+            });
+
+            expect(stored?.status).toBe("new");
+            // No session behind a public form — the record must survive
+            // without a submitting user.
+            expect(stored?.submittedById).toBeNull();
+            expect(stored?.contactName).toBe(SUBMISSION.contactName);
+            expect(stored?.contactEmail).toBe(SUBMISSION.contactEmail);
+            expect(stored?.signature).toContain(SUBMISSION.company);
+            expect(stored?.companyContact?.company).toBe(SUBMISSION.company);
+            expect(stored?.companyContact?.eventTypes).toEqual(
+                SUBMISSION.eventTypes,
+            );
+            expect(stored?.companyContact?.semesters).toEqual(
+                SUBMISSION.semesters,
+            );
+            expect(stored?.companyContact?.comment).toBe(SUBMISSION.comment);
+        },
+    );
+
+    integrationTest(
+        "only company-contact handlers see it in the admin inbox",
+        async ({ ctx }) => {
+            await publicClient(ctx, "203.0.113.11").api.company.contact.$post({
+                json: SUBMISSION,
+            });
+
+            // Næringslivsministeren.
+            const handler = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(handler, [
+                "applications:company-contact:view",
+                "applications:company-contact:manage",
+            ]);
+            const handlerClient = await ctx.utils.clientForUser(handler);
+
+            const list = await handlerClient.api.applications.$get({
+                query: {},
+            });
+            expect(list.status).toBe(200);
+            const items = await list.json();
+            expect(items).toHaveLength(1);
+            expect(items[0]?.type).toBe("company_contact");
+            // The list title is what a handler scans for.
+            expect(items[0]?.title).toBe(SUBMISSION.company);
+
+            const detail = await handlerClient.api.applications[":id"].$get({
+                param: { id: items[0]?.id ?? "" },
+            });
+            const detailJson = await detail.json();
+            expect(detailJson.companyContact?.eventTypes).toEqual(
+                SUBMISSION.eventTypes,
+            );
+
+            // A Finansminister has no business seeing bedriftshenvendelser.
+            const finance = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(finance, [
+                "applications:expense:view",
+            ]);
+            const financeClient = await ctx.utils.clientForUser(finance);
+            const financeList = await financeClient.api.applications.$get({
+                query: {},
+            });
+            expect(await financeList.json()).toHaveLength(0);
+        },
+    );
+
+    integrationTest(
+        "a handler can set the status without emailing the company",
+        async ({ ctx }) => {
+            await publicClient(ctx, "203.0.113.12").api.company.contact.$post({
+                json: SUBMISSION,
+            });
+
+            const stored = await ctx.db.query.application.findFirst({
+                where: eq(schema.application.type, "company_contact"),
+            });
+
+            const handler = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(handler, [
+                "applications:company-contact:view",
+                "applications:company-contact:manage",
+            ]);
+            const handlerClient = await ctx.utils.clientForUser(handler);
+
+            const updated = await handlerClient.api.applications[
+                ":id"
+            ].status.$patch({
+                param: { id: stored?.id ?? "" },
+                json: {
+                    status: "approved",
+                    internalComment: "Avtalt bedpres i oktober",
+                },
+            });
+
+            expect(updated.status).toBe(200);
+            const updatedJson = await updated.json();
+            expect(updatedJson.status).toBe("approved");
+            expect(updatedJson.internalComment).toBe(
+                "Avtalt bedpres i oktober",
+            );
+            expect(updatedJson.handledByName).toBeTruthy();
+        },
+    );
+
+    integrationTest(
+        "bedriftshenvendelser have no PDF to regenerate",
+        async ({ ctx }) => {
+            await publicClient(ctx, "203.0.113.13").api.company.contact.$post({
+                json: SUBMISSION,
+            });
+
+            const stored = await ctx.db.query.application.findFirst({
+                where: eq(schema.application.type, "company_contact"),
+            });
+
+            const handler = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(handler, [
+                "applications:company-contact:view",
+                "applications:company-contact:manage",
+            ]);
+            const handlerClient = await ctx.utils.clientForUser(handler);
+
+            const detail = await handlerClient.api.applications[":id"].$get({
+                param: { id: stored?.id ?? "" },
+            });
+            expect((await detail.json()).hasPdf).toBe(false);
+
+            const regenerate = await handlerClient.api.applications[
+                ":id"
+            ].pdf.regenerate.$post({ param: { id: stored?.id ?? "" } });
+            expect(regenerate.status).toBe(400);
+        },
+    );
+});

--- a/apps/kvark/src/components/soknader/admin-detail-dialog.tsx
+++ b/apps/kvark/src/components/soknader/admin-detail-dialog.tsx
@@ -86,6 +86,18 @@ function detailFields(application: ApplicationDetail): Field[] {
         ];
     }
 
+    if (application.companyContact) {
+        const contact = application.companyContact;
+        return [
+            { label: "Bedrift", value: contact.company },
+            { label: "Arrangementer", value: contact.eventTypes.join(", ") },
+            { label: "Semester", value: contact.semesters.join(", ") },
+            ...(contact.comment
+                ? [{ label: "Kommentar", value: contact.comment }]
+                : []),
+        ];
+    }
+
     return [];
 }
 
@@ -291,7 +303,11 @@ export function AdminDetailDialog({
                                 />
                             </div>
 
-                            {isDecision && (
+                            {/* Bedriftshenvendelser get no automated decision
+                                email — the Næringslivsminister answers them
+                                directly — so offering a message would be a
+                                field that goes nowhere. */}
+                            {isDecision && !application.companyContact && (
                                 <div className="flex flex-col gap-2">
                                     <Label htmlFor="application-message">
                                         Melding til innsender

--- a/apps/kvark/src/routes/admin.tsx
+++ b/apps/kvark/src/routes/admin.tsx
@@ -175,6 +175,7 @@ const sidebarMenuGroups: SidebarGroup[] = [
                     "applications:support:view",
                     "applications:sports-support:view",
                     "applications:hs-case:view",
+                    "applications:company-contact:view",
                 ],
             },
         ],

--- a/apps/kvark/src/routes/admin/soknader.tsx
+++ b/apps/kvark/src/routes/admin/soknader.tsx
@@ -33,7 +33,13 @@ const searchSchema = z.object({
     /** Deep link from the notification email opens this søknad directly. */
     id: z.string().optional(),
     type: z
-        .enum(["expense", "support", "sports_support", "hs_case"])
+        .enum([
+            "expense",
+            "support",
+            "sports_support",
+            "hs_case",
+            "company_contact",
+        ])
         .optional(),
 });
 
@@ -46,7 +52,8 @@ export const Route = createFileRoute("/admin/soknader")({
 /**
  * Which type tab a viewer sees depends on what they may handle: the
  * Finansminister gets Utlegg and Støtte, HS gets Støtte and HS-saker, IdKom
- * only Idrettslag. The API narrows the data the same way — this just keeps
+ * only Idrettslag, Næringslivsministeren Bedrifter. The API narrows the data
+ * the same way — this just keeps
  * the UI from offering empty tabs.
  */
 const TYPE_TABS: {
@@ -73,6 +80,11 @@ const TYPE_TABS: {
         value: "hs_case",
         label: "Saker til HS",
         permissions: ["applications:view", "applications:hs-case:view"],
+    },
+    {
+        value: "company_contact",
+        label: "Bedrifter",
+        permissions: ["applications:view", "applications:company-contact:view"],
     },
 ];
 
@@ -157,7 +169,7 @@ function AdminApplicationsPage() {
             <div className="flex flex-col gap-6">
                 <AdminPageHeader
                     title="Søknader"
-                    description="Utlegg, søknader om støtte og saker meldt inn til Hovedstyret."
+                    description="Utlegg, søknader om støtte, saker meldt inn til Hovedstyret og henvendelser fra bedrifter."
                 />
                 <AdminEmptyState
                     icon={FileText}
@@ -172,7 +184,7 @@ function AdminApplicationsPage() {
         <div className="flex flex-col gap-6">
             <AdminPageHeader
                 title="Søknader"
-                description="Utlegg, søknader om støtte og saker meldt inn til Hovedstyret."
+                description="Utlegg, søknader om støtte, saker meldt inn til Hovedstyret og henvendelser fra bedrifter."
             />
 
             <Tabs

--- a/packages/auth/src/rbac/permissions/registry.ts
+++ b/packages/auth/src/rbac/permissions/registry.ts
@@ -91,8 +91,9 @@ export const PERMISSION_REGISTRY = {
      * a plain member right, so those routes only require authentication. The
      * sub-domains exist because the four types are handled by different
      * people: utlegg by the Finansminister, idrettslagsstøtte by IdKom, saker
-     * til HS by Hovedstyret. The top-level view/manage pair is the
-     * all-types grant held by root/admin.
+     * til HS by Hovedstyret, bedriftshenvendelser by the Næringslivsminister.
+     * The top-level view/manage pair is the all-types grant held by
+     * root/admin.
      */
     applications: {
         actions: ["view", "manage"],
@@ -106,6 +107,9 @@ export const PERMISSION_REGISTRY = {
             actions: ["view", "manage"],
         },
         "hs-case": {
+            actions: ["view", "manage"],
+        },
+        "company-contact": {
             actions: ["view", "manage"],
         },
     },

--- a/packages/db/drizzle/0031_stormy_wrecking_crew.sql
+++ b/packages/db/drizzle/0031_stormy_wrecking_crew.sql
@@ -1,0 +1,10 @@
+ALTER TYPE "public"."application_type" ADD VALUE 'company_contact';--> statement-breakpoint
+CREATE TABLE "application_company_contact" (
+	"application_id" uuid PRIMARY KEY NOT NULL,
+	"company" text NOT NULL,
+	"event_types" text[] NOT NULL,
+	"semesters" text[] NOT NULL,
+	"comment" text
+);
+--> statement-breakpoint
+ALTER TABLE "application_company_contact" ADD CONSTRAINT "application_company_contact_application_id_application_id_fk" FOREIGN KEY ("application_id") REFERENCES "public"."application"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/drizzle/meta/0031_snapshot.json
+++ b/packages/db/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,6260 @@
+{
+  "id": "1b337de0-64be-44ee-a803-e068ab25e5fa",
+  "prevId": "bc96185d-2800-5d2c-a21e-0561d5ed6ca9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apikey_api_key": {
+      "name": "apikey_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_api_key_created_by_user_id_auth_user_id_fk": {
+          "name": "apikey_api_key_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "apikey_api_key",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "apikey_api_key_key_hash_unique": {
+          "name": "apikey_api_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "application_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "submitted_by_id": {
+          "name": "submitted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_asset_key": {
+          "name": "pdf_asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_comment": {
+          "name": "internal_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled_by_id": {
+          "name": "handled_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled_at": {
+          "name": "handled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_submitted_by_id_created_at_index": {
+          "name": "application_submitted_by_id_created_at_index",
+          "columns": [
+            {
+              "expression": "submitted_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_type_status_created_at_index": {
+          "name": "application_type_status_created_at_index",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_submitted_by_id_auth_user_id_fk": {
+          "name": "application_submitted_by_id_auth_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "submitted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_handled_by_id_auth_user_id_fk": {
+          "name": "application_handled_by_id_auth_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "handled_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_attachment": {
+      "name": "application_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "application_attachment_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_attachment_application_id_index": {
+          "name": "application_attachment_application_id_index",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_attachment_application_id_application_id_fk": {
+          "name": "application_attachment_application_id_application_id_fk",
+          "tableFrom": "application_attachment",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_company_contact": {
+      "name": "application_company_contact",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semesters": {
+          "name": "semesters",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_company_contact_application_id_application_id_fk": {
+          "name": "application_company_contact_application_id_application_id_fk",
+          "tableFrom": "application_company_contact",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_expense": {
+      "name": "application_expense",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cc_email": {
+          "name": "cc_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_nok": {
+          "name": "amount_nok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expense_date": {
+          "name": "expense_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_type": {
+          "name": "budget_type",
+          "type": "application_budget_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_expense_application_id_application_id_fk": {
+          "name": "application_expense_application_id_application_id_fk",
+          "tableFrom": "application_expense",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_expense_group_slug_org_group_slug_fk": {
+          "name": "application_expense_group_slug_org_group_slug_fk",
+          "tableFrom": "application_expense",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_hs_case": {
+      "name": "application_hs_case",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_name": {
+          "name": "case_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_type": {
+          "name": "case_type",
+          "type": "application_case_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_hs_case_application_id_application_id_fk": {
+          "name": "application_hs_case_application_id_application_id_fk",
+          "tableFrom": "application_hs_case",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_support": {
+      "name": "application_support",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_description": {
+          "name": "event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_nok": {
+          "name": "total_amount_nok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_link": {
+          "name": "budget_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_support_application_id_application_id_fk": {
+          "name": "application_support_application_id_application_id_fk",
+          "tableFrom": "application_support",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_support_group_slug_org_group_slug_fk": {
+          "name": "application_support_group_slug_org_group_slug_fk",
+          "tableFrom": "application_support",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_file": {
+      "name": "asset_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "asset_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_file_uploaded_by_id_auth_user_id_fk": {
+          "name": "asset_file_uploaded_by_id_auth_user_id_fk",
+          "tableFrom": "asset_file",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_file_key_unique": {
+          "name": "asset_file_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_session_id_auth_session_id_fk": {
+          "name": "auth_oauth_access_token_session_id_auth_session_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_refresh_id_auth_oauth_refresh_token_id_fk": {
+          "name": "auth_oauth_access_token_refresh_id_auth_oauth_refresh_token_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_token_unique": {
+          "name": "auth_oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_client": {
+      "name": "auth_oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_client_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_client_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_client",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_client_client_id_unique": {
+          "name": "auth_oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_refresh_token": {
+      "name": "auth_oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_refresh_token_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_refresh_token_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_refresh_token_session_id_auth_session_id_fk": {
+          "name": "auth_oauth_refresh_token_session_id_auth_session_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_refresh_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_refresh_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_refresh_token_token_unique": {
+          "name": "auth_oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_session_token_unique": {
+          "name": "auth_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_user_email_unique": {
+          "name": "auth_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "auth_user_username_unique": {
+          "name": "auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banner_banner": {
+      "name": "banner_banner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_text": {
+          "name": "link_text",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_from": {
+          "name": "visible_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visible_until": {
+          "name": "visible_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banner_banner_created_by_user_id_auth_user_id_fk": {
+          "name": "banner_banner_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "banner_banner",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_event": {
+      "name": "event_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_waitlist": {
+          "name": "allow_waitlist",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "contact_person_id": {
+          "name": "contact_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_by_user_id": {
+          "name": "update_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_start": {
+          "name": "registration_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_end": {
+          "name": "registration_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_deadline": {
+          "name": "cancellation_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_registration_closed": {
+          "name": "is_registration_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_paid_event": {
+          "name": "is_paid_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_signing_up": {
+          "name": "requires_signing_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_grace_period_minutes": {
+          "name": "payment_grace_period_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions_allowed": {
+          "name": "reactions_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizer_group_slug": {
+          "name": "organizer_group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforces_previous_strikes": {
+          "name": "enforces_previous_strikes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_cause_strikes": {
+          "name": "can_cause_strikes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "no_show_processed_at": {
+          "name": "no_show_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_allow_prioritized": {
+          "name": "only_allow_prioritized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "event_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_event_category_slug_event_category_slug_fk": {
+          "name": "event_event_category_slug_event_category_slug_fk",
+          "tableFrom": "event_event",
+          "tableTo": "event_category",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_event_contact_person_id_auth_user_id_fk": {
+          "name": "event_event_contact_person_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "contact_person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_created_by_user_id_auth_user_id_fk": {
+          "name": "event_event_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_update_by_user_id_auth_user_id_fk": {
+          "name": "event_event_update_by_user_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "update_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_organizer_group_slug_org_group_slug_fk": {
+          "name": "event_event_organizer_group_slug_org_group_slug_fk",
+          "tableFrom": "event_event",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "organizer_group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_event_slug_unique": {
+          "name": "event_event_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_category": {
+      "name": "event_category",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_favorite": {
+      "name": "event_favorite",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_favorite_user_id_auth_user_id_fk": {
+          "name": "event_favorite_user_id_auth_user_id_fk",
+          "tableFrom": "event_favorite",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_favorite_event_id_event_event_id_fk": {
+          "name": "event_favorite_event_id_event_event_id_fk",
+          "tableFrom": "event_favorite",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_favorite_user_id_event_id_pk": {
+          "name": "event_favorite_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_feedback": {
+      "name": "event_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_feedback_event_id_event_event_id_fk": {
+          "name": "event_feedback_event_id_event_event_id_fk",
+          "tableFrom": "event_feedback",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_feedback_user_id_auth_user_id_fk": {
+          "name": "event_feedback_user_id_auth_user_id_fk",
+          "tableFrom": "event_feedback",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_payment": {
+      "name": "event_payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOK'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_payment_id": {
+          "name": "provider_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "received_payment_at": {
+          "name": "received_payment_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_payment_event_id_event_event_id_fk": {
+          "name": "event_payment_event_id_event_event_id_fk",
+          "tableFrom": "event_payment",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_payment_user_id_auth_user_id_fk": {
+          "name": "event_payment_user_id_auth_user_id_fk",
+          "tableFrom": "event_payment",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_pool": {
+      "name": "event_priority_pool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority_score": {
+          "name": "priority_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_pool_event_id_event_event_id_fk": {
+          "name": "event_priority_pool_event_id_event_event_id_fk",
+          "tableFrom": "event_priority_pool",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_pool_group": {
+      "name": "event_priority_pool_group",
+      "schema": "",
+      "columns": {
+        "priority_pool_id": {
+          "name": "priority_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_pool_group_priority_pool_id_event_priority_pool_id_fk": {
+          "name": "event_priority_pool_group_priority_pool_id_event_priority_pool_id_fk",
+          "tableFrom": "event_priority_pool_group",
+          "tableTo": "event_priority_pool",
+          "columnsFrom": [
+            "priority_pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_priority_pool_group_group_slug_org_group_slug_fk": {
+          "name": "event_priority_pool_group_group_slug_org_group_slug_fk",
+          "tableFrom": "event_priority_pool_group",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_priority_pool_group_priority_pool_id_group_slug_pk": {
+          "name": "event_priority_pool_group_priority_pool_id_group_slug_pk",
+          "columns": [
+            "priority_pool_id",
+            "group_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reaction": {
+      "name": "event_reaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reaction_user_id_auth_user_id_fk": {
+          "name": "event_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "event_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reaction_event_id_event_event_id_fk": {
+          "name": "event_reaction_event_id_event_event_id_fk",
+          "tableFrom": "event_reaction",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_reaction_user_id_event_id_pk": {
+          "name": "event_reaction_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_registration": {
+      "name": "event_registration",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "waitlist_position": {
+          "name": "waitlist_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended_at": {
+          "name": "attended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_photo": {
+          "name": "allow_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_registration_event_id_event_event_id_fk": {
+          "name": "event_registration_event_id_event_event_id_fk",
+          "tableFrom": "event_registration",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_registration_user_id_auth_user_id_fk": {
+          "name": "event_registration_user_id_auth_user_id_fk",
+          "tableFrom": "event_registration",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_registration_user_id_event_id_pk": {
+          "name": "event_registration_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_strike": {
+      "name": "event_strike",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_strike_event_id_event_event_id_fk": {
+          "name": "event_strike_event_id_event_event_id_fk",
+          "tableFrom": "event_strike",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_strike_user_id_auth_user_id_fk": {
+          "name": "event_strike_user_id_auth_user_id_fk",
+          "tableFrom": "event_strike",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_form": {
+      "name": "form_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_answer": {
+      "name": "form_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_text": {
+          "name": "answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_answer_submission_id_form_submission_id_fk": {
+          "name": "form_answer_submission_id_form_submission_id_fk",
+          "tableFrom": "form_answer",
+          "tableTo": "form_submission",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_answer_field_id_form_field_id_fk": {
+          "name": "form_answer_field_id_form_field_id_fk",
+          "tableFrom": "form_answer",
+          "tableTo": "form_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_answer_option": {
+      "name": "form_answer_option",
+      "schema": "",
+      "columns": {
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_answer_option_answer_id_form_answer_id_fk": {
+          "name": "form_answer_option_answer_id_form_answer_id_fk",
+          "tableFrom": "form_answer_option",
+          "tableTo": "form_answer",
+          "columnsFrom": [
+            "answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_answer_option_option_id_form_option_id_fk": {
+          "name": "form_answer_option_option_id_form_option_id_fk",
+          "tableFrom": "form_answer_option",
+          "tableTo": "form_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_event_form": {
+      "name": "form_event_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_event_form_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_event_form_form_id_form_form_id_fk": {
+          "name": "form_event_form_form_id_form_form_id_fk",
+          "tableFrom": "form_event_form",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_event_form_event_id_event_event_id_fk": {
+          "name": "form_event_form_event_id_event_event_id_fk",
+          "tableFrom": "form_event_form",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_type": {
+          "name": "unique_event_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_field": {
+      "name": "form_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_field_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_field_form_id_form_form_id_fk": {
+          "name": "form_field_form_id_form_form_id_fk",
+          "tableFrom": "form_field",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_group_form": {
+      "name": "form_group_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_receiver_on_submit": {
+          "name": "email_receiver_on_submit",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_submit_multiple": {
+          "name": "can_submit_multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_open_for_submissions": {
+          "name": "is_open_for_submissions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "only_for_group_members": {
+          "name": "only_for_group_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_group_form_form_id_form_form_id_fk": {
+          "name": "form_group_form_form_id_form_form_id_fk",
+          "tableFrom": "form_group_form",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_group_form_group_slug_org_group_slug_fk": {
+          "name": "form_group_form_group_slug_org_group_slug_fk",
+          "tableFrom": "form_group_form",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_option": {
+      "name": "form_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_option_field_id_form_field_id_fk": {
+          "name": "form_option_field_id_form_field_id_fk",
+          "tableFrom": "form_option",
+          "tableTo": "form_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_submission": {
+      "name": "form_submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_submission_form_id_form_form_id_fk": {
+          "name": "form_submission_form_id_form_form_id_fk",
+          "tableFrom": "form_submission",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_submission_user_id_auth_user_id_fk": {
+          "name": "form_submission_user_id_auth_user_id_fk",
+          "tableFrom": "form_submission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_contract": {
+      "name": "org_contract",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signature_placement": {
+          "name": "signature_placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_placement": {
+          "name": "name_placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_contract_created_by_user_id_auth_user_id_fk": {
+          "name": "org_contract_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_contract",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_contract_signature": {
+      "name": "org_contract_signature",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signed_name": {
+          "name": "signed_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_pdf_key": {
+          "name": "signed_pdf_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_pdf_hash": {
+          "name": "signed_pdf_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_file_key": {
+          "name": "signature_file_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signer_ip": {
+          "name": "signer_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer_ua": {
+          "name": "signer_ua",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contract_signature_unique_idx": {
+          "name": "contract_signature_unique_idx",
+          "columns": [
+            {
+              "expression": "contract_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_contract_signature_contract_id_org_contract_id_fk": {
+          "name": "org_contract_signature_contract_id_org_contract_id_fk",
+          "tableFrom": "org_contract_signature",
+          "tableTo": "org_contract",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_contract_signature_user_id_auth_user_id_fk": {
+          "name": "org_contract_signature_user_id_auth_user_id_fk",
+          "tableFrom": "org_contract_signature",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_fine": {
+      "name": "org_fine",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defense": {
+          "name": "defense",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "org_fine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_fine_user_id_auth_user_id_fk": {
+          "name": "org_fine_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_fine_group_slug_org_group_slug_fk": {
+          "name": "org_fine_group_slug_org_group_slug_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_fine_created_by_user_id_auth_user_id_fk": {
+          "name": "org_fine_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_fine_approved_by_user_id_auth_user_id_fk": {
+          "name": "org_fine_approved_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group": {
+      "name": "org_group",
+      "schema": "",
+      "columns": {
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fine_info": {
+          "name": "fine_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fines_activated": {
+          "name": "fines_activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fines_admin_id": {
+          "name": "fines_admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leader_role_id": {
+          "name": "leader_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "org_group_permission_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'leader_only'"
+        },
+        "contract_signing_required": {
+          "name": "contract_signing_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_fines_admin_id_auth_user_id_fk": {
+          "name": "org_group_fines_admin_id_auth_user_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "fines_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_group_role_id_rbac_role_id_fk": {
+          "name": "org_group_role_id_rbac_role_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "rbac_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_group_leader_role_id_rbac_role_id_fk": {
+          "name": "org_group_leader_role_id_rbac_role_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "rbac_role",
+          "columnsFrom": [
+            "leader_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_law": {
+      "name": "org_group_law",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paragraph": {
+          "name": "paragraph",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_law_group_slug_org_group_slug_fk": {
+          "name": "org_group_law_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_law",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_membership": {
+      "name": "org_group_membership",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_group_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_membership_user_id_auth_user_id_fk": {
+          "name": "org_group_membership_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_membership_group_slug_org_group_slug_fk": {
+          "name": "org_group_membership_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_membership",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_group_membership_user_id_group_slug_pk": {
+          "name": "org_group_membership_user_id_group_slug_pk",
+          "columns": [
+            "user_id",
+            "group_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_position": {
+      "name": "org_group_position",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "org_group_position_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'group'"
+        },
+        "linked_group_slug": {
+          "name": "linked_group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_position_group_slug_org_group_slug_fk": {
+          "name": "org_group_position_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_position",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_linked_group_slug_org_group_slug_fk": {
+          "name": "org_group_position_linked_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_position",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "linked_group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_position_holder": {
+      "name": "org_group_position_holder",
+      "schema": "",
+      "columns": {
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_position_holder_position_id_org_group_position_id_fk": {
+          "name": "org_group_position_holder_position_id_org_group_position_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "org_group_position",
+          "columnsFrom": [
+            "position_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_holder_user_id_auth_user_id_fk": {
+          "name": "org_group_position_holder_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_holder_granted_by_auth_user_id_fk": {
+          "name": "org_group_position_holder_granted_by_auth_user_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_study_program": {
+      "name": "org_study_program",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feide_code": {
+          "name": "feide_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "org_study_program_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_study_program_slug_unique": {
+          "name": "org_study_program_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "org_study_program_feide_code_unique": {
+          "name": "org_study_program_feide_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feide_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_study_program_membership": {
+      "name": "org_study_program_membership",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_program_id": {
+          "name": "study_program_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_campus": {
+          "name": "confirmed_campus",
+          "type": "org_campus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_study_program_membership_user_id_auth_user_id_fk": {
+          "name": "org_study_program_membership_user_id_auth_user_id_fk",
+          "tableFrom": "org_study_program_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_study_program_membership_study_program_id_org_study_program_id_fk": {
+          "name": "org_study_program_membership_study_program_id_org_study_program_id_fk",
+          "tableFrom": "org_study_program_membership",
+          "tableTo": "org_study_program",
+          "columnsFrom": [
+            "study_program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_study_program_membership_user_id_study_program_id_pk": {
+          "name": "org_study_program_membership_user_id_study_program_id_pk",
+          "columns": [
+            "user_id",
+            "study_program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_role": {
+      "name": "rbac_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rbac_role_name_unique": {
+          "name": "rbac_role_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_user_permission": {
+      "name": "rbac_user_permission",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'*'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rbac_user_permission_user_id_auth_user_id_fk": {
+          "name": "rbac_user_permission_user_id_auth_user_id_fk",
+          "tableFrom": "rbac_user_permission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_user_permission_granted_by_auth_user_id_fk": {
+          "name": "rbac_user_permission_granted_by_auth_user_id_fk",
+          "tableFrom": "rbac_user_permission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rbac_user_permission_user_id_permission_scope_pk": {
+          "name": "rbac_user_permission_user_id_permission_scope_pk",
+          "columns": [
+            "user_id",
+            "permission",
+            "scope"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_user_role": {
+      "name": "rbac_user_role",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rbac_user_role_user_id_auth_user_id_fk": {
+          "name": "rbac_user_role_user_id_auth_user_id_fk",
+          "tableFrom": "rbac_user_role",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_user_role_role_id_rbac_role_id_fk": {
+          "name": "rbac_user_role_role_id_rbac_role_id_fk",
+          "tableFrom": "rbac_user_role",
+          "tableTo": "rbac_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rbac_user_role_user_id_role_id_pk": {
+          "name": "rbac_user_role_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_notification": {
+      "name": "notification_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_notification_user_id_auth_user_id_fk": {
+          "name": "notification_notification_user_id_auth_user_id_fk",
+          "tableFrom": "notification_notification",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_news": {
+      "name": "news_news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emojis_allowed": {
+          "name": "emojis_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_news_created_by_user_id_auth_user_id_fk": {
+          "name": "news_news_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "news_news",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_reaction": {
+      "name": "news_reaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "news_id": {
+          "name": "news_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_reaction_user_id_auth_user_id_fk": {
+          "name": "news_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "news_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "news_reaction_news_id_news_news_id_fk": {
+          "name": "news_reaction_news_id_news_news_id_fk",
+          "tableFrom": "news_reaction",
+          "tableTo": "news_news",
+          "columnsFrom": [
+            "news_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "news_reaction_user_id_news_id_pk": {
+          "name": "news_reaction_user_id_news_id_pk",
+          "columns": [
+            "user_id",
+            "news_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_job_post": {
+      "name": "job_job_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingress": {
+          "name": "ingress",
+          "type": "varchar(800)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_continuously_hiring": {
+          "name": "is_continuously_hiring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_start": {
+          "name": "class_start",
+          "type": "user_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'first'"
+        },
+        "class_end": {
+          "name": "class_end",
+          "type": "user_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fifth'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_job_post_created_by_user_id_auth_user_id_fk": {
+          "name": "job_job_post_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "job_job_post",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_allergy": {
+      "name": "user_allergy",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_user_setting_allergy": {
+      "name": "user_user_setting_allergy",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergy_slug": {
+          "name": "allergy_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_user_setting_allergy_user_id_user_settings_user_id_fk": {
+          "name": "user_user_setting_allergy_user_id_user_settings_user_id_fk",
+          "tableFrom": "user_user_setting_allergy",
+          "tableTo": "user_settings",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_user_setting_allergy_allergy_slug_user_allergy_slug_fk": {
+          "name": "user_user_setting_allergy_allergy_slug_user_allergy_slug_fk",
+          "tableFrom": "user_user_setting_allergy",
+          "tableTo": "user_allergy",
+          "columnsFrom": [
+            "allergy_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_user_setting_allergy_user_id_allergy_slug_pk": {
+          "name": "user_user_setting_allergy_user_id_allergy_slug_pk",
+          "columns": [
+            "user_id",
+            "allergy_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "user_gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allows_photos_by_default": {
+          "name": "allows_photos_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_event_rules": {
+          "name": "accepts_event_rules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_description": {
+          "name": "bio_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_mail_communication": {
+          "name": "receive_mail_communication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_onboarded": {
+          "name": "is_onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_auth_user_id_fk": {
+          "name": "user_settings_user_id_auth_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.toddel_issue": {
+      "name": "toddel_issue",
+      "schema": "",
+      "columns": {
+        "edition": {
+          "name": "edition",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qrcode_qr_code": {
+      "name": "qrcode_qr_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "qrcode_qr_code_user_id_auth_user_id_fk": {
+          "name": "qrcode_qr_code_user_id_auth_user_id_fk",
+          "tableFrom": "qrcode_qr_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_event": {
+      "name": "motetid_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dates": {
+          "name": "dates",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_duration": {
+          "name": "slot_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "motetid_event_created_by_id_index": {
+          "name": "motetid_event_created_by_id_index",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_event_created_by_id_auth_user_id_fk": {
+          "name": "motetid_event_created_by_id_auth_user_id_fk",
+          "tableFrom": "motetid_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "motetid_event_slug_unique": {
+          "name": "motetid_event_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_google_credential": {
+      "name": "motetid_google_credential",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "motetid_google_credential_user_id_auth_user_id_fk": {
+          "name": "motetid_google_credential_user_id_auth_user_id_fk",
+          "tableFrom": "motetid_google_credential",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_participant": {
+      "name": "motetid_participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "motetid_participant_event_id_user_id_index": {
+          "name": "motetid_participant_event_id_user_id_index",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "motetid_participant_user_id_index": {
+          "name": "motetid_participant_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_participant_event_id_motetid_event_id_fk": {
+          "name": "motetid_participant_event_id_motetid_event_id_fk",
+          "tableFrom": "motetid_participant",
+          "tableTo": "motetid_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "motetid_participant_user_id_auth_user_id_fk": {
+          "name": "motetid_participant_user_id_auth_user_id_fk",
+          "tableFrom": "motetid_participant",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_slot": {
+      "name": "motetid_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "motetid_slot_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "motetid_slot_participant_id_date_time_index": {
+          "name": "motetid_slot_participant_id_date_time_index",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "motetid_slot_event_id_date_time_index": {
+          "name": "motetid_slot_event_id_date_time_index",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_slot_participant_id_motetid_participant_id_fk": {
+          "name": "motetid_slot_participant_id_motetid_participant_id_fk",
+          "tableFrom": "motetid_slot",
+          "tableTo": "motetid_participant",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "motetid_slot_event_id_motetid_event_id_fk": {
+          "name": "motetid_slot_event_id_motetid_event_id_fk",
+          "tableFrom": "motetid_slot",
+          "tableTo": "motetid_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.application_attachment_kind": {
+      "name": "application_attachment_kind",
+      "schema": "public",
+      "values": [
+        "receipt",
+        "budget",
+        "attachment"
+      ]
+    },
+    "public.application_budget_type": {
+      "name": "application_budget_type",
+      "schema": "public",
+      "values": [
+        "social_budget",
+        "group_budget",
+        "approved_hs_application",
+        "approved_idkom_application"
+      ]
+    },
+    "public.application_case_type": {
+      "name": "application_case_type",
+      "schema": "public",
+      "values": [
+        "discussion",
+        "decision",
+        "orientation"
+      ]
+    },
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "in_progress",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.application_type": {
+      "name": "application_type",
+      "schema": "public",
+      "values": [
+        "expense",
+        "support",
+        "sports_support",
+        "hs_case",
+        "company_contact"
+      ]
+    },
+    "public.asset_status": {
+      "name": "asset_status",
+      "schema": "public",
+      "values": [
+        "staged",
+        "ready"
+      ]
+    },
+    "public.asset_visibility": {
+      "name": "asset_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "private"
+      ]
+    },
+    "public.event_visibility": {
+      "name": "event_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "members"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "refunded",
+        "failed"
+      ]
+    },
+    "public.event_registration_status": {
+      "name": "event_registration_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "waitlisted",
+        "cancelled",
+        "attended",
+        "no_show",
+        "pending"
+      ]
+    },
+    "public.form_event_form_type": {
+      "name": "form_event_form_type",
+      "schema": "public",
+      "values": [
+        "survey",
+        "evaluation"
+      ]
+    },
+    "public.form_field_type": {
+      "name": "form_field_type",
+      "schema": "public",
+      "values": [
+        "text_answer",
+        "multiple_select",
+        "single_select"
+      ]
+    },
+    "public.org_campus": {
+      "name": "org_campus",
+      "schema": "public",
+      "values": [
+        "trondheim",
+        "gjovik",
+        "alesund"
+      ]
+    },
+    "public.org_fine_status": {
+      "name": "org_fine_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "paid",
+        "rejected"
+      ]
+    },
+    "public.org_group_membership_role": {
+      "name": "org_group_membership_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "leader"
+      ]
+    },
+    "public.org_group_permission_mode": {
+      "name": "org_group_permission_mode",
+      "schema": "public",
+      "values": [
+        "leader_only",
+        "member",
+        "custom"
+      ]
+    },
+    "public.org_group_position_scope": {
+      "name": "org_group_position_scope",
+      "schema": "public",
+      "values": [
+        "group",
+        "global"
+      ]
+    },
+    "public.org_group_type": {
+      "name": "org_group_type",
+      "schema": "public",
+      "values": [
+        "studyyear",
+        "interestgroup",
+        "committee",
+        "study",
+        "private",
+        "board",
+        "subgroup",
+        "tihlde"
+      ]
+    },
+    "public.org_study_program_type": {
+      "name": "org_study_program_type",
+      "schema": "public",
+      "values": [
+        "bachelor",
+        "master"
+      ]
+    },
+    "public.job_type": {
+      "name": "job_type",
+      "schema": "public",
+      "values": [
+        "full_time",
+        "part_time",
+        "summer_job",
+        "other"
+      ]
+    },
+    "public.user_class": {
+      "name": "user_class",
+      "schema": "public",
+      "values": [
+        "first",
+        "second",
+        "third",
+        "fourth",
+        "fifth",
+        "alumni"
+      ]
+    },
+    "public.user_gender": {
+      "name": "user_gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other"
+      ]
+    },
+    "public.motetid_slot_status": {
+      "name": "motetid_slot_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "IF_NEEDED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1784980469803,
       "tag": "0030_faulty_quentin_quire",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1785094877646,
+      "tag": "0031_stormy_wrecking_crew",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/application.ts
+++ b/packages/db/src/schema/application.ts
@@ -24,12 +24,19 @@ import { group } from "./org";
  * `support` and `sports_support` share the exact same field set — they only
  * differ in who receives and handles them — so they share a detail table and
  * are told apart by this discriminator.
+ *
+ * `company_contact` is the odd one out: it comes from the public /bedrift
+ * form, so it has no submitting user. It rides along here because a business
+ * enquiry needs exactly what a søknad needs — a status, a handler and a
+ * permanent record — and reusing the pipeline gives it the whole admin
+ * inbox for free.
  */
 export const applicationTypeVariants = [
     "expense",
     "support",
     "sports_support",
     "hs_case",
+    "company_contact",
 ] as const;
 
 export const applicationType = pgEnum(
@@ -196,6 +203,28 @@ export const applicationHsCase = pgTable("application_hs_case", {
     recommendation: text("recommendation"),
 });
 
+/**
+ * Henvendelse fra en bedrift, submitted through the public /bedrift form.
+ *
+ * `eventTypes` and `semesters` are free-form label arrays rather than enums:
+ * the option lists are marketing copy that changes between semesters, and a
+ * stored enquiry must keep the wording it was actually sent with.
+ */
+export const applicationCompanyContact = pgTable(
+    "application_company_contact",
+    {
+        applicationId: uuid("application_id")
+            .primaryKey()
+            .references(() => application.id, { onDelete: "cascade" }),
+        company: text("company").notNull(),
+        /** Which kinds of arrangement the company is interested in. */
+        eventTypes: text("event_types").array().notNull(),
+        /** Which semesters they asked about, e.g. "Høst 2026". */
+        semesters: text("semesters").array().notNull(),
+        comment: text("comment"),
+    },
+);
+
 export const applicationAttachment = pgTable(
     "application_attachment",
     {
@@ -234,6 +263,10 @@ export const applicationRelations = relations(application, ({ one, many }) => ({
     hsCase: one(applicationHsCase, {
         fields: [application.id],
         references: [applicationHsCase.applicationId],
+    }),
+    companyContact: one(applicationCompanyContact, {
+        fields: [application.id],
+        references: [applicationCompanyContact.applicationId],
     }),
     attachments: many(applicationAttachment),
 }));
@@ -276,6 +309,16 @@ export const applicationHsCaseRelations = relations(
     }),
 );
 
+export const applicationCompanyContactRelations = relations(
+    applicationCompanyContact,
+    ({ one }) => ({
+        application: one(application, {
+            fields: [applicationCompanyContact.applicationId],
+            references: [application.id],
+        }),
+    }),
+);
+
 export const applicationAttachmentRelations = relations(
     applicationAttachment,
     ({ one }) => ({
@@ -291,4 +334,6 @@ export type NewApplication = typeof application.$inferInsert;
 export type ApplicationExpense = typeof applicationExpense.$inferSelect;
 export type ApplicationSupport = typeof applicationSupport.$inferSelect;
 export type ApplicationHsCase = typeof applicationHsCase.$inferSelect;
+export type ApplicationCompanyContact =
+    typeof applicationCompanyContact.$inferSelect;
 export type ApplicationAttachment = typeof applicationAttachment.$inferSelect;

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -493,7 +493,7 @@ export interface paths {
         put?: never;
         /**
          * Submit company contact form
-         * @description Public endpoint used by the company landing page. Emails the submission to TIHLDE's business contact. Rate limited per client.
+         * @description Public endpoint used by the company landing page. Stores the enquiry as an application so the Næringslivsminister can handle it in /admin/soknader, and emails it to TIHLDE's business contact. Rate limited per client.
          */
         post: operations["submitCompanyContact"];
         delete?: never;
@@ -2171,7 +2171,7 @@ export interface components {
             /** Format: uuid */
             id: string;
             /** @enum {string} */
-            type: "expense" | "support" | "sports_support" | "hs_case";
+            type: "expense" | "support" | "sports_support" | "hs_case" | "company_contact";
             /** @description Norwegian type label */
             typeLabel: string;
             /** @enum {string} */
@@ -2290,7 +2290,7 @@ export interface components {
             /** Format: uuid */
             id: string;
             /** @enum {string} */
-            type: "expense" | "support" | "sports_support" | "hs_case";
+            type: "expense" | "support" | "sports_support" | "hs_case" | "company_contact";
             /** @description Norwegian type label */
             typeLabel: string;
             /** @enum {string} */
@@ -2355,6 +2355,12 @@ export interface components {
                 background: string;
                 assessment: string;
                 recommendation: string | null;
+            } | null;
+            companyContact: {
+                company: string;
+                eventTypes: string[];
+                semesters: string[];
+                comment: string | null;
             } | null;
         };
         UpdateApplicationStatus: {
@@ -4605,7 +4611,7 @@ export interface components {
     };
     responses: never;
     parameters: {
-        ListApplicationsQuery: "expense" | "support" | "sports_support" | "hs_case";
+        ListApplicationsQuery: "expense" | "support" | "sports_support" | "hs_case" | "company_contact";
     };
     requestBodies: never;
     headers: never;


### PR DESCRIPTION
## Hva og hvorfor

Kontaktskjemaet på `/bedrift` sendte kun e-post til `naeringslivsminister@tihlde.org`. Ingenting ble lagret, som betyr at:

- en henvendelse var tapt hvis mailen feilet eller ble slettet
- næringslivsministeren hadde ingen oversikt over hva som var kommet inn, hva som var svart på, eller hva forrige styre gjorde

Henvendelser lagres nå på samme måte som søknader, og dukker opp i samme admin-innboks med status og behandler-logg.

## Løsning

`company_contact` er lagt inn som en ny søknadstype i den eksisterende søknads-pipelinen, framfor et eget parallelt system. Det gir status-flyt, behandler-logg, rettighetsmodell og admin-UI uten ny infrastruktur.

**Database**
- Ny detaljtabell `application_company_contact` (bedrift, arrangementer, semestre, kommentar) + migrasjon `0031`
- `eventTypes`/`semesters` er tekst-arrays, ikke enums: alternativlistene er markedsføringstekst som endrer seg per semester, og en lagret henvendelse må beholde ordlyden den faktisk ble sendt med

**Backend**
- `POST /api/company/contact` lagrer først, sender e-post etterpå. E-postfeil logges nå i stedet for å feile requesten — databasen er fasit, og bedriften skal ikke få vite at innsendingen gikk tapt når den ikke gjorde det
- Innsenderen er ekstern, så `submittedById` er null (kolonnen var allerede nullable) og `signature` sier hvor henvendelsen kom fra: `"Testbedrift AS (innsendt via tihlde.org/bedrift)"`
- Nye rettigheter `applications:company-contact:view/manage`, med samme to-trinns mønster som de andre typene: billig gate i middleware, per-type-innsnevring i handleren
- Ingen automatisk «Godkjent/Avslått»-e-post til bedriften. En bedrift er ikke en innsender med «Mine søknader»-side, og et automatisk avslag er feil måte å svare på en henvendelse — næringslivsministeren svarer direkte
- Ingen PDF for denne typen; `pdf/regenerate` gir 400 med forklaring i stedet for å feile inne i renderen

**Frontend**
- Ny «Bedrifter»-fane i `/admin/soknader`, med bedrift/arrangementer/semester/kommentar i detaljdialogen
- «Melding til innsender»-feltet er skjult for denne typen, siden det ikke ville gått noe sted

## Til reviewer

**Tilgang:** rettighetene havner automatisk på `root`, `admin` og `hs` ved oppstart — `hs`-rollen bygges ved subtraksjon, og `backfillRolePermissions` er additiv, så prod plukker dem opp ved neste deploy. Næringslivsministeren sitter i HS og får dermed tilgang uten manuelt oppsett. Vil vi snevre det inn til bare vervet, må `applications:company-contact:` legges til i `HS_EXCLUDED_PREFIXES` og gis eksplisitt i `/admin/roller`. Si fra hvis det er ønsket.

**Migrasjonen** kjører `ALTER TYPE ... ADD VALUE` — den nye verdien brukes ikke i samme migrasjon, så den er trygg på PG17.

Selve skjemaet på `/bedrift` er uendret; det poster til samme endepunkt med samme payload.

## Verifisering

- `bun run typecheck`, `lint`, `format` og `build` passerer
- 4 nye integrasjonstester + de 8 eksisterende søknadstestene: 12/12 grønne
- Mot lokal DB: postet skjemaet, bekreftet radene i `application` og `application_company_contact` med psql, og at rollene fikk de nye rettighetene ved oppstart
- I nettleseren: «Bedrifter»-fanen viser henvendelsen, detaljdialogen viser alle feltene, statusendring til Godkjent registrerte behandler — og ingen e-post gikk til bedriften

E-postjobben ble lagt korrekt i køen, men landet ikke i Mailpit i mitt lokale oppsett; det gjelder også uendret kode, og selve e-postkallet er likt som før.

🤖 Generated with [Claude Code](https://claude.com/claude-code)