### PR TITLE
Dev til main: sharp-fiks og alumni-regresjon

### DIFF
--- a/apps/api/src/test/feide/baseline-roles.test.ts
+++ b/apps/api/src/test/feide/baseline-roles.test.ts
@@ -1,0 +1,185 @@
+import { syncBaselineRoles } from "@photon/auth/feide";
+import { type DbSchema, schema } from "@photon/db";
+import { eq, inArray } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * An empty Feide result is not evidence that someone graduated.
+ *
+ * Every member migrated from Lepton carries group memberships, so treating
+ * those as "has a TIHLDE tie" demoted all of them the moment Feide returned no
+ * cohort — which is exactly what happened in production on 2026-07-29 to a
+ * third-year ITBAITBEDR student who had never stopped studying. Only a
+ * study-programme membership, written by an earlier login that did see them
+ * enrolled, is proof enough to take "member" away.
+ */
+describe("syncBaselineRoles", () => {
+    const seedRoles = async (db: NodePgDatabase<DbSchema>) => {
+        await db
+            .insert(schema.role)
+            .values([{ name: "member" }, { name: "alumni" }])
+            .onConflictDoNothing();
+
+        const rows = await db
+            .select({ id: schema.role.id, name: schema.role.name })
+            .from(schema.role)
+            .where(inArray(schema.role.name, ["member", "alumni"]));
+
+        const byName = new Map(rows.map((r) => [r.name, r.id]));
+        const member = byName.get("member");
+        const alumni = byName.get("alumni");
+        if (member === undefined || alumni === undefined) {
+            throw new Error("Could not seed baseline roles");
+        }
+        return { member, alumni };
+    };
+
+    const rolesOf = async (db: NodePgDatabase<DbSchema>, userId: string) => {
+        const rows = await db
+            .select({ name: schema.role.name })
+            .from(schema.userRole)
+            .innerJoin(schema.role, eq(schema.role.id, schema.userRole.roleId))
+            .where(eq(schema.userRole.userId, userId));
+        return rows.map((r) => r.name).sort();
+    };
+
+    integrationTest(
+        "keeps member when Feide reports nothing and we never saw them enrolled",
+        async ({ ctx }) => {
+            const roles = await seedRoles(ctx.db);
+            const user = await ctx.utils.createTestUser();
+
+            await ctx.db
+                .insert(schema.userRole)
+                .values({ userId: user.id, roleId: roles.member })
+                .onConflictDoNothing();
+
+            // A migrated member: group memberships, but no study programme.
+            await ctx.db
+                .insert(schema.group)
+                .values({
+                    slug: "index",
+                    name: "Index",
+                    type: "SUBGROUP",
+                    finesInfo: "",
+                    finesActivated: false,
+                })
+                .onConflictDoNothing();
+
+            await ctx.db
+                .insert(schema.groupMembership)
+                .values({
+                    userId: user.id,
+                    groupSlug: "index",
+                    role: "member",
+                })
+                .onConflictDoNothing();
+
+            await ctx.db.transaction((tx) =>
+                syncBaselineRoles(tx, user.id, false),
+            );
+
+            expect(await rolesOf(ctx.db, user.id)).toEqual(["member"]);
+        },
+    );
+
+    integrationTest(
+        "demotes to alumni once a study programme proves they were enrolled",
+        async ({ ctx }) => {
+            const roles = await seedRoles(ctx.db);
+            const user = await ctx.utils.createTestUser();
+
+            await ctx.db
+                .insert(schema.userRole)
+                .values({ userId: user.id, roleId: roles.member })
+                .onConflictDoNothing();
+
+            const [program] = await ctx.db
+                .insert(schema.studyProgram)
+                .values({
+                    slug: "digital-forretningsutvikling",
+                    feideCode: "ITBAITBEDR",
+                    displayName: "Digital forretningsutvikling",
+                    type: "bachelor",
+                })
+                .returning();
+            if (!program) throw new Error("Could not seed study programme");
+
+            await ctx.db.insert(schema.studyProgramMembership).values({
+                userId: user.id,
+                studyProgramId: program.id,
+                startYear: 2021,
+            });
+
+            await ctx.db.transaction((tx) =>
+                syncBaselineRoles(tx, user.id, false),
+            );
+
+            expect(await rolesOf(ctx.db, user.id)).toEqual(["alumni"]);
+        },
+    );
+
+    integrationTest(
+        "restores member when Feide reports an active programme again",
+        async ({ ctx }) => {
+            const roles = await seedRoles(ctx.db);
+            const user = await ctx.utils.createTestUser();
+
+            await ctx.db
+                .insert(schema.userRole)
+                .values({ userId: user.id, roleId: roles.alumni })
+                .onConflictDoNothing();
+
+            await ctx.db.transaction((tx) =>
+                syncBaselineRoles(tx, user.id, true),
+            );
+
+            expect(await rolesOf(ctx.db, user.id)).toEqual(["member"]);
+        },
+    );
+
+    integrationTest(
+        "leaves a stranger with neither role untouched",
+        async ({ ctx }) => {
+            await seedRoles(ctx.db);
+            const user = await ctx.utils.createTestUser();
+
+            await ctx.db.transaction((tx) =>
+                syncBaselineRoles(tx, user.id, false),
+            );
+
+            expect(await rolesOf(ctx.db, user.id)).toEqual([]);
+        },
+    );
+
+    integrationTest(
+        "does not touch roles other than the baseline pair",
+        async ({ ctx }) => {
+            const roles = await seedRoles(ctx.db);
+            const user = await ctx.utils.createTestUser();
+
+            const [adminRole] = await ctx.db
+                .insert(schema.role)
+                .values({ name: "admin-test" })
+                .onConflictDoNothing()
+                .returning();
+            if (!adminRole) throw new Error("Could not seed extra role");
+
+            await ctx.db.insert(schema.userRole).values([
+                { userId: user.id, roleId: roles.member },
+                { userId: user.id, roleId: adminRole.id },
+            ]);
+
+            await ctx.db.transaction((tx) =>
+                syncBaselineRoles(tx, user.id, false),
+            );
+
+            expect(await rolesOf(ctx.db, user.id)).toEqual([
+                "admin-test",
+                "member",
+            ]);
+        },
+    );
+});

--- a/apps/api/src/test/groups/positions.test.ts
+++ b/apps/api/src/test/groups/positions.test.ts
@@ -782,7 +782,7 @@ describe("group positions", () => {
 
     describe("baseline role sync", () => {
         integrationTest(
-            "active student gets member, inactive with history gets alumni, stranger gets nothing",
+            "active student gets member, only study-programme history earns alumni, stranger gets nothing",
             async ({ ctx }) => {
                 const memberRole = await createTestingRole(ctx, {
                     name: "member",
@@ -801,12 +801,26 @@ describe("group positions", () => {
                 const alumnus = await ctx.utils.createTestUser();
                 const stranger = await ctx.utils.createTestUser();
 
-                // Alumnus has TIHLDE history via a group membership
-                const group = await ctx.utils.createTestGroup();
-                await ctx.db.insert(schema.groupMembership).values({
+                // Only a study-programme membership counts as proof that we
+                // once saw someone enrolled. Group memberships do not: every
+                // member migrated from Lepton has those, so treating them as
+                // history demoted the whole membership the first time Feide
+                // came back empty.
+                const [program] = await ctx.db
+                    .insert(schema.studyProgram)
+                    .values({
+                        slug: "baseline-roles-program",
+                        feideCode: "BIDATA",
+                        displayName: "Dataingeniør",
+                        type: "bachelor",
+                    })
+                    .returning();
+                if (!program) throw new Error("Could not seed study programme");
+
+                await ctx.db.insert(schema.studyProgramMembership).values({
                     userId: alumnus.id,
-                    groupSlug: group.slug,
-                    role: "member",
+                    studyProgramId: program.id,
+                    startYear: 2019,
                 });
 
                 await ctx.db.transaction(async (tx) => {
@@ -821,12 +835,26 @@ describe("group positions", () => {
                 expect(strangerRoles).not.toContain("member");
                 expect(strangerRoles).not.toContain("alumni");
 
-                // Graduating: student loses member, becomes alumni once they
-                // have history
+                // A group membership alone must never cost anyone "member":
+                // an empty Feide result is equally consistent with the
+                // programme simply not coming through.
+                const group = await ctx.utils.createTestGroup();
                 await ctx.db.insert(schema.groupMembership).values({
                     userId: student.id,
                     groupSlug: group.slug,
                     role: "member",
+                });
+                await ctx.db.transaction(async (tx) => {
+                    await syncBaselineRoles(tx, student.id, false);
+                });
+                expect(await getUserRoles(ctx, student.id)).toContain("member");
+
+                // Graduating: once a study programme proves they were
+                // enrolled, an empty Feide result does mean they finished.
+                await ctx.db.insert(schema.studyProgramMembership).values({
+                    userId: student.id,
+                    studyProgramId: program.id,
+                    startYear: 2021,
                 });
                 await ctx.db.transaction(async (tx) => {
                     await syncBaselineRoles(tx, student.id, false);

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -374,11 +374,18 @@ export const syncFeideHook: (
  *
  * - Active student (Feide returned ≥1 TIHLDE study programme): assign
  *   "member", remove "alumni".
- * - Not active, but with TIHLDE history (a study-programme membership or any
- *   group membership — both additive, "én gang TIHLDE-medlem, alltid
- *   TIHLDE-medlem"): assign "alumni", remove "member".
- * - No TIHLDE tie (e.g. an NTNU student outside TIHLDE's programmes): remove
- *   both.
+ * - Previously confirmed active, but no longer (a study-programme membership
+ *   exists from an earlier login): assign "alumni", remove "member".
+ * - Anything else: leave the baseline roles exactly as they are.
+ *
+ * That last case used to assign "alumni" on the strength of *any* group
+ * membership, which read as "has a TIHLDE tie". Every member migrated from
+ * Lepton has those, so an empty Feide result demoted them — and on
+ * 2026-07-29 that hit a third-year student on ITBAITBEDR who is very much
+ * active. An empty result is not evidence of graduation: it is equally
+ * consistent with Feide not returning the programme at all, which is the open
+ * question this same login exposed. Only a study-programme membership proves
+ * we once saw them enrolled, so only that earns the demotion.
  *
  * No-ops for roles that don't exist yet (unseeded databases), so the login
  * flow never breaks on a missing role.
@@ -406,14 +413,11 @@ export async function syncBaselineRoles(
             .from(studyProgramMembership)
             .where(eq(studyProgramMembership.userId, userId))
             .limit(1);
-        const [groupHistory] = studyHistory
-            ? [studyHistory]
-            : await tx
-                  .select({ userId: groupMembership.userId })
-                  .from(groupMembership)
-                  .where(eq(groupMembership.userId, userId))
-                  .limit(1);
-        if (studyHistory || groupHistory) target = "alumni";
+        // No row means we have never seen this member enrolled, so an empty
+        // Feide result tells us nothing about whether they graduated. Leaving
+        // the roles untouched is the only honest option.
+        if (!studyHistory) return;
+        target = "alumni";
     }
 
     const assign = async (roleId: number) => {
@@ -699,8 +703,36 @@ async function fetchValidStudyPrograms(
         );
     }
 
+    const programs = parseValidStudyPrograms(groups);
+
+    /**
+     * Groups came back, but none of them read as a TIHLDE cohort. That is
+     * either a member who really has finished studying, or a gap between what
+     * Feide sends and what {@link parseValidStudyPrograms} expects — and the
+     * two are indistinguishable in the data. Name the cohort groups we did
+     * see, plus a tally of the other types, so one login settles it. Group ids
+     * carry programme codes and years, not anything personal.
+     */
+    if (groups.length > 0 && programs.length === 0) {
+        const cohorts = groups.filter((g) => g.type === "fc:fs:kull");
+        const typeCounts = Object.entries(
+            groups.reduce<Record<string, number>>((acc, g) => {
+                acc[g.type] = (acc[g.type] ?? 0) + 1;
+                return acc;
+            }, {}),
+        )
+            .map(([type, count]) => `${type}×${count}`)
+            .join(", ");
+
+        console.warn(
+            `Feide returned ${groups.length} groups but no TIHLDE cohort. Types: ${typeCounts}. Cohort ids: ${
+                cohorts.map((g) => g.id).join(", ") || "(none)"
+            }`,
+        );
+    }
+
     return {
-        programs: parseValidStudyPrograms(groups),
+        programs,
         campus: resolveCampus(groups),
     };
 }


### PR DESCRIPTION
Vanlig dev → main. Inneholder to hastefikser som må ut i prod.

## Innhold

- **#310** — `fix(auth): ikke degrader aktive medlemmer til alumni`. **Regresjonen er live nå**: hver Feide-innlogging tar `member` fra medlemmet. To av to som har logget inn er allerede degradert, den ene er tredjeklassing på ITBAITBEDR.
- **#309** — `fix(api): la ikke sharp kunne ta ned hele API-et`. Allerede i prod, ligger her fordi `main` måtte gjenopprettes (se under).
- Logging av gruppetyper og kull-id-er når ingen kull parser, så rotårsaken bak manglende studieprogram lar seg avgjøre på én innlogging.

## Om at `main` forsvant

Jeg opprettet PR #311 med `main` som **head**-branch og `dev` som base. Da den ble merget, slettet GitHub head-branchen — altså `main`. Min feil; en synk skal gå andre veien.

`main` er gjenopprettet på `0709edb`, nøyaktig der den sto. Ingenting gikk tapt: `dev` inneholdt allerede hele historikken.

## Verifisering

`bun run test` — 44 filer, 325 tester, alle grønne lokalt. `bun run typecheck` 9/9, `oxfmt` og `oxlint` grønt.

**Bruk merge-commit, ikke squash.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)