### PR TITLE
fix(auth): send Feide-innlogging tilbake til nettsiden, ikke API-et

### DIFF
--- a/apps/kvark/src/api/auth.ts
+++ b/apps/kvark/src/api/auth.ts
@@ -208,11 +208,21 @@ export async function authClientWithPermission(
  * Feide, which redirects back to the backend callback and finally to
  * `callbackURL` on success. Provider id must match `feidePlugin` in
  * @photon/auth. Requires the backend Feide client to be configured.
+ *
+ * The callbacks MUST be absolute frontend URLs: Better Auth resolves a
+ * relative callback against its own baseURL — the API host — so a plain "/"
+ * dumps the user on photon.tihlde.org (a 404 from the API router) instead of
+ * back on the website. Sanitized first, so only same-site paths are ever
+ * absolutized. Browser-only, so window.location.origin is available.
  */
 export async function signInWithFeide(callbackURL: string) {
+    const toFrontendUrl = (path: string) =>
+        new URL(sanitizeRedirectTo(path), window.location.origin).toString();
+
     const result = await clientAuthInstance.signIn.oauth2({
         providerId: "feide",
-        callbackURL: sanitizeRedirectTo(callbackURL),
+        callbackURL: toFrontendUrl(callbackURL),
+        errorCallbackURL: toFrontendUrl("/login"),
     });
 
     if (result.error) {

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -208,7 +208,20 @@ export const syncFeideHook: (
     ) {
         const session = middlewareContext.context.newSession;
         if (!session) {
-            throw new Error("No session found after Feide callback executed");
+            /**
+             * The callback did NOT authenticate anyone — an expired or reused
+             * state ("State mismatch: verification not found"), a denied
+             * consent, a provider error. Better Auth has already produced its
+             * own error response (and redirects to the sign-in's
+             * errorCallbackURL when one was given); throwing here replaced
+             * that with a bare 500 and an empty body, which is exactly what
+             * users hit on photon.tihlde.org/api/auth/oauth2/callback/feide.
+             * There is nothing to sync, so leave the response alone.
+             */
+            console.warn(
+                "Feide callback finished without a session; skipping sync.",
+            );
+            return;
         }
 
         const userId = session.user.id;

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -291,7 +291,18 @@ export function createAuth(options: CreateAuthOptions) {
                 if (!isFeideConfigured) return;
                 // Syncs the user's TIHLDE study-program memberships after a
                 // successful Feide callback; a no-op for every other request.
-                await syncFeideHook(ctx, { db: options.services.db });
+                //
+                // Never allowed to fail the request: by the time this runs the
+                // session cookie is already set, so throwing would hand a
+                // logged-in user a 500 at the callback URL instead of sending
+                // them back to the website. A failed sync costs them their
+                // baseline role until the next login — a 500 costs them the
+                // login itself.
+                try {
+                    await syncFeideHook(ctx, { db: options.services.db });
+                } catch (error) {
+                    console.error("Feide sync failed after callback:", error);
+                }
             }),
         },
 


### PR DESCRIPTION
Feide-innlogging endte to steder den ikke skulle: en vellykket innlogging landet på API-hosten (404), og en feilet callback ga en naken 500.

## 1. Vellykket innlogging landet på photon.tihlde.org (404)

Frontenden sendte en **relativ** `callbackURL` (`"/"` eller `"/profil"`) inn i OAuth-flyten. Better Auth løser relative callbacks mot sin egen baseURL — altså API-hosten — så brukeren ble sendt til `photon.tihlde.org/`, der API-routeren svarer `{"status":404,"message":"Route not found: GET /"}`.

Callbacken bygges nå absolutt mot frontendens origin. `sanitizeRedirectTo` kjører først, så bare same-site-stier absolutteres og `?redirectTo=https://evil.example` er fortsatt blokkert. `errorCallbackURL` settes til frontendens `/login`, så også feiltilfellet lander på nettsiden.

Samme feilklasse som `withFrontendCallback` allerede fikser for e-postlenker.

## 2. Feilet callback ga 500 med tom body

Better Auth kaster sin egen feil på callbacken (f.eks. `State mismatch: verification not found`). Vår after-hook kjørte likevel, fant ingen sesjon og kastet `No session found after Feide callback executed` — det erstattet Better Auths feilrespons med en **500 uten body**, som var det brukerne faktisk så på `/api/auth/oauth2/callback/feide`.

- `syncFeideHook` logger nå en warning og returnerer når ingen ble logget inn. Ingen sesjon = ingenting å synce.
- Hele syncen er pakket i try/catch i `createAuth`. Når hooken kjører er sesjonscookien allerede satt, så en feil der (f.eks. Dataporten groups-API som svarer non-OK) ga 500 til en bruker som faktisk *var* innlogget. En mislykket sync koster nå baseline-rollen til neste innlogging; en 500 kostet selve innloggingen.

## Verifisering

Kjørt mot ekte lokal API + kvark-dev, ikke bare typecheck. Staten backenden lagrer, lest ut av Redis:

| | før | etter |
|---|---|---|
| lagret state | `{"callbackURL":"/profil"}`, ingen `errorURL` | `{"callbackURL":"http://localhost:49294/profil","errorURL":"http://localhost:49294/login"}` |
| ugyldig state | `500`, tom body | `302 → /api/auth/error?error=state_mismatch` |
| ugyldig state, med `errorCallbackURL` | — | `302 → http://localhost:49294/login?error=state_mismatch` |

Flyten nådde `auth.dataporten.no/oauth/authorization` med riktig `redirect_uri`. `typecheck`, `lint`, `format`, `build` og auth-testene er grønne.

## Verdt å vite for review

Dette fjerner maskeringen av feilen, men forklarer ikke *hvorfor* staten manglet i prod. Etter deploy vil årsaken stå i `?error=`-parameteren og i API-loggene i stedet for å forsvinne i en tom 500. Ledende kandidater: gjenbrukt/refresha callback-URL, utløpt verification (10 min TTL), eller at synken kastet etter en vellykket innlogging.

Prod-DB var ikke tilgjengelig herfra (krever NTNU-nett/VPN), så det er ikke sjekket om brukere ble opprettet i de feilende forsøkene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)