### PR TITLE
fix: vis avkrysningsbokser riktig i admin-skjemaer

### DIFF
--- a/apps/kvark/src/routes/admin/_super-admin/oauth-clients.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/oauth-clients.tsx
@@ -325,7 +325,7 @@ function CreateClientDialog({
                                 placeholder="https://app.example.com/oauth/callback"
                             />
                         </Field>
-                        <Field className="flex-row items-center gap-2">
+                        <Field orientation="horizontal" className="gap-2">
                             <Checkbox
                                 id="oauth-client-public"
                                 checked={isPublic}

--- a/apps/kvark/src/routes/admin/arrangementer.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.tsx
@@ -314,7 +314,7 @@ function EventAdminPage() {
                                     </SelectContent>
                                 </Select>
                             </Field>
-                            <Field className="flex-row items-center gap-3">
+                            <Field orientation="horizontal" className="gap-3">
                                 <Checkbox
                                     id="event-paid"
                                     checked={isPaidEvent}
@@ -342,7 +342,7 @@ function EventAdminPage() {
                                     />
                                 </Field>
                             )}
-                            <Field className="flex-row items-center gap-3">
+                            <Field orientation="horizontal" className="gap-3">
                                 <Checkbox
                                     id="event-strikes"
                                     checked={canCauseStrikes}

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -152,7 +152,7 @@ function GroupCard({
             {expanded && (
                 <CardContent className="flex flex-col gap-6">
                     <FieldGroup>
-                        <Field className="flex-row items-center gap-3">
+                        <Field orientation="horizontal" className="gap-3">
                             <Checkbox
                                 id={`signing-${group.slug}`}
                                 checked={requiresSigning}


### PR DESCRIPTION
## Hva

`<Field>` i `@tihlde/ui` har `orientation="vertical"` som standard, og den varianten setter `*:w-full` på alle barn. Sammen med `shrink-0` på `Checkbox` ble avkrysningsboksen 100 % bred, og `FieldLabel` ble dyttet ut til høyre for kortet. `className="flex-row"` overstyrer `flex-col`, men fjerner ikke `*:w-full` — derfor fikset ved å bruke `orientation="horizontal"`.

Resultatet var at «Rediger» på `/admin/grupper` så ut som et tomt skjema, og at det ikke virket mulig å redigere grupper.

Berørte steder:

- `apps/kvark/src/routes/admin/grupper.tsx` — «Krev kontraktsignering for denne gruppen»
- `apps/kvark/src/routes/admin/arrangementer.tsx` — «Betalt arrangement» og «Kan gi prikker»
- `apps/kvark/src/routes/admin/_super-admin/oauth-clients.tsx` — «Offentlig klient (PKCE …)»

## Verifisering

Kjørt lokalt mot dev-API og dev-DB, innlogget som testbruker:

- Målt i DOM før fiks: checkbox 600px bred, label på x=612 i en 600px-container. Etter fiks: checkbox 16px, label rett ved siden av.
- `/admin/grupper` → «Rediger» viser checkbox + label. Huket av og lagret → `contractSigningRequired` ble `true` i API-et, badge «Kontrakt påkrevd» og signeringstabellen dukket opp. Satt tilbake til `false` etterpå.
- `/admin/arrangementer` → begge avkrysningsboksene 16px med synlig label.
- `/admin/oauth-clients` er ikke verifisert visuelt (krever super-admin), men endringen er identisk.

`bun run --filter kvark typecheck`, `lint` og `format` er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)