### PR TITLE
fix(kvark): slå av Töddel-PDF-opplasting som proxyen avviser

### DIFF
--- a/apps/kvark/src/api/queries/assets.ts
+++ b/apps/kvark/src/api/queries/assets.ts
@@ -3,6 +3,7 @@ import {
     queryOptions,
     useMutation,
 } from "@tanstack/react-query";
+import { HTTPError } from "ky";
 import { apiClient } from "#/api/api-client";
 import { assetPublicUrl } from "#/lib/assets";
 
@@ -29,11 +30,43 @@ export const getAssetMetadataQuery = (key: string) =>
             }),
     });
 
+/**
+ * Uploads pass a reverse proxy that rejects large bodies before they reach the
+ * API. That rejection carries no CORS headers, so the browser hides the 413 and
+ * surfaces a bare `TypeError` instead — the size has to come from the file we
+ * tried to send rather than from the response.
+ */
+function uploadErrorMessage(error: unknown, formData: FormData): string {
+    const file = formData.get("file");
+    const name = file instanceof File ? `«${file.name}»` : "Filen";
+    const size =
+        file instanceof File
+            ? ` (${(file.size / 1024 / 1024).toFixed(1)} MB)`
+            : "";
+
+    if (error instanceof HTTPError && error.response.status === 413) {
+        return `${name}${size} er for stor til å lastes opp. Prøv en mindre fil.`;
+    }
+
+    if (error instanceof TypeError) {
+        return `Fikk ikke lastet opp ${name}${size}. Filen er trolig for stor, eller nettverket ustabilt. Prøv en mindre fil.`;
+    }
+
+    return error instanceof Error ? error.message : String(error);
+}
+
 export const uploadAssetMutation = mutationOptions({
-    mutationFn: ({ formData }: { formData: FormData }) =>
-        apiClient.post("/api/assets", {
-            body: formData,
-        } as never),
+    mutationFn: async ({ formData }: { formData: FormData }) => {
+        try {
+            return await apiClient.post("/api/assets", {
+                body: formData,
+            } as never);
+        } catch (error) {
+            throw new Error(uploadErrorMessage(error, formData), {
+                cause: error,
+            });
+        }
+    },
 });
 
 /**

--- a/apps/kvark/src/routes/admin/toddel.tsx
+++ b/apps/kvark/src/routes/admin/toddel.tsx
@@ -1,9 +1,16 @@
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { BookOpenIcon, PencilIcon, PlusIcon, Trash2 } from "lucide-react";
+import {
+    AlertCircleIcon,
+    BookOpenIcon,
+    PencilIcon,
+    PlusIcon,
+    Trash2,
+} from "lucide-react";
 import { Suspense, useState } from "react";
 
 import type { ToddelIssue } from "@tihlde/sdk";
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent } from "@tihlde/ui/ui/card";
 import {
@@ -13,7 +20,12 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@tihlde/ui/ui/dialog";
-import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
+import {
+    Field,
+    FieldDescription,
+    FieldGroup,
+    FieldLabel,
+} from "@tihlde/ui/ui/field";
 import { Input } from "@tihlde/ui/ui/input";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import {
@@ -47,6 +59,22 @@ export const Route = createFileRoute("/admin/toddel")({
 /** The upload route rejects anything larger, so say so before the round trip. */
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
+/**
+ * nginx in front of the API caps request bodies at 1 MB and answers 413 without
+ * CORS headers, so the browser only ever sees a network error. Töddel PDFs are
+ * always larger than that — cover images are compressed in the browser and slip
+ * under — so publishing an issue cannot succeed until the proxy limit is
+ * raised (`client_max_body_size 10M`). Everything that does not upload a PDF is
+ * left working so the rest of the admin panel stays testable.
+ *
+ * Flip this back to `false` once the server config is fixed; nothing else has
+ * to change.
+ */
+const PDF_UPLOAD_BLOCKED = true;
+
+const PDF_UPLOAD_BLOCKED_NOTE =
+    "Serveren avviser filer over 1 MB, og Töddel-PDF-er er større. Nye utgaver kan legges ut når grensen er hevet.";
+
 function ToddelAdminPage() {
     const [dialog, setDialog] = useState<
         { mode: "create" } | { mode: "edit"; issue: ToddelIssue } | null
@@ -58,12 +86,25 @@ function ToddelAdminPage() {
                 title="TÖDDEL"
                 description="Legg ut nye utgaver av studentbladet, og rediger de som allerede ligger ute."
                 action={
-                    <Button onClick={() => setDialog({ mode: "create" })}>
+                    <Button
+                        disabled={PDF_UPLOAD_BLOCKED}
+                        onClick={() => setDialog({ mode: "create" })}
+                    >
                         <PlusIcon className="size-4" />
                         Ny utgave
                     </Button>
                 }
             />
+
+            {PDF_UPLOAD_BLOCKED && (
+                <Alert>
+                    <AlertCircleIcon />
+                    <AlertTitle>Opplasting av PDF er midlertidig av</AlertTitle>
+                    <AlertDescription>
+                        {PDF_UPLOAD_BLOCKED_NOTE}
+                    </AlertDescription>
+                </Alert>
+            )}
 
             <Suspense fallback={<TableSkeleton />}>
                 <IssuesTable
@@ -351,11 +392,17 @@ function IssueDialog({
                                 id="toddel-pdf"
                                 type="file"
                                 accept="application/pdf"
-                                required={!isEdit}
+                                required={!isEdit && !PDF_UPLOAD_BLOCKED}
+                                disabled={PDF_UPLOAD_BLOCKED}
                                 onChange={(event) =>
                                     setPdf(event.target.files?.[0] ?? null)
                                 }
                             />
+                            {PDF_UPLOAD_BLOCKED && (
+                                <FieldDescription>
+                                    {PDF_UPLOAD_BLOCKED_NOTE}
+                                </FieldDescription>
+                            )}
                         </Field>
                         <AdminImageField
                             label="Forsidebilde (valgfritt)"


### PR DESCRIPTION
## Hva

Deaktiverer opplasting av Töddel-PDF i admin-panelet bak ett flagg, og gjør opplastingsfeil lesbare i UI-et.

- «Ny utgave» er deaktivert, med en forklarende melding over tabellen.
- PDF-feltet i rediger-dialogen er låst med samme forklaring. Tittel, publiseringsdato og forsidebilde kan fortsatt endres.
- Arkiv, PDF-lenker og sletting er urørt.
- `uploadAssetMutation` oversetter 413 og nettverksfeil til meldinger som «"UTG12024HØST.pdf" (4.2 MB) er for stor til å lastes opp», i stedet for «Request failed due to a network error».

## Hvorfor

Publisering av en ny utgave feilet i prod med det som så ut som en CORS-feil. Rotårsaken er nginx foran API-et:

| Test mot prod | Resultat |
|---|---|
| `OPTIONS /api/assets` med `Origin: https://new.tihlde.org` | 204, korrekte CORS-headere |
| `POST /api/assets`, 900 KB | 401 — når frem til appen, CORS-headere med |
| `POST /api/assets`, 2 MB | **413 fra nginx**, ingen CORS-headere |

nginx svarer 413 selv, før forespørselen når Hono, så CORS-middlewaren rekker aldri å legge på `Access-Control-Allow-Origin`. Nettleseren skjuler statuskoden og rapporterer en generisk nettverksfeil. Töddel-PDF-er er alltid over 1 MB; bilder komprimeres i nettleseren og havner under, derfor har dette ikke slått ut andre steder.

## Til reviewer

Dette er en midlertidig avstengning, ikke en fiks. Den ekte fiksen er `client_max_body_size 10M;` i nginx-konfigen for `photon.tihlde.org` på Drift-serveren. Når den er på plass er dette én linje å reversere: `PDF_UPLOAD_BLOCKED = false` i `apps/kvark/src/routes/admin/toddel.tsx`. Kommentaren over flagget forklarer bakgrunnen.

Typecheck, lint, format og build er grønne. Endringen er ikke kjørt i nettleser lokalt — port 3000 var opptatt av en annen dev-server, og 413-oppførselen krever uansett nginx foran API-et, som ikke finnes i dev-oppsettet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)