### PR TITLE
fix(kvark): vis TIHLDE-logoen i full størrelse i admin-sidebaren

### DIFF
--- a/apps/kvark/src/routes/admin.tsx
+++ b/apps/kvark/src/routes/admin.tsx
@@ -240,9 +240,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                                 />
                             }
                         >
-                            <div className="size-8">
-                                <TihldeLogo />
-                            </div>
+                            {/* size-8! slår sidebar-knappens [&_svg]:size-4-regel */}
+                            <TihldeLogo className="size-8! shrink-0" />
                             <span className="text-sm font-stretch-condensed font-extrabold">
                                 TIHLDE
                             </span>


### PR DESCRIPTION
## Problem

Logoen i admin-sidebaren så forvrengt/klemt ut sammenlignet med resten av appen.

## Årsak

`SidebarMenuButton` har regelen `[&_svg]:size-4` (packages/ui/src/components/ui/sidebar.tsx:495). Etterkommer-selektoren (klasse + element) har høyere spesifisitet enn logoens egen klasse, så svg-en ble tvunget ned til 16px inne i `size-8`-wrapperen — halv størrelse mot site-header, `_auth` og forsiden.

## Endring

Droppet wrapper-diven og satt størrelsen direkte på svg-en med `!`:

```tsx
<TihldeLogo className="size-8! shrink-0" />
```

## Verifisering

- Målte klassene mot dev-serverens faktiske stilark på en tro kopi av markupen: svg er nå 32×32 (kvadratisk, ikke klippet i den 48px høye raden), mot 16×16 før.
- `bun run typecheck` — 9/9 grønn
- `bun run build` — 4/4 grønn

🤖 Generated with [Claude Code](https://claude.com/claude-code)