### PR TITLE
feat(bilder): komprimer opplastede bilder og vis publisert utsnitt i admin

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,6 +35,7 @@
         "pdf-lib": "^1.17.1",
         "pino": "^10.3.1",
         "react": "catalog:frontend",
+        "sharp": "^0.35.3",
         "zod": "catalog:"
     },
     "devDependencies": {

--- a/apps/api/src/lib/asset/image.ts
+++ b/apps/api/src/lib/asset/image.ts
@@ -1,0 +1,102 @@
+import sharp from "sharp";
+import type { LoggerType } from "~/middleware/logger";
+
+/**
+ * Longest edge an uploaded image is allowed to keep. Anything larger is scaled
+ * down — no surface on the site renders wider than this, so the extra pixels
+ * only cost bandwidth.
+ */
+export const IMAGE_MAX_DIMENSION = 2560;
+
+/**
+ * WebP quality. 80 is the point where the format stops being visibly lossy for
+ * photographic content while still cutting most of the bytes.
+ */
+export const IMAGE_WEBP_QUALITY = 80;
+
+/**
+ * MIME types we re-encode. GIF is deliberately excluded: it is the only allowed
+ * image type that can be animated, and a naive re-encode would drop the
+ * animation.
+ */
+const OPTIMIZABLE_MIME_TYPES = new Set([
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+]);
+
+export function isOptimizableImage(contentType: string | undefined): boolean {
+    return contentType !== undefined && OPTIMIZABLE_MIME_TYPES.has(contentType);
+}
+
+export type OptimizedImage = {
+    buffer: Buffer;
+    contentType: string;
+    /** Filename with the extension swapped to match `contentType`. */
+    filename: string;
+    width: number;
+    height: number;
+};
+
+/**
+ * Re-encode an uploaded image to WebP, scaled to fit within
+ * {@link IMAGE_MAX_DIMENSION} and stripped of metadata.
+ *
+ * Returns `null` when the input is not an optimizable image or when the
+ * re-encode would not actually save bytes — callers then store the original.
+ * Decoding failures are treated the same way: a file we cannot parse is a file
+ * the uploader should get an error about from the storage layer, not one we
+ * should reject here.
+ */
+export async function optimizeImage(
+    buffer: Buffer,
+    contentType: string | undefined,
+    originalFilename: string,
+    logger?: LoggerType,
+): Promise<OptimizedImage | null> {
+    if (!isOptimizableImage(contentType)) {
+        return null;
+    }
+
+    try {
+        const optimized = await sharp(buffer, { failOn: "none" })
+            // Bake EXIF orientation into the pixels before we strip metadata,
+            // otherwise portrait phone photos come out sideways.
+            .rotate()
+            .resize({
+                width: IMAGE_MAX_DIMENSION,
+                height: IMAGE_MAX_DIMENSION,
+                fit: "inside",
+                withoutEnlargement: true,
+            })
+            .webp({ quality: IMAGE_WEBP_QUALITY })
+            .toBuffer({ resolveWithObject: true });
+
+        // Small, already-optimized images can grow when re-encoded. Keeping the
+        // original is strictly better for those.
+        if (optimized.data.length >= buffer.length) {
+            return null;
+        }
+
+        return {
+            buffer: optimized.data,
+            contentType: "image/webp",
+            filename: replaceExtension(originalFilename, "webp"),
+            width: optimized.info.width,
+            height: optimized.info.height,
+        };
+    } catch (error) {
+        logger?.warn(
+            { err: error, originalFilename, contentType },
+            "Image optimization failed, storing original",
+        );
+        return null;
+    }
+}
+
+/** Swap a filename's extension, appending one when it has none. */
+export function replaceExtension(filename: string, extension: string): string {
+    const dot = filename.lastIndexOf(".");
+    const base = dot > 0 ? filename.slice(0, dot) : filename;
+    return `${base}.${extension}`;
+}

--- a/apps/api/src/routes/asset/upload.ts
+++ b/apps/api/src/routes/asset/upload.ts
@@ -4,6 +4,7 @@ import {
     generateAssetKey,
     isAllowedMimeType,
 } from "~/lib/asset";
+import { IMAGE_MAX_DIMENSION, optimizeImage } from "~/lib/asset/image";
 import { HTTPAppException } from "~/lib/errors";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -23,6 +24,9 @@ Requires either session authentication or a valid API key.
 **Constraints:**
 - Maximum file size: 10MB
 - Allowed MIME types: ${ALLOWED_MIME_TYPES.join(", ")}
+
+**Image optimization:**
+JPEG, PNG and WebP uploads are re-encoded to WebP, scaled to fit within ${IMAGE_MAX_DIMENSION}x${IMAGE_MAX_DIMENSION} px and stripped of metadata. The response therefore reports the stored \`contentType\`, \`size\` and \`originalFilename\` (extension swapped to \`.webp\`), which may differ from what was sent. GIF is passed through untouched so animation survives.
 
 **Usage:**
 Send the file as multipart/form-data with a field named "file".
@@ -85,17 +89,32 @@ Pass an optional "visibility" field set to "private" for files that must not be 
         }
         const visibility = visibilityField === "private" ? "private" : "public";
 
-        // Generate unique key
-        const key = generateAssetKey(file.name);
-
         // Convert file to buffer
         const arrayBuffer = await file.arrayBuffer();
         const buffer = Buffer.from(arrayBuffer);
 
+        // Re-encode images to WebP before they reach storage. Clients compress
+        // too, but this is the only step every upload passes through — API keys
+        // and migration scripts included — so it is what actually guarantees no
+        // oversized original is ever served.
+        const optimized = await optimizeImage(
+            buffer,
+            file.type,
+            file.name,
+            c.get("logger"),
+        );
+
+        const storedBuffer = optimized?.buffer ?? buffer;
+        const storedFilename = optimized?.filename ?? file.name;
+        const storedContentType = optimized?.contentType ?? file.type;
+
+        // Generate unique key
+        const key = generateAssetKey(storedFilename);
+
         // Upload to storage
-        await bucket.upload(key, buffer, {
-            originalFilename: file.name,
-            contentType: file.type,
+        await bucket.upload(key, storedBuffer, {
+            originalFilename: storedFilename,
+            contentType: storedContentType,
             uploadedById,
             visibility,
         });

--- a/apps/api/src/test/asset/asset.test.ts
+++ b/apps/api/src/test/asset/asset.test.ts
@@ -301,6 +301,111 @@ describe("Asset Upload/Download System", () => {
     );
 
     integrationTest(
+        "Upload re-encodes oversized images to WebP and leaves other files alone",
+        async ({ ctx }) => {
+            const { app, bucket } = ctx;
+
+            const testUser = await ctx.utils.createTestUser();
+            const { createApiKeyService } =
+                await import("~/lib/service/api-key");
+            const apiKeyService = createApiKeyService(ctx);
+            const apiKeyResult = await apiKeyService.create({
+                name: "Test Optimization Key",
+                description: "For image optimization testing",
+                permissions: ["root"],
+                createdById: testUser.id,
+            });
+            const authHeaders = { Authorization: `Bearer ${apiKeyResult.key}` };
+
+            const sharp = (await import("sharp")).default;
+
+            // A 4000x3000 photo-like PNG — bigger than any surface renders and
+            // far bigger than the 2560px cap.
+            const largePng = await sharp({
+                create: {
+                    width: 4000,
+                    height: 3000,
+                    channels: 3,
+                    background: { r: 190, g: 40, b: 60 },
+                },
+            })
+                .png()
+                .toBuffer();
+
+            const imageForm = new FormData();
+            imageForm.append(
+                "file",
+                new Blob([largePng], { type: "image/png" }),
+                "stort-bilde.png",
+            );
+
+            const imageResponse = await app.request("/api/assets", {
+                method: "POST",
+                body: imageForm,
+                headers: authHeaders,
+            });
+
+            expect(imageResponse.status).toBe(201);
+            const imageResult = (await imageResponse.json()) as any;
+
+            // Stored as WebP, with the key and filename following the new type.
+            expect(imageResult.contentType).toBe("image/webp");
+            expect(imageResult.originalFilename).toBe("stort-bilde.webp");
+            expect(imageResult.key).toMatch(/_stort-bilde\.webp$/);
+            expect(imageResult.size).toBeLessThan(largePng.length);
+
+            // And the bytes actually served are a WebP capped at 2560px.
+            const stored = await bucket.download(imageResult.key);
+            const meta = await sharp(stored).metadata();
+            expect(meta.format).toBe("webp");
+            expect(meta.width).toBe(2560);
+            expect(meta.height).toBe(1920);
+
+            // GIF must survive untouched, otherwise animation would be lost.
+            const gifBytes = Buffer.from("GIF89a not really a gif");
+            const gifForm = new FormData();
+            gifForm.append(
+                "file",
+                new Blob([gifBytes], { type: "image/gif" }),
+                "animasjon.gif",
+            );
+
+            const gifResponse = await app.request("/api/assets", {
+                method: "POST",
+                body: gifForm,
+                headers: authHeaders,
+            });
+
+            expect(gifResponse.status).toBe(201);
+            const gifResult = (await gifResponse.json()) as any;
+            expect(gifResult.contentType).toBe("image/gif");
+            expect(gifResult.originalFilename).toBe("animasjon.gif");
+
+            // PDFs are not images and must pass through byte for byte.
+            const pdfBytes = Buffer.from("%PDF-1.4 fake pdf body");
+            const pdfForm = new FormData();
+            pdfForm.append(
+                "file",
+                new Blob([pdfBytes], { type: "application/pdf" }),
+                "dokument.pdf",
+            );
+
+            const pdfResponse = await app.request("/api/assets", {
+                method: "POST",
+                body: pdfForm,
+                headers: authHeaders,
+            });
+
+            expect(pdfResponse.status).toBe(201);
+            const pdfResult = (await pdfResponse.json()) as any;
+            expect(pdfResult.contentType).toBe("application/pdf");
+            expect(pdfResult.size).toBe(pdfBytes.length);
+            expect(await bucket.download(pdfResult.key)).toEqual(pdfBytes);
+        },
+        600_000,
+    );
+
+    integrationTest(
         "Cleanup removes staged assets older than 2 days",
         async ({ ctx }) => {
             const { db, bucket } = ctx;

--- a/apps/kvark/src/api/queries/assets.ts
+++ b/apps/kvark/src/api/queries/assets.ts
@@ -1,5 +1,10 @@
-import { mutationOptions, queryOptions } from "@tanstack/react-query";
+import {
+    mutationOptions,
+    queryOptions,
+    useMutation,
+} from "@tanstack/react-query";
 import { apiClient } from "#/api/api-client";
+import { assetPublicUrl } from "#/lib/assets";
 
 const AssetQueryKeys = {
     detail: ["assets", "detail"] as const,
@@ -30,3 +35,23 @@ export const uploadAssetMutation = mutationOptions({
             body: formData,
         } as never),
 });
+
+/**
+ * Upload a single image and get back the URL to store on the resource.
+ *
+ * The API re-encodes images to WebP on the way in, so the returned key does not
+ * necessarily match the file's original extension — always use the key from the
+ * response rather than deriving one from the file name.
+ */
+export function useImageUploader() {
+    const uploadAsset = useMutation(uploadAssetMutation);
+
+    async function uploadImage(file: File): Promise<string> {
+        const formData = new FormData();
+        formData.append("file", file);
+        const asset = await uploadAsset.mutateAsync({ formData });
+        return assetPublicUrl(asset.key);
+    }
+
+    return { uploadImage, isUploading: uploadAsset.isPending };
+}

--- a/apps/kvark/src/components/admin-image-field.tsx
+++ b/apps/kvark/src/components/admin-image-field.tsx
@@ -1,0 +1,56 @@
+import { Field, FieldDescription, FieldLabel } from "@tihlde/ui/ui/field";
+import { ImageDropzone } from "@tihlde/ui/ui/image-dropzone";
+import type { ImagePresetName } from "@tihlde/ui/ui/image-preset";
+
+import { imageDropzoneLabels } from "#/lib/image";
+
+type AdminImageFieldProps = {
+    label: string;
+    description?: string;
+    /**
+     * Which public surface the image ends up on. Drives the crop the editor
+     * previews, so the dropzone shows the published result rather than a
+     * generic thumbnail.
+     */
+    preset: ImagePresetName;
+    value: File | null;
+    onChange: (file: File | null) => void;
+    /** Image already saved on the resource, shown until a new one is picked. */
+    existingImageUrl?: string | null;
+    disabled?: boolean;
+};
+
+/**
+ * Single-image upload field for the admin panel.
+ *
+ * Wraps the shared dropzone so every admin surface gets the same behaviour:
+ * in-browser compression before upload, and a preview in the exact crop the
+ * image will have once published.
+ */
+export function AdminImageField({
+    label,
+    description,
+    preset,
+    value,
+    onChange,
+    existingImageUrl,
+    disabled,
+}: AdminImageFieldProps) {
+    return (
+        <Field>
+            <FieldLabel>{label}</FieldLabel>
+            {description ? (
+                <FieldDescription>{description}</FieldDescription>
+            ) : null}
+            <ImageDropzone
+                preset={preset}
+                value={value ? [value] : []}
+                onValueChange={(next) => onChange(next[0] ?? null)}
+                existingImageUrl={existingImageUrl}
+                accept={{ "image/*": [] }}
+                disabled={disabled}
+                labels={imageDropzoneLabels}
+            />
+        </Field>
+    );
+}

--- a/apps/kvark/src/components/detail-hero.tsx
+++ b/apps/kvark/src/components/detail-hero.tsx
@@ -1,3 +1,5 @@
+import { IMAGE_PRESETS } from "@tihlde/ui/ui/image-preset";
+
 import { DEFAULT_COVER_IMAGE } from "#/lib/image";
 
 type DetailHeroProps = {
@@ -7,7 +9,9 @@ type DetailHeroProps = {
 
 export function DetailHero({ imageUrl, alt = "" }: DetailHeroProps) {
     return (
-        <div className="aspect-[16/7] w-full overflow-hidden rounded-xl bg-muted">
+        <div
+            className={`${IMAGE_PRESETS["cover-wide"].aspectClassName} w-full overflow-hidden rounded-xl bg-muted`}
+        >
             <img
                 src={imageUrl || DEFAULT_COVER_IMAGE}
                 alt={alt}

--- a/apps/kvark/src/components/form/field/image-dropzone.tsx
+++ b/apps/kvark/src/components/form/field/image-dropzone.tsx
@@ -3,6 +3,7 @@ import {
     ImageDropzone as ImageDropzonePrimitive,
     type ImageDropzoneProps as ImageDropzonePrimitiveProps,
 } from "@tihlde/ui/ui/image-dropzone";
+import { imageDropzoneLabels } from "#/lib/image";
 import { useField } from "./field";
 
 type ImageDropzoneProps = Omit<
@@ -19,19 +20,7 @@ type ImageDropzoneProps = Omit<
     labels?: ImageDropzonePrimitiveProps["labels"];
 };
 
-const defaultLabels = {
-    typeRejected: "Filtypen støttes ikke",
-    dropToUpload: "Slipp for å laste opp",
-    limitReached: (max: number) => `Maks ${max} bilder lastet opp`,
-    addMore: (count: number, max?: number) =>
-        max
-            ? `Klikk eller dra for å legge til (${count}/${max})`
-            : "Klikk eller dra for å legge til flere",
-    replaceSingle: "Klikk eller dra for å bytte bilde",
-    defaultPlaceholder: "Klikk eller dra et bilde hit for å laste opp",
-    previewLabel: (name: string) => `Forhåndsvis ${name}`,
-    removeLabel: "Fjern bilde",
-};
+const defaultLabels = imageDropzoneLabels;
 
 export function ImageDropzone({
     multiple = false,

--- a/apps/kvark/src/components/gallery-card.tsx
+++ b/apps/kvark/src/components/gallery-card.tsx
@@ -5,6 +5,7 @@ import {
     CardHeader,
     CardTitle,
 } from "@tihlde/ui/ui/card";
+import { IMAGE_PRESETS } from "@tihlde/ui/ui/image-preset";
 
 export type GalleryCardProps = {
     slug: string;
@@ -37,7 +38,7 @@ export function GalleryCard({
                     src={imageUrl}
                     alt=""
                     loading="lazy"
-                    className="aspect-video w-full object-cover"
+                    className={`${IMAGE_PRESETS["cover-video"].aspectClassName} w-full object-cover`}
                 />
             )}
             <CardHeader>

--- a/apps/kvark/src/components/issue-card.tsx
+++ b/apps/kvark/src/components/issue-card.tsx
@@ -1,4 +1,5 @@
 import { Card, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
+import { IMAGE_PRESETS } from "@tihlde/ui/ui/image-preset";
 
 import { DEFAULT_COVER_IMAGE } from "#/lib/image";
 
@@ -26,7 +27,7 @@ export function IssueCard({
             <img
                 src={coverUrl || DEFAULT_COVER_IMAGE}
                 alt={title}
-                className="aspect-[3/4] w-full object-cover"
+                className={`${IMAGE_PRESETS["cover-portrait"].aspectClassName} w-full object-cover`}
                 loading="lazy"
             />
             <CardHeader>

--- a/apps/kvark/src/components/list-card.tsx
+++ b/apps/kvark/src/components/list-card.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@tihlde/ui/ui/badge";
 import { useRender } from "@tihlde/ui/hooks/use-render";
+import { IMAGE_PRESETS } from "@tihlde/ui/ui/image-preset";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -39,7 +40,9 @@ export function ListCard({
                      * flex child it would otherwise stretch to the row height,
                      * making covers taller on cards with two-line titles.
                      */}
-                    <div className="relative aspect-[16/7] w-full shrink-0 overflow-hidden rounded-t-2xl bg-muted sm:w-52 sm:self-start sm:rounded-lg">
+                    <div
+                        className={`relative ${IMAGE_PRESETS["cover-wide"].aspectClassName} w-full shrink-0 overflow-hidden rounded-t-2xl bg-muted sm:w-52 sm:self-start sm:rounded-lg`}
+                    >
                         <img
                             src={imageUrl || DEFAULT_COVER_IMAGE}
                             alt={imageAlt ?? ""}

--- a/apps/kvark/src/components/news-card.tsx
+++ b/apps/kvark/src/components/news-card.tsx
@@ -6,6 +6,7 @@ import {
     CardHeader,
     CardTitle,
 } from "@tihlde/ui/ui/card";
+import { IMAGE_PRESETS } from "@tihlde/ui/ui/image-preset";
 
 import { DEFAULT_COVER_IMAGE } from "#/lib/image";
 
@@ -37,7 +38,7 @@ export function NewsCard({
             <img
                 src={imageUrl || DEFAULT_COVER_IMAGE}
                 alt=""
-                className="aspect-[16/7] w-full object-cover"
+                className={`${IMAGE_PRESETS["cover-wide"].aspectClassName} w-full object-cover`}
             />
             <CardHeader>
                 <CardTitle>{title}</CardTitle>

--- a/apps/kvark/src/lib/image.ts
+++ b/apps/kvark/src/lib/image.ts
@@ -3,3 +3,23 @@
  * image (event/job/news cards, detail heroes, Töddel covers).
  */
 export const DEFAULT_COVER_IMAGE = "/browser-icons/cover-image.jpg";
+
+/**
+ * Norwegian labels for the shared image dropzone. Kept here so every upload
+ * surface — admin panel, søknadsskjemaer, galleri — speaks with one voice.
+ */
+export const imageDropzoneLabels = {
+    typeRejected: "Filtypen støttes ikke",
+    dropToUpload: "Slipp for å laste opp",
+    limitReached: (max: number) => `Maks ${max} bilder lastet opp`,
+    addMore: (count: number, max?: number) =>
+        max
+            ? `Klikk eller dra for å legge til (${count}/${max})`
+            : "Klikk eller dra for å legge til flere",
+    replaceSingle: "Klikk eller dra for å bytte bilde",
+    defaultPlaceholder: "Klikk eller dra et bilde hit for å laste opp",
+    previewLabel: (name: string) => `Forhåndsvis ${name}`,
+    removeLabel: "Fjern bilde",
+    compressing: "Optimaliserer bilde …",
+    replaceImage: "Klikk for å bytte bilde",
+};

--- a/apps/kvark/src/routes/admin/annonser.tsx
+++ b/apps/kvark/src/routes/admin/annonser.tsx
@@ -44,6 +44,7 @@ import {
 } from "@tihlde/ui/ui/table";
 import { Textarea } from "@tihlde/ui/ui/textarea";
 
+import { useImageUploader } from "#/api/queries/assets";
 import {
     createJobMutation,
     deleteJobMutation,
@@ -51,6 +52,7 @@ import {
     updateJobMutation,
 } from "#/api/queries/jobs";
 import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { nextWholeHour } from "#/lib/date";
 
@@ -341,6 +343,7 @@ function JobDialog({
     const [link, setLink] = useState(job?.link ?? "");
     const [ingress, setIngress] = useState(job?.ingress ?? "");
     const [body, setBody] = useState(job?.body ?? "");
+    const [image, setImage] = useState<File | null>(null);
     const [error, setError] = useState<string | null>(null);
 
     // Ny annonse: foreslå en søknadsfrist to uker fram på en hel time.
@@ -351,7 +354,8 @@ function JobDialog({
 
     const create = useMutation(createJobMutation);
     const update = useMutation(updateJobMutation);
-    const isPending = create.isPending || update.isPending;
+    const { uploadImage, isUploading } = useImageUploader();
+    const isPending = create.isPending || update.isPending || isUploading;
 
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
@@ -360,6 +364,10 @@ function JobDialog({
         const deadlineIso = deadline ? deadline.toISOString() : null;
 
         try {
+            // Uploaded before the write, so a failing upload cannot save an ad
+            // that quietly lost its image.
+            const imageUrl = image ? await uploadImage(image) : undefined;
+
             if (isEdit && job) {
                 await update.mutateAsync({
                     jobId: job.id,
@@ -376,6 +384,9 @@ function JobDialog({
                         link: link || null,
                         ingress,
                         body,
+                        // Left out when unchanged, so editing other fields
+                        // never clears an existing image.
+                        ...(imageUrl ? { imageUrl } : {}),
                     },
                 });
             } else {
@@ -393,6 +404,7 @@ function JobDialog({
                         link: link || undefined,
                         ingress,
                         body,
+                        imageUrl,
                     },
                 });
             }
@@ -619,6 +631,14 @@ function JobDialog({
                                 }
                             />
                         </Field>
+                        <AdminImageField
+                            label={`Bilde${isEdit ? " (la stå tom for å beholde)" : ""}`}
+                            preset="cover-wide"
+                            value={image}
+                            onChange={setImage}
+                            existingImageUrl={job?.imageUrl}
+                            disabled={isPending}
+                        />
                     </FieldGroup>
                     {error && (
                         <p className="text-sm text-destructive" role="alert">

--- a/apps/kvark/src/routes/admin/arrangementer.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.tsx
@@ -21,8 +21,10 @@ import {
 import { CheckCircle2, XCircle } from "lucide-react";
 import { nb } from "date-fns/locale";
 
+import { useImageUploader } from "#/api/queries/assets";
 import { createEventMutation } from "#/api/queries/events";
 import { getGroupsQuery } from "#/api/queries/groups";
+import { AdminImageField } from "#/components/admin-image-field";
 import { richRegistry } from "#/components/markdown/directives/presets";
 import { nextWholeHour } from "#/lib/date";
 
@@ -66,6 +68,9 @@ function EventAdminPage() {
     const [isPaidEvent, setIsPaidEvent] = useState(false);
     const [canCauseStrikes, setCanCauseStrikes] = useState(false);
     const [price, setPrice] = useState("");
+    const [image, setImage] = useState<File | null>(null);
+    const [imageAlt, setImageAlt] = useState("");
+    const [uploadError, setUploadError] = useState<string | null>(null);
 
     // Sett standardverdier på klienten for å unngå SSR-hydration-mismatch.
     useEffect(() => {
@@ -76,14 +81,30 @@ function EventAdminPage() {
     }, []);
 
     const createEvent = useMutation(createEventMutation);
+    const { uploadImage, isUploading } = useImageUploader();
 
-    function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
+        setUploadError(null);
 
         const startIso = toIso(start);
         const endIso = toIso(end);
         const registrationEndIso = toIso(registrationEnd);
         if (!startIso || !endIso || !registrationEndIso) return;
+
+        // Uploaded first: a failed upload must not leave an event behind that
+        // silently lost its cover.
+        let imageUrl: string | null = null;
+        if (image) {
+            try {
+                imageUrl = await uploadImage(image);
+            } catch (err) {
+                setUploadError(
+                    err instanceof Error ? err.message : String(err),
+                );
+                return;
+            }
+        }
 
         createEvent.mutate(
             {
@@ -93,7 +114,8 @@ function EventAdminPage() {
                     categorySlug,
                     organizerGroupSlug,
                     location,
-                    imageUrl: null,
+                    imageUrl,
+                    imageAlt: imageUrl ? imageAlt || null : null,
                     start: startIso,
                     end: endIso,
                     registrationStart: null,
@@ -131,6 +153,8 @@ function EventAdminPage() {
                     setIsPaidEvent(false);
                     setCanCauseStrikes(false);
                     setPrice("");
+                    setImage(null);
+                    setImageAlt("");
                 },
             },
         );
@@ -367,6 +391,45 @@ function EventAdminPage() {
                     </CardContent>
                 </Card>
 
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Forsidebilde</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <FieldGroup>
+                            <AdminImageField
+                                label="Bilde"
+                                description="Vises på arrangementskortet og øverst på arrangementssiden. Forhåndsvisningen er samme utsnitt som besøkende ser."
+                                preset="cover-wide"
+                                value={image}
+                                onChange={setImage}
+                            />
+                            <Field>
+                                <FieldLabel htmlFor="event-image-alt">
+                                    Bildebeskrivelse
+                                </FieldLabel>
+                                <Input
+                                    id="event-image-alt"
+                                    type="text"
+                                    maxLength={255}
+                                    placeholder="Kort beskrivelse for skjermlesere"
+                                    value={imageAlt}
+                                    onChange={(event) =>
+                                        setImageAlt(event.target.value)
+                                    }
+                                />
+                            </Field>
+                        </FieldGroup>
+                    </CardContent>
+                </Card>
+
+                {uploadError && (
+                    <Alert variant="destructive">
+                        <XCircle className="size-4" />
+                        <AlertTitle>Kunne ikke laste opp bildet</AlertTitle>
+                        <AlertDescription>{uploadError}</AlertDescription>
+                    </Alert>
+                )}
                 {createEvent.isSuccess && (
                     <Alert>
                         <CheckCircle2 className="size-4" />
@@ -389,9 +452,13 @@ function EventAdminPage() {
                 <div className="flex justify-end">
                     <Button
                         type="submit"
-                        disabled={createEvent.isPending || !organizerGroupSlug}
+                        disabled={
+                            createEvent.isPending ||
+                            isUploading ||
+                            !organizerGroupSlug
+                        }
                     >
-                        Publiser
+                        {isUploading ? "Laster opp bilde …" : "Publiser"}
                     </Button>
                 </div>
             </form>

--- a/apps/kvark/src/routes/admin/galleri.tsx
+++ b/apps/kvark/src/routes/admin/galleri.tsx
@@ -38,20 +38,12 @@ import {
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { assetPublicUrl } from "#/lib/assets";
+import { imageDropzoneLabels } from "#/lib/image";
 
 /** The dropzone primitive ships English copy; the admin panel is Norwegian. */
 const dropzoneLabels = {
-    typeRejected: "Filtypen støttes ikke",
-    dropToUpload: "Slipp for å laste opp",
-    limitReached: (max: number) => `Maks ${max} bilder lastet opp`,
-    addMore: (count: number, max?: number) =>
-        max
-            ? `Klikk eller dra for å legge til (${count}/${max})`
-            : "Klikk eller dra for å legge til flere",
-    replaceSingle: "Klikk eller dra for å bytte bilde",
+    ...imageDropzoneLabels,
     defaultPlaceholder: "Klikk eller dra bilder hit for å laste opp",
-    previewLabel: (name: string) => `Forhåndsvis ${name}`,
-    removeLabel: "Fjern bilde",
 };
 
 export const Route = createFileRoute("/admin/galleri")({
@@ -312,6 +304,7 @@ function UploadPicturesCard() {
                                     <FieldLabel>Bilder</FieldLabel>
                                     <ImageDropzone
                                         multiple
+                                        preset="natural"
                                         value={files}
                                         onValueChange={setFiles}
                                         labels={dropzoneLabels}

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -28,12 +28,14 @@ import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import { CheckCircle2, UsersIcon, XCircle } from "lucide-react";
 import { useState } from "react";
 
+import { useImageUploader } from "#/api/queries/assets";
 import { getGroupsQuery, updateGroupMutation } from "#/api/queries/groups";
 import {
     getGroupSignaturesQuery,
     revokeSignatureMutation,
 } from "#/api/queries/contracts";
 import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { groupTypeLabel } from "#/lib/group";
 
@@ -117,8 +119,30 @@ function GroupCard({
     const [requiresSigning, setRequiresSigning] = useState(
         group.contractSigningRequired,
     );
+    const [image, setImage] = useState<File | null>(null);
+    const [error, setError] = useState<string | null>(null);
 
     const updateGroup = useMutation(updateGroupMutation);
+    const { uploadImage, isUploading } = useImageUploader();
+
+    async function handleSave() {
+        setError(null);
+        try {
+            const imageUrl = image ? await uploadImage(image) : undefined;
+            await updateGroup.mutateAsync({
+                slug: group.slug,
+                data: {
+                    contractSigningRequired: requiresSigning,
+                    // Omitted when unchanged, so saving the checkbox never
+                    // clears the group's existing logo.
+                    ...(imageUrl ? { imageUrl } : {}),
+                },
+            });
+            setImage(null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        }
+    }
 
     const signaturesQuery = useQuery({
         ...getGroupSignaturesQuery(group.slug),
@@ -164,20 +188,26 @@ function GroupCard({
                                 Krev kontraktsignering for denne gruppen
                             </FieldLabel>
                         </Field>
+                        <AdminImageField
+                            label="Gruppebilde (la stå tom for å beholde)"
+                            preset="avatar"
+                            value={image}
+                            onChange={setImage}
+                            existingImageUrl={group.imageUrl}
+                            disabled={updateGroup.isPending || isUploading}
+                        />
                     </FieldGroup>
+                    {error && (
+                        <p className="text-sm text-destructive" role="alert">
+                            {error}
+                        </p>
+                    )}
                     <Button
                         className="self-start"
-                        disabled={updateGroup.isPending}
-                        onClick={() =>
-                            updateGroup.mutate({
-                                slug: group.slug,
-                                data: {
-                                    contractSigningRequired: requiresSigning,
-                                },
-                            })
-                        }
+                        disabled={updateGroup.isPending || isUploading}
+                        onClick={handleSave}
                     >
-                        Lagre
+                        {isUploading ? "Laster opp bilde …" : "Lagre"}
                     </Button>
                     {requiresSigning &&
                         (signaturesQuery.data ? (

--- a/apps/kvark/src/routes/admin/nyheter.tsx
+++ b/apps/kvark/src/routes/admin/nyheter.tsx
@@ -17,7 +17,9 @@ import { Input } from "@tihlde/ui/ui/input";
 import { Textarea } from "@tihlde/ui/ui/textarea";
 import { CheckCircle2, XCircle } from "lucide-react";
 
+import { useImageUploader } from "#/api/queries/assets";
 import { createNewsMutation } from "#/api/queries/news";
+import { AdminImageField } from "#/components/admin-image-field";
 import { richRegistry } from "#/components/markdown/directives/presets";
 
 export const Route = createFileRoute("/admin/nyheter")({
@@ -28,11 +30,29 @@ function NewsAdminPage() {
     const [title, setTitle] = useState("");
     const [excerpt, setExcerpt] = useState("");
     const [body, setBody] = useState("");
+    const [image, setImage] = useState<File | null>(null);
+    const [imageAlt, setImageAlt] = useState("");
+    const [uploadError, setUploadError] = useState<string | null>(null);
 
     const createNews = useMutation(createNewsMutation);
+    const { uploadImage, isUploading } = useImageUploader();
 
-    function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
+        setUploadError(null);
+
+        let imageUrl: string | undefined;
+        if (image) {
+            try {
+                imageUrl = await uploadImage(image);
+            } catch (err) {
+                setUploadError(
+                    err instanceof Error ? err.message : String(err),
+                );
+                return;
+            }
+        }
+
         createNews.mutate(
             {
                 data: {
@@ -40,6 +60,8 @@ function NewsAdminPage() {
                     header: excerpt,
                     body,
                     emojisAllowed: false,
+                    imageUrl,
+                    imageAlt: imageUrl ? imageAlt || undefined : undefined,
                 },
             },
             {
@@ -47,6 +69,8 @@ function NewsAdminPage() {
                     setTitle("");
                     setExcerpt("");
                     setBody("");
+                    setImage(null);
+                    setImageAlt("");
                 },
             },
         );
@@ -113,6 +137,49 @@ function NewsAdminPage() {
                     </CardContent>
                 </Card>
 
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Forsidebilde</CardTitle>
+                        <CardDescription>
+                            Bildet vises på nyhetskortet og øverst på
+                            nyhetssiden. Forhåndsvisningen under er nøyaktig
+                            samme utsnitt som besøkende ser.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <FieldGroup>
+                            <AdminImageField
+                                label="Bilde"
+                                preset="cover-wide"
+                                value={image}
+                                onChange={setImage}
+                            />
+                            <Field>
+                                <FieldLabel htmlFor="news-image-alt">
+                                    Bildebeskrivelse
+                                </FieldLabel>
+                                <Input
+                                    id="news-image-alt"
+                                    type="text"
+                                    maxLength={255}
+                                    placeholder="Kort beskrivelse for skjermlesere"
+                                    value={imageAlt}
+                                    onChange={(event) =>
+                                        setImageAlt(event.target.value)
+                                    }
+                                />
+                            </Field>
+                        </FieldGroup>
+                    </CardContent>
+                </Card>
+
+                {uploadError && (
+                    <Alert variant="destructive">
+                        <XCircle className="size-4" />
+                        <AlertTitle>Kunne ikke laste opp bildet</AlertTitle>
+                        <AlertDescription>{uploadError}</AlertDescription>
+                    </Alert>
+                )}
                 {createNews.isSuccess && (
                     <Alert>
                         <CheckCircle2 className="size-4" />
@@ -133,8 +200,11 @@ function NewsAdminPage() {
                 )}
 
                 <div className="flex justify-end">
-                    <Button type="submit" disabled={createNews.isPending}>
-                        Publiser
+                    <Button
+                        type="submit"
+                        disabled={createNews.isPending || isUploading}
+                    >
+                        {isUploading ? "Laster opp bilde …" : "Publiser"}
                     </Button>
                 </div>
             </form>

--- a/apps/kvark/src/routes/admin/toddel.tsx
+++ b/apps/kvark/src/routes/admin/toddel.tsx
@@ -33,6 +33,7 @@ import {
     updateToddelMutation,
 } from "#/api/queries/toddel";
 import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
 
 export const Route = createFileRoute("/admin/toddel")({
@@ -356,19 +357,14 @@ function IssueDialog({
                                 }
                             />
                         </Field>
-                        <Field>
-                            <FieldLabel htmlFor="toddel-cover">
-                                Forsidebilde (valgfritt)
-                            </FieldLabel>
-                            <Input
-                                id="toddel-cover"
-                                type="file"
-                                accept="image/png,image/jpeg,image/webp"
-                                onChange={(event) =>
-                                    setCover(event.target.files?.[0] ?? null)
-                                }
-                            />
-                        </Field>
+                        <AdminImageField
+                            label="Forsidebilde (valgfritt)"
+                            preset="cover-portrait"
+                            value={cover}
+                            onChange={setCover}
+                            existingImageUrl={issue?.imageUrl}
+                            disabled={isPending}
+                        />
                     </FieldGroup>
 
                     {error && (

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "pdf-lib": "^1.17.1",
         "pino": "^10.3.1",
         "react": "catalog:frontend",
+        "sharp": "^0.35.3",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -252,6 +253,7 @@
         "@tiptap/pm": "^3.22.4",
         "@tiptap/react": "^3.22.4",
         "@tiptap/starter-kit": "^3.22.4",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "catalog:frontend",
         "clsx": "catalog:frontend",
         "cmdk": "^1.1.1",
@@ -593,53 +595,57 @@
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.1.0" }, "os": "darwin", "cpu": "arm64" }, "sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.1.0" }, "os": "darwin", "cpu": "x64" }, "sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.1.0", "", { "os": "linux", "cpu": "arm" }, "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.1.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.1.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.1.0" }, "os": "linux", "cpu": "arm" }, "sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.1.0" }, "os": "linux", "cpu": "arm64" }, "sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.1.0" }, "os": "linux", "cpu": "s390x" }, "sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.1.0" }, "os": "linux", "cpu": "x64" }, "sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.1.0" }, "os": "linux", "cpu": "arm64" }, "sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.1.0" }, "os": "linux", "cpu": "x64" }, "sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.1", "", { "dependencies": { "@emnapi/runtime": "^1.4.0" }, "cpu": "none" }, "sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw=="],
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.1", "", { "os": "win32", "cpu": "x64" }, "sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -1682,6 +1688,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "brotli": ["brotli@1.3.3", "", { "dependencies": { "base64-js": "^1.1.2" } }, "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg=="],
+
+    "browser-image-compression": ["browser-image-compression@2.0.2", "", { "dependencies": { "uzip": "0.20201231.0" } }, "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw=="],
 
     "browserify-zlib": ["browserify-zlib@0.2.0", "", { "dependencies": { "pako": "~1.0.5" } }, "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA=="],
 
@@ -2973,7 +2981,7 @@
 
     "shadcn": ["shadcn@4.13.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "kleur": "^4.1.5", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "undici": "^7.27.2", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-5fuJ4jI/GcPeA/iTL4cJivCZuYQGXz/N3bIzyd+Gd/FM6xUCy2MxGG+LaDQuw2cjNy9zGPSFPTEmI048UwPTZA=="],
 
-    "sharp": ["sharp@0.34.1", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.7.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.1", "@img/sharp-darwin-x64": "0.34.1", "@img/sharp-libvips-darwin-arm64": "1.1.0", "@img/sharp-libvips-darwin-x64": "1.1.0", "@img/sharp-libvips-linux-arm": "1.1.0", "@img/sharp-libvips-linux-arm64": "1.1.0", "@img/sharp-libvips-linux-ppc64": "1.1.0", "@img/sharp-libvips-linux-s390x": "1.1.0", "@img/sharp-libvips-linux-x64": "1.1.0", "@img/sharp-libvips-linuxmusl-arm64": "1.1.0", "@img/sharp-libvips-linuxmusl-x64": "1.1.0", "@img/sharp-linux-arm": "0.34.1", "@img/sharp-linux-arm64": "0.34.1", "@img/sharp-linux-s390x": "0.34.1", "@img/sharp-linux-x64": "0.34.1", "@img/sharp-linuxmusl-arm64": "0.34.1", "@img/sharp-linuxmusl-x64": "0.34.1", "@img/sharp-wasm32": "0.34.1", "@img/sharp-win32-ia32": "0.34.1", "@img/sharp-win32-x64": "0.34.1" } }, "sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg=="],
+    "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" } }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -3231,6 +3239,8 @@
 
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
+    "uzip": ["uzip@0.20201231.0", "", {}, "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="],
+
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
@@ -3369,8 +3379,6 @@
 
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
 
-    "@img/sharp-linux-ppc64/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
-
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
@@ -3488,6 +3496,8 @@
     "@react-email/preview-server/react": ["react@19.0.0", "", {}, "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="],
 
     "@react-email/preview-server/react-dom": ["react-dom@19.0.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ=="],
+
+    "@react-email/preview-server/sharp": ["sharp@0.34.1", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.7.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.1", "@img/sharp-darwin-x64": "0.34.1", "@img/sharp-libvips-darwin-arm64": "1.1.0", "@img/sharp-libvips-darwin-x64": "1.1.0", "@img/sharp-libvips-linux-arm": "1.1.0", "@img/sharp-libvips-linux-arm64": "1.1.0", "@img/sharp-libvips-linux-ppc64": "1.1.0", "@img/sharp-libvips-linux-s390x": "1.1.0", "@img/sharp-libvips-linux-x64": "1.1.0", "@img/sharp-libvips-linuxmusl-arm64": "1.1.0", "@img/sharp-libvips-linuxmusl-x64": "1.1.0", "@img/sharp-linux-arm": "0.34.1", "@img/sharp-linux-arm64": "0.34.1", "@img/sharp-linux-s390x": "0.34.1", "@img/sharp-linux-x64": "0.34.1", "@img/sharp-linuxmusl-arm64": "0.34.1", "@img/sharp-linuxmusl-x64": "0.34.1", "@img/sharp-wasm32": "0.34.1", "@img/sharp-win32-ia32": "0.34.1", "@img/sharp-win32-x64": "0.34.1" } }, "sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg=="],
 
     "@react-email/preview-server/sonner": ["sonner@2.0.3", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-njQ4Hht92m0sMqqHVDL32V2Oun9W1+PHO9NDv9FHfJjT3JT22IG4Jpo3FPQy+mouRKCXFWO+r67v6MrHX2zeIA=="],
 
@@ -3899,6 +3909,46 @@
 
     "@react-email/preview-server/react-dom/scheduler": ["scheduler@0.25.0", "", {}, "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="],
 
+    "@react-email/preview-server/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.1.0" }, "os": "darwin", "cpu": "arm64" }, "sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.1.0" }, "os": "darwin", "cpu": "x64" }, "sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.1.0", "", { "os": "linux", "cpu": "arm" }, "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.1.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.1.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.1.0" }, "os": "linux", "cpu": "arm" }, "sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.1.0" }, "os": "linux", "cpu": "arm64" }, "sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.1.0" }, "os": "linux", "cpu": "s390x" }, "sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.1.0" }, "os": "linux", "cpu": "x64" }, "sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.1.0" }, "os": "linux", "cpu": "arm64" }, "sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.1.0" }, "os": "linux", "cpu": "x64" }, "sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.1", "", { "dependencies": { "@emnapi/runtime": "^1.4.0" }, "cpu": "none" }, "sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw=="],
+
+    "@react-email/preview-server/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.1", "", { "os": "win32", "cpu": "x64" }, "sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw=="],
+
     "@react-email/preview-server/tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "@react-email/preview-server/tailwindcss/jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
@@ -3973,6 +4023,8 @@
 
     "next/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
 
+    "next/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
     "next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
 
     "next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
@@ -3985,6 +4037,10 @@
 
     "next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
 
+    "next/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "next/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
     "next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
 
     "next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
@@ -3994,6 +4050,8 @@
     "next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
 
     "next/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "next/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
 
     "next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
 

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -355,6 +355,9 @@ export interface paths {
          *     - Maximum file size: 10MB
          *     - Allowed MIME types: image/jpeg, image/png, image/gif, image/webp, application/pdf
          *
+         *     **Image optimization:**
+         *     JPEG, PNG and WebP uploads are re-encoded to WebP, scaled to fit within 2560x2560 px and stripped of metadata. The response therefore reports the stored `contentType`, `size` and `originalFilename` (extension swapped to `.webp`), which may differ from what was sent. GIF is passed through untouched so animation survives.
+         *
          *     **Usage:**
          *     Send the file as multipart/form-data with a field named "file".
          *

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,6 +11,7 @@
         ".": "./src/index.ts",
         "./styles.css": "./src/styles.css",
         "./utils": "./src/lib/utils.ts",
+        "./lib/*": "./src/lib/*.ts",
         "./hooks/*": "./src/hooks/*.ts",
         "./complex/*": "./src/components/complex/*/index.ts",
         "./*": "./src/components/*.tsx"
@@ -34,6 +35,7 @@
         "@tiptap/pm": "^3.22.4",
         "@tiptap/react": "^3.22.4",
         "@tiptap/starter-kit": "^3.22.4",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "catalog:frontend",
         "clsx": "catalog:frontend",
         "cmdk": "^1.1.1",

--- a/packages/ui/src/components/ui/image-dropzone.tsx
+++ b/packages/ui/src/components/ui/image-dropzone.tsx
@@ -1,12 +1,18 @@
 "use client";
 
 import * as React from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { ImagePlusIcon, UploadIcon, XIcon } from "lucide-react";
 import { type Accept, useDropzone } from "react-dropzone";
 
 import { cn } from "#/lib/utils";
+import { compressImageFiles } from "#/lib/image-compression";
 import { Button } from "#/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "#/components/ui/dialog";
+import {
+    IMAGE_PRESETS,
+    type ImagePresetName,
+    ImagePresetFrame,
+} from "#/components/ui/image-preset";
 
 export interface ImageDropzoneProps {
     value: File[];
@@ -26,6 +32,22 @@ export interface ImageDropzoneProps {
     "aria-invalid"?: boolean;
     className?: string;
     labels?: Partial<DropzoneLabels>;
+    /**
+     * Which surface the image ends up on. When set, the preview is rendered in
+     * that surface's exact crop instead of a generic thumbnail, so the editor
+     * sees the published result before saving.
+     */
+    preset?: ImagePresetName;
+    /**
+     * Already-uploaded image to show when nothing new has been picked. Lets an
+     * edit form open on the current image rather than an empty dropzone.
+     */
+    existingImageUrl?: string | null;
+    /**
+     * Skip the in-browser downscale. Only for files that must reach the server
+     * byte for byte; the server still optimizes images either way.
+     */
+    disableCompression?: boolean;
 }
 
 export interface DropzoneLabels {
@@ -37,6 +59,8 @@ export interface DropzoneLabels {
     defaultPlaceholder: string;
     previewLabel: (name: string) => string;
     removeLabel: string;
+    compressing: string;
+    replaceImage: string;
 }
 
 const defaultLabels: DropzoneLabels = {
@@ -49,6 +73,8 @@ const defaultLabels: DropzoneLabels = {
     defaultPlaceholder: "Click or drag an image here to upload",
     previewLabel: (name) => `Preview ${name}`,
     removeLabel: "Remove image",
+    compressing: "Preparing image…",
+    replaceImage: "Click to replace image",
 };
 
 type Preview = { file: File; url: string };
@@ -106,6 +132,9 @@ export function ImageDropzone({
     "aria-invalid": ariaInvalid,
     className,
     labels: userLabels,
+    preset,
+    existingImageUrl,
+    disableCompression = false,
 }: ImageDropzoneProps) {
     const labels = React.useMemo(
         () => ({ ...defaultLabels, ...userLabels }),
@@ -115,6 +144,7 @@ export function ImageDropzone({
 
     const [previews, setPreviews] = React.useState<Preview[]>([]);
     const [previewIndex, setPreviewIndex] = React.useState<number | null>(null);
+    const [isCompressing, setIsCompressing] = React.useState(false);
 
     React.useEffect(() => {
         const next = value.map((file) => ({
@@ -137,17 +167,28 @@ export function ImageDropzone({
             maxSize,
             maxFiles: multiple ? maxFiles : 1,
             multiple,
-            disabled: disabled || reachedLimit,
+            disabled: disabled || reachedLimit || isCompressing,
             noClick: true,
             noKeyboard: true,
-            onDrop: (accepted, rejected) => {
+            onDrop: async (accepted, rejected) => {
                 onError?.(
                     rejected.flatMap((r) => r.errors.map((e) => e.message)),
                 );
+
+                let files: File[] = accepted;
+                if (!disableCompression && accepted.length > 0) {
+                    setIsCompressing(true);
+                    try {
+                        files = await compressImageFiles(accepted);
+                    } finally {
+                        setIsCompressing(false);
+                    }
+                }
+
                 if (!multiple) {
-                    onValueChange(accepted.slice(0, 1));
+                    onValueChange(files.slice(0, 1));
                 } else {
-                    const merged = [...value, ...accepted];
+                    const merged = [...value, ...files];
                     onValueChange(
                         maxFiles ? merged.slice(0, maxFiles) : merged,
                     );
@@ -169,18 +210,29 @@ export function ImageDropzone({
         }
     };
 
-    const dropzoneText = getDropzoneText(
-        {
-            isDragReject,
-            isDragActive,
-            reachedLimit,
-            multiple,
-            fileCount: previews.length,
-            maxFiles,
-            placeholder: resolvedPlaceholder,
-        },
-        labels,
-    );
+    const dropzoneText = isCompressing
+        ? labels.compressing
+        : getDropzoneText(
+              {
+                  isDragReject,
+                  isDragActive,
+                  reachedLimit,
+                  multiple,
+                  fileCount: previews.length,
+                  maxFiles,
+                  placeholder: resolvedPlaceholder,
+              },
+              labels,
+          );
+
+    // With a preset and a single slot, the preview *is* the control: the editor
+    // clicks the framed image itself to swap it, exactly as it will look once
+    // published.
+    const singlePresetPreview =
+        preset && !multiple
+            ? (previews[0]?.url ?? existingImageUrl ?? null)
+            : null;
+    const showSingleFrame = preset !== undefined && !multiple;
 
     return (
         <>
@@ -197,23 +249,82 @@ export function ImageDropzone({
                         "aria-invalid": ariaInvalid,
                     })}
                 />
-                <Button
-                    type="button"
-                    variant="outline"
-                    onClick={open}
-                    disabled={disabled || reachedLimit}
-                    aria-invalid={ariaInvalid}
-                    className="flex h-auto w-full flex-col items-center justify-center gap-2 px-4 py-6 aria-invalid:text-destructive"
-                >
-                    <ImagePlusIcon className="size-5" />
-                    <span>{dropzoneText}</span>
-                </Button>
-                {previews.length > 0 && (
-                    <ul className="flex flex-col gap-1">
+
+                {showSingleFrame ? (
+                    <ImagePresetFrame
+                        preset={preset}
+                        src={singlePresetPreview ?? undefined}
+                        alt=""
+                        containerClassName={cn(
+                            "border-2 border-dashed",
+                            isDragActive && !isDragReject && "border-primary",
+                            isDragReject && "border-destructive",
+                            ariaInvalid && "border-destructive",
+                        )}
+                        fallback={
+                            <span className="flex flex-col items-center gap-2 px-4 text-center">
+                                <ImagePlusIcon className="size-6" />
+                                <span>{dropzoneText}</span>
+                            </span>
+                        }
+                        overlay={
+                            <button
+                                type="button"
+                                onClick={open}
+                                disabled={disabled || isCompressing}
+                                aria-label={labels.replaceImage}
+                                className={cn(
+                                    "absolute inset-0 flex flex-col items-center justify-center gap-2 text-sm font-medium text-white transition-opacity focus-visible:outline-none disabled:cursor-not-allowed",
+                                    singlePresetPreview
+                                        ? "bg-black/55 opacity-0 hover:opacity-100 focus-visible:opacity-100"
+                                        : "opacity-0",
+                                )}
+                            >
+                                <UploadIcon className="size-6" aria-hidden />
+                                <span>
+                                    {isCompressing
+                                        ? labels.compressing
+                                        : labels.replaceImage}
+                                </span>
+                            </button>
+                        }
+                    />
+                ) : (
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={open}
+                        disabled={disabled || reachedLimit || isCompressing}
+                        aria-invalid={ariaInvalid}
+                        className="flex h-auto w-full flex-col items-center justify-center gap-2 px-4 py-6 aria-invalid:text-destructive"
+                    >
+                        <ImagePlusIcon className="size-5" />
+                        <span>{dropzoneText}</span>
+                    </Button>
+                )}
+
+                {preset ? (
+                    <p className="text-xs text-muted-foreground">
+                        {IMAGE_PRESETS[preset].hint}
+                        {IMAGE_PRESETS[preset].recommended
+                            ? ` Anbefalt størrelse: ${IMAGE_PRESETS[preset].recommended.width}×${IMAGE_PRESETS[preset].recommended.height} px.`
+                            : ""}
+                    </p>
+                ) : null}
+
+                {previews.length > 0 && !showSingleFrame && (
+                    <ul
+                        className={cn(
+                            preset
+                                ? "grid grid-cols-2 gap-3 sm:grid-cols-3"
+                                : "flex flex-col gap-1",
+                        )}
+                    >
                         {previews.map((preview, i) => (
                             <DropzonePreviewItem
                                 key={`${preview.file.name}-${preview.file.size}-${i}`}
                                 preview={preview}
+                                preset={preset}
                                 disabled={disabled}
                                 previewLabel={labels.previewLabel}
                                 removeLabel={labels.removeLabel}
@@ -222,6 +333,26 @@ export function ImageDropzone({
                             />
                         ))}
                     </ul>
+                )}
+
+                {previews.length > 0 && showSingleFrame && (
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="text-xs text-muted-foreground">
+                            {previews[0]?.file.name}
+                            {previews[0]
+                                ? ` · ${formatSize(previews[0].file.size)}`
+                                : ""}
+                        </span>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => removeAt(0)}
+                            disabled={disabled}
+                        >
+                            {labels.removeLabel}
+                        </Button>
+                    </div>
                 )}
             </div>
             <DropzonePreviewDialog
@@ -238,6 +369,7 @@ export function ImageDropzone({
 
 interface DropzonePreviewItemProps {
     preview: Preview;
+    preset?: ImagePresetName;
     disabled?: boolean;
     previewLabel: (name: string) => string;
     removeLabel: string;
@@ -247,6 +379,7 @@ interface DropzonePreviewItemProps {
 
 function DropzonePreviewItem({
     preview,
+    preset,
     disabled,
     previewLabel,
     removeLabel,
@@ -255,6 +388,45 @@ function DropzonePreviewItem({
 }: DropzonePreviewItemProps) {
     const { file, url } = preview;
     const type = formatType(file);
+
+    // With a preset, each item is shown in the published crop rather than as a
+    // row, so a batch upload is checked at a glance.
+    if (preset) {
+        return (
+            <li className="flex flex-col gap-1">
+                <ImagePresetFrame
+                    preset={preset}
+                    src={url}
+                    alt={file.name}
+                    overlay={
+                        <>
+                            <button
+                                type="button"
+                                onClick={onPreview}
+                                aria-label={previewLabel(file.name)}
+                                className="absolute inset-0 focus-visible:outline-none"
+                            />
+                            <Button
+                                type="button"
+                                size="icon-xs"
+                                variant="secondary"
+                                onClick={onRemove}
+                                disabled={disabled}
+                                aria-label={removeLabel}
+                                className="absolute top-1 right-1"
+                            >
+                                <XIcon />
+                            </Button>
+                        </>
+                    }
+                />
+                <span className="truncate text-xs text-muted-foreground">
+                    {formatSize(file.size)}
+                    {type ? ` · ${type}` : ""}
+                </span>
+            </li>
+        );
+    }
 
     return (
         <li

--- a/packages/ui/src/components/ui/image-preset.tsx
+++ b/packages/ui/src/components/ui/image-preset.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "#/lib/utils";
+
+/**
+ * The shapes images are actually rendered in on the public site.
+ *
+ * This is the single source of truth: the public cards and the admin upload
+ * previews both read from here, which is what makes "what the editor sees" and
+ * "what the visitor sees" the same crop by construction rather than by
+ * two class strings that happen to agree today.
+ *
+ * `aspectClassName` must stay a literal Tailwind class — the scanner reads
+ * this file, so a computed string would not produce any CSS.
+ */
+export type ImagePresetDefinition = {
+    /** Human label, shown to editors above the preview. */
+    label: string;
+    /** What the editor should know about how this crop behaves. */
+    hint: string;
+    /**
+     * Tailwind aspect-ratio class, or `null` for surfaces that render the
+     * image at its own proportions.
+     */
+    aspectClassName: string | null;
+    /** How the image fills its box on the public site. */
+    fit: "cover" | "contain";
+    /** Size we ask editors to aim for, in CSS pixels. */
+    recommended: { width: number; height: number } | null;
+};
+
+export const IMAGE_PRESETS = {
+    /**
+     * Nyheter, arrangementer and jobbannonser. Used by NewsCard, ListCard and
+     * DetailHero — every one of them 16/7.
+     */
+    "cover-wide": {
+        label: "Bredt forsidebilde",
+        hint: "Vises i 16:7 på kort og øverst på siden. Alt utenfor rammen blir beskåret.",
+        aspectClassName: "aspect-[16/7]",
+        fit: "cover",
+        recommended: { width: 1600, height: 700 },
+    },
+    /** Galleriforsider and bedriftstilbud — 16/9. */
+    "cover-video": {
+        label: "Forsidebilde 16:9",
+        hint: "Vises i 16:9. Alt utenfor rammen blir beskåret.",
+        aspectClassName: "aspect-video",
+        fit: "cover",
+        recommended: { width: 1600, height: 900 },
+    },
+    /** Töddel-forsider — portrait, like a printed magazine cover. */
+    "cover-portrait": {
+        label: "Forsidebilde i høydeformat",
+        hint: "Vises i 3:4, som en bladforside. Alt utenfor rammen blir beskåret.",
+        aspectClassName: "aspect-[3/4]",
+        fit: "cover",
+        recommended: { width: 1200, height: 1600 },
+    },
+    /** Gruppelogoer and profilbilder — square, usually inside an Avatar. */
+    avatar: {
+        label: "Kvadratisk bilde",
+        hint: "Vises kvadratisk, ofte i en sirkel. Hold motivet midt i bildet.",
+        aspectClassName: "aspect-square",
+        fit: "cover",
+        recommended: { width: 512, height: 512 },
+    },
+    /** Galleribilder — shown at their own proportions in the masonry grid. */
+    natural: {
+        label: "Bilde",
+        hint: "Vises i sitt eget format, uten beskjæring.",
+        aspectClassName: null,
+        fit: "contain",
+        recommended: null,
+    },
+} as const satisfies Record<string, ImagePresetDefinition>;
+
+export type ImagePresetName = keyof typeof IMAGE_PRESETS;
+
+export function getImagePreset(name: ImagePresetName): ImagePresetDefinition {
+    return IMAGE_PRESETS[name];
+}
+
+export interface ImagePresetFrameProps extends Omit<
+    React.ComponentProps<"img">,
+    "children"
+> {
+    preset: ImagePresetName;
+    /** Rendered instead of the image when there is no `src`. */
+    fallback?: React.ReactNode;
+    /** Overlaid on top of the image, e.g. a "replace" button. */
+    overlay?: React.ReactNode;
+    containerClassName?: string;
+}
+
+/**
+ * Renders an image in exactly the frame a given surface uses in production.
+ *
+ * Public components should use this instead of hand-writing an aspect class,
+ * so that changing a crop changes it everywhere — including in the admin
+ * preview — at once.
+ */
+export function ImagePresetFrame({
+    preset,
+    src,
+    alt = "",
+    fallback,
+    overlay,
+    className,
+    containerClassName,
+    ...rest
+}: ImagePresetFrameProps) {
+    const { aspectClassName, fit } = IMAGE_PRESETS[preset];
+
+    return (
+        <div
+            className={cn(
+                "relative w-full overflow-hidden rounded-lg bg-muted",
+                aspectClassName,
+                containerClassName,
+            )}
+        >
+            {src ? (
+                <img
+                    {...rest}
+                    src={src}
+                    alt={alt}
+                    className={cn(
+                        aspectClassName
+                            ? "absolute inset-0 size-full"
+                            : "block h-auto w-full",
+                        fit === "cover" ? "object-cover" : "object-contain",
+                        className,
+                    )}
+                />
+            ) : (
+                <div
+                    className={cn(
+                        "flex items-center justify-center text-sm text-muted-foreground",
+                        aspectClassName ? "absolute inset-0" : "py-10",
+                    )}
+                >
+                    {fallback}
+                </div>
+            )}
+            {overlay}
+        </div>
+    );
+}

--- a/packages/ui/src/lib/image-compression.ts
+++ b/packages/ui/src/lib/image-compression.ts
@@ -1,0 +1,83 @@
+/**
+ * Client-side image compression, applied before a file is ever uploaded.
+ *
+ * The API re-encodes every image as well, and that server pass is what
+ * *guarantees* optimized assets. This one exists for the upload itself: a 12 MB
+ * phone photo on conference wifi is a slow, failure-prone request, and shrinking
+ * it in a worker first turns that into well under a megabyte.
+ */
+
+/** Longest edge kept in the browser. Matches the API's cap. */
+export const CLIENT_MAX_DIMENSION = 2560;
+
+/** Ceiling for the compressed file. The API caps uploads at 10 MB. */
+export const CLIENT_MAX_SIZE_MB = 4;
+
+const COMPRESSION_OPTIONS = {
+    maxSizeMB: CLIENT_MAX_SIZE_MB,
+    maxWidthOrHeight: CLIENT_MAX_DIMENSION,
+    useWebWorker: true,
+    initialQuality: 0.85,
+};
+
+/**
+ * GIF is excluded because compressing it through a canvas would flatten an
+ * animation to a single frame.
+ */
+function isCompressibleImage(file: File): boolean {
+    return file.type.startsWith("image/") && file.type !== "image/gif";
+}
+
+function inferMimeFromFilename(name: string): string | null {
+    const ext = name.toLowerCase().split(".").pop();
+    switch (ext) {
+        case "jpg":
+        case "jpeg":
+            return "image/jpeg";
+        case "png":
+            return "image/png";
+        case "webp":
+            return "image/webp";
+        case "gif":
+            return "image/gif";
+        case "pdf":
+            return "application/pdf";
+        default:
+            return null;
+    }
+}
+
+/**
+ * Shrink an image file. Non-images, GIFs, and anything that fails to compress
+ * are returned untouched — a failed optimization must never cost the user their
+ * upload.
+ */
+export async function compressImageFile(file: File): Promise<File> {
+    if (!isCompressibleImage(file)) return file;
+
+    try {
+        const { default: imageCompression } =
+            await import("browser-image-compression");
+        const compressed = await imageCompression(file, COMPRESSION_OPTIONS);
+
+        // Already-small images can come back larger than they went in.
+        if (compressed.size >= file.size) return file;
+
+        if (compressed.type) return compressed as File;
+
+        // Some browsers drop the MIME type on the resulting Blob. Re-wrap it so
+        // the server still receives a recognizable Content-Type.
+        const fallbackType =
+            file.type ||
+            inferMimeFromFilename(file.name) ||
+            "application/octet-stream";
+        return new File([compressed], file.name, { type: fallbackType });
+    } catch {
+        return file;
+    }
+}
+
+/** {@link compressImageFile} over a list, compressing in parallel. */
+export async function compressImageFiles(files: File[]): Promise<File[]> {
+    return Promise.all(files.map(compressImageFile));
+}


### PR DESCRIPTION
## Hvorfor

Bilder ble lagret rått i MinIO — ingen komprimering, ingen nedskalering. Samtidig viste `ImageDropzone` bare en 40×40 thumbnail, så en redaktør hadde ingen måte å se hvordan bildet faktisk ville bli beskåret på den publiserte siden.

Underveis fant jeg noe større: **nyheter, arrangementer, jobbannonser og grupper hadde `imageUrl` i både API og database, men ingen bildeopplasting i admin i det hele tatt.** `arrangementer.tsx` sendte hardkodet `imageUrl: null`. Kun töddel og galleri hadde opplasting.

## Komprimering — to lag

**Server** ([`apps/api/src/lib/asset/image.ts`](apps/api/src/lib/asset/image.ts)) — `POST /api/assets` re-koder JPEG/PNG/WebP til WebP, skalerer til å passe innenfor 2560 px og stripper metadata. EXIF-rotasjon bakes inn i pikslene før metadata fjernes, ellers kommer portrettbilder fra mobil ut liggende.

Dette laget er det som *garanterer* optimaliserte assets: det er det eneste punktet alle opplastinger passerer, også API-nøkler og migreringsskript. GIF slippes urørt så animasjon overlever, PDF likeså. Feiler re-kodingen — eller blir resultatet større enn originalen — lagres originalen. En mislykket optimalisering skal aldri koste noen opplastingen.

**Klient** ([`packages/ui/src/lib/image-compression.ts`](packages/ui/src/lib/image-compression.ts)) — dropzone-en krymper i en web worker før opplasting. Dette er for selve overføringen, ikke lagringen: et 5 MB mobilbilde på dårlig wifi blir til drøyt 1 MB.

## Ett format-register, delt mellom admin og publisert side

[`packages/ui/src/components/ui/image-preset.tsx`](packages/ui/src/components/ui/image-preset.tsx) er nå én kilde til sannhet for hvert bildeformat.

Det viktige her: **de offentlige kortene leser fra samme register som admin-forhåndsvisningen.** `NewsCard`, `ListCard`, `DetailHero`, `GalleryCard` og `IssueCard` er skrevet om til å hente `aspectClassName` derfra i stedet for å skrive `aspect-[16/7]` for hånd. Endrer man et utsnitt, endres det begge steder samtidig — admin og publisert side kan ikke drifte fra hverandre.

| Preset | Format | Brukes av |
|---|---|---|
| `cover-wide` | 16:7 | nyheter, arrangementer, jobbannonser |
| `cover-video` | 16:9 | galleriforsider |
| `cover-portrait` | 3:4 | töddel |
| `avatar` | 1:1 | grupper |
| `natural` | eget format | galleribilder |

## Ny opplasting i admin

Nyheter, arrangementer, jobbannonser og grupper har nå bildeopplasting via [`admin-image-field.tsx`](apps/kvark/src/components/admin-image-field.tsx). Töddel har byttet ut sitt rå `<input type="file">`.

Redigeringsskjemaer viser eksisterende bilde til et nytt velges, og utelater feltet i mutasjonen når det ikke er endret — så lagring av andre felt aldri sletter et bilde. Opplasting skjer før skrivingen, slik at en feilende opplasting ikke etterlater innhold som stille mistet forsidebildet sitt.

## Verifisering

- **Server:** ny integrasjonstest laster opp et ekte 4000×3000-bilde og sjekker de faktisk lagrede bytene — `webp`, `2560×1920`, mindre enn originalen. GIF og PDF passerer urørt. Alle 9 asset-tester passerer.
- **Klient, i nettleseren:** lastet opp 4032×3024 / 5,30 MB i `/admin/nyheter` → **1,3 MB / 2560×1920**. Rammen målt til `aspect-ratio: 16 / 7`, `object-fit: cover`.
- **Utsnitt:** bekreftet visuelt at grupper viser logo kvadratisk og töddel viser forsiden i 3:4.
- **sharp i produksjon:** kjørte en faktisk WebP-konvertering inne i Linux-containeren Dockerfilen bygger — fungerer.
- Typecheck, lint og build grønt i hele monorepoet.

## For reviewer

**Docker-imaget bygger ikke — men det er ikke denne PR-en.** `docker build -f infra/docker/Dockerfile .` feiler på `msgpackr-extract`. Jeg bekreftet at et rent `git archive HEAD` feiler helt likt, altså pre-eksisterende på `dev`. Derfor kunne jeg ikke bygge hele imaget for å teste `sharp`, og verifiserte i stedet i containeren fra `install`-steget — samme `node_modules` som kopieres inn i release-imaget. Bør fikses separat siden det blokkerer all deploy.

**Eksisterende bilder er urørt.** Alt som allerede ligger i MinIO, inkludert de migrerte Lepton-bildene, er fortsatt ukomprimert — komprimeringen skjer ved opplasting. Responsive varianter (`?w=640` + `srcset`), som ville dekket de gamle også, ble bevisst valgt bort i denne omgangen.

**Ny avhengighet:** `sharp` i `@photon/api`, `browser-image-compression` i `@tihlde/ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)