### PR TITLE
fix(api): la ikke sharp kunne ta ned hele API-et

### DIFF
--- a/apps/api/src/lib/asset/image.ts
+++ b/apps/api/src/lib/asset/image.ts
@@ -1,5 +1,43 @@
-import sharp from "sharp";
+import type Sharp from "sharp";
 import type { LoggerType } from "~/middleware/logger";
+
+/**
+ * Resolved sharp module, or `null` once we know it cannot be loaded here.
+ * `undefined` means we have not tried yet.
+ */
+let sharpModule: typeof Sharp | null | undefined;
+
+/**
+ * Load sharp on first use instead of at import time.
+ *
+ * sharp ships its codec as a platform-specific binary, and when that binary
+ * does not match the host it throws on import. As a static import that killed
+ * the entire API at boot: this module is pulled in by the asset upload route,
+ * so a failure to load an image optimizer took down authentication, events and
+ * everything else with it — which is exactly what happened in production on
+ * 2026-07-29.
+ *
+ * Optimization is a nice-to-have; serving the site is not. Resolving it lazily
+ * confines the blast radius to uploads, which already fall back to storing the
+ * original whenever re-encoding fails.
+ */
+async function loadSharp(logger?: LoggerType): Promise<typeof Sharp | null> {
+    if (sharpModule !== undefined) {
+        return sharpModule;
+    }
+
+    try {
+        sharpModule = (await import("sharp")).default;
+    } catch (error) {
+        sharpModule = null;
+        logger?.error(
+            { err: error },
+            "sharp could not be loaded; uploads will be stored without optimization",
+        );
+    }
+
+    return sharpModule;
+}
 
 /**
  * Longest edge an uploaded image is allowed to keep. Anything larger is scaled
@@ -55,6 +93,11 @@ export async function optimizeImage(
     logger?: LoggerType,
 ): Promise<OptimizedImage | null> {
     if (!isOptimizableImage(contentType)) {
+        return null;
+    }
+
+    const sharp = await loadSharp(logger);
+    if (!sharp) {
         return null;
     }
 


### PR DESCRIPTION
**Hastefiks — prod er nede.** API-et crash-looper og nginx svarer 502 på alt.

## Feilen

```
error: Could not load the "sharp" module using the linux-x64 runtime
  at /usr/src/app/src/lib/asset/image.ts:1:1
  at /usr/src/app/src/routes/asset/upload.ts:7:1
```

`import sharp from "sharp"` står på toppnivå i `lib/asset/image.ts`, som dras inn av opplastingsruta og dermed er del av rutetreet. Lastes ikke binæren, dør hele API-et ved oppstart — innlogging, arrangementer, alt.

## Hva denne PR-en gjør *ikke*

Den forklarer ikke hvorfor binæren ikke lastes på verten. Jeg bygget imaget lokalt fra `3c817c8` og hentet ned det CI faktisk pushet (`sha256:ecb8a407…`) — **begge laster sharp fint** (`libvips 8.18.3`), og `@img/sharp-linux-x64@0.35.3` ligger i node_modules i begge. Så lockfil, Dockerfile og CI-bygg er ikke feilen.

Forskjellen mellom vert og testmiljø er uavklart. Ett spor: prod logger `Bun v1.3.14 (Linux x64 baseline)` — baseline-varianten brukes når CPU-en mangler AVX2, og jeg kjørte emulert på arm64, så jeg reproduserte aldri den CPU-en.

## Hva den gjør

Gjør lastingen lat. Feiler den, logges det én gang og `optimizeImage` returnerer `null` — samme vei koden allerede tar når re-koding feiler, der originalen lagres uendret.

Poenget er ikke å skjule feilen, men å begrense den: **en valgfri bildeoptimalisering skal ikke kunne ta ned autentisering.** Opplastinger fungerer fortsatt, bare ukomprimert, og loggen sier ifra.

## Verifisering

A/B mot imaget med `@img/sharp-*-x64` fjernet, som reproduserer prod-feilen:

| Image | Resultat |
|---|---|
| Dagens kode | Krasjer: `Could not load the "sharp" module` |
| Denne PR-en | Kommer forbi modullasting, videre til Redis-oppkobling |

Boot er altså frisk uten sharp. `bun run typecheck` grønt 9/9, `oxfmt` og `oxlint` grønt.

## Etterpå

- Går mot `main` direkte fordi prod er nede. **`dev` må synkes etter merge**, ellers reverterer neste dev→main-merge fiksen.
- Rotårsaken på verten står fortsatt åpen: sjekk hvilken digest containeren faktisk kjører, og om noe monteres over `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)