### PR TITLE
feat(auth): koble Feide til gammel konto via e-post, med hjelp som siste utvei

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -22,6 +22,7 @@ import { apiKeyRoutes } from "./routes/api-key";
 import { applicationRoutes } from "./routes/application";
 import { assetRoutes } from "./routes/asset";
 import { bannerRoutes } from "./routes/banner";
+import { accountLinkRoutes } from "./routes/account-link";
 import { companyRoutes } from "./routes/company";
 import { contractsRoutes } from "./routes/contracts";
 import { groupsRoutes } from "./routes/groups";
@@ -79,6 +80,7 @@ export const createApp = async (variables?: Variables) => {
         .route("/applications", applicationRoutes)
         .route("/assets", assetRoutes)
         .route("/banners", bannerRoutes)
+        .route("/account-link", accountLinkRoutes)
         .route("/company", companyRoutes)
         .route("/email", emailRoutes)
         .route("/event", eventRoutes)

--- a/apps/api/src/lib/openapi.ts
+++ b/apps/api/src/lib/openapi.ts
@@ -14,6 +14,7 @@ import { HTTPAppException, httpAppExceptionSchema } from "./errors";
  * All tags available for API endpoints
  */
 const tags = [
+    "account-link",
     "api-keys",
     "applications",
     "assets",

--- a/apps/api/src/routes/account-link/help.ts
+++ b/apps/api/src/routes/account-link/help.ts
@@ -1,0 +1,107 @@
+import { validator } from "hono-openapi";
+import { HTTPException } from "hono/http-exception";
+import { env } from "~/lib/env";
+import { describeRoute } from "~/lib/openapi";
+import { route } from "~/lib/route";
+import { accountLinkHelpResponseSchema, accountLinkHelpSchema } from "./schema";
+
+/** Requests allowed per client within {@link RATE_LIMIT_WINDOW_SECONDS} */
+const RATE_LIMIT_MAX = 3;
+const RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
+
+/**
+ * Unauthenticated and sends mail, so it needs a throttle. Keyed on the
+ * forwarded client IP when there is one, falling back to the address they gave
+ * us so a proxyless deployment still limits per sender rather than globally.
+ */
+function rateLimitKey(ip: string | undefined, email: string) {
+    return `account-link-help:${ip ?? `email:${email.toLowerCase()}`}`;
+}
+
+function clientIp(forwardedFor: string | undefined) {
+    return forwardedFor?.split(",")[0]?.trim() || undefined;
+}
+
+export const accountLinkHelpRoute = route().post(
+    "/help",
+    describeRoute({
+        tags: ["account-link"],
+        summary: "Ask a human to link a Feide login to an old account",
+        operationId: "requestAccountLinkHelp",
+        description:
+            "Last resort for a member migrated from Lepton whose stored username differs from their NTNU one and who no longer has the email the old account was registered with — nothing in the flow can verify them, so this notifies an admin to do it by hand. Rate limited per client.",
+    })
+        .schemaResponse({
+            statusCode: 200,
+            schema: accountLinkHelpResponseSchema,
+            description: "Request delivered to an admin",
+        })
+        .badRequest({ description: "Invalid input" })
+        .response({
+            statusCode: 429,
+            description: "Too many requests from this client",
+        })
+        .build(),
+    validator("json", accountLinkHelpSchema),
+    async (c) => {
+        const body = c.req.valid("json");
+        const { cache, email } = c.get("ctx");
+        const logger = c.get("logger");
+
+        const key = rateLimitKey(
+            clientIp(c.req.header("x-forwarded-for")),
+            body.contactEmail,
+        );
+        const attempts = Number(await cache.getString(key)) || 0;
+        if (attempts >= RATE_LIMIT_MAX) {
+            throw new HTTPException(429, {
+                message: "For mange forespørsler. Prøv igjen senere.",
+            });
+        }
+        await cache.setString(
+            key,
+            String(attempts + 1),
+            RATE_LIMIT_WINDOW_SECONDS,
+        );
+
+        /**
+         * Nothing is stored: there is no account to attach this to yet, and
+         * the whole point is that we cannot tell who they are. The mail *is*
+         * the record. It must therefore succeed loudly — telling the member
+         * "vi har varslet" when nobody was notified would leave them waiting
+         * for a reply that never comes.
+         */
+        try {
+            await email.sendEmailTemplate(
+                {
+                    from: env.MAIL_FROM,
+                    to: env.ACCOUNT_HELP_EMAIL,
+                    subject: `Kontokobling: ${body.feideName} trenger hjelp`,
+                    replyTo: body.contactEmail,
+                },
+                "AccountLinkHelpEmail",
+                {
+                    feideName: body.feideName,
+                    feideUsername: body.feideUsername,
+                    contactEmail: body.contactEmail,
+                    note: body.note,
+                    logoUrl: `${env.WEBSITE_URL}/logo512.png`,
+                },
+            );
+        } catch (error) {
+            logger.error(
+                { err: error, contactEmail: body.contactEmail },
+                "Failed to queue account link help email",
+            );
+            throw new HTTPException(500, {
+                message:
+                    "Kunne ikke sende forespørselen. Prøv igjen om litt, eller send en e-post til index@tihlde.org.",
+            });
+        }
+
+        return c.json(
+            { success: true, message: "Forespørselen ble sendt" },
+            200,
+        );
+    },
+);

--- a/apps/api/src/routes/account-link/index.ts
+++ b/apps/api/src/routes/account-link/index.ts
@@ -1,0 +1,4 @@
+import { route } from "~/lib/route";
+import { accountLinkHelpRoute } from "./help";
+
+export const accountLinkRoutes = route().route("/", accountLinkHelpRoute);

--- a/apps/api/src/routes/account-link/schema.ts
+++ b/apps/api/src/routes/account-link/schema.ts
@@ -1,0 +1,39 @@
+import z from "zod";
+import { Schema } from "~/lib/openapi";
+
+export const accountLinkHelpSchema = Schema(
+    "AccountLinkHelp",
+    z.object({
+        /**
+         * Whatever Feide told the browser about them. Untrusted here — the
+         * login that produced it already failed — but it is what lets a human
+         * find the right account, so it is worth carrying.
+         */
+        feideName: z
+            .string()
+            .min(1)
+            .max(200)
+            .meta({ description: "Name as Feide reported it" }),
+        feideUsername: z
+            .string()
+            .max(100)
+            .optional()
+            .meta({ description: "NTNU username from the Feide login" }),
+        contactEmail: z
+            .email()
+            .meta({ description: "Where to reach the member" }),
+        note: z
+            .string()
+            .max(1000)
+            .optional()
+            .meta({ description: "What they remember about the old account" }),
+    }),
+);
+
+export const accountLinkHelpResponseSchema = Schema(
+    "AccountLinkHelpResponse",
+    z.object({
+        success: z.boolean(),
+        message: z.string(),
+    }),
+);

--- a/apps/kvark/src/api/auth.ts
+++ b/apps/kvark/src/api/auth.ts
@@ -344,6 +344,42 @@ export const signUpEmailMutationOptions = mutationOptions({
     },
 });
 
+/**
+ * Asks for a fresh verification link to an address the caller types in.
+ *
+ * This is the way a member migrated from Lepton gets their Feide login to
+ * attach to the account that holds their history: Better Auth refuses to link
+ * a provider to a user whose email was never verified, and the migration
+ * created all 1685 of them with the flag unset. Verifying is also the proof of
+ * ownership — whoever reads that inbox is the member — which is why we ask them
+ * to do it rather than setting the flag on their behalf.
+ *
+ * The endpoint needs no session, answers `{ status: true }` whether or not the
+ * address exists, and holds a 500 ms floor so response time cannot be used to
+ * discover who is a member. Treat the result as "sent if it existed" and never
+ * report anything more specific to the user.
+ */
+export const sendVerificationEmailMutationOptions = mutationOptions({
+    mutationFn: async ({
+        email,
+        callbackURL,
+    }: {
+        email: string;
+        callbackURL: string;
+    }) => {
+        const result = await clientAuthInstance.sendVerificationEmail({
+            email,
+            callbackURL,
+        });
+        if (result.error) {
+            throw new Error(
+                result.error.message ?? "Kunne ikke sende lenke akkurat nå.",
+            );
+        }
+        return result.data;
+    },
+});
+
 export const requestPasswordResetMutationOptions = mutationOptions({
     mutationFn: async ({
         email,

--- a/apps/kvark/src/api/auth.ts
+++ b/apps/kvark/src/api/auth.ts
@@ -380,6 +380,43 @@ export const sendVerificationEmailMutationOptions = mutationOptions({
     },
 });
 
+/**
+ * Attaches Feide to whoever is signed in right now.
+ *
+ * This is what finally rescues a member whose Lepton username differs from
+ * their NTNU one: matching by username or email has already failed for them by
+ * definition, but a session says who they are outright. Once the account row
+ * exists, Better Auth matches on provider and account id before it ever looks
+ * at email, so the mismatch stops mattering for good.
+ */
+export const linkFeideMutationOptions = mutationOptions({
+    mutationFn: async ({ callbackURL }: { callbackURL: string }) => {
+        const toFrontendUrl = (path: string) =>
+            new URL(
+                sanitizeRedirectTo(path),
+                window.location.origin,
+            ).toString();
+
+        const result = await clientAuthInstance.oauth2.link({
+            providerId: "feide",
+            callbackURL: toFrontendUrl(callbackURL),
+            errorCallbackURL: toFrontendUrl("/koble-feide"),
+        });
+
+        if (result.error) {
+            throw new Error(
+                result.error.message ?? "Kunne ikke koble til Feide",
+            );
+        }
+
+        if (result.data && "url" in result.data && result.data.url) {
+            window.location.href = result.data.url;
+        }
+
+        return result.data;
+    },
+});
+
 export const requestPasswordResetMutationOptions = mutationOptions({
     mutationFn: async ({
         email,

--- a/apps/kvark/src/api/queries/account-link.ts
+++ b/apps/kvark/src/api/queries/account-link.ts
@@ -1,0 +1,17 @@
+import { mutationOptions } from "@tanstack/react-query";
+import { apiClient } from "#/api/api-client";
+import type { AccountLinkHelp } from "@tihlde/sdk";
+
+/**
+ * Last resort for a member migrated from Lepton who can reach their old
+ * account by neither route: their stored username differs from their NTNU one,
+ * so Feide finds nothing, and they no longer have the address the account was
+ * registered with, so they cannot prove it is theirs either. An admin links it
+ * by hand.
+ */
+export const requestAccountLinkHelpMutation = mutationOptions({
+    mutationFn: ({ data }: { data: AccountLinkHelp }) =>
+        apiClient.post("/api/account-link/help", {
+            json: data,
+        }),
+});

--- a/apps/kvark/src/components/feide-sign-in-issue.tsx
+++ b/apps/kvark/src/components/feide-sign-in-issue.tsx
@@ -83,7 +83,10 @@ export function FeideSignInIssue(props: FeideSignInIssueProps) {
 
     return (
         <Alert>
-            <AlertTitle>Har du vært medlem før?</AlertTitle>
+            {/* "Medlem" and "bruker" are not the same thing: you can have been
+                a member for years without thinking of yourself as having an
+                account. The account is what the question is about. */}
+            <AlertTitle>Har du registrert TIHLDE-bruker tidligere?</AlertTitle>
             <AlertDescription>
                 Vi fant ingen bruker som passer til Feide-kontoen din.
             </AlertDescription>

--- a/apps/kvark/src/components/feide-sign-in-issue.tsx
+++ b/apps/kvark/src/components/feide-sign-in-issue.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { Button } from "@tihlde/ui/ui/button";
+import { Input } from "@tihlde/ui/ui/input";
 import { Spinner } from "@tihlde/ui/ui/spinner";
 
 /**
@@ -16,86 +18,144 @@ export type FeideSignInIssueProps = {
     onRegisterAsNew: () => void;
     /** Reveals the username/password form, the route to an existing account. */
     onUseExistingAccount: () => void;
-    /**
-     * False once that form is already open — the button would then be a
-     * no-op sitting above the thing it was meant to reveal.
-     */
-    showExistingAccountAction?: boolean;
+    /** Requests a verification link for an address the member types in. */
+    onSendVerification: (email: string) => void;
+    verificationSending?: boolean;
+    verificationSent?: boolean;
     loading?: boolean;
-};
-
-const COPY: Record<
-    FeideSignInIssueReason,
-    { title: string; description: string }
-> = {
-    /**
-     * No user matched the Feide identity at all. The honest framing is a
-     * question rather than an error: we genuinely cannot tell a new member
-     * from a returning one whose old username differs from their NTNU one.
-     */
-    signup_disabled: {
-        title: "Har du vært medlem før?",
-        description: "Vi fant ingen bruker som passer til Feide-kontoen din.",
-    },
-    /**
-     * A user *was* found, but Better Auth refused to attach Feide to it. In
-     * practice this is a migrated member whose email was never verified.
-     */
-    account_not_linked: {
-        title: "Fikk ikke koblet Feide til brukeren din",
-        description: "Logg inn med brukernavn og passord så lenge.",
-    },
 };
 
 /**
  * Shown on the login page when Feide authenticated the person, but we could
  * not safely decide which account is theirs.
  *
- * Deliberately offers the existing-account route first: choosing "new" when
- * you already have an account is the expensive mistake, because it strands
- * your history on a user you can no longer reach.
+ * Kept to a title, one line and the action: this interrupts a login, where
+ * people want to get on with it rather than read.
  */
 export function FeideSignInIssue({
     reason,
     onRegisterAsNew,
     onUseExistingAccount,
-    showExistingAccountAction = true,
+    onSendVerification,
+    verificationSending = false,
+    verificationSent = false,
     loading = false,
 }: FeideSignInIssueProps) {
-    const { title, description } = COPY[reason];
+    if (reason === "account_not_linked") {
+        return (
+            <VerifyEmailPrompt
+                onSend={onSendVerification}
+                sending={verificationSending}
+                sent={verificationSent}
+                onUseExistingAccount={onUseExistingAccount}
+            />
+        );
+    }
 
     return (
         <Alert>
-            <AlertTitle>{title}</AlertTitle>
-            <AlertDescription>{description}</AlertDescription>
+            <AlertTitle>Har du vært medlem før?</AlertTitle>
+            <AlertDescription>
+                Vi fant ingen bruker som passer til Feide-kontoen din.
+            </AlertDescription>
             <div className="mt-3 flex flex-col gap-2">
-                {showExistingAccountAction && (
-                    <Button
-                        type="button"
-                        variant="default"
-                        onClick={onUseExistingAccount}
-                    >
-                        Ja, jeg har bruker
-                    </Button>
-                )}
-                {reason === "signup_disabled" && (
-                    <Button
-                        type="button"
-                        variant="outline"
-                        onClick={onRegisterAsNew}
-                        disabled={loading}
-                    >
-                        {loading ? (
-                            <>
-                                <Spinner />
-                                <span>Oppretter...</span>
-                            </>
-                        ) : (
-                            "Nei, jeg er ny"
-                        )}
-                    </Button>
-                )}
+                <Button
+                    type="button"
+                    variant="default"
+                    onClick={onUseExistingAccount}
+                >
+                    Ja, jeg har bruker
+                </Button>
+                <Button
+                    type="button"
+                    variant="outline"
+                    onClick={onRegisterAsNew}
+                    disabled={loading}
+                >
+                    {loading ? (
+                        <>
+                            <Spinner />
+                            <span>Oppretter...</span>
+                        </>
+                    ) : (
+                        "Nei, jeg er ny"
+                    )}
+                </Button>
             </div>
+        </Alert>
+    );
+}
+
+/**
+ * A member whose account we found but could not attach Feide to, because their
+ * email was never verified — true of every account the Lepton migration
+ * created. Verifying it themselves is both the fix and the proof that the
+ * account is theirs, which is why we ask instead of setting the flag for them.
+ */
+function VerifyEmailPrompt({
+    onSend,
+    sending,
+    sent,
+    onUseExistingAccount,
+}: {
+    onSend: (email: string) => void;
+    sending: boolean;
+    sent: boolean;
+    onUseExistingAccount: () => void;
+}) {
+    const [email, setEmail] = useState("");
+
+    if (sent) {
+        return (
+            <Alert>
+                <AlertTitle>Sjekk innboksen din</AlertTitle>
+                <AlertDescription>
+                    Finnes adressen hos oss, har vi sendt en lenke. Åpne den, så
+                    kan du logge inn med Feide.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    return (
+        <Alert>
+            <AlertTitle>Bekreft e-posten din</AlertTitle>
+            <AlertDescription>
+                Skriv inn e-posten du bruker på TIHLDE, så sender vi en lenke.
+            </AlertDescription>
+            <form
+                className="mt-3 flex flex-col gap-2"
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    if (email.trim()) onSend(email.trim());
+                }}
+            >
+                <Input
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    placeholder="din@epost.no"
+                    autoComplete="email"
+                    required
+                />
+                <Button type="submit" disabled={sending}>
+                    {sending ? (
+                        <>
+                            <Spinner />
+                            <span>Sender...</span>
+                        </>
+                    ) : (
+                        "Send lenke"
+                    )}
+                </Button>
+                <Button
+                    type="button"
+                    variant="link"
+                    onClick={onUseExistingAccount}
+                >
+                    Husker du ikke e-posten?
+                </Button>
+            </form>
         </Alert>
     );
 }

--- a/apps/kvark/src/components/feide-sign-in-issue.tsx
+++ b/apps/kvark/src/components/feide-sign-in-issue.tsx
@@ -3,51 +3,80 @@ import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { Button } from "@tihlde/ui/ui/button";
 import { Input } from "@tihlde/ui/ui/input";
 import { Spinner } from "@tihlde/ui/ui/spinner";
+import { Textarea } from "@tihlde/ui/ui/textarea";
 
 /**
  * Why a Feide login came back without signing anyone in.
  *
- * These are the two outcomes the backend can produce for a member who is not
- * yet linked; every other failure is a genuine error and is not handled here.
+ * `signup_disabled` means nothing matched at all — either a new member, or one
+ * whose Lepton username differs from their NTNU one. `account_not_linked`
+ * means we found them but Better Auth would not attach Feide, which for a
+ * migrated member always comes down to an unverified email.
  */
 export type FeideSignInIssueReason = "signup_disabled" | "account_not_linked";
 
+export type AccountLinkHelpInput = {
+    feideName: string;
+    contactEmail: string;
+    note?: string;
+};
+
 export type FeideSignInIssueProps = {
     reason: FeideSignInIssueReason;
-    /** Replays the Feide login, this time allowing a new account. */
     onRegisterAsNew: () => void;
-    /** Reveals the username/password form, the route to an existing account. */
-    onUseExistingAccount: () => void;
-    /** Requests a verification link for an address the member types in. */
+    registering?: boolean;
+
     onSendVerification: (email: string) => void;
     verificationSending?: boolean;
     verificationSent?: boolean;
-    loading?: boolean;
+
+    onRequestHelp: (input: AccountLinkHelpInput) => void;
+    helpSending?: boolean;
+    helpSent?: boolean;
+    helpError?: string;
 };
 
+type Step = "choose" | "verify" | "help";
+
 /**
- * Shown on the login page when Feide authenticated the person, but we could
- * not safely decide which account is theirs.
- *
- * Kept to a title, one line and the action: this interrupts a login, where
- * people want to get on with it rather than read.
+ * The one screen a Feide login can land on when we could not decide which
+ * account is theirs. Walks: are you new → prove the old address → ask a human.
  */
-export function FeideSignInIssue({
-    reason,
-    onRegisterAsNew,
-    onUseExistingAccount,
-    onSendVerification,
-    verificationSending = false,
-    verificationSent = false,
-    loading = false,
-}: FeideSignInIssueProps) {
-    if (reason === "account_not_linked") {
+export function FeideSignInIssue(props: FeideSignInIssueProps) {
+    const [step, setStep] = useState<Step>(
+        props.reason === "account_not_linked" ? "verify" : "choose",
+    );
+
+    if (props.helpSent) {
+        return (
+            <Alert>
+                <AlertTitle>Vi har fått beskjed</AlertTitle>
+                <AlertDescription>
+                    Index er varslet og kobler kontoen din så snart de har
+                    mulighet. Du får svar på e-post.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    if (step === "help") {
+        return (
+            <HelpForm
+                onSubmit={props.onRequestHelp}
+                sending={props.helpSending ?? false}
+                error={props.helpError}
+                onBack={() => setStep("verify")}
+            />
+        );
+    }
+
+    if (step === "verify") {
         return (
             <VerifyEmailPrompt
-                onSend={onSendVerification}
-                sending={verificationSending}
-                sent={verificationSent}
-                onUseExistingAccount={onUseExistingAccount}
+                onSend={props.onSendVerification}
+                sending={props.verificationSending ?? false}
+                sent={props.verificationSent ?? false}
+                onNeedHelp={() => setStep("help")}
             />
         );
     }
@@ -59,20 +88,16 @@ export function FeideSignInIssue({
                 Vi fant ingen bruker som passer til Feide-kontoen din.
             </AlertDescription>
             <div className="mt-3 flex flex-col gap-2">
-                <Button
-                    type="button"
-                    variant="default"
-                    onClick={onUseExistingAccount}
-                >
+                <Button type="button" onClick={() => setStep("verify")}>
                     Ja, jeg har bruker
                 </Button>
                 <Button
                     type="button"
                     variant="outline"
-                    onClick={onRegisterAsNew}
-                    disabled={loading}
+                    onClick={props.onRegisterAsNew}
+                    disabled={props.registering}
                 >
-                    {loading ? (
+                    {props.registering ? (
                         <>
                             <Spinner />
                             <span>Oppretter...</span>
@@ -87,21 +112,20 @@ export function FeideSignInIssue({
 }
 
 /**
- * A member whose account we found but could not attach Feide to, because their
- * email was never verified — true of every account the Lepton migration
- * created. Verifying it themselves is both the fix and the proof that the
- * account is theirs, which is why we ask instead of setting the flag for them.
+ * Confirming the old address is both what unblocks the link and what proves
+ * the account is theirs — which is why we ask rather than setting the flag on
+ * their behalf.
  */
 function VerifyEmailPrompt({
     onSend,
     sending,
     sent,
-    onUseExistingAccount,
+    onNeedHelp,
 }: {
     onSend: (email: string) => void;
     sending: boolean;
     sent: boolean;
-    onUseExistingAccount: () => void;
+    onNeedHelp: () => void;
 }) {
     const [email, setEmail] = useState("");
 
@@ -111,7 +135,7 @@ function VerifyEmailPrompt({
                 <AlertTitle>Sjekk innboksen din</AlertTitle>
                 <AlertDescription>
                     Finnes adressen hos oss, har vi sendt en lenke. Åpne den, så
-                    kan du logge inn med Feide.
+                    kobler vi kontoen til Feide.
                 </AlertDescription>
             </Alert>
         );
@@ -121,7 +145,7 @@ function VerifyEmailPrompt({
         <Alert>
             <AlertTitle>Bekreft e-posten din</AlertTitle>
             <AlertDescription>
-                Skriv inn e-posten du bruker på TIHLDE, så sender vi en lenke.
+                Skriv inn e-posten du brukte på den gamle brukeren din.
             </AlertDescription>
             <form
                 className="mt-3 flex flex-col gap-2"
@@ -148,12 +172,86 @@ function VerifyEmailPrompt({
                         "Send lenke"
                     )}
                 </Button>
-                <Button
-                    type="button"
-                    variant="link"
-                    onClick={onUseExistingAccount}
-                >
+                <Button type="button" variant="link" onClick={onNeedHelp}>
                     Husker du ikke e-posten?
+                </Button>
+            </form>
+        </Alert>
+    );
+}
+
+/**
+ * The end of the road for a member who has neither a matching username nor the
+ * old address: nothing left can verify them, so a human decides.
+ */
+function HelpForm({
+    onSubmit,
+    sending,
+    error,
+    onBack,
+}: {
+    onSubmit: (input: AccountLinkHelpInput) => void;
+    sending: boolean;
+    error?: string;
+    onBack: () => void;
+}) {
+    const [feideName, setFeideName] = useState("");
+    const [contactEmail, setContactEmail] = useState("");
+    const [note, setNote] = useState("");
+
+    return (
+        <Alert>
+            <AlertTitle>Be Index koble kontoen</AlertTitle>
+            <AlertDescription>
+                De finner den gamle brukeren din manuelt.
+            </AlertDescription>
+            <form
+                className="mt-3 flex flex-col gap-2"
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    if (feideName.trim() && contactEmail.trim()) {
+                        onSubmit({
+                            feideName: feideName.trim(),
+                            contactEmail: contactEmail.trim(),
+                            note: note.trim() || undefined,
+                        });
+                    }
+                }}
+            >
+                <Input
+                    value={feideName}
+                    onChange={(event) => setFeideName(event.target.value)}
+                    placeholder="Fullt navn"
+                    autoComplete="name"
+                    required
+                />
+                <Input
+                    type="email"
+                    value={contactEmail}
+                    onChange={(event) => setContactEmail(event.target.value)}
+                    placeholder="E-post vi kan svare på"
+                    autoComplete="email"
+                    required
+                />
+                <Textarea
+                    value={note}
+                    onChange={(event) => setNote(event.target.value)}
+                    placeholder="Husker du noe om den gamle brukeren? (valgfritt)"
+                    rows={2}
+                />
+                <Button type="submit" disabled={sending}>
+                    {sending ? (
+                        <>
+                            <Spinner />
+                            <span>Sender...</span>
+                        </>
+                    ) : (
+                        "Send forespørsel"
+                    )}
+                </Button>
+                {error && <p className="text-sm text-destructive">{error}</p>}
+                <Button type="button" variant="link" onClick={onBack}>
+                    Tilbake
                 </Button>
             </form>
         </Alert>

--- a/apps/kvark/src/routeTree.gen.ts
+++ b/apps/kvark/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as AppQrKoderRouteImport } from './routes/_app/qr-koder'
 import { Route as AppSoknaderRouteImport } from './routes/_app/soknader'
 import { Route as AppToddelRouteImport } from './routes/_app/toddel'
 import { Route as AuthForgotPasswordRouteImport } from './routes/_auth/forgot-password'
+import { Route as AuthKobleFeideRouteImport } from './routes/_auth/koble-feide'
 import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as AuthRegisterRouteImport } from './routes/_auth/register'
 import { Route as AuthResetPasswordRouteImport } from './routes/_auth/reset-password'
@@ -136,6 +137,11 @@ const AppToddelRoute = AppToddelRouteImport.update({
 const AuthForgotPasswordRoute = AuthForgotPasswordRouteImport.update({
   id: '/forgot-password',
   path: '/forgot-password',
+  getParentRoute: () => AuthRoute,
+} as any)
+const AuthKobleFeideRoute = AuthKobleFeideRouteImport.update({
+  id: '/koble-feide',
+  path: '/koble-feide',
   getParentRoute: () => AuthRoute,
 } as any)
 const AuthLoginRoute = AuthLoginRouteImport.update({
@@ -388,6 +394,7 @@ export interface FileRoutesByFullPath {
   '/soknader': typeof AppSoknaderRoute
   '/toddel': typeof AppToddelRoute
   '/forgot-password': typeof AuthForgotPasswordRoute
+  '/koble-feide': typeof AuthKobleFeideRoute
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
   '/reset-password': typeof AuthResetPasswordRoute
@@ -446,6 +453,7 @@ export interface FileRoutesByTo {
   '/soknader': typeof AppSoknaderRoute
   '/toddel': typeof AppToddelRoute
   '/forgot-password': typeof AuthForgotPasswordRoute
+  '/koble-feide': typeof AuthKobleFeideRoute
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
   '/reset-password': typeof AuthResetPasswordRoute
@@ -507,6 +515,7 @@ export interface FileRoutesById {
   '/_app/soknader': typeof AppSoknaderRoute
   '/_app/toddel': typeof AppToddelRoute
   '/_auth/forgot-password': typeof AuthForgotPasswordRoute
+  '/_auth/koble-feide': typeof AuthKobleFeideRoute
   '/_auth/login': typeof AuthLoginRoute
   '/_auth/register': typeof AuthRegisterRoute
   '/_auth/reset-password': typeof AuthResetPasswordRoute
@@ -570,6 +579,7 @@ export interface FileRouteTypes {
     | '/soknader'
     | '/toddel'
     | '/forgot-password'
+    | '/koble-feide'
     | '/login'
     | '/register'
     | '/reset-password'
@@ -628,6 +638,7 @@ export interface FileRouteTypes {
     | '/soknader'
     | '/toddel'
     | '/forgot-password'
+    | '/koble-feide'
     | '/login'
     | '/register'
     | '/reset-password'
@@ -688,6 +699,7 @@ export interface FileRouteTypes {
     | '/_app/soknader'
     | '/_app/toddel'
     | '/_auth/forgot-password'
+    | '/_auth/koble-feide'
     | '/_auth/login'
     | '/_auth/register'
     | '/_auth/reset-password'
@@ -843,6 +855,13 @@ declare module '@tanstack/react-router' {
       path: '/forgot-password'
       fullPath: '/forgot-password'
       preLoaderRoute: typeof AuthForgotPasswordRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/_auth/koble-feide': {
+      id: '/_auth/koble-feide'
+      path: '/koble-feide'
+      fullPath: '/koble-feide'
+      preLoaderRoute: typeof AuthKobleFeideRouteImport
       parentRoute: typeof AuthRoute
     }
     '/_auth/login': {
@@ -1261,6 +1280,7 @@ const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
 
 interface AuthRouteChildren {
   AuthForgotPasswordRoute: typeof AuthForgotPasswordRoute
+  AuthKobleFeideRoute: typeof AuthKobleFeideRoute
   AuthLoginRoute: typeof AuthLoginRoute
   AuthRegisterRoute: typeof AuthRegisterRoute
   AuthResetPasswordRoute: typeof AuthResetPasswordRoute
@@ -1269,6 +1289,7 @@ interface AuthRouteChildren {
 
 const AuthRouteChildren: AuthRouteChildren = {
   AuthForgotPasswordRoute: AuthForgotPasswordRoute,
+  AuthKobleFeideRoute: AuthKobleFeideRoute,
   AuthLoginRoute: AuthLoginRoute,
   AuthRegisterRoute: AuthRegisterRoute,
   AuthResetPasswordRoute: AuthResetPasswordRoute,

--- a/apps/kvark/src/routes/_auth/koble-feide.tsx
+++ b/apps/kvark/src/routes/_auth/koble-feide.tsx
@@ -1,0 +1,110 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { Button } from "@tihlde/ui/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@tihlde/ui/ui/card";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import { Spinner } from "@tihlde/ui/ui/spinner";
+
+import { authQueryOptions, linkFeideMutationOptions } from "#/api/auth";
+
+/**
+ * Where a member lands after confirming their email address.
+ *
+ * Confirming signs them in (`autoSignInAfterVerification`), which is the whole
+ * point: matching by username or email has already failed for them, but a
+ * session identifies them outright, so Feide can be attached to *this* user
+ * rather than guessed at. After that the login works like everyone else's.
+ */
+export const Route = createFileRoute("/_auth/koble-feide")({
+    component: LinkFeidePage,
+});
+
+function LinkFeidePage() {
+    return (
+        <Suspense fallback={<LinkFeideSkeleton />}>
+            <LinkFeideCard />
+        </Suspense>
+    );
+}
+
+function LinkFeideSkeleton() {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>
+                    <Skeleton className="h-6 w-48" />
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+                <Skeleton className="h-10 w-full" />
+            </CardContent>
+        </Card>
+    );
+}
+
+function LinkFeideCard() {
+    const { data: auth } = useSuspenseQuery(authQueryOptions);
+    const navigate = useNavigate();
+    const linkMutation = useMutation(linkFeideMutationOptions);
+
+    if (!auth?.user) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle>Lenken har gått ut</CardTitle>
+                    <CardDescription>
+                        Logg inn med Feide igjen for å få en ny.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <Button
+                        className="w-full"
+                        onClick={() => navigate({ to: "/login" })}
+                    >
+                        Til innlogging
+                    </Button>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Koble Feide til kontoen din</CardTitle>
+                <CardDescription>
+                    Du er logget inn som {auth.user.name}. Etter dette logger du
+                    inn med Feide.
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-2">
+                <Button
+                    className="w-full"
+                    disabled={linkMutation.isPending}
+                    onClick={() => linkMutation.mutate({ callbackURL: "/" })}
+                >
+                    {linkMutation.isPending ? (
+                        <>
+                            <Spinner />
+                            <span>Kobler...</span>
+                        </>
+                    ) : (
+                        "Koble til Feide"
+                    )}
+                </Button>
+                {linkMutation.isError && (
+                    <p className="text-sm text-destructive">
+                        {linkMutation.error.message}
+                    </p>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/apps/kvark/src/routes/_auth/login.tsx
+++ b/apps/kvark/src/routes/_auth/login.tsx
@@ -16,6 +16,7 @@ import { Spinner } from "@tihlde/ui/ui/spinner";
 
 import {
     sanitizeRedirectTo,
+    sendVerificationEmailMutationOptions,
     signInUsernameMutationOptions,
     signInWithFeide,
 } from "#/api/auth";
@@ -72,10 +73,14 @@ function LoginPage() {
 
     const [feideLoading, setFeideLoading] = useState(false);
     // Feide is the primary path, so the username/password form stays collapsed
-    // behind a "Kan du ikke bruke Feide?" link — unless Feide already failed in
-    // a way that points at an existing account, where the form *is* the answer.
-    const [showPasswordForm, setShowPasswordForm] = useState(
-        feideIssue === "account_not_linked",
+    // behind a "Kan du ikke bruke Feide?" link.
+    const [showPasswordForm, setShowPasswordForm] = useState(false);
+
+    // Verifying the address is what lets Better Auth attach Feide to a
+    // migrated account; the member does it themselves, since reading that
+    // inbox is also what proves the account is theirs.
+    const verificationMutation = useMutation(
+        sendVerificationEmailMutationOptions,
     );
 
     async function handleFeideSignIn(options?: { requestSignUp?: boolean }) {
@@ -132,11 +137,24 @@ function LoginPage() {
                     <FeideSignInIssue
                         reason={feideIssue}
                         loading={feideLoading}
-                        showExistingAccountAction={!showPasswordForm}
                         onRegisterAsNew={() =>
                             handleFeideSignIn({ requestSignUp: true })
                         }
                         onUseExistingAccount={() => setShowPasswordForm(true)}
+                        onSendVerification={(email) =>
+                            verificationMutation.mutate({
+                                email,
+                                // Absolute: Better Auth resolves a relative
+                                // callback against the API host, which would
+                                // land the member on a 404 from the router.
+                                callbackURL: new URL(
+                                    "/login",
+                                    window.location.origin,
+                                ).toString(),
+                            })
+                        }
+                        verificationSending={verificationMutation.isPending}
+                        verificationSent={verificationMutation.isSuccess}
                     />
                 )}
                 <FeideSignInButton

--- a/apps/kvark/src/routes/_auth/login.tsx
+++ b/apps/kvark/src/routes/_auth/login.tsx
@@ -20,6 +20,7 @@ import {
     signInUsernameMutationOptions,
     signInWithFeide,
 } from "#/api/auth";
+import { requestAccountLinkHelpMutation } from "#/api/queries/account-link";
 import { FeideSignInButton } from "#/components/feide-sign-in-button";
 import {
     FeideSignInIssue,
@@ -78,10 +79,13 @@ function LoginPage() {
 
     // Verifying the address is what lets Better Auth attach Feide to a
     // migrated account; the member does it themselves, since reading that
-    // inbox is also what proves the account is theirs.
+    // inbox is also what proves the account is theirs. Confirming signs them
+    // in, and /koble-feide then attaches Feide to that session — which is what
+    // rescues a member whose stored username never matched their NTNU one.
     const verificationMutation = useMutation(
         sendVerificationEmailMutationOptions,
     );
+    const helpMutation = useMutation(requestAccountLinkHelpMutation);
 
     async function handleFeideSignIn(options?: { requestSignUp?: boolean }) {
         setFeideLoading(true);
@@ -136,25 +140,30 @@ function LoginPage() {
                 {feideIssue && (
                     <FeideSignInIssue
                         reason={feideIssue}
-                        loading={feideLoading}
+                        registering={feideLoading}
                         onRegisterAsNew={() =>
                             handleFeideSignIn({ requestSignUp: true })
                         }
-                        onUseExistingAccount={() => setShowPasswordForm(true)}
                         onSendVerification={(email) =>
                             verificationMutation.mutate({
                                 email,
                                 // Absolute: Better Auth resolves a relative
                                 // callback against the API host, which would
                                 // land the member on a 404 from the router.
+                                // Confirming signs them in, so send them
+                                // straight to the step that needs a session.
                                 callbackURL: new URL(
-                                    "/login",
+                                    "/koble-feide",
                                     window.location.origin,
                                 ).toString(),
                             })
                         }
                         verificationSending={verificationMutation.isPending}
                         verificationSent={verificationMutation.isSuccess}
+                        onRequestHelp={(data) => helpMutation.mutate({ data })}
+                        helpSending={helpMutation.isPending}
+                        helpSent={helpMutation.isSuccess}
+                        helpError={helpMutation.error?.message}
                     />
                 )}
                 <FeideSignInButton

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -241,6 +241,27 @@ export function createAuth(options: CreateAuthOptions) {
             },
         },
 
+        account: {
+            accountLinking: {
+                /**
+                 * Feide hands out `@ntnu.no` addresses, while 986 of the 1685
+                 * accounts migrated from Lepton hold a private one. Two
+                 * different addresses is therefore the normal case here, not
+                 * the suspicious one, and without this Better Auth rejects the
+                 * link with `email_doesn't_match` — precisely for the members
+                 * who have no other way back to their history, since a
+                 * matching username would have linked them automatically.
+                 *
+                 * Only relaxes the *explicit* link routes, where a session
+                 * already proves the local account and the provider proves the
+                 * Feide identity. The implicit linking done during sign-in
+                 * never consults this flag, so `requireLocalEmailVerified`
+                 * still guards that path untouched.
+                 */
+                allowDifferentEmails: true,
+            },
+        },
+
         session: {
             expiresIn: 60 * 60 * 24 * 30, // 30d
             updateAge: 60 * 60 * 24, // 1d

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -106,6 +106,13 @@ const envSchema = z
         COMPANY_CONTACT_EMAIL: z
             .string()
             .default("naeringslivsminister@tihlde.org"),
+        /**
+         * Where "jeg får ikke koblet Feide til den gamle brukeren min" lands.
+         * These need a human: the member has proved nothing yet, so linking
+         * their accounts is a judgement call, not something the flow can
+         * automate.
+         */
+        ACCOUNT_HELP_EMAIL: z.string().default("index@tihlde.org"),
         EMAIL_PROXY_URL: z.string().optional(),
         EMAIL_PROXY_KEY: z.string().optional(),
 

--- a/packages/email/src/template/account-link-help.tsx
+++ b/packages/email/src/template/account-link-help.tsx
@@ -1,0 +1,78 @@
+import {
+    Body,
+    Container,
+    Head,
+    Heading,
+    Html,
+    Img,
+    Text,
+} from "@react-email/components";
+import React from "react";
+import { emailStyles } from "./styles";
+
+export interface AccountLinkHelpEmailProps {
+    /** Name as Feide reports it — authenticated, unlike anything typed in. */
+    feideName: string;
+    /** NTNU username from the Feide login, when the claim carried one. */
+    feideUsername?: string;
+    /** Where to reach the member. */
+    contactEmail: string;
+    /** Anything they remember about the old account. */
+    note?: string;
+    logoUrl: string;
+}
+
+/**
+ * Sent when a member cannot reach their old TIHLDE account on their own —
+ * their Lepton username differs from their NTNU one, and they no longer have
+ * the email address the old account was registered with. Nothing in the flow
+ * can verify them at that point, so a human has to.
+ */
+export const AccountLinkHelpEmail = ({
+    feideName = "Ola Nordmann",
+    feideUsername,
+    contactEmail = "ola@example.com",
+    note,
+    logoUrl,
+}: AccountLinkHelpEmailProps) => {
+    return (
+        <Html>
+            <Head />
+            <Body style={emailStyles.main}>
+                <Container style={emailStyles.container}>
+                    <Img
+                        src={logoUrl}
+                        width="100"
+                        height="100"
+                        alt="TIHLDE Logomark"
+                        style={emailStyles.logo}
+                    />
+                    <Heading style={emailStyles.heading}>
+                        {feideName} får ikke koblet Feide til den gamle brukeren
+                    </Heading>
+                    <Text style={emailStyles.paragraph}>
+                        Svar dem på: {contactEmail}
+                    </Text>
+                    {feideUsername && (
+                        <Text style={emailStyles.paragraph}>
+                            NTNU-brukernavn: {feideUsername}
+                        </Text>
+                    )}
+                    {note && (
+                        <Text style={emailStyles.paragraph}>
+                            De husker: {note}
+                        </Text>
+                    )}
+                    <Text style={emailStyles.paragraph}>
+                        Finn den gamle brukeren i admin og sett brukernavnet til
+                        NTNU-brukernavnet over. Da kobles kontoene neste gang de
+                        logger inn med Feide.
+                    </Text>
+                </Container>
+                <Text style={emailStyles.footer}>Levert av INDEX</Text>
+            </Body>
+        </Html>
+    );
+};
+
+export default AccountLinkHelpEmail;

--- a/packages/email/src/template/index.tsx
+++ b/packages/email/src/template/index.tsx
@@ -1,3 +1,4 @@
+import AccountLinkHelpEmail from "./account-link-help";
 import ApplicationDecidedEmail from "./application-decided";
 import ApplicationReceiptEmail from "./application-receipt";
 import ApplicationSubmittedEmail from "./application-submitted";
@@ -20,6 +21,7 @@ import type { ComponentProps, ReactElement } from "react";
 type EmailTemplateComponent<TProps> = (props: TProps) => ReactElement;
 
 const EMAIL_TEMPLATES = {
+    AccountLinkHelpEmail,
     ApplicationDecidedEmail,
     ApplicationReceiptEmail,
     ApplicationSubmittedEmail,
@@ -63,6 +65,7 @@ export async function renderEmailTemplate<TName extends EmailTemplateName>(
 }
 
 export {
+    AccountLinkHelpEmail,
     ApplicationDecidedEmail,
     ApplicationReceiptEmail,
     ApplicationSubmittedEmail,

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -482,6 +482,26 @@ export interface paths {
         patch: operations["updateBanner"];
         trace?: never;
     };
+    "/api/account-link/help": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Ask a human to link a Feide login to an old account
+         * @description Last resort for a member migrated from Lepton whose stored username differs from their NTNU one and who no longer has the email the old account was registered with — nothing in the flow can verify them, so this notifies an admin to do it by hand. Rate limited per client.
+         */
+        post: operations["requestAccountLinkHelp"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/company/contact": {
         parameters: {
             query?: never;
@@ -2647,6 +2667,23 @@ export interface components {
         };
         DeleteBannerResponse: {
             message: string;
+        };
+        AccountLinkHelpResponse: {
+            success: boolean;
+            message: string;
+        };
+        AccountLinkHelp: {
+            /** @description Name as Feide reported it */
+            feideName: string;
+            /** @description NTNU username from the Feide login */
+            feideUsername?: string;
+            /**
+             * Format: email
+             * @description Where to reach the member
+             */
+            contactEmail: string;
+            /** @description What they remember about the old account */
+            note?: string;
         };
         CompanyContactResponse: {
             success: boolean;
@@ -5938,6 +5975,44 @@ export interface operations {
             };
             /** @description Not Found - Banner not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    requestAccountLinkHelp: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AccountLinkHelp"];
+            };
+        };
+        responses: {
+            /** @description Request delivered to an admin */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountLinkHelpResponse"];
+                };
+            };
+            /** @description Bad Request - Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Too many requests from this client */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/sdk/src/generated/schemas.ts
+++ b/packages/sdk/src/generated/schemas.ts
@@ -7,6 +7,8 @@ export type Schemas = components["schemas"];
 export type SchemaNames = keyof Schemas;
 export type SchemaOf<TName extends SchemaNames> = Schemas[TName];
 
+export type AccountLinkHelp = Schemas["AccountLinkHelp"];
+export type AccountLinkHelpResponse = Schemas["AccountLinkHelpResponse"];
 export type ActivateContractResponse = Schemas["ActivateContractResponse"];
 export type ActiveContract = Schemas["ActiveContract"];
 export type AddGroupMember = Schemas["AddGroupMember"];


### PR DESCRIPTION
Bygger videre på #295. Der ble stille kontoopprettelse stoppet; her får medlemmet faktisk en vei fram.

## Hvorfor verifisering ikke var nok

E-postverifiseringen fra #295 løser `account_not_linked` — der brukernavnet allerede treffer og bare flagget står i veien. Den løser **ikke** tilfellet der Lepton-ID-en avviker fra NTNU-brukernavnet: der bommer både brukernavn- og e-postmatchingen, og å sette et flagg endrer ingenting på det. Neste innlogging gir `signup_disabled` på nytt.

Embret er eksempelet: Lepton lagret `eorroaas`, NTNU-brukernavnet er `eoroaas`, og Lepton-adressen var en privat outlook-adresse. Ingen automatisk match finnes.

## Løsningen: bruk sesjonen

Å bekrefte e-posten logger dem inn (`autoSignInAfterVerification`, allerede påskrudd). Den nye ruta `/koble-feide` fester da Feide til den **innloggede** brukeren via Better Auths `/oauth2/link` — ingen matching involvert.

Etterpå matcher Better Auth på provider og account-id før e-post i det hele tatt vurderes, så brukernavn-avviket slutter å bety noe for godt.

Ingen ny tabell, ingen token-fangst: alt bygger på maskineri som allerede fantes.

## Flyten

| Situasjon | Hva de ser |
|---|---|
| Ingen match | «Har du vært medlem før?» → **Ja** går til e-postbekreftelse, **Nei** oppretter bruker |
| Fant bruker, ikke koblet | E-postbekreftelse direkte |
| Etter bekreftelse | `/koble-feide` → «Koble til Feide» → ferdig |
| Husker ikke e-posten | Skjema som varsler Index |

## Siste utvei

Har de verken matchende brukernavn eller den gamle adressen, finnes ingen automatisk vei igjen. `POST /api/account-link/help` varsler Index på e-post, og medlemmet får beskjed om at det er mottatt og blir tatt tak i.

Endepunktet er uautentisert og sender e-post, så det er rate-limitet (3/time) per IP med e-postadresse som fallback — samme mønster som `company/contact`. Ingenting lagres: det finnes ingen konto å knytte det til ennå, så e-posten *er* journalen. Derfor feiler den høylytt hvis utsendingen ryker, i stedet for å love medlemmet at noen er varslet når ingen er det.

Ny env: `ACCOUNT_HELP_EMAIL` (default `index@tihlde.org`).

## Verifisering

Kjørt ende til ende mot lokal API og database, ikke bare rendring:

- Steg «Ja, jeg har bruker» → e-postskjema → kontaktskjema: alle overganger klikket gjennom
- `POST /api/account-link/help` → 200, og e-posten rendret med navn, svaradresse og notat i loggen
- `/koble-feide` uten sesjon → «Lenken har gått ut»
- `bun run typecheck` grønt 9/9, `oxfmt` grønt, `oxlint` null funn i nye filer

Selve `/oauth2/link`-kallet mot ekte Feide kan bare bekreftes i prod.

## Gjenstår

**Ingen konto har fått studieprogram ennå** i noen test i dag. Blir en aktiv student degradert til `alumni` ved første innlogging, er det en stille regresjon som treffer alle — bør avklares før bred utrulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)