### PR TITLE
fix(auth): logg formen på userid_sec-claimet fra Feide

### DIFF
--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -106,7 +106,7 @@ const CAMPUS_BY_LETTER: Record<string, Campus> = {
  *
  * Docs: https://docs.feide.no/reference/apis/userinfo.html
  */
-interface OpenIDProfile {
+type OpenIDProfile = {
     /**
      * The internal ID of the authenticated user. This ID is stable but opaque, not releasing any additional information about the user. Always included.
      */
@@ -126,7 +126,7 @@ interface OpenIDProfile {
      * `username`.
      */
     "https://n.feide.no/claims/userid_sec"?: string[];
-}
+};
 
 /**
  * Feide group membership
@@ -781,6 +781,45 @@ export function feideUsernameOf(profile: {
 }
 
 /**
+ * Describe the shape of every `userid_sec` claim Dataporten sent, without
+ * putting the identifiers themselves in the log.
+ *
+ * Knowing the claim is *present* is not enough to explain why no username came
+ * out of it: a JSON string reads as an iterable of single characters, so
+ * {@link feideUsernameOf} would loop over letters and match nothing, and that
+ * looks exactly like an array whose entries carry a prefix other than
+ * `feide:`. Reporting the type, the length and the prefix before the first
+ * colon separates the two, and a prefix is not personal data the way the
+ * identifier after it is.
+ *
+ * Covers the two Dataporten-specific aliases as well as the standard claim,
+ * since they are not documented to agree and a usable value may sit in one
+ * while the one we read is empty.
+ */
+function describeUserIdClaims(profile: Record<string, unknown>): string {
+    const keys = [
+        "https://n.feide.no/claims/userid_sec",
+        "dataporten-userid_sec",
+        "connect-userid_sec",
+    ];
+
+    return keys
+        .map((key) => {
+            const raw = profile[key];
+            if (raw === undefined) return `${key}: absent`;
+            if (Array.isArray(raw)) {
+                const prefixes = raw.map((v) => `${String(v).split(":")[0]}:…`);
+                return `${key}: array(${raw.length}) [${prefixes.join(", ")}]`;
+            }
+            if (typeof raw === "string") {
+                return `${key}: string(${raw.length}) "${raw.split(":")[0]}:…"`;
+            }
+            return `${key}: ${typeof raw}`;
+        })
+        .join("; ");
+}
+
+/**
  * The email a migrated account should be resolved by, or null to use Feide's.
  *
  * Better Auth matches a first-time OAuth login to an existing user by email
@@ -871,7 +910,7 @@ const createGetUserInfo =
          */
         if (!feideUsernameOf(profile)) {
             console.warn(
-                `Feide userinfo carried no usable userid_sec claim, so a migrated account cannot be matched by username. Claims received: ${Object.keys(profile).join(", ")}`,
+                `Feide userinfo carried no usable userid_sec claim, so a migrated account cannot be matched by username. Claims received: ${Object.keys(profile).join(", ")}. ${describeUserIdClaims(profile)}`,
             );
         }
 


### PR DESCRIPTION
## Hva vi vet nå

Loggingen fra #290 er kjørt i prod. Resultatet snudde bildet:

```
Claims received: aud, sub, connect-userid_sec, dataporten-userid_sec,
                 https://n.feide.no/claims/userid_sec, name, email, email_verified
```

`https://n.feide.no/claims/userid_sec` **er med i svaret**. Feide utleverer det vi ber om — attributtgruppene, scope-autoriseringen og samtykket var aldri problemet. Varselet om tomt grupperesultat kom heller ikke, så `groups-edu` fungerer også.

Feilen ligger altså i `feideUsernameOf`: claimet finnes, men ingen verdi i det begynner med `feide:`.

## Hva denne PR-en gjør

Logger formen på claimet, ikke bare at det finnes. To forklaringer gir i dag identisk utfall:

- Verdien er en **streng** i stedet for et array. `for...of` itererer da over enkelttegn, og intet enkelttegn begynner med `feide:`.
- Verdien er et array, men oppføringene har et **annet prefiks**.

`describeUserIdClaims` rapporterer type, lengde og prefikset foran første kolon for alle tre variantene Dataporten sender. Identifikatoren selv holdes utenfor loggen — et prefiks er ikke personopplysning slik resten av strengen er.

`OpenIDProfile` er gjort om fra `interface` til `type`, fordi interfaces ikke får implisitt indekssignatur og derfor ikke kan slås opp med dynamisk nøkkel. Det følger også konvensjonen i CLAUDE.md om `type` framfor `interface`.

## For reviewer

- Fortsatt rent additivt på oppførsel: ingen endring i kontrollflyt eller returverdier.
- Dette er runde to av to. Neste steg er ikke mer logging, men selve fiksen i `feideUsernameOf` når vi vet formen.
- Uavhengig av dette: `email_verified` er `false` på 1685 av 1687 brukere fordi migreringen aldri satte feltet, og `requireLocalEmailVerified` (default `true`) blokkerer kontolenking selv når brukernavnet blir utledet riktig.

## Verifisering

- `bun run typecheck` — grønt, 9/9 pakker
- `oxfmt --check` — grønt
- `oxlint` — null funn i `feide.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)