### PR TITLE
chore(auth): logg hele programgruppa fra Feide

### DIFF
--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -724,9 +724,26 @@ async function fetchValidStudyPrograms(
             .map(([type, count]) => `${type}×${count}`)
             .join(", ");
 
+        /**
+         * NTNU turned out not to hand this service any `fc:fs:kull` groups at
+         * all — a third-year ITBAITBEDR student came back with 18 `fc:fs:emne`
+         * and a single `fc:fs:prg`. The programme group is what we will have to
+         * read instead, but unlike a cohort it carries no start year, and
+         * `studyProgramMembership.startYear` is NOT NULL.
+         *
+         * So dump every non-course group whole: the id tells us where the
+         * programme code sits, and `displayName` plus whatever `membership`
+         * holds is the only place a year could still be hiding. Course groups
+         * are excluded because there are ~18 of them and they are already
+         * accounted for by the type tally.
+         */
+        const nonCourse = groups.filter((g) => g.type !== "fc:fs:emne");
+
         console.warn(
             `Feide returned ${groups.length} groups but no TIHLDE cohort. Types: ${typeCounts}. Cohort ids: ${
                 cohorts.map((g) => g.id).join(", ") || "(none)"
+            }. Non-course groups: ${
+                JSON.stringify(nonCourse).slice(0, 2000) || "(none)"
             }`,
         );
     }


### PR DESCRIPTION
Siste diagnoserunde før selve fiksen. Ren logging, ingen atferdsendring.

## Hva vi vet nå

Loggen fra forrige runde ga svaret på hvorfor ingen får studieprogram:

```
Feide returned 19 groups but no TIHLDE cohort.
Types: fc:fs:emne×18, fc:fs:prg×1
Cohort ids: (none)
```

**NTNU utleverer ikke `fc:fs:kull` til denne tjenesten i det hele tatt.** En tredjeklassing på ITBAITBEDR — aktiv, medlem av Index — kom tilbake med 18 emnegrupper og én programgruppe. Ingen kullgruppe.

`parseValidStudyPrograms` leter kun etter `fc:fs:kull` ([feide.ts:723](packages/auth/src/feide.ts:723)), så den returnerer tomt for alle. Følgene:

- `org_study_program_membership` er tom for samtlige 1709 brukere
- `isActiveStudent` blir `false` for alle → ingen får `member` bekreftet ved innlogging
- Kull-gruppene som 252 av 273 prioritetspuljer peker på, fylles aldri

## Hvorfor ikke fikse det i denne PR-en

Programgruppa må leses i stedet — det er den veien vi kontrollerer selv, siden Sikt ikke kommer til å utlevere noe spesifikt til oss. Men den bærer **ikke startår**, og `studyProgramMembership.startYear` er `NOT NULL`.

Jeg vil ikke gjette på id-formatet. Fire ganger i dag har jeg gjettet på hva Feide sender og tatt feil hver gang; logging har løst det hver gang.

Denne dumper derfor hele gruppeobjektet for alle ikke-emne-grupper. Da ser vi i én innlogging:

- hvor i id-en programkoden sitter, så parsingen kan gjøres robust framfor posisjonell
- om `displayName` eller `membership` bærer et årstall vi kan bruke

Emnegruppene holdes utenfor — 18 av dem, og de er dekket av type-opptellingen.

## Verifisering

`bun run typecheck` 9/9 grønt, `oxfmt` og `oxlint` grønt, `src/test/feide/` 43/43.

## Neste steg

Når vi ser formatet: les `fc:fs:prg`, match programkoden mot `ALLOWED_PROGRAM_CODES` ved å søke gjennom id-delene framfor å peke på en fast posisjon, og finn en ærlig kilde til startår — eller gjør kolonnen nullable hvis det ikke finnes noen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)