### PR TITLE
fix(migrasjon): gjør gruppeskjemaer idempotente med deterministisk id

### DIFF
--- a/packages/lepton-migration/src/phases/10-forms.ts
+++ b/packages/lepton-migration/src/phases/10-forms.ts
@@ -313,7 +313,11 @@ export async function migrateForms(
         }
 
         groupFormRecords.push({
-            id: crypto.randomUUID(),
+            // Derive the id from Lepton's, never at random: the insert below
+            // resolves conflicts on the primary key alone, so a random id
+            // collides with nothing and every re-run inserts the whole set
+            // again. Prod reached three copies of all 28 rows that way.
+            id: char32ToUuid(gf.form_ptr_id),
             formId: newFormId,
             groupSlug,
             emailReceiverOnSubmit:


### PR DESCRIPTION
Oppfølger til #298 — denne committen landet etter at #298 ble merget.

## Feilen

Fase 10 satte inn gruppeskjemaer med `crypto.randomUUID()`, mens innsettingen løser konflikter på primærnøkkelen alene. En tilfeldig id kolliderer med ingenting, så **hver kjøring la inn hele settet på nytt**.

Prod hadde rukket å bli **84 rader med 28 unike** (form, gruppe) — tre kopier av hver, som i praksis betyr at skjemaet dukket opp tre ganger i gruppens liste.

Id-en utledes nå av Leptons egen id, slik alle de andre fasene gjør.

## Verifisering

- Prod ryddet til **28 rader / 28 unike**
- Full ny pipelinekjøring etterpå: tallet står stille på 28 — idempotent
- Øvrige migrerte tabeller kontrollert for samme mønster og er rene: event-skjemaer (187/187), prioriteringsbassenger (320/320), favoritter (1587/1587), påmeldinger (24848/24848), medlemskap (6281/6281), lover (891/891), roller (1722/1722), felt (1408/1408)

## Anbefalt oppfølging

`form_group_form` mangler en unik indeks på `(form_id, group_slug)`. Deterministisk id fikser dette skriptet, men databasen håndhever fortsatt ingenting — en unik indeks ville gjort hele klassen av feil umulig. Holdt utenfor her siden det krever migrasjon og deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)