### PR TITLE
feat(admin): studie- og rollefiltrering på brukere-siden + ekte «medlem siden»

### DIFF
--- a/apps/api/src/routes/groups/members/list.ts
+++ b/apps/api/src/routes/groups/members/list.ts
@@ -1,5 +1,5 @@
 import { schema } from "@photon/db";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -52,6 +52,83 @@ export const listMembersRoute = route().get(
             },
         });
 
-        return c.json(members);
+        /**
+         * Study programme and cohort are a projection of Feide onto ordinary
+         * groups (types STUDY/STUDYYEAR), so they come from the same
+         * membership table rather than `studyProgramMembership` — the latter
+         * is only ever written by a Feide login, which leaves everyone
+         * migrated from Lepton without a row. The type is stored in UPPERCASE
+         * from Lepton, so compare case-insensitively.
+         */
+        const userIds = members.map((m) => m.userId);
+        const studyRows =
+            userIds.length === 0
+                ? []
+                : await db
+                      .select({
+                          userId: schema.groupMembership.userId,
+                          groupName: schema.group.name,
+                          groupType:
+                              sql<string>`lower(${schema.group.type})`.as(
+                                  "group_type",
+                              ),
+                      })
+                      .from(schema.groupMembership)
+                      .innerJoin(
+                          schema.group,
+                          eq(
+                              schema.groupMembership.groupSlug,
+                              schema.group.slug,
+                          ),
+                      )
+                      .where(
+                          and(
+                              inArray(schema.groupMembership.userId, userIds),
+                              inArray(sql`lower(${schema.group.type})`, [
+                                  "study",
+                                  "studyyear",
+                              ]),
+                          ),
+                      );
+
+        const studyByUser = new Map<
+            string,
+            { studyProgram: string | null; studyStartYear: number | null }
+        >();
+        for (const row of studyRows) {
+            const entry = studyByUser.get(row.userId) ?? {
+                studyProgram: null,
+                studyStartYear: null,
+            };
+            if (row.groupType === "study") {
+                entry.studyProgram ??= row.groupName;
+            } else {
+                // Several cohorts can linger on one account (a bachelor who
+                // continued into a master). The most recent one is the useful
+                // one — it is what class year is computed from.
+                const year = Number.parseInt(row.groupName, 10);
+                if (
+                    Number.isFinite(year) &&
+                    (entry.studyStartYear === null ||
+                        year > entry.studyStartYear)
+                ) {
+                    entry.studyStartYear = year;
+                }
+            }
+            studyByUser.set(row.userId, entry);
+        }
+
+        return c.json(
+            members.map((member) => ({
+                ...member,
+                user: {
+                    ...member.user,
+                    studyProgram:
+                        studyByUser.get(member.userId)?.studyProgram ?? null,
+                    studyStartYear:
+                        studyByUser.get(member.userId)?.studyStartYear ?? null,
+                },
+            })),
+        );
     },
 );

--- a/apps/api/src/routes/groups/schema.ts
+++ b/apps/api/src/routes/groups/schema.ts
@@ -206,6 +206,14 @@ export const memberSchema = Schema(
                     .string()
                     .nullable()
                     .meta({ description: "User profile image URL" }),
+                studyProgram: z.string().nullable().meta({
+                    description:
+                        "Name of the member's study programme, derived from their STUDY group membership. Null when the member has none (alumni, honorary members).",
+                }),
+                studyStartYear: z.number().int().nullable().meta({
+                    description:
+                        "The year the member started studying (kull), derived from their STUDYYEAR group membership. Null when unknown.",
+                }),
             })
             .meta({ description: "Public user info for the member" }),
     }),

--- a/apps/api/src/test/groups/members.test.ts
+++ b/apps/api/src/test/groups/members.test.ts
@@ -426,6 +426,103 @@ describe("group members", () => {
         );
 
         integrationTest(
+            "includes study programme and cohort derived from the member's study groups",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "study-list",
+                });
+                // Lepton stores these types in UPPERCASE — the route has to
+                // match case-insensitively, so seed them that way.
+                const study = await ctx.utils.createTestGroup({
+                    slug: "dataingenior",
+                    name: "Dataingeniør",
+                    type: "STUDY",
+                });
+                const olderCohort = await ctx.utils.createTestGroup({
+                    slug: "2021",
+                    name: "2021",
+                    type: "STUDYYEAR",
+                });
+                const cohort = await ctx.utils.createTestGroup({
+                    slug: "2024",
+                    name: "2024",
+                    type: "STUDYYEAR",
+                });
+
+                const student = await ctx.auth.api.createUser({
+                    body: {
+                        email: "student@test.com",
+                        name: "Student",
+                        password: "test123!",
+                    },
+                });
+                const alumni = await ctx.auth.api.createUser({
+                    body: {
+                        email: "alumni@test.com",
+                        name: "Alumni",
+                        password: "test123!",
+                    },
+                });
+
+                await ctx.db.insert(schema.groupMembership).values([
+                    {
+                        userId: student.user.id,
+                        groupSlug: group.slug,
+                        role: "member",
+                    },
+                    {
+                        userId: student.user.id,
+                        groupSlug: study.slug,
+                        role: "member",
+                    },
+                    {
+                        userId: student.user.id,
+                        groupSlug: olderCohort.slug,
+                        role: "member",
+                    },
+                    {
+                        userId: student.user.id,
+                        groupSlug: cohort.slug,
+                        role: "member",
+                    },
+                    {
+                        userId: alumni.user.id,
+                        groupSlug: group.slug,
+                        role: "member",
+                    },
+                ]);
+
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].members.$get({
+                    param: { groupSlug: group.slug },
+                });
+
+                expect(response.status).toBe(200);
+
+                const json = await response.json();
+                const studentRow = json.find(
+                    (m) => m.userId === student.user.id,
+                );
+                const alumniRow = json.find((m) => m.userId === alumni.user.id);
+
+                expect(studentRow?.user).toMatchObject({
+                    studyProgram: "Dataingeniør",
+                    // The most recent cohort wins when someone has several.
+                    studyStartYear: 2024,
+                });
+                expect(alumniRow?.user).toMatchObject({
+                    studyProgram: null,
+                    studyStartYear: null,
+                });
+            },
+            500_000,
+        );
+
+        integrationTest(
             "returns empty array for group with no members",
             async ({ ctx }) => {
                 const user = await ctx.utils.createTestUser();

--- a/apps/kvark/src/routes/admin/brukere.tsx
+++ b/apps/kvark/src/routes/admin/brukere.tsx
@@ -1,11 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { PlusIcon, Trash2, UsersIcon } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
 import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent } from "@tihlde/ui/ui/card";
+import { Input } from "@tihlde/ui/ui/input";
 import {
     Dialog,
     DialogContent,
@@ -48,7 +49,7 @@ import {
     type UserSearchOption,
 } from "#/components/user-search-combobox";
 import { useDebounced } from "#/lib/use-debounced";
-import { initials } from "#/lib/utils";
+import { computeClassYear, initials } from "#/lib/utils";
 
 const ROLE_LABELS: Record<string, string> = {
     leader: "Leder",
@@ -60,6 +61,27 @@ const MEMBER_SINCE_FORMAT = new Intl.DateTimeFormat("nb-NO", {
     month: "long",
     year: "numeric",
 });
+
+/** Sentinel for "no filter" — the Select needs a concrete value. */
+const ALL = "__all__";
+/** Sentinel for members without a registered study programme. */
+const NO_STUDY = "__none__";
+
+/**
+ * Studieprogram + klassetrinn på én linje, f.eks. "Dataingeniør · 3. klasse".
+ * Klassetrinn vises bare i intervallet 1–5 (bachelor 3 + master 2) — utenfor
+ * det er medlemmet i praksis alumni, siden medlemskap aldri fjernes.
+ */
+function formatStudy(
+    programme: string | null,
+    startYear: number | null,
+): string | null {
+    if (!programme) return null;
+    if (startYear === null) return programme;
+    const classYear = computeClassYear(startYear);
+    if (classYear < 1 || classYear > 5) return programme;
+    return `${programme} · ${classYear}. klasse`;
+}
 
 /** Prefer the API's own error message over ky's generic HTTP status text. */
 async function extractErrorMessage(error: unknown): Promise<string> {
@@ -155,6 +177,68 @@ function MembersTable({ groupSlug }: { groupSlug: string }) {
     const updateRole = useMutation(updateGroupMemberRoleMutation);
     const remove = useMutation(removeGroupMemberMutation);
 
+    const [search, setSearch] = useState("");
+    const [study, setStudy] = useState<string>(ALL);
+    const [role, setRole] = useState<string>(ALL);
+    const [year, setYear] = useState<string>(ALL);
+
+    const debouncedSearch = useDebounced(search);
+
+    // Filtervalgene speiler dataene som faktisk ligger i gruppen, slik at man
+    // ikke kan velge et studie eller et år som gir null treff.
+    const studyOptions = useMemo(
+        () =>
+            Array.from(
+                new Set(
+                    (members ?? [])
+                        .map((m) => m.user.studyProgram)
+                        .filter((p): p is string => Boolean(p)),
+                ),
+            ).sort((a, b) => a.localeCompare(b, "nb-NO")),
+        [members],
+    );
+
+    const yearOptions = useMemo(
+        () =>
+            Array.from(
+                new Set(
+                    (members ?? []).map((m) =>
+                        new Date(m.createdAt).getFullYear(),
+                    ),
+                ),
+            ).sort((a, b) => b - a),
+        [members],
+    );
+
+    const filtered = useMemo(() => {
+        const needle = debouncedSearch.toLowerCase();
+        return (members ?? []).filter((member) => {
+            if (needle && !member.user.name.toLowerCase().includes(needle)) {
+                return false;
+            }
+            if (role !== ALL && member.role !== role) {
+                return false;
+            }
+            if (study === NO_STUDY && member.user.studyProgram) {
+                return false;
+            }
+            if (
+                study !== ALL &&
+                study !== NO_STUDY &&
+                member.user.studyProgram !== study
+            ) {
+                return false;
+            }
+            if (
+                year !== ALL &&
+                String(new Date(member.createdAt).getFullYear()) !== year
+            ) {
+                return false;
+            }
+            return true;
+        });
+    }, [members, debouncedSearch, role, study, year]);
+
     if (isPending) {
         return (
             <Card>
@@ -192,110 +276,232 @@ function MembersTable({ groupSlug }: { groupSlug: string }) {
     }
 
     return (
-        <Card>
-            <CardContent className="p-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Navn</TableHead>
-                            <TableHead>Rolle</TableHead>
-                            <TableHead>Medlem siden</TableHead>
-                            <TableHead className="text-right">
-                                Handlinger
-                            </TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {members.map((member) => (
-                            <TableRow key={member.userId}>
-                                <TableCell>
-                                    <div className="flex items-center gap-2">
-                                        <Avatar className="size-7">
-                                            <AvatarImage
-                                                src={
-                                                    member.user.image ??
-                                                    undefined
-                                                }
-                                            />
-                                            <AvatarFallback>
-                                                {initials(
-                                                    member.user.name ?? "?",
-                                                )}
-                                            </AvatarFallback>
-                                        </Avatar>
-                                        <span className="text-sm font-medium">
-                                            {member.user.name}
-                                        </span>
-                                    </div>
-                                </TableCell>
-                                <TableCell>
-                                    <Select
-                                        items={Object.entries(ROLE_LABELS).map(
-                                            ([value, label]) => ({
-                                                value,
-                                                label,
-                                            }),
-                                        )}
-                                        value={member.role}
-                                        onValueChange={(value) => {
-                                            if (
-                                                !value ||
-                                                value === member.role
-                                            ) {
-                                                return;
-                                            }
-                                            updateRole.mutate({
-                                                groupSlug,
-                                                userId: member.userId,
-                                                data: {
-                                                    role: value as
-                                                        | "member"
-                                                        | "leader",
-                                                },
-                                            });
-                                        }}
-                                    >
-                                        <SelectTrigger className="w-36">
-                                            <SelectValue />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {Object.entries(ROLE_LABELS).map(
-                                                ([value, label]) => (
-                                                    <SelectItem
-                                                        key={value}
-                                                        value={value}
-                                                    >
-                                                        {label}
-                                                    </SelectItem>
-                                                ),
+        <div className="flex flex-col gap-4">
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <Field>
+                    <FieldLabel htmlFor="member-search">Navn</FieldLabel>
+                    <Input
+                        id="member-search"
+                        value={search}
+                        onChange={(event) => setSearch(event.target.value)}
+                        placeholder="Søk etter navn…"
+                    />
+                </Field>
+                <Field>
+                    <FieldLabel htmlFor="member-filter-study">
+                        Studie
+                    </FieldLabel>
+                    <FilterSelect
+                        id="member-filter-study"
+                        value={study}
+                        onValueChange={setStudy}
+                        allLabel="Alle studier"
+                        options={[
+                            ...studyOptions.map((option) => ({
+                                value: option,
+                                label: option,
+                            })),
+                            { value: NO_STUDY, label: "Uten studie" },
+                        ]}
+                    />
+                </Field>
+                <Field>
+                    <FieldLabel htmlFor="member-filter-role">Rolle</FieldLabel>
+                    <FilterSelect
+                        id="member-filter-role"
+                        value={role}
+                        onValueChange={setRole}
+                        allLabel="Alle roller"
+                        options={Object.entries(ROLE_LABELS).map(
+                            ([value, label]) => ({ value, label }),
+                        )}
+                    />
+                </Field>
+                <Field>
+                    <FieldLabel htmlFor="member-filter-year">
+                        Medlem siden
+                    </FieldLabel>
+                    <FilterSelect
+                        id="member-filter-year"
+                        value={year}
+                        onValueChange={setYear}
+                        allLabel="Alle år"
+                        options={yearOptions.map((option) => ({
+                            value: String(option),
+                            label: String(option),
+                        }))}
+                    />
+                </Field>
+            </div>
+
+            <p className="text-sm">
+                Viser {filtered.length} av {members.length} medlemmer
+            </p>
+
+            {filtered.length === 0 ? (
+                <Card>
+                    <CardContent>
+                        <AdminEmptyState
+                            icon={UsersIcon}
+                            title="Ingen treff"
+                            description="Ingen medlemmer passer med filtrene."
+                        />
+                    </CardContent>
+                </Card>
+            ) : (
+                <Card>
+                    <CardContent className="p-0">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Navn</TableHead>
+                                    <TableHead>Studie</TableHead>
+                                    <TableHead>Rolle</TableHead>
+                                    <TableHead>Medlem siden</TableHead>
+                                    <TableHead className="text-right">
+                                        Handlinger
+                                    </TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {filtered.map((member) => (
+                                    <TableRow key={member.userId}>
+                                        <TableCell>
+                                            <div className="flex items-center gap-2">
+                                                <Avatar className="size-7">
+                                                    <AvatarImage
+                                                        src={
+                                                            member.user.image ??
+                                                            undefined
+                                                        }
+                                                    />
+                                                    <AvatarFallback>
+                                                        {initials(
+                                                            member.user.name ??
+                                                                "?",
+                                                        )}
+                                                    </AvatarFallback>
+                                                </Avatar>
+                                                <span className="text-sm font-medium">
+                                                    {member.user.name}
+                                                </span>
+                                            </div>
+                                        </TableCell>
+                                        <TableCell>
+                                            {formatStudy(
+                                                member.user.studyProgram,
+                                                member.user.studyStartYear,
+                                            ) ?? "—"}
+                                        </TableCell>
+                                        <TableCell>
+                                            <Select
+                                                items={Object.entries(
+                                                    ROLE_LABELS,
+                                                ).map(([value, label]) => ({
+                                                    value,
+                                                    label,
+                                                }))}
+                                                value={member.role}
+                                                onValueChange={(value) => {
+                                                    if (
+                                                        !value ||
+                                                        value === member.role
+                                                    ) {
+                                                        return;
+                                                    }
+                                                    updateRole.mutate({
+                                                        groupSlug,
+                                                        userId: member.userId,
+                                                        data: {
+                                                            role: value as
+                                                                | "member"
+                                                                | "leader",
+                                                        },
+                                                    });
+                                                }}
+                                            >
+                                                <SelectTrigger className="w-36">
+                                                    <SelectValue />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    {Object.entries(
+                                                        ROLE_LABELS,
+                                                    ).map(([value, label]) => (
+                                                        <SelectItem
+                                                            key={value}
+                                                            value={value}
+                                                        >
+                                                            {label}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </TableCell>
+                                        <TableCell>
+                                            {MEMBER_SINCE_FORMAT.format(
+                                                new Date(member.createdAt),
                                             )}
-                                        </SelectContent>
-                                    </Select>
-                                </TableCell>
-                                <TableCell>
-                                    {MEMBER_SINCE_FORMAT.format(
-                                        new Date(member.createdAt),
-                                    )}
-                                </TableCell>
-                                <TableCell>
-                                    <div className="flex justify-end">
-                                        <Button
-                                            variant="destructive"
-                                            size="sm"
-                                            disabled={remove.isPending}
-                                            onClick={() => handleRemove(member)}
-                                        >
-                                            <Trash2 className="size-4" />
-                                            Fjern
-                                        </Button>
-                                    </div>
-                                </TableCell>
-                            </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </CardContent>
-        </Card>
+                                        </TableCell>
+                                        <TableCell>
+                                            <div className="flex justify-end">
+                                                <Button
+                                                    variant="destructive"
+                                                    size="sm"
+                                                    disabled={remove.isPending}
+                                                    onClick={() =>
+                                                        handleRemove(member)
+                                                    }
+                                                >
+                                                    <Trash2 className="size-4" />
+                                                    Fjern
+                                                </Button>
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+            )}
+        </div>
+    );
+}
+
+/**
+ * Nedtrekk for et enkelt kolonnefilter, med et fast "alle"-valg øverst.
+ */
+function FilterSelect({
+    id,
+    value,
+    onValueChange,
+    allLabel,
+    options,
+}: {
+    id: string;
+    value: string;
+    onValueChange: (value: string) => void;
+    allLabel: string;
+    options: { value: string; label: string }[];
+}) {
+    const items = [{ value: ALL, label: allLabel }, ...options];
+    return (
+        <Select
+            items={items}
+            value={value}
+            onValueChange={(next) => onValueChange((next as string) ?? ALL)}
+        >
+            <SelectTrigger id={id} className="w-full">
+                <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+                {items.map((item) => (
+                    <SelectItem key={item.value} value={item.value}>
+                        {item.label}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
     );
 }
 

--- a/packages/lepton-migration/import-memberships.ts
+++ b/packages/lepton-migration/import-memberships.ts
@@ -10,12 +10,20 @@
  * the one key guaranteed to agree between the two systems. The Lepton user_id
  * is translated to an email via the user export cache.
  *
- * Idempotent: ON CONFLICT DO NOTHING on the (user, group) pair, and a re-run
- * reports zero new rows. Without --commit nothing is written.
+ * `created_at` follows the membership over: "medlem siden" is when someone
+ * actually joined the group in Lepton, not when the import happened to run.
+ * A row that already exists only ever gets its date moved *earlier* — a
+ * membership created natively in Photon after the migration keeps its own
+ * date, and a re-run never drags anything forward.
+ *
+ * Idempotent: the (user, group) pair conflicts are resolved as described
+ * above, and a settled re-run reports zero new and zero corrected rows.
+ * Without --commit nothing is written.
  *
  * Usage: DATABASE_URL=... bun import-memberships.ts [--commit]
  */
 import { createDb, schema } from "@photon/db";
+import { and, eq } from "drizzle-orm";
 
 const commit = process.argv.includes("--commit");
 
@@ -66,10 +74,30 @@ const main = async () => {
         ),
     );
 
+    // Existing rows, so an already-imported membership can have its join date
+    // corrected instead of being silently skipped.
+    const existing = new Map(
+        (
+            await db
+                .select({
+                    userId: schema.groupMembership.userId,
+                    groupSlug: schema.groupMembership.groupSlug,
+                    createdAt: schema.groupMembership.createdAt,
+                })
+                .from(schema.groupMembership)
+        ).map((m) => [`${m.userId} ${m.groupSlug}`, m.createdAt]),
+    );
+
     const rows: (typeof schema.groupMembership.$inferInsert)[] = [];
+    const corrections: {
+        userId: string;
+        groupSlug: string;
+        createdAt: Date;
+    }[] = [];
     let unknownUser = 0;
     let unknownGroup = 0;
     let unknownRole = 0;
+    let missingJoinDate = 0;
 
     for (const [slug, list] of Object.entries(memberships)) {
         if (!knownGroups.has(slug)) {
@@ -102,13 +130,42 @@ const main = async () => {
                 continue;
             }
 
-            rows.push({ userId, groupSlug: slug, role });
+            const joined = m.created_at ? new Date(m.created_at) : null;
+            const joinedAt =
+                joined && !Number.isNaN(joined.getTime()) ? joined : null;
+            if (!joinedAt) {
+                missingJoinDate++;
+            }
+
+            const current = existing.get(`${userId} ${slug}`);
+            if (current) {
+                // Only ever move the date backwards — see the file header.
+                if (joinedAt && joinedAt < current) {
+                    corrections.push({
+                        userId,
+                        groupSlug: slug,
+                        createdAt: joinedAt,
+                    });
+                }
+                continue;
+            }
+
+            rows.push({
+                userId,
+                groupSlug: slug,
+                role,
+                ...(joinedAt ? { createdAt: joinedAt } : {}),
+            });
         }
     }
 
     console.log(`${rows.length} medlemskap klare til innsetting`);
+    console.log(
+        `${corrections.length} medlemskap får korrigert «medlem siden»`,
+    );
 
     let inserted = 0;
+    let corrected = 0;
     if (commit && rows.length > 0) {
         for (let i = 0; i < rows.length; i += 500) {
             const batch = rows.slice(i, i + 500);
@@ -121,6 +178,21 @@ const main = async () => {
         }
     }
 
+    if (commit && corrections.length > 0) {
+        for (const c of corrections) {
+            await db
+                .update(schema.groupMembership)
+                .set({ createdAt: c.createdAt })
+                .where(
+                    and(
+                        eq(schema.groupMembership.userId, c.userId),
+                        eq(schema.groupMembership.groupSlug, c.groupSlug),
+                    ),
+                );
+            corrected++;
+        }
+    }
+
     console.log();
     console.log(commit ? "=== KJØRT ===" : "=== TØRRKJØRING (read-only) ===");
     console.log(`klare:            ${rows.length}`);
@@ -129,9 +201,15 @@ const main = async () => {
             ? `satt inn:         ${inserted}`
             : "satt inn:         0 (tørrkjøring)",
     );
+    console.log(
+        commit
+            ? `dato korrigert:   ${corrected}`
+            : `dato korrigert:   0 (tørrkjøring, ${corrections.length} klare)`,
+    );
     console.log(`bruker mangler:   ${unknownUser}`);
     console.log(`gruppe mangler:   ${unknownGroup}`);
     console.log(`ukjent rolle:     ${unknownRole}`);
+    console.log(`uten dato:        ${missingJoinDate}`);
 };
 
 await main();

--- a/packages/lepton-migration/src/phases/02-groups.ts
+++ b/packages/lepton-migration/src/phases/02-groups.ts
@@ -101,6 +101,8 @@ export async function migrateGroups(
         userId: string;
         groupSlug: string;
         role: "member" | "leader";
+        createdAt?: Date;
+        updatedAt?: Date;
     }> = [];
 
     /**
@@ -120,10 +122,14 @@ export async function migrateGroups(
             continue;
         }
 
+        // Carry the join date over: "medlem siden" has to say when someone
+        // actually joined the group, not when the import ran.
         membershipRecords.push({
             userId: newUserId,
             groupSlug,
             role: mapMembershipRole(m.membership_type),
+            ...(m.created_at ? { createdAt: new Date(m.created_at) } : {}),
+            ...(m.updated_at ? { updatedAt: new Date(m.updated_at) } : {}),
         });
     }
 

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3701,6 +3701,10 @@ export interface components {
                 name: string;
                 /** @description User profile image URL */
                 image: string | null;
+                /** @description Name of the member's study programme, derived from their STUDY group membership. Null when the member has none (alumni, honorary members). */
+                studyProgram: string | null;
+                /** @description The year the member started studying (kull), derived from their STUDYYEAR group membership. Null when unknown. */
+                studyStartYear: number | null;
             };
         };
         GroupMemberList: components["schemas"]["GroupMember"][];


### PR DESCRIPTION
## Hva

**Brukere-siden i admin** (`/admin/brukere`) viser nå **Navn · Studie · Rolle · Medlem siden**, med filtrering på alle fire:

- fritekstsøk på navn (debounced)
- nedtrekk for studie, rolle og år for «medlem siden»
- filtervalgene bygges fra medlemmene som faktisk ligger i gruppen, så du aldri kan velge noe som gir null treff — pluss et eget «Uten studie»-valg
- teller («Viser X av Y medlemmer») og en «Ingen treff»-tilstand

Studie-kolonnen viser programnavn, og klassetrinn når det gir mening (`Dataingeniør · 3. klasse`). Trinn utenfor 1–5 utelates, siden de i praksis er alumni — medlemskap fjernes aldri.

**API:** `GET /api/groups/:slug/members` returnerer `user.studyProgram` og `user.studyStartYear`.

**«Medlem siden» viste feil dato.** Kolonnen viste når raden ble importert fra Lepton, ikke når medlemmet faktisk ble med.

## Hvorfor

Studie utledes fra medlemskapene i `STUDY`/`STUDYYEAR`-gruppene, ikke fra `studyProgramMembership`. Sistnevnte skrives bare ved en Feide-innlogging, så alle Lepton-migrerte medlemmer ville stått uten studie. Én ekstra spørring, ingen n+1.

Datofeilen kom av at både `src/phases/02-groups.ts` og `import-memberships.ts` droppet Leptons `created_at` ved innsetting. Bekreftet mot dev-DB: 6222 rader stemplet 20. juni 2026, 351 stemplet 22. juli 2026. Begge importene bærer datoen med seg nå, og `import-memberships.ts` retter i tillegg eksisterende rader — den flytter `created_at` **bare bakover, aldri fram**, slik at medlemskap opprettet i Photon etter migreringen beholder sin egen dato, og en ny kjøring aldri drar noe framover.

## Til revieweren

**Koden alene fikser ikke prod-dataene.** Datoene i prod står fortsatt på importtidspunktet til dette kjøres (krever Lepton-token, så det må skje _før_ `SUPERADMIN_TOKEN` roteres):

\`\`\`bash
LEPTON_TOKEN=… bun packages/lepton-migration/fetch-lepton-memberships.ts
\`\`\`

\`\`\`bash
DATABASE_URL=<prod> bun packages/lepton-migration/import-memberships.ts   # tørrkjøring, --commit for å skrive
\`\`\`

`auth_user.createdAt` har samme defekt (alle brukere «opprettet» ved importen), men vises ingen steder ennå og er bevisst ikke rørt her.

Filtreringen skjer klientside — endepunktet returnerte allerede alle medlemmer, så serverside-filtre ville ikke redusert lasten.

## Verifisert

- `bun run typecheck`, `bun run lint` og `bun run format` grønne
- alle 311 API-tester passerer, inkludert en ny test for studie-/kullfeltene (case-insensitiv `STUDY`/`STUDYYEAR`, nyeste kull vinner, alumni får `null`)
- kjørt i browser mot lokal API + dev-DB: alle fire filtre verifisert hver for seg og i kombinasjon, inkludert «Ingen treff»
- datokorrigeringen kjørt mot dev-DB med et syntetisk eksport-sett: 2 rader korrigert, én med senere dato urørt, ukjent bruker hoppet over, riktige datoer i UI-et etterpå. Dev-dataene er tilbakestilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)