### PR TITLE
fix(auth): be om userid-feide-scopet så userid_sec faktisk fylles

### DIFF
--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -173,9 +173,25 @@ export const feidePlugin = (db: NodePgDatabase<DbSchema>) =>
                           clientSecret: env.FEIDE_CLIENT_SECRET,
                           discoveryUrl:
                               "https://auth.dataporten.no/.well-known/openid-configuration",
+                          /**
+                           * `userid` alone only buys the `userid_sec` claim
+                           * itself — it arrives as an empty array unless the
+                           * authorization request *also* asks for the
+                           * attribute group that fills it. Feide's rule is
+                           * that userinfo returns the intersection of what the
+                           * client has authorized and what the request asks
+                           * for, so having `userid-feide` enabled in
+                           * Kundeportalen is not enough on its own.
+                           *
+                           * `groups-edu` below is the same pattern, and it is
+                           * why groups worked while usernames did not: there
+                           * the scope happens to carry the attribute group's
+                           * own name.
+                           */
                           scopes: [
                               "openid",
                               "userid",
+                              "userid-feide",
                               "profile",
                               "groups-edu",
                               "email",


### PR DESCRIPTION
## Rotårsaken, endelig

Loggingen fra #291 kjørte i prod:

```
Claims received: aud, sub, connect-userid_sec, dataporten-userid_sec,
                 https://n.feide.no/claims/userid_sec, name, email, email_verified.
https://n.feide.no/claims/userid_sec: array(0) [];
dataporten-userid_sec: array(0) [];
connect-userid_sec: array(0) []
```

Alle tre `userid_sec`-claimene er **tomme arrays**. Claimet finnes, men uten en eneste verdi — så feilen var hverken i Feide-portalen eller i `feideUsernameOf`. Det var ingenting å parse.

## Fiksen

[Feides dokumentasjon](https://docs.feide.no/reference/apis/userinfo.html) er eksplisitt: userinfo returnerer snittet av hva klienten har **autorisert** og hva autorisasjonsforespørselen **ber om**.

Attributtgruppen `userid-feide` er autorisert i Kundeportalen — samtykkesiden viser «Feide bruker-ID» — men vi ba bare om scopet `userid`. Det gir selve beholderen. Innholdet kommer fra attributtgruppene `userid-feide`, `userid-nin`, `userid-edugain`, `userid-social` og `eidas`.

Legger derfor `userid-feide` til i scope-lista.

At `groups-edu` fungerte hele veien er samme regel sett fra andre siden: der bærer scopet attributtgruppens eget navn, så vi ba om det uten å tenke over det.

## Hvorfor dette tok tre PR-er

Verdt å notere for ettertiden: symptomet var en **ny tom brukerkonto uten feilmelding**. `resolveMigratedEmail` returnerer `null` både når claimet mangler, når det er tomt, og når ingen bruker matcher — og alle tre endte i «opprett ny bruker». I prod ga det fire tomme kontoer og fire feilaktige hypoteser om Feide-oppsettet før loggingen fra #290/#291 viste hva som faktisk kom over ledningen.

## For reviewer

- Én linje i scope-lista er den funksjonelle endringen; resten er kommentar.
- Loggingen fra #290 og #291 beholdes — den er billig og fanger nøyaktig denne klassen feil neste gang.
- **Gjenstår etter dette:** `email_verified` er `false` på 1685 av 1687 brukere fordi migreringen aldri satte feltet, og Better Auths `requireLocalEmailVerified` (default `true`) blokkerer kontolenking selv når brukernavnet nå blir utledet riktig. Backfill må kjøres før migrerte medlemmer faktisk kommer inn på kontoene sine.
- Tomme Feide-kontoer opprettet under feilsøkingen bør ryddes når dette er verifisert.

## Verifisering

- `bun run typecheck` — grønt, 9/9 pakker
- `oxfmt --check` — grønt
- `oxlint` — null funn i `feide.ts`
- Selve scope-endringen kan bare verifiseres mot ekte Feide i prod: neste innlogging skal gi `array(1) [feide:…]` i stedet for `array(0) []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)