### PR TITLE
fix(auth): gjør stille Feide-attributtfeil synlige i loggen

### DIFF
--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -647,6 +647,21 @@ async function fetchValidStudyPrograms(
     }
 
     const groups = (await response.json()) as FeideGroup[];
+
+    /**
+     * An empty response is indistinguishable from "not a TIHLDE student" in
+     * the data alone, but the two need very different fixes: one is a member
+     * who graduated, the other is `groups-edu` not being released to the
+     * service at all. Name the types we did get so the log can tell them
+     * apart — a login that returns no groups whatsoever is a configuration
+     * problem, not a graduation.
+     */
+    if (groups.length === 0) {
+        console.warn(
+            "Feide groups API returned no groups at all; is `groups-edu` released to this service?",
+        );
+    }
+
     return {
         programs: parseValidStudyPrograms(groups),
         campus: resolveCampus(groups),
@@ -842,6 +857,23 @@ const createGetUserInfo =
         }
 
         const profile = (await response.json()) as OpenIDProfile;
+
+        /**
+         * `userid_sec` is the only thing that ties a first-time Feide login to
+         * a migrated member, and Feide drops it silently when the `userid`
+         * scope is not released — no error, no empty field, just an absent
+         * key. {@link resolveMigratedEmail} then returns null and Better Auth
+         * mints a brand-new empty account while the member's history sits on
+         * the old one. That failure is invisible in the data: the only trace
+         * is a user row with no username, which reads exactly like a member
+         * who never had one. Name the claims we actually received so one
+         * login is enough to tell a missing scope from a missing member.
+         */
+        if (!feideUsernameOf(profile)) {
+            console.warn(
+                `Feide userinfo carried no usable userid_sec claim, so a migrated account cannot be matched by username. Claims received: ${Object.keys(profile).join(", ")}`,
+            );
+        }
 
         const migratedEmail = await resolveMigratedEmail(db, profile);
 


### PR DESCRIPTION
## Hva

Legger til to `console.warn` i `packages/auth/src/feide.ts`. Ingen atferdsendring — kun observerbarhet.

1. I `createGetUserInfo`: varsler når `userid_sec` ikke lar seg utlede fra userinfo-svaret, og lister **hvilke claims Feide faktisk sendte**.
2. I `fetchValidStudyPrograms`: varsler når gruppe-API-et returnerer null grupper i det hele tatt.

## Hvorfor

Når Feide ikke slipper ut `userid_sec`, returnerer `resolveMigratedEmail` `null`. Better Auth faller da tilbake på e-postmatch, bommer (996 av 1686 migrerte medlemmer registrerte seg i Lepton med privat adresse), og oppretter en **ny tom konto** mens medlemmets historikk blir liggende igjen på den migrerte.

Feilen er usynlig: ingen exception, ingen loggmelding. Eneste spor er en brukerrad uten `username`, som ser nøyaktig ut som et medlem som aldri hadde ett. I prod rakk det å bli tre tomme kontoer før årsaken lot seg utlede ved å grave i databasen — én av dem tilhørte et medlem med 27 påmeldinger og 159 bøter på den riktige kontoen.

Samme sak for `groups-edu`: at Feide returnerer null grupper er umulig å skille fra «ikke lenger aktiv student» i dataene alene, men det ene er et konfigurasjonsproblem og det andre er en helt normal uteksaminering.

## For reviewer

- Rent additivt, ingen endring i kontrollflyt eller returverdier.
- Loggingen er det som skal til for å avgjøre en pågående produksjonsfeil: attributtgruppene `userid-feide` og `groups-edu` er avhuket i Feide Kundeportal, og prod kjører kode som inneholder brukernavn-broen (`ec56207`), men claimet kommer likevel ikke fram. Uten dette famler vi videre i portalen uten tilbakemelding.
- Gjenstår uavhengig av denne PR-en: `email_verified` er `false` på 1685 av 1687 brukere fordi migreringen aldri satte feltet, og Better Auths `requireLocalEmailVerified` (default `true`) blokkerer derfor kontolenking selv når broen treffer.

## Verifisering

- `bun run typecheck` — grønt, 9/9 pakker
- `oxfmt --check` — grønt
- `oxlint` — null funn i `feide.ts` (advarslene som vises er eksisterende, i testfiler og `env.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)