### PR TITLE
Skjul knapper og lenker brukeren ikke har tilgang til

### DIFF
--- a/apps/api/src/routes/event/get.ts
+++ b/apps/api/src/routes/event/get.ts
@@ -151,6 +151,7 @@ export const getRoute = route().get(
             closed: event.isRegistrationClosed,
             image: event.imageUrl,
             imageAlt: event.imageAlt,
+            createdById: event.createdByUserId,
             createdAt: event.createdAt.toISOString(),
             updatedAt: event.updatedAt.toISOString(),
             reactions,

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -501,6 +501,10 @@ export const eventDetailSchema = Schema(
             .string()
             .nullable()
             .meta({ description: "Alt text for the event image (nullable)" }),
+        createdById: z.string().nullable().meta({
+            description:
+                "Creator user ID. The creator may update and delete their own event, so clients need it to decide whether to offer those actions.",
+        }),
         createdAt: z.iso
             .datetime()
             .meta({ description: "Event creation time (ISO 8601)" }),

--- a/apps/api/src/routes/groups/members/add.ts
+++ b/apps/api/src/routes/groups/members/add.ts
@@ -6,6 +6,7 @@ import { addUserToGroup, isDerivedGroupType } from "~/lib/group";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
+import { isGroupLeader } from "~/lib/group/middleware";
 import { requireAuth } from "~/middleware/auth";
 import { addMemberSchema, membershipResponseSchema } from "../schema";
 
@@ -16,7 +17,7 @@ export const addMemberRoute = route().post(
         summary: "Add member to group",
         operationId: "addGroupMember",
         description:
-            "Add a member to a group. Requires 'groups:manage' permission.",
+            "Add a member to a group. Requires 'groups:manage' (globally or scoped to the group), or being the group's leader.",
     })
         .schemaResponse({
             statusCode: 201,
@@ -27,7 +28,14 @@ export const addMemberRoute = route().post(
         .notFound({ description: "Group not found" })
         .build(),
     requireAuth,
-    requireAccess({ permission: "groups:manage" }),
+    // A group's leader manages their own roster; "groups:manage" scoped to the
+    // group does the same for anyone else. Derived (Feide) groups are refused
+    // further down regardless of who asks.
+    requireAccess({
+        permission: "groups:manage",
+        scope: (c) => `group:${c.req.param("groupSlug")}`,
+        ownership: { param: "groupSlug", check: isGroupLeader },
+    }),
     validator("json", addMemberSchema),
     async (c) => {
         const body = c.req.valid("json");
@@ -84,6 +92,16 @@ export const addMemberRoute = route().post(
         if (existingMembership.length > 0) {
             throw new HTTPException(400, {
                 message: `User is already a member of group "${groupSlug}"`,
+            });
+        }
+
+        // Handing out leadership is an escalation — a subgroup leader also
+        // gets the leader role and a seat in HS — so it stays with
+        // "groups:manage". A group's own leader may add plain members only.
+        if (body.role === "leader" && c.get("isResourceOwner")) {
+            throw new HTTPException(403, {
+                message:
+                    "Adding a member as leader requires the 'groups:manage' permission",
             });
         }
 

--- a/apps/api/src/routes/groups/members/remove.ts
+++ b/apps/api/src/routes/groups/members/remove.ts
@@ -5,6 +5,7 @@ import { isDerivedGroupType, removeUserFromGroup } from "~/lib/group";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
+import { isGroupLeader } from "~/lib/group/middleware";
 import { requireAuth } from "~/middleware/auth";
 
 export const removeMemberRoute = route().delete(
@@ -14,7 +15,7 @@ export const removeMemberRoute = route().delete(
         summary: "Remove member from group",
         operationId: "removeGroupMember",
         description:
-            "Remove a member from a group. Requires 'groups:manage' permission.",
+            "Remove a member from a group. Requires 'groups:manage' (globally or scoped to the group), or being the group's leader.",
     })
         .response({
             statusCode: 204,
@@ -23,7 +24,14 @@ export const removeMemberRoute = route().delete(
         .notFound({ description: "Group, user, or membership not found" })
         .build(),
     requireAuth,
-    requireAccess({ permission: "groups:manage" }),
+    // A group's leader manages their own roster; "groups:manage" scoped to the
+    // group does the same for anyone else. Derived (Feide) groups are refused
+    // further down regardless of who asks.
+    requireAccess({
+        permission: "groups:manage",
+        scope: (c) => `group:${c.req.param("groupSlug")}`,
+        ownership: { param: "groupSlug", check: isGroupLeader },
+    }),
     async (c) => {
         const groupSlug = c.req.param("groupSlug");
         const userId = c.req.param("userId");

--- a/apps/api/src/test/groups/members.test.ts
+++ b/apps/api/src/test/groups/members.test.ts
@@ -118,6 +118,80 @@ describe("group members", () => {
         );
 
         integrationTest(
+            "a group's leader may add a plain member without groups:manage",
+            async ({ ctx }) => {
+                const leader = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(leader);
+
+                const group = await ctx.utils.createTestGroup();
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: leader.id,
+                    groupSlug: group.slug,
+                    role: "leader",
+                });
+
+                const memberUser = await ctx.auth.api.createUser({
+                    body: {
+                        email: "led-member@test.com",
+                        name: "Led Member",
+                        password: "test123!",
+                    },
+                });
+
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].members.$post({
+                    param: { groupSlug: group.slug },
+                    json: {
+                        userId: memberUser.user.id,
+                        role: "member",
+                    },
+                });
+
+                expect(response.status).toBe(201);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "a group's leader may not add another leader",
+            async ({ ctx }) => {
+                const leader = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(leader);
+
+                const group = await ctx.utils.createTestGroup();
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: leader.id,
+                    groupSlug: group.slug,
+                    role: "leader",
+                });
+
+                const other = await ctx.auth.api.createUser({
+                    body: {
+                        email: "would-be-leader@test.com",
+                        name: "Would Be Leader",
+                        password: "test123!",
+                    },
+                });
+
+                // Leadership carries the group's leader role and, for
+                // subgroups, a seat in HS — that stays with groups:manage.
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].members.$post({
+                    param: { groupSlug: group.slug },
+                    json: {
+                        userId: other.user.id,
+                        role: "leader",
+                    },
+                });
+
+                expect(response.status).toBe(403);
+            },
+            500_000,
+        );
+
+        integrationTest(
             "returns 404 when adding member to non-existent group",
             async ({ ctx }) => {
                 const user = await ctx.utils.createTestUser();

--- a/apps/kvark/src/api/auth.ts
+++ b/apps/kvark/src/api/auth.ts
@@ -124,7 +124,7 @@ function parsePermission(raw: string): { permission: string; scope: string } {
  */
 export function sessionHasPermission(
     permissions: string[] | undefined,
-    required: string | string[],
+    required: string | readonly string[],
 ): boolean {
     if (!permissions) return false;
 
@@ -138,6 +138,62 @@ export function sessionHasPermission(
             const parsed = parsePermission(raw);
             return parsed.permission === name && parsed.scope === GLOBAL_SCOPE;
         }),
+    );
+}
+
+/**
+ * Whether the session holds a permission globally OR within `scope`.
+ *
+ * Mirrors `hasScopedPermission` in @photon/auth/rbac, which is what
+ * `requireAccess({ permission, scope })` uses server-side: a global grant
+ * satisfies any scope, a scoped grant only satisfies its exact scope.
+ * Scopes look like `"group:fotball"`.
+ */
+export function sessionHasScopedPermission(
+    permissions: string[] | undefined,
+    required: string | readonly string[],
+    scope: string,
+): boolean {
+    if (!permissions) return false;
+
+    const names = Array.isArray(required) ? required : [required];
+    if (names.length === 0) return false;
+
+    if (permissions.includes("root")) return true;
+
+    return names.some((name) =>
+        permissions.some((raw) => {
+            const parsed = parsePermission(raw);
+            if (parsed.permission !== name) return false;
+            return parsed.scope === GLOBAL_SCOPE || parsed.scope === scope;
+        }),
+    );
+}
+
+/**
+ * Whether the session holds a permission in ANY scope — globally or scoped to
+ * some group.
+ *
+ * Use this where the UI cannot know which scope an action will end up needing,
+ * typically a listing that mixes resources from several groups (the admin
+ * sections). Hiding an entry point from someone who holds the permission for
+ * *one* group would lock them out of work they may do, so we err on the side
+ * of showing it and let the API reject the individual request. Never use it
+ * when the scope IS known — use {@link sessionHasScopedPermission} there.
+ */
+export function sessionHasPermissionInAnyScope(
+    permissions: string[] | undefined,
+    required: string | readonly string[],
+): boolean {
+    if (!permissions) return false;
+
+    const names = Array.isArray(required) ? required : [required];
+    if (names.length === 0) return false;
+
+    if (permissions.includes("root")) return true;
+
+    return names.some((name) =>
+        permissions.some((raw) => parsePermission(raw).permission === name),
     );
 }
 

--- a/apps/kvark/src/components/admin-no-access.tsx
+++ b/apps/kvark/src/components/admin-no-access.tsx
@@ -1,0 +1,25 @@
+import { LockIcon } from "lucide-react";
+
+import { AdminEmptyState } from "#/components/admin-empty-state";
+
+type AdminNoAccessProps = {
+    /** What the viewer would have been able to do here, e.g. "publisere nyheter". */
+    action: string;
+};
+
+/**
+ * Shown in place of an admin tool the viewer lacks the permission for.
+ *
+ * Used where the whole page is one privileged action (the news editor, the
+ * attendance list): hiding just the submit button would leave a form that
+ * cannot be submitted, which reads as a bug rather than as missing access.
+ */
+export function AdminNoAccess({ action }: AdminNoAccessProps) {
+    return (
+        <AdminEmptyState
+            icon={LockIcon}
+            title="Du har ikke tilgang"
+            description={`Du mangler tilgangen som kreves for å ${action}. Ta kontakt med lederen din hvis du mener du skal ha den.`}
+        />
+    );
+}

--- a/apps/kvark/src/components/group-fine-dialog.tsx
+++ b/apps/kvark/src/components/group-fine-dialog.tsx
@@ -16,12 +16,19 @@ type GroupFineDialogProps = {
     fines: Fine[];
     openIndex: number | null;
     onOpenChange: (i: number | null) => void;
+    /**
+     * Whether the viewer may act on the fine. Members can see the group's
+     * fines but only the botsjef and fines:* holders may settle them, so the
+     * action row is hidden rather than shown and rejected.
+     */
+    canManage: boolean;
 };
 
 export function GroupFineDialog({
     fines,
     openIndex,
     onOpenChange,
+    canManage,
 }: GroupFineDialogProps) {
     const fine = openIndex !== null ? fines[openIndex] : null;
 
@@ -83,22 +90,24 @@ export function GroupFineDialog({
                                     className="max-h-80 w-full rounded-md object-contain"
                                 />
                             ) : null}
-                            <div className="flex flex-wrap gap-2">
-                                <Button size="sm" variant="outline">
-                                    Merk som godkjent
-                                </Button>
-                                <Button size="sm" variant="outline">
-                                    Merk som betalt
-                                </Button>
-                                <Button size="sm" variant="outline">
-                                    <Pencil />
-                                    Rediger bot
-                                </Button>
-                                <Button size="sm" variant="outline">
-                                    <Trash2 />
-                                    Slett bot
-                                </Button>
-                            </div>
+                            {canManage ? (
+                                <div className="flex flex-wrap gap-2">
+                                    <Button size="sm" variant="outline">
+                                        Merk som godkjent
+                                    </Button>
+                                    <Button size="sm" variant="outline">
+                                        Merk som betalt
+                                    </Button>
+                                    <Button size="sm" variant="outline">
+                                        <Pencil />
+                                        Rediger bot
+                                    </Button>
+                                    <Button size="sm" variant="outline">
+                                        <Trash2 />
+                                        Slett bot
+                                    </Button>
+                                </div>
+                            ) : null}
                         </div>
                         <DialogFooter className="justify-between sm:justify-between">
                             <Button

--- a/apps/kvark/src/components/group-fines-tab.tsx
+++ b/apps/kvark/src/components/group-fines-tab.tsx
@@ -17,6 +17,8 @@ type GroupingMode = "all" | "per-member";
 type GroupFinesTabProps = {
     fines: Fine[];
     memberCount: number;
+    /** Whether the viewer may approve, edit or delete the group's fines. */
+    canManage: boolean;
 };
 
 function fineFilterMatches(fine: Fine, approved: TriState, paid: TriState) {
@@ -32,7 +34,11 @@ function perMember(value: number, memberCount: number): string {
     return (value / memberCount).toFixed(1);
 }
 
-export function GroupFinesTab({ fines, memberCount }: GroupFinesTabProps) {
+export function GroupFinesTab({
+    fines,
+    memberCount,
+    canManage,
+}: GroupFinesTabProps) {
     const [grouping, setGrouping] = useState<GroupingMode>("all");
     const [approved, setApproved] = useState<TriState>("all");
     const [paid, setPaid] = useState<TriState>("all");
@@ -188,6 +194,7 @@ export function GroupFinesTab({ fines, memberCount }: GroupFinesTabProps) {
                 fines={filtered}
                 openIndex={openIndex}
                 onOpenChange={setOpenIndex}
+                canManage={canManage}
             />
         </div>
     );

--- a/apps/kvark/src/components/group-form-row.tsx
+++ b/apps/kvark/src/components/group-form-row.tsx
@@ -7,9 +7,11 @@ import type { Form } from "#/lib/group";
 
 type GroupFormRowProps = {
     form: Form;
+    /** Whether the viewer may administer the form (edit it, see answers). */
+    canManage: boolean;
 };
 
-export function GroupFormRow({ form }: GroupFormRowProps) {
+export function GroupFormRow({ form, canManage }: GroupFormRowProps) {
     return (
         <Card>
             <CardHeader>
@@ -24,9 +26,11 @@ export function GroupFormRow({ form }: GroupFormRowProps) {
                     </p>
                 ) : null}
                 <div className="flex flex-wrap items-center gap-2">
-                    <Button variant="outline" size="sm">
-                        Administrer
-                    </Button>
+                    {canManage ? (
+                        <Button variant="outline" size="sm">
+                            Administrer
+                        </Button>
+                    ) : null}
                     <Button
                         variant="outline"
                         size="sm"

--- a/apps/kvark/src/components/group-forms-tab.tsx
+++ b/apps/kvark/src/components/group-forms-tab.tsx
@@ -31,7 +31,7 @@ export function GroupFormsTab({ forms, isAdmin }: GroupFormsTabProps) {
                 <ul className="flex flex-col gap-3">
                     {forms.map((form) => (
                         <li key={form.id}>
-                            <GroupFormRow form={form} />
+                            <GroupFormRow form={form} canManage={isAdmin} />
                         </li>
                     ))}
                 </ul>

--- a/apps/kvark/src/components/group-law-item.tsx
+++ b/apps/kvark/src/components/group-law-item.tsx
@@ -4,16 +4,16 @@ import type { Law } from "#/lib/group";
 
 type GroupLawItemProps = {
     law: Law;
-    onEdit: () => void;
+    /**
+     * Omitted when the viewer may not edit the lovverk — the row is then plain
+     * text instead of something that looks clickable but does nothing.
+     */
+    onEdit?: () => void;
 };
 
 export function GroupLawItem({ law, onEdit }: GroupLawItemProps) {
-    return (
-        <Button
-            variant="ghost"
-            onClick={onEdit}
-            className="flex h-auto w-full flex-col items-stretch gap-3 px-4 py-4 text-left whitespace-normal"
-        >
+    const content = (
+        <>
             <div className="flex items-baseline gap-3">
                 <h3 className="font-medium">
                     {law.paragraph} - {law.title}
@@ -25,6 +25,24 @@ export function GroupLawItem({ law, onEdit }: GroupLawItemProps) {
             <p className="pl-6 text-sm text-muted-foreground">
                 {law.description}
             </p>
+        </>
+    );
+
+    if (!onEdit) {
+        return (
+            <div className="flex w-full flex-col items-stretch gap-3 px-4 py-4 text-left">
+                {content}
+            </div>
+        );
+    }
+
+    return (
+        <Button
+            variant="ghost"
+            onClick={onEdit}
+            className="flex h-auto w-full flex-col items-stretch gap-3 px-4 py-4 text-left whitespace-normal"
+        >
+            {content}
         </Button>
     );
 }

--- a/apps/kvark/src/components/group-laws-tab.tsx
+++ b/apps/kvark/src/components/group-laws-tab.tsx
@@ -53,9 +53,7 @@ export function GroupLawsTab({
                         <GroupLawItem
                             key={law.id}
                             law={law}
-                            onEdit={() => {
-                                if (canManage) openEdit(law);
-                            }}
+                            onEdit={canManage ? () => openEdit(law) : undefined}
                         />
                     ))}
                 </div>

--- a/apps/kvark/src/components/soknader/admin-detail-dialog.tsx
+++ b/apps/kvark/src/components/soknader/admin-detail-dialog.tsx
@@ -109,6 +109,12 @@ type AdminDetailDialogProps = {
     /** Object URLs for the attachments, keyed by asset key. */
     attachmentUrls: Record<string, string>;
     isSaving: boolean;
+    /**
+     * Whether the viewer may actually decide the søknad. Holders of the
+     * `*:view` permission can open it but not change its status, so the whole
+     * decision block is hidden from them rather than left there to fail.
+     */
+    canManage: boolean;
     onSave: (values: {
         status: ApplicationStatus;
         internalComment: string;
@@ -124,6 +130,7 @@ export function AdminDetailDialog({
     isLoading,
     attachmentUrls,
     isSaving,
+    canManage,
     onSave,
     onDownloadPdf,
 }: AdminDetailDialogProps) {
@@ -249,97 +256,109 @@ export function AdminDetailDialog({
                             </>
                         )}
 
-                        <Separator />
+                        {canManage ? (
+                            <>
+                                <Separator />
 
-                        <div className="flex flex-col gap-4">
-                            <div className="flex flex-col gap-2">
-                                <Label htmlFor="application-status">
-                                    Status
-                                </Label>
-                                <Select
-                                    value={status}
-                                    onValueChange={(value) =>
-                                        setStatus(value as ApplicationStatus)
-                                    }
-                                >
-                                    <SelectTrigger
-                                        id="application-status"
-                                        className="w-full"
-                                    >
-                                        <SelectValue>
-                                            {(value) =>
-                                                STATUS_OPTIONS.find(
-                                                    (option) =>
-                                                        option.value === value,
-                                                )?.label ?? null
+                                <div className="flex flex-col gap-4">
+                                    <div className="flex flex-col gap-2">
+                                        <Label htmlFor="application-status">
+                                            Status
+                                        </Label>
+                                        <Select
+                                            value={status}
+                                            onValueChange={(value) =>
+                                                setStatus(
+                                                    value as ApplicationStatus,
+                                                )
                                             }
-                                        </SelectValue>
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {STATUS_OPTIONS.map((option) => (
-                                            <SelectItem
-                                                key={option.value}
-                                                value={option.value}
+                                        >
+                                            <SelectTrigger
+                                                id="application-status"
+                                                className="w-full"
                                             >
-                                                {option.label}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </div>
+                                                <SelectValue>
+                                                    {(value) =>
+                                                        STATUS_OPTIONS.find(
+                                                            (option) =>
+                                                                option.value ===
+                                                                value,
+                                                        )?.label ?? null
+                                                    }
+                                                </SelectValue>
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {STATUS_OPTIONS.map(
+                                                    (option) => (
+                                                        <SelectItem
+                                                            key={option.value}
+                                                            value={option.value}
+                                                        >
+                                                            {option.label}
+                                                        </SelectItem>
+                                                    ),
+                                                )}
+                                            </SelectContent>
+                                        </Select>
+                                    </div>
 
-                            <div className="flex flex-col gap-2">
-                                <Label htmlFor="application-comment">
-                                    Internt notat
-                                </Label>
-                                <Textarea
-                                    id="application-comment"
-                                    rows={3}
-                                    value={internalComment}
-                                    onChange={(event) =>
-                                        setInternalComment(event.target.value)
-                                    }
-                                    placeholder="Kun synlig for behandlere"
-                                />
-                            </div>
+                                    <div className="flex flex-col gap-2">
+                                        <Label htmlFor="application-comment">
+                                            Internt notat
+                                        </Label>
+                                        <Textarea
+                                            id="application-comment"
+                                            rows={3}
+                                            value={internalComment}
+                                            onChange={(event) =>
+                                                setInternalComment(
+                                                    event.target.value,
+                                                )
+                                            }
+                                            placeholder="Kun synlig for behandlere"
+                                        />
+                                    </div>
 
-                            {/* Bedriftshenvendelser get no automated decision
+                                    {/* Bedriftshenvendelser get no automated decision
                                 email — the Næringslivsminister answers them
                                 directly — so offering a message would be a
                                 field that goes nowhere. */}
-                            {isDecision && !application.companyContact && (
-                                <div className="flex flex-col gap-2">
-                                    <Label htmlFor="application-message">
-                                        Melding til innsender
-                                    </Label>
-                                    <Textarea
-                                        id="application-message"
-                                        rows={3}
-                                        value={messageToSubmitter}
-                                        onChange={(event) =>
-                                            setMessageToSubmitter(
-                                                event.target.value,
-                                            )
-                                        }
-                                        placeholder="Valgfritt — blir med i e-posten om avgjørelsen"
-                                    />
-                                </div>
-                            )}
+                                    {isDecision &&
+                                        !application.companyContact && (
+                                            <div className="flex flex-col gap-2">
+                                                <Label htmlFor="application-message">
+                                                    Melding til innsender
+                                                </Label>
+                                                <Textarea
+                                                    id="application-message"
+                                                    rows={3}
+                                                    value={messageToSubmitter}
+                                                    onChange={(event) =>
+                                                        setMessageToSubmitter(
+                                                            event.target.value,
+                                                        )
+                                                    }
+                                                    placeholder="Valgfritt — blir med i e-posten om avgjørelsen"
+                                                />
+                                            </div>
+                                        )}
 
-                            <Button
-                                disabled={isSaving}
-                                onClick={() =>
-                                    onSave({
-                                        status,
-                                        internalComment,
-                                        messageToSubmitter,
-                                    })
-                                }
-                            >
-                                {isSaving ? <Spinner /> : null}
-                                Lagre
-                            </Button>
-                        </div>
+                                    <Button
+                                        disabled={isSaving}
+                                        onClick={() =>
+                                            onSave({
+                                                status,
+                                                internalComment,
+                                                messageToSubmitter,
+                                            })
+                                        }
+                                    >
+                                        {isSaving ? <Spinner /> : null}
+                                        Lagre
+                                    </Button>
+                                </div>
+                            </>
+                        ) : null}
                     </>
                 )}
             </DialogContent>

--- a/apps/kvark/src/hooks/use-permission.ts
+++ b/apps/kvark/src/hooks/use-permission.ts
@@ -1,6 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
 
-import { authQueryOptions, sessionHasPermission } from "#/api/auth";
+import {
+    authQueryOptions,
+    sessionHasPermission,
+    sessionHasPermissionInAnyScope,
+    sessionHasScopedPermission,
+} from "#/api/auth";
+import { ALL_ADMIN_SECTION_PERMISSIONS } from "#/lib/admin-sections";
 
 /**
  * Whether the current session holds `required` globally.
@@ -9,73 +16,111 @@ import { authQueryOptions, sessionHasPermission } from "#/api/auth";
  * so this is purely cosmetic. See {@link sessionHasPermission}: `"root"` grants
  * everything and a scoped grant does NOT satisfy a global check.
  */
-export function usePermission(required: string | string[]): boolean {
+export function usePermission(required: string | readonly string[]): boolean {
     const { data: session } = useQuery(authQueryOptions);
     return sessionHasPermission(session?.permissions, required);
 }
 
 /**
- * Permissions that grant access to at least one section of the admin
- * dashboard. Holding any of these (or `"root"`) makes a user an "admin" for
- * the purpose of showing admin entry points that live outside the dashboard
- * (e.g. the "Admin" links in the command menu and profile nav).
- *
- * View-only permissions are intentionally excluded — regular members hold
- * those, and they are not admins.
+ * Whether the current session holds `required` globally or within `scope`
+ * (e.g. `"group:fotball"`). Use this when the action's scope is known — it is
+ * exactly what the API checks. See {@link sessionHasScopedPermission}.
  */
-export const ADMIN_DASHBOARD_PERMISSIONS = [
-    "roles:create",
-    "roles:update",
-    "roles:delete",
-    "roles:assign",
-    "users:create",
-    "users:update",
-    "users:delete",
-    "users:manage",
-    "events:create",
-    "events:update",
-    "events:delete",
-    "events:manage",
-    "groups:create",
-    "groups:update",
-    "groups:delete",
-    "groups:manage",
-    "fines:create",
-    "fines:update",
-    "fines:delete",
-    "fines:manage",
-    "forms:create",
-    "forms:update",
-    "forms:delete",
-    "forms:manage",
-    "news:create",
-    "news:update",
-    "news:delete",
-    "news:manage",
-    "jobs:create",
-    "jobs:update",
-    "jobs:delete",
-    "jobs:manage",
-    "galleries:create",
-    "galleries:update",
-    "galleries:delete",
-    "galleries:manage",
-    "banners:create",
-    "banners:update",
-    "banners:delete",
-    "banners:manage",
-    "applications:manage",
-    "applications:expense:manage",
-    "applications:support:manage",
-    "applications:sports-support:manage",
-    "applications:hs-case:manage",
-] as const;
+export function useScopedPermission(
+    required: string | readonly string[],
+    scope: string,
+): boolean {
+    const { data: session } = useQuery(authQueryOptions);
+    return sessionHasScopedPermission(session?.permissions, required, scope);
+}
 
 /**
- * Whether the current user is an admin, i.e. holds any management permission
- * across the admin dashboard sections (or `"root"`). Use this to decide
- * whether to show admin entry points outside the dashboard.
+ * Whether the current session holds `required` in any scope at all.
+ *
+ * For entry points that lead to a mixed listing (the admin sections), where
+ * hiding the entry from someone holding the permission for a single group
+ * would take away work they are allowed to do. Prefer
+ * {@link useScopedPermission} whenever the scope is known.
+ */
+export function useAnyScopePermission(
+    required: string | readonly string[],
+): boolean {
+    const { data: session } = useQuery(authQueryOptions);
+    return sessionHasPermissionInAnyScope(session?.permissions, required);
+}
+
+/**
+ * Returns a predicate for "may act on this specific resource".
+ *
+ * News articles, job postings and events all let their creator edit and
+ * delete their own item without any permission — `requireAccess({ ownership })`
+ * server-side. Gating those buttons on the permission alone would hide them
+ * from the very person who wrote the item, so pass the resource's
+ * `createdById` and let the predicate account for that.
+ */
+export function useCanActOnResource(
+    required: string | readonly string[],
+): (createdById: string | null | undefined) => boolean {
+    const { data: session } = useQuery(authQueryOptions);
+    const hasPermission = sessionHasPermissionInAnyScope(
+        session?.permissions,
+        required,
+    );
+    const userId = session?.user?.id;
+
+    return useCallback(
+        (createdById: string | null | undefined) =>
+            hasPermission || (Boolean(createdById) && createdById === userId),
+        [hasPermission, userId],
+    );
+}
+
+/**
+ * Permissions that grant access to at least one section of the admin panel.
+ * Holding any of these (or `"root"`) makes a user an "admin" for the purpose
+ * of showing admin entry points that live outside the panel (e.g. the "Admin"
+ * links in the command menu and profile nav).
+ *
+ * Derived from {@link ADMIN_SECTION_PERMISSIONS} so the entry points can never
+ * drift from what the sidebar actually shows. Deliberately does NOT include
+ * `fines:create` and the other permissions in the baseline `member` role —
+ * every student holds those, and they open no admin section.
+ */
+export const ADMIN_DASHBOARD_PERMISSIONS = ALL_ADMIN_SECTION_PERMISSIONS;
+
+/**
+ * Whether the current user is the leader of `slug`. Several endpoints let a
+ * group's leader act without any permission grant (`ownership: isGroupLeader`),
+ * so the UI has to know about it too.
+ */
+export function useIsGroupLeaderOf(slug: string): boolean {
+    const { data: session } = useQuery(authQueryOptions);
+    return Boolean(
+        session?.groups?.some(
+            (group) => group.slug === slug && group.role === "leader",
+        ),
+    );
+}
+
+/**
+ * Whether the current user leads at least one group. Group leaders may create
+ * and assign group-scoped verv without holding any global `roles:*`
+ * permission, so they have real work in the admin panel too.
+ */
+export function useIsGroupLeader(): boolean {
+    const { data: session } = useQuery(authQueryOptions);
+    return Boolean(session?.groups?.some((group) => group.role === "leader"));
+}
+
+/**
+ * Whether the current user has anything to do in the admin panel — any
+ * permission that opens a section (in any scope), or leadership of a group.
+ * Use this to decide whether to show admin entry points outside the panel.
  */
 export function useIsAdmin(): boolean {
-    return usePermission(ADMIN_DASHBOARD_PERMISSIONS as unknown as string[]);
+    const hasSectionPermission = useAnyScopePermission(
+        ADMIN_DASHBOARD_PERMISSIONS,
+    );
+    const isGroupLeader = useIsGroupLeader();
+    return hasSectionPermission || isGroupLeader;
 }

--- a/apps/kvark/src/lib/admin-sections.ts
+++ b/apps/kvark/src/lib/admin-sections.ts
@@ -1,0 +1,102 @@
+/**
+ * Which permissions unlock each section of the admin panel.
+ *
+ * One list per section, mirroring what the API's `requireAccess` demands on
+ * the endpoints that section calls. Shared by the admin sidebar, the
+ * dashboard shortcuts and {@link useIsAdmin} so the entry points, the menu and
+ * the pages never disagree about who may do what.
+ *
+ * These are checked with `sessionHasPermissionInAnyScope`: several sections
+ * list resources from more than one group, and a group-scoped grant is enough
+ * to have work to do there. The API still rejects the individual request when
+ * the scope does not match.
+ */
+export const ADMIN_SECTION_PERMISSIONS = {
+    arrangementer: [
+        "events:create",
+        "events:update",
+        "events:delete",
+        "events:manage",
+    ],
+    oppmote: ["events:update", "events:manage"],
+    nyheter: ["news:create", "news:manage"],
+    annonser: ["jobs:create", "jobs:update", "jobs:delete", "jobs:manage"],
+    bannere: [
+        "banners:view",
+        "banners:create",
+        "banners:update",
+        "banners:delete",
+        "banners:manage",
+    ],
+    galleri: [
+        "galleries:create",
+        "galleries:update",
+        "galleries:delete",
+        "galleries:manage",
+    ],
+    toddel: [
+        "toddel:create",
+        "toddel:update",
+        "toddel:delete",
+        "toddel:manage",
+    ],
+    brukere: [
+        "users:view",
+        "users:create",
+        "users:update",
+        "users:delete",
+        "users:manage",
+    ],
+    grupper: [
+        "contracts:view",
+        "contracts:manage",
+        "groups:update",
+        "groups:manage",
+    ],
+    prikker: [
+        "events:strikes:view",
+        "events:strikes:create",
+        "events:strikes:delete",
+        "events:manage",
+    ],
+    roller: [
+        "roles:view",
+        "roles:create",
+        "roles:update",
+        "roles:delete",
+        "roles:assign",
+    ],
+    opptak: [
+        "contracts:view",
+        "contracts:create",
+        "contracts:update",
+        "contracts:manage",
+    ],
+    soknader: [
+        "applications:view",
+        "applications:manage",
+        "applications:expense:view",
+        "applications:expense:manage",
+        "applications:support:view",
+        "applications:support:manage",
+        "applications:sports-support:view",
+        "applications:sports-support:manage",
+        "applications:hs-case:view",
+        "applications:hs-case:manage",
+        "applications:company-contact:view",
+        "applications:company-contact:manage",
+    ],
+} as const satisfies Record<string, readonly string[]>;
+
+export type AdminSection = keyof typeof ADMIN_SECTION_PERMISSIONS;
+
+/**
+ * Every permission that unlocks at least one admin section.
+ *
+ * Note this includes view-only permissions: `users:view` alone gives a real
+ * page to visit, so someone holding it should still be offered the way in.
+ * The baseline `member`/`alumni` roles hold none of these.
+ */
+export const ALL_ADMIN_SECTION_PERMISSIONS: string[] = Array.from(
+    new Set(Object.values(ADMIN_SECTION_PERMISSIONS).flat()),
+);

--- a/apps/kvark/src/routes/_app/annonser.$slug.tsx
+++ b/apps/kvark/src/routes/_app/annonser.$slug.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 
 import { getJobByIdQuery } from "#/api/queries/jobs";
+import { useCanActOnResource } from "#/hooks/use-permission";
 import { DetailField } from "#/components/detail-field";
 import { DetailHero } from "#/components/detail-hero";
 import { DetailIdentity } from "#/components/detail-identity";
@@ -47,6 +48,10 @@ function JobDetailPage() {
     const { slug } = Route.useParams();
 
     const { data: job } = useSuspenseQuery(getJobByIdQuery(slug));
+    // Same rule as the API: the permission, or having created the posting.
+    const canEdit = useCanActOnResource(["jobs:update", "jobs:manage"])(
+        job.createdById,
+    );
 
     const applyUrl =
         job.link || (job.email ? `mailto:${job.email}` : undefined);
@@ -72,10 +77,12 @@ function JobDetailPage() {
                         <DetailIdentity name={job.company} />
                         <div className="flex items-center gap-1">
                             <ShareButton label="Del stilling" />
-                            <IconActionButton
-                                icon={PencilLine}
-                                label="Rediger annonse"
-                            />
+                            {canEdit ? (
+                                <IconActionButton
+                                    icon={PencilLine}
+                                    label="Rediger annonse"
+                                />
+                            ) : null}
                         </div>
                     </div>
                     <h1 className="text-3xl md:text-4xl">{job.title}</h1>

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -31,6 +31,7 @@ import { EventRegistrationCard } from "#/components/event-registration-card";
 import { IconActionButton } from "#/components/icon-action-button";
 import { MapLink } from "#/components/map-link";
 import { ShareButton } from "#/components/share-button";
+import { useCanActOnResource } from "#/hooks/use-permission";
 import { buildGoogleCalendarUrl } from "#/lib/calendar-url";
 import { buildMapsUrls } from "#/lib/maps";
 import {
@@ -46,8 +47,6 @@ export const Route = createFileRoute("/_app/arrangementer/$slug")({
         context.queryClient.ensureQueryData(getEventByIdQuery(params.slug)),
 });
 
-const ADMIN_PERMISSIONS = ["events:update", "events:manage", "events:delete"];
-
 function EventDetailPage() {
     const { slug } = Route.useParams();
     const navigate = useNavigate();
@@ -61,11 +60,13 @@ function EventDetailPage() {
     const registerMutation = useMutation(registerForEventMutation);
     const unregisterMutation = useMutation(unregisterFromEventMutation);
 
-    const isAdmin = Boolean(
-        session?.permissions?.some(
-            (p) => ADMIN_PERMISSIONS.includes(p) || p === "root",
-        ),
-    );
+    // Same rule as the API: the permission (a group-scoped one counts), or
+    // having created the event.
+    const isAdmin = useCanActOnResource([
+        "events:update",
+        "events:manage",
+        "events:delete",
+    ])(event.createdById);
 
     const registrationState = deriveRegistrationState(
         event.registration,

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -5,6 +5,11 @@ import { z } from "zod";
 
 import { authQueryOptions } from "#/api/auth";
 import {
+    useAnyScopePermission,
+    useIsGroupLeaderOf,
+    useScopedPermission,
+} from "#/hooks/use-permission";
+import {
     createLawMutation,
     deleteLawMutation,
     getGroupBySlugQuery,
@@ -51,8 +56,6 @@ export const Route = createFileRoute("/_app/grupper/$slug")({
         context.queryClient.ensureQueryData(getGroupBySlugQuery(params.slug)),
 });
 
-const ADMIN_PERMISSIONS = ["groups:update", "groups:manage", "groups:delete"];
-
 function GroupDetailPage() {
     const { slug } = Route.useParams();
     const { tab: active } = Route.useSearch();
@@ -83,15 +86,33 @@ function GroupDetailPage() {
     const updateLaw = useMutation(updateLawMutation);
     const deleteLaw = useMutation(deleteLawMutation);
 
-    const isAdmin = Boolean(
-        session?.permissions?.some(
-            (p) => ADMIN_PERMISSIONS.includes(p) || p === "root",
-        ),
+    // The scope is known here, so these mirror the API exactly: a grant for
+    // this group counts, a grant for another group does not.
+    const canEditGroup = useScopedPermission(
+        ["groups:update", "groups:manage", "groups:delete"],
+        `group:${slug}`,
     );
-    const isLeader = Boolean(
-        session?.groups?.some((g) => g.slug === slug && g.role === "leader"),
+    const isLeader = useIsGroupLeaderOf(slug);
+    const canManage = canEditGroup || isLeader;
+    // Roster changes: `groups:manage` for this group, or being its leader.
+    // Adding someone AS leader still needs `groups:manage` — the dialog only
+    // adds plain members, and the API refuses the rest.
+    const hasGroupsManage = useScopedPermission(
+        "groups:manage",
+        `group:${slug}`,
     );
-    const canManage = isAdmin || isLeader;
+    const canManageMembers = hasGroupsManage || isLeader;
+    // Creating forms: forms:create, or being the group's leader.
+    const hasFormsPermission = useAnyScopePermission([
+        "forms:create",
+        "forms:manage",
+    ]);
+    const canManageForms = hasFormsPermission || isLeader;
+    const hasFinesManage = useScopedPermission("fines:manage", `group:${slug}`);
+    const hasFinesEdit = useScopedPermission(
+        ["fines:update", "fines:delete", "fines:manage"],
+        `group:${slug}`,
+    );
 
     const members = useMemo(
         () => (apiMembers ?? []).map(mapMember),
@@ -116,7 +137,12 @@ function GroupDetailPage() {
     const isFinesAdmin = Boolean(
         session && apiGroup.finesAdminId === session.user?.id,
     );
-    const canManageLaws = canManage || isFinesAdmin;
+    // Lovverk: the fines admin (botsjef), the leader, or fines:manage for
+    // this group — same as `canManageLaws` server-side.
+    const canManageLaws = isLeader || isFinesAdmin || hasFinesManage;
+    // Approving, editing and deleting fines: the fines admin, or the
+    // matching fines:* permission for this group.
+    const canManageFines = isFinesAdmin || hasFinesEdit;
 
     function openGiveFine() {
         setActive("boter");
@@ -146,7 +172,7 @@ function GroupDetailPage() {
                         <GroupMembersTab
                             leader={leader}
                             members={regularMembers}
-                            isAdmin={canManage}
+                            isAdmin={canManageMembers}
                         />
                     ) : null}
                     {active === "arrangementer" ? <GroupEventsTab /> : null}
@@ -154,6 +180,7 @@ function GroupDetailPage() {
                         <GroupFinesTab
                             fines={fines}
                             memberCount={members.length}
+                            canManage={canManageFines}
                         />
                     ) : null}
                     {active === "lovverk" ? (
@@ -180,7 +207,7 @@ function GroupDetailPage() {
                         />
                     ) : null}
                     {active === "sporreskjema" ? (
-                        <GroupFormsTab forms={forms} isAdmin={canManage} />
+                        <GroupFormsTab forms={forms} isAdmin={canManageForms} />
                     ) : null}
                 </DetailLayoutContent>
             </DetailLayout>

--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -8,7 +8,7 @@ import { Plus } from "lucide-react";
 import { Suspense } from "react";
 
 import { authQueryOptions } from "#/api/auth";
-import { usePermission } from "#/hooks/use-permission";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import { getEventsQuery } from "#/api/queries/events";
 import { getVisibleBannersQuery } from "#/api/queries/banners";
 import { EventCard } from "#/components/event-card";
@@ -55,9 +55,14 @@ const NEWS: NewsCardProps[] = [
 ];
 
 function Home() {
-    // Admin-only shortcuts — the API enforces these permissions server-side too.
-    const canCreateEvent = usePermission("events:create");
-    const canCreateNews = usePermission("news:create");
+    // Admin-only shortcuts — the API enforces these permissions server-side
+    // too. Any-scope: a group-scoped events:create is a real grant, and
+    // hiding the shortcut from that user would take away work they may do.
+    const canCreateEvent = useAnyScopePermission([
+        "events:create",
+        "events:manage",
+    ]);
+    const canCreateNews = useAnyScopePermission(["news:create", "news:manage"]);
 
     return (
         <>

--- a/apps/kvark/src/routes/_app/nyheter.$slug.tsx
+++ b/apps/kvark/src/routes/_app/nyheter.$slug.tsx
@@ -6,6 +6,7 @@ import { MarkdownView } from "@tihlde/ui/complex/markdown";
 import { ArrowLeft, CalendarDays, Clock3, PencilLine } from "lucide-react";
 
 import { getNewsByIdQuery } from "#/api/queries/news";
+import { useCanActOnResource } from "#/hooks/use-permission";
 import { DetailField } from "#/components/detail-field";
 import { DetailHero } from "#/components/detail-hero";
 import { DetailPage } from "#/components/detail-page";
@@ -23,6 +24,10 @@ function NewsDetailPage() {
     const { slug } = Route.useParams();
 
     const { data: news } = useSuspenseQuery(getNewsByIdQuery(slug));
+    // Same rule as the API: the permission, or having written the article.
+    const canEdit = useCanActOnResource(["news:update", "news:manage"])(
+        news.createdById,
+    );
 
     const updated = wasNewsUpdated(news.createdAt, news.updatedAt);
 
@@ -55,10 +60,12 @@ function NewsDetailPage() {
                             ) : null}
                         </div>
                         <div className="flex shrink-0 flex-wrap items-center gap-2">
-                            <Button variant="outline" size="sm">
-                                <PencilLine />
-                                Rediger nyhet
-                            </Button>
+                            {canEdit ? (
+                                <Button variant="outline" size="sm">
+                                    <PencilLine />
+                                    Rediger nyhet
+                                </Button>
+                            ) : null}
                             <ShareButton label="Del nyhet" />
                         </div>
                     </div>

--- a/apps/kvark/src/routes/admin.tsx
+++ b/apps/kvark/src/routes/admin.tsx
@@ -44,8 +44,9 @@ import * as React from "react";
 import {
     authClientWithRedirect,
     authQueryOptions,
-    sessionHasPermission,
+    sessionHasPermissionInAnyScope,
 } from "#/api/auth";
+import { ADMIN_SECTION_PERMISSIONS } from "#/lib/admin-sections";
 import { AdminLayoutHeader } from "#/components/AdminLayoutHeader";
 import { TihldeLogo } from "#/components/icons/tihlde";
 
@@ -82,11 +83,14 @@ type SidebarGroup = {
 
         icon?: LucideIcon;
         /**
-         * Hide this entry unless the session holds one of these permissions
-         * globally. Omit for sections everyone signed in may reach. Cosmetic
-         * only — the API is what actually enforces access.
+         * Hide this entry unless the session holds one of these permissions,
+         * globally or scoped to a group. Cosmetic only — the API is what
+         * actually enforces access — but a member who cannot use a section
+         * should not be offered it.
          */
-        permission?: string | string[];
+        permission?: string | readonly string[];
+        /** Also show it to anyone who leads a group. */
+        allowGroupLeader?: boolean;
     }[];
 };
 
@@ -113,16 +117,19 @@ const sidebarMenuGroups: SidebarGroup[] = [
                 label: "Arrangementer",
                 icon: CalendarIcon,
                 link: linkOptions({ to: "/admin/arrangementer" }),
+                permission: ADMIN_SECTION_PERMISSIONS.arrangementer,
             },
             {
                 label: "Oppmøte",
                 icon: CircleCheckBigIcon,
                 link: linkOptions({ to: "/admin/oppmote" }),
+                permission: ADMIN_SECTION_PERMISSIONS.oppmote,
             },
             {
                 label: "Nyheter",
                 icon: NewspaperIcon,
                 link: linkOptions({ to: "/admin/nyheter" }),
+                permission: ADMIN_SECTION_PERMISSIONS.nyheter,
             },
             {
                 label: "Annonser",
@@ -130,33 +137,25 @@ const sidebarMenuGroups: SidebarGroup[] = [
                 link: linkOptions({
                     to: "/admin/annonser",
                 }),
+                permission: ADMIN_SECTION_PERMISSIONS.annonser,
             },
             {
                 label: "Bannere",
                 icon: BookmarkIcon,
                 link: linkOptions({ to: "/admin/bannere" }),
+                permission: ADMIN_SECTION_PERMISSIONS.bannere,
             },
             {
                 label: "Galleri",
                 icon: ImagesIcon,
                 link: linkOptions({ to: "/admin/galleri" }),
-                permission: [
-                    "galleries:create",
-                    "galleries:update",
-                    "galleries:delete",
-                    "galleries:manage",
-                ],
+                permission: ADMIN_SECTION_PERMISSIONS.galleri,
             },
             {
                 label: "TÖDDEL",
                 icon: BookOpenIcon,
                 link: linkOptions({ to: "/admin/toddel" }),
-                permission: [
-                    "toddel:create",
-                    "toddel:update",
-                    "toddel:delete",
-                    "toddel:manage",
-                ],
+                permission: ADMIN_SECTION_PERMISSIONS.toddel,
             },
         ],
     },
@@ -168,39 +167,41 @@ const sidebarMenuGroups: SidebarGroup[] = [
                 label: "Brukere",
                 icon: UserIcon,
                 link: linkOptions({ to: "/admin/brukere" }),
+                permission: ADMIN_SECTION_PERMISSIONS.brukere,
             },
             {
                 label: "Grupper",
                 icon: Users2Icon,
                 link: linkOptions({ to: "/admin/grupper" }),
+                permission: ADMIN_SECTION_PERMISSIONS.grupper,
             },
             {
                 label: "Prikker",
                 icon: DotSquare,
                 link: linkOptions({ to: "/admin/prikker" }),
+                permission: ADMIN_SECTION_PERMISSIONS.prikker,
             },
             {
+                // Group leaders reach this one without any global roles:*
+                // permission — they may create and assign verv inside their
+                // own group. The page hides the "Roller"-tab from them.
                 label: "Roller og verv",
                 icon: CrownIcon,
                 link: linkOptions({ to: "/admin/roller" }),
+                permission: ADMIN_SECTION_PERMISSIONS.roller,
+                allowGroupLeader: true,
             },
             {
                 label: "Opptak",
                 icon: FileUserIcon,
                 link: linkOptions({ to: "/admin/opptak" }),
+                permission: ADMIN_SECTION_PERMISSIONS.opptak,
             },
             {
                 label: "Søknader",
                 icon: FileTextIcon,
                 link: linkOptions({ to: "/admin/soknader" }),
-                permission: [
-                    "applications:view",
-                    "applications:expense:view",
-                    "applications:support:view",
-                    "applications:sports-support:view",
-                    "applications:hs-case:view",
-                    "applications:company-contact:view",
-                ],
+                permission: ADMIN_SECTION_PERMISSIONS.soknader,
             },
         ],
     },
@@ -212,21 +213,25 @@ const sidebarMenuGroups: SidebarGroup[] = [
                 label: "API Nøkler",
                 icon: KeyIcon,
                 link: linkOptions({ to: "/admin/api-keys" }),
+                permission: "root",
             },
             {
                 label: "OAuth-klienter",
                 icon: ShieldCheckIcon,
                 link: linkOptions({ to: "/admin/oauth-clients" }),
+                permission: "root",
             },
             {
                 label: "Database Viewer",
                 icon: DatabaseIcon,
                 link: linkOptions({ to: "/admin/database" }),
+                permission: "root",
             },
             {
                 label: "Logs",
                 icon: LogsIcon,
                 link: linkOptions({ to: "/admin/logs" }),
+                permission: "root",
             },
         ],
     },
@@ -234,16 +239,24 @@ const sidebarMenuGroups: SidebarGroup[] = [
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     const { data: session } = useQuery(authQueryOptions);
+    const isGroupLeader = Boolean(
+        session?.groups?.some((group) => group.role === "leader"),
+    );
 
-    // Drop entries the viewer cannot use, then drop groups left empty.
+    // Drop entries the viewer cannot use, then drop groups left empty. A
+    // group-scoped grant counts: the section lists more than one group's
+    // resources, and the API rejects the ones outside the grant.
     const visibleGroups = sidebarMenuGroups
         .map((group) => ({
             ...group,
-            items: group.items.filter(
-                (item) =>
-                    !item.permission ||
-                    sessionHasPermission(session?.permissions, item.permission),
-            ),
+            items: group.items.filter((item) => {
+                if (!item.permission) return true;
+                if (item.allowGroupLeader && isGroupLeader) return true;
+                return sessionHasPermissionInAnyScope(
+                    session?.permissions,
+                    item.permission as string | string[],
+                );
+            }),
         }))
         .filter((group) => group.items.length > 0);
 

--- a/apps/kvark/src/routes/admin/annonser.tsx
+++ b/apps/kvark/src/routes/admin/annonser.tsx
@@ -54,6 +54,10 @@ import {
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import {
+    useAnyScopePermission,
+    useCanActOnResource,
+} from "#/hooks/use-permission";
 import { nextWholeHour } from "#/lib/date";
 
 const JOB_TYPES = ["full_time", "part_time", "summer_job", "other"] as const;
@@ -96,6 +100,7 @@ export const Route = createFileRoute("/admin/annonser")({
 });
 
 function JobsAdminPage() {
+    const canCreate = useAnyScopePermission(["jobs:create", "jobs:manage"]);
     const [search, setSearch] = useState("");
     const [jobType, setJobType] = useState<JobType | "all">("all");
     const [showExpired, setShowExpired] = useState(true);
@@ -109,10 +114,12 @@ function JobsAdminPage() {
                 title="Annonser"
                 description="Opprett og administrer stillingsannonser fra bedrifter."
                 action={
-                    <Button onClick={() => setDialog({ mode: "create" })}>
-                        <PlusIcon className="size-4" />
-                        Ny annonse
-                    </Button>
+                    canCreate ? (
+                        <Button onClick={() => setDialog({ mode: "create" })}>
+                            <PlusIcon className="size-4" />
+                            Ny annonse
+                        </Button>
+                    ) : null
                 }
             />
 
@@ -203,6 +210,10 @@ function JobsTable({
 }) {
     const { data } = useSuspenseQuery(getJobsQuery(0, { expired: true }));
     const remove = useMutation(deleteJobMutation);
+    // The API lets the creator edit and delete their own posting, so the row
+    // buttons follow the item, not just the global permission.
+    const canEdit = useCanActOnResource(["jobs:update", "jobs:manage"]);
+    const canDelete = useCanActOnResource(["jobs:delete", "jobs:manage"]);
 
     const filtered = useMemo(() => {
         const term = search.trim().toLowerCase();
@@ -283,22 +294,28 @@ function JobsTable({
                                 </TableCell>
                                 <TableCell>
                                     <div className="flex justify-end gap-2">
-                                        <Button
-                                            variant="outline"
-                                            size="sm"
-                                            onClick={() => onEdit(job)}
-                                        >
-                                            <PencilIcon className="size-4" />
-                                            Rediger
-                                        </Button>
-                                        <Button
-                                            variant="destructive"
-                                            size="sm"
-                                            disabled={remove.isPending}
-                                            onClick={() => handleDelete(job)}
-                                        >
-                                            <Trash2 className="size-4" />
-                                        </Button>
+                                        {canEdit(job.createdById) ? (
+                                            <Button
+                                                variant="outline"
+                                                size="sm"
+                                                onClick={() => onEdit(job)}
+                                            >
+                                                <PencilIcon className="size-4" />
+                                                Rediger
+                                            </Button>
+                                        ) : null}
+                                        {canDelete(job.createdById) ? (
+                                            <Button
+                                                variant="destructive"
+                                                size="sm"
+                                                disabled={remove.isPending}
+                                                onClick={() =>
+                                                    handleDelete(job)
+                                                }
+                                            >
+                                                <Trash2 className="size-4" />
+                                            </Button>
+                                        ) : null}
                                     </div>
                                 </TableCell>
                             </TableRow>

--- a/apps/kvark/src/routes/admin/arrangementer.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.tsx
@@ -34,6 +34,8 @@ import { getGroupsQuery } from "#/api/queries/groups";
 import { getInstitutesQuery } from "#/api/queries/institutes";
 import { AddressCombobox } from "#/components/address-combobox";
 import { AdminImageField } from "#/components/admin-image-field";
+import { AdminNoAccess } from "#/components/admin-no-access";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import { richRegistry } from "#/components/markdown/directives/presets";
 import { nextWholeHour } from "#/lib/date";
 import { useDebounced } from "#/lib/use-debounced";
@@ -67,6 +69,7 @@ function eventDateDefaults() {
 }
 
 function EventAdminPage() {
+    const canCreate = useAnyScopePermission(["events:create", "events:manage"]);
     const { data: groups } = useSuspenseQuery(getGroupsQuery(0));
     const { data: institutes } = useSuspenseQuery(getInstitutesQuery());
 
@@ -224,348 +227,360 @@ function EventAdminPage() {
                 </p>
             </div>
 
-            <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Detaljer</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <FieldGroup>
-                            <Field>
-                                <FieldLabel htmlFor="event-title">
-                                    Tittel
-                                </FieldLabel>
-                                <Input
-                                    id="event-title"
-                                    type="text"
-                                    required
-                                    value={title}
-                                    onChange={(event) =>
-                                        setTitle(event.target.value)
-                                    }
-                                />
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-category">
-                                    Kategori (slug)
-                                </FieldLabel>
-                                <Input
-                                    id="event-category"
-                                    type="text"
-                                    required
-                                    value={categorySlug}
-                                    onChange={(event) =>
-                                        setCategorySlug(event.target.value)
-                                    }
-                                    placeholder="sosialt"
-                                />
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-organizer">
-                                    Arrangørgruppe
-                                </FieldLabel>
-                                <Select
-                                    items={groups.map((group) => ({
-                                        value: group.slug,
-                                        label: group.name,
-                                    }))}
-                                    value={organizerGroupSlug}
-                                    onValueChange={(value) =>
-                                        setOrganizerGroupSlug(value ?? "")
-                                    }
-                                >
-                                    <SelectTrigger id="event-organizer">
-                                        <SelectValue placeholder="Velg gruppe" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {groups.map((group) => (
-                                            <SelectItem
-                                                key={group.slug}
-                                                value={group.slug}
-                                            >
-                                                {group.name}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-location">
-                                    Sted
-                                </FieldLabel>
-                                <AddressCombobox
-                                    id="event-location"
-                                    required
-                                    value={location}
-                                    onValueChange={handleLocationChange}
-                                    suggestions={addressSuggestions ?? []}
-                                    isSearching={isSearchingAddress}
-                                    onSelectSuggestion={handleSelectAddress}
-                                />
-                                <FieldDescription>
-                                    {locationCoords
-                                        ? "Adressen er lenket til kart på arrangementssiden."
-                                        : "Søk opp en adresse for å legge ved kartlenke, eller skriv fritt (f.eks. «Digitalt»)."}
-                                </FieldDescription>
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-start">
-                                    Starttidspunkt
-                                </FieldLabel>
-                                <DateTimePicker
-                                    id="event-start"
-                                    locale={nb}
-                                    placeholder="Velg starttidspunkt"
-                                    value={start}
-                                    onValueChange={setStart}
-                                />
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-end">
-                                    Sluttidspunkt
-                                </FieldLabel>
-                                <DateTimePicker
-                                    id="event-end"
-                                    locale={nb}
-                                    placeholder="Velg sluttidspunkt"
-                                    minDate={start ?? undefined}
-                                    value={end}
-                                    onValueChange={setEnd}
-                                />
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-reg-end">
-                                    Påmeldingsfrist
-                                </FieldLabel>
-                                <DateTimePicker
-                                    id="event-reg-end"
-                                    locale={nb}
-                                    placeholder="Velg påmeldingsfrist"
-                                    maxDate={start ?? undefined}
-                                    value={registrationEnd}
-                                    onValueChange={setRegistrationEnd}
-                                />
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-capacity">
-                                    Kapasitet (valgfritt)
-                                </FieldLabel>
-                                <Input
-                                    id="event-capacity"
-                                    type="number"
-                                    min={1}
-                                    value={capacity}
-                                    onChange={(event) =>
-                                        setCapacity(event.target.value)
-                                    }
-                                />
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-visibility">
-                                    Synlighet
-                                </FieldLabel>
-                                <Select
-                                    items={[
-                                        {
-                                            value: "public",
-                                            label: "Offentlig",
-                                        },
-                                        {
-                                            value: "members",
-                                            label: "Kun for medlemmer",
-                                        },
-                                    ]}
-                                    value={visibility}
-                                    onValueChange={(value) =>
-                                        setVisibility(
-                                            value === "members"
-                                                ? "members"
-                                                : "public",
-                                        )
-                                    }
-                                >
-                                    <SelectTrigger id="event-visibility">
-                                        <SelectValue placeholder="Velg synlighet" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="public">
-                                            Offentlig
-                                        </SelectItem>
-                                        <SelectItem value="members">
-                                            Kun for medlemmer
-                                        </SelectItem>
-                                    </SelectContent>
-                                </Select>
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-institute">
-                                    Institutt
-                                </FieldLabel>
-                                <Select
-                                    items={[
-                                        {
-                                            value: ALL_INSTITUTES,
-                                            label: "Alle institutt",
-                                        },
-                                        ...institutes.map((institute) => ({
-                                            value: institute.slug,
-                                            label: institute.shortName,
-                                        })),
-                                    ]}
-                                    value={instituteSlug}
-                                    onValueChange={(value) =>
-                                        setInstituteSlug(
-                                            value ?? ALL_INSTITUTES,
-                                        )
-                                    }
-                                >
-                                    <SelectTrigger id="event-institute">
-                                        <SelectValue placeholder="Velg institutt" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value={ALL_INSTITUTES}>
-                                            Alle institutt
-                                        </SelectItem>
-                                        {institutes.map((institute) => (
-                                            <SelectItem
-                                                key={institute.slug}
-                                                value={institute.slug}
-                                            >
-                                                {institute.shortName} –{" "}
-                                                {institute.name}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                                <FieldDescription>
-                                    Begrenser påmelding til studenter ved dette
-                                    instituttet.
-                                </FieldDescription>
-                            </Field>
-                            <Field orientation="horizontal" className="gap-3">
-                                <Checkbox
-                                    id="event-paid"
-                                    checked={isPaidEvent}
-                                    onCheckedChange={(checked) =>
-                                        setIsPaidEvent(Boolean(checked))
-                                    }
-                                />
-                                <FieldLabel htmlFor="event-paid">
-                                    Betalt arrangement
-                                </FieldLabel>
-                            </Field>
-                            {isPaidEvent && (
+            {!canCreate ? (
+                <AdminNoAccess action="opprette arrangementer" />
+            ) : null}
+
+            {canCreate ? (
+                <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Detaljer</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <FieldGroup>
                                 <Field>
-                                    <FieldLabel htmlFor="event-price">
-                                        Pris (NOK)
+                                    <FieldLabel htmlFor="event-title">
+                                        Tittel
                                     </FieldLabel>
                                     <Input
-                                        id="event-price"
-                                        type="number"
-                                        min={0}
-                                        value={price}
+                                        id="event-title"
+                                        type="text"
+                                        required
+                                        value={title}
                                         onChange={(event) =>
-                                            setPrice(event.target.value)
+                                            setTitle(event.target.value)
                                         }
                                     />
                                 </Field>
-                            )}
-                            <Field orientation="horizontal" className="gap-3">
-                                <Checkbox
-                                    id="event-strikes"
-                                    checked={canCauseStrikes}
-                                    onCheckedChange={(checked) =>
-                                        setCanCauseStrikes(Boolean(checked))
-                                    }
-                                />
-                                <FieldLabel htmlFor="event-strikes">
-                                    Kan gi prikker (avmelding etter frist og
-                                    no-show)
-                                </FieldLabel>
-                            </Field>
-                            <Field>
-                                <FieldLabel>Beskrivelse</FieldLabel>
-                                <RichEditor
-                                    registry={richRegistry}
-                                    value={description}
-                                    onChange={setDescription}
-                                />
-                            </Field>
-                        </FieldGroup>
-                    </CardContent>
-                </Card>
+                                <Field>
+                                    <FieldLabel htmlFor="event-category">
+                                        Kategori (slug)
+                                    </FieldLabel>
+                                    <Input
+                                        id="event-category"
+                                        type="text"
+                                        required
+                                        value={categorySlug}
+                                        onChange={(event) =>
+                                            setCategorySlug(event.target.value)
+                                        }
+                                        placeholder="sosialt"
+                                    />
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-organizer">
+                                        Arrangørgruppe
+                                    </FieldLabel>
+                                    <Select
+                                        items={groups.map((group) => ({
+                                            value: group.slug,
+                                            label: group.name,
+                                        }))}
+                                        value={organizerGroupSlug}
+                                        onValueChange={(value) =>
+                                            setOrganizerGroupSlug(value ?? "")
+                                        }
+                                    >
+                                        <SelectTrigger id="event-organizer">
+                                            <SelectValue placeholder="Velg gruppe" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {groups.map((group) => (
+                                                <SelectItem
+                                                    key={group.slug}
+                                                    value={group.slug}
+                                                >
+                                                    {group.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-location">
+                                        Sted
+                                    </FieldLabel>
+                                    <AddressCombobox
+                                        id="event-location"
+                                        required
+                                        value={location}
+                                        onValueChange={handleLocationChange}
+                                        suggestions={addressSuggestions ?? []}
+                                        isSearching={isSearchingAddress}
+                                        onSelectSuggestion={handleSelectAddress}
+                                    />
+                                    <FieldDescription>
+                                        {locationCoords
+                                            ? "Adressen er lenket til kart på arrangementssiden."
+                                            : "Søk opp en adresse for å legge ved kartlenke, eller skriv fritt (f.eks. «Digitalt»)."}
+                                    </FieldDescription>
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-start">
+                                        Starttidspunkt
+                                    </FieldLabel>
+                                    <DateTimePicker
+                                        id="event-start"
+                                        locale={nb}
+                                        placeholder="Velg starttidspunkt"
+                                        value={start}
+                                        onValueChange={setStart}
+                                    />
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-end">
+                                        Sluttidspunkt
+                                    </FieldLabel>
+                                    <DateTimePicker
+                                        id="event-end"
+                                        locale={nb}
+                                        placeholder="Velg sluttidspunkt"
+                                        minDate={start ?? undefined}
+                                        value={end}
+                                        onValueChange={setEnd}
+                                    />
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-reg-end">
+                                        Påmeldingsfrist
+                                    </FieldLabel>
+                                    <DateTimePicker
+                                        id="event-reg-end"
+                                        locale={nb}
+                                        placeholder="Velg påmeldingsfrist"
+                                        maxDate={start ?? undefined}
+                                        value={registrationEnd}
+                                        onValueChange={setRegistrationEnd}
+                                    />
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-capacity">
+                                        Kapasitet (valgfritt)
+                                    </FieldLabel>
+                                    <Input
+                                        id="event-capacity"
+                                        type="number"
+                                        min={1}
+                                        value={capacity}
+                                        onChange={(event) =>
+                                            setCapacity(event.target.value)
+                                        }
+                                    />
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-visibility">
+                                        Synlighet
+                                    </FieldLabel>
+                                    <Select
+                                        items={[
+                                            {
+                                                value: "public",
+                                                label: "Offentlig",
+                                            },
+                                            {
+                                                value: "members",
+                                                label: "Kun for medlemmer",
+                                            },
+                                        ]}
+                                        value={visibility}
+                                        onValueChange={(value) =>
+                                            setVisibility(
+                                                value === "members"
+                                                    ? "members"
+                                                    : "public",
+                                            )
+                                        }
+                                    >
+                                        <SelectTrigger id="event-visibility">
+                                            <SelectValue placeholder="Velg synlighet" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="public">
+                                                Offentlig
+                                            </SelectItem>
+                                            <SelectItem value="members">
+                                                Kun for medlemmer
+                                            </SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-institute">
+                                        Institutt
+                                    </FieldLabel>
+                                    <Select
+                                        items={[
+                                            {
+                                                value: ALL_INSTITUTES,
+                                                label: "Alle institutt",
+                                            },
+                                            ...institutes.map((institute) => ({
+                                                value: institute.slug,
+                                                label: institute.shortName,
+                                            })),
+                                        ]}
+                                        value={instituteSlug}
+                                        onValueChange={(value) =>
+                                            setInstituteSlug(
+                                                value ?? ALL_INSTITUTES,
+                                            )
+                                        }
+                                    >
+                                        <SelectTrigger id="event-institute">
+                                            <SelectValue placeholder="Velg institutt" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value={ALL_INSTITUTES}>
+                                                Alle institutt
+                                            </SelectItem>
+                                            {institutes.map((institute) => (
+                                                <SelectItem
+                                                    key={institute.slug}
+                                                    value={institute.slug}
+                                                >
+                                                    {institute.shortName} –{" "}
+                                                    {institute.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    <FieldDescription>
+                                        Begrenser påmelding til studenter ved
+                                        dette instituttet.
+                                    </FieldDescription>
+                                </Field>
+                                <Field
+                                    orientation="horizontal"
+                                    className="gap-3"
+                                >
+                                    <Checkbox
+                                        id="event-paid"
+                                        checked={isPaidEvent}
+                                        onCheckedChange={(checked) =>
+                                            setIsPaidEvent(Boolean(checked))
+                                        }
+                                    />
+                                    <FieldLabel htmlFor="event-paid">
+                                        Betalt arrangement
+                                    </FieldLabel>
+                                </Field>
+                                {isPaidEvent && (
+                                    <Field>
+                                        <FieldLabel htmlFor="event-price">
+                                            Pris (NOK)
+                                        </FieldLabel>
+                                        <Input
+                                            id="event-price"
+                                            type="number"
+                                            min={0}
+                                            value={price}
+                                            onChange={(event) =>
+                                                setPrice(event.target.value)
+                                            }
+                                        />
+                                    </Field>
+                                )}
+                                <Field
+                                    orientation="horizontal"
+                                    className="gap-3"
+                                >
+                                    <Checkbox
+                                        id="event-strikes"
+                                        checked={canCauseStrikes}
+                                        onCheckedChange={(checked) =>
+                                            setCanCauseStrikes(Boolean(checked))
+                                        }
+                                    />
+                                    <FieldLabel htmlFor="event-strikes">
+                                        Kan gi prikker (avmelding etter frist og
+                                        no-show)
+                                    </FieldLabel>
+                                </Field>
+                                <Field>
+                                    <FieldLabel>Beskrivelse</FieldLabel>
+                                    <RichEditor
+                                        registry={richRegistry}
+                                        value={description}
+                                        onChange={setDescription}
+                                    />
+                                </Field>
+                            </FieldGroup>
+                        </CardContent>
+                    </Card>
 
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Forsidebilde</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <FieldGroup>
-                            <AdminImageField
-                                label="Bilde"
-                                description="Vises på arrangementskortet og øverst på arrangementssiden. Forhåndsvisningen er samme utsnitt som besøkende ser."
-                                preset="cover-wide"
-                                value={image}
-                                onChange={setImage}
-                            />
-                            <Field>
-                                <FieldLabel htmlFor="event-image-alt">
-                                    Bildebeskrivelse
-                                </FieldLabel>
-                                <Input
-                                    id="event-image-alt"
-                                    type="text"
-                                    maxLength={255}
-                                    placeholder="Kort beskrivelse for skjermlesere"
-                                    value={imageAlt}
-                                    onChange={(event) =>
-                                        setImageAlt(event.target.value)
-                                    }
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Forsidebilde</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <FieldGroup>
+                                <AdminImageField
+                                    label="Bilde"
+                                    description="Vises på arrangementskortet og øverst på arrangementssiden. Forhåndsvisningen er samme utsnitt som besøkende ser."
+                                    preset="cover-wide"
+                                    value={image}
+                                    onChange={setImage}
                                 />
-                            </Field>
-                        </FieldGroup>
-                    </CardContent>
-                </Card>
+                                <Field>
+                                    <FieldLabel htmlFor="event-image-alt">
+                                        Bildebeskrivelse
+                                    </FieldLabel>
+                                    <Input
+                                        id="event-image-alt"
+                                        type="text"
+                                        maxLength={255}
+                                        placeholder="Kort beskrivelse for skjermlesere"
+                                        value={imageAlt}
+                                        onChange={(event) =>
+                                            setImageAlt(event.target.value)
+                                        }
+                                    />
+                                </Field>
+                            </FieldGroup>
+                        </CardContent>
+                    </Card>
 
-                {uploadError && (
-                    <Alert variant="destructive">
-                        <XCircle className="size-4" />
-                        <AlertTitle>Kunne ikke laste opp bildet</AlertTitle>
-                        <AlertDescription>{uploadError}</AlertDescription>
-                    </Alert>
-                )}
-                {createEvent.isSuccess && (
-                    <Alert>
-                        <CheckCircle2 className="size-4" />
-                        <AlertTitle>Publisert</AlertTitle>
-                        <AlertDescription>
-                            Arrangementet ble opprettet.
-                        </AlertDescription>
-                    </Alert>
-                )}
-                {createEvent.isError && (
-                    <Alert variant="destructive">
-                        <XCircle className="size-4" />
-                        <AlertTitle>Kunne ikke publisere</AlertTitle>
-                        <AlertDescription>
-                            {createEvent.error.message}
-                        </AlertDescription>
-                    </Alert>
-                )}
+                    {uploadError && (
+                        <Alert variant="destructive">
+                            <XCircle className="size-4" />
+                            <AlertTitle>Kunne ikke laste opp bildet</AlertTitle>
+                            <AlertDescription>{uploadError}</AlertDescription>
+                        </Alert>
+                    )}
+                    {createEvent.isSuccess && (
+                        <Alert>
+                            <CheckCircle2 className="size-4" />
+                            <AlertTitle>Publisert</AlertTitle>
+                            <AlertDescription>
+                                Arrangementet ble opprettet.
+                            </AlertDescription>
+                        </Alert>
+                    )}
+                    {createEvent.isError && (
+                        <Alert variant="destructive">
+                            <XCircle className="size-4" />
+                            <AlertTitle>Kunne ikke publisere</AlertTitle>
+                            <AlertDescription>
+                                {createEvent.error.message}
+                            </AlertDescription>
+                        </Alert>
+                    )}
 
-                <div className="flex justify-end">
-                    <Button
-                        type="submit"
-                        disabled={
-                            createEvent.isPending ||
-                            isUploading ||
-                            !organizerGroupSlug
-                        }
-                    >
-                        {isUploading ? "Laster opp bilde …" : "Publiser"}
-                    </Button>
-                </div>
-            </form>
+                    <div className="flex justify-end">
+                        <Button
+                            type="submit"
+                            disabled={
+                                createEvent.isPending ||
+                                isUploading ||
+                                !organizerGroupSlug
+                            }
+                        >
+                            {isUploading ? "Laster opp bilde …" : "Publiser"}
+                        </Button>
+                    </div>
+                </form>
+            ) : null}
         </div>
     );
 }

--- a/apps/kvark/src/routes/admin/bannere.tsx
+++ b/apps/kvark/src/routes/admin/bannere.tsx
@@ -38,6 +38,7 @@ import {
 } from "#/api/queries/banners";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 
 export const Route = createFileRoute("/admin/bannere")({
     component: BannersAdminPage,
@@ -48,6 +49,10 @@ export const Route = createFileRoute("/admin/bannere")({
 });
 
 function BannersAdminPage() {
+    const canCreate = useAnyScopePermission([
+        "banners:create",
+        "banners:manage",
+    ]);
     const [dialog, setDialog] = useState<
         { mode: "create" } | { mode: "edit"; banner: Banner } | null
     >(null);
@@ -58,10 +63,12 @@ function BannersAdminPage() {
                 title="Bannere"
                 description="Tidsstyrte toppbannere for viktige beskjeder på forsiden."
                 action={
-                    <Button onClick={() => setDialog({ mode: "create" })}>
-                        <PlusIcon className="size-4" />
-                        Nytt banner
-                    </Button>
+                    canCreate ? (
+                        <Button onClick={() => setDialog({ mode: "create" })}>
+                            <PlusIcon className="size-4" />
+                            Nytt banner
+                        </Button>
+                    ) : null
                 }
             />
 
@@ -86,6 +93,11 @@ function BannersAdminPage() {
 function BannersTable({ onEdit }: { onEdit: (banner: Banner) => void }) {
     const { data: banners } = useSuspenseQuery(getBannersQuery());
     const remove = useMutation(deleteBannerMutation);
+    const canEdit = useAnyScopePermission(["banners:update", "banners:manage"]);
+    const canDelete = useAnyScopePermission([
+        "banners:delete",
+        "banners:manage",
+    ]);
 
     if (banners.length === 0) {
         return (
@@ -141,22 +153,28 @@ function BannersTable({ onEdit }: { onEdit: (banner: Banner) => void }) {
                                 </TableCell>
                                 <TableCell>
                                     <div className="flex justify-end gap-2">
-                                        <Button
-                                            variant="outline"
-                                            size="sm"
-                                            onClick={() => onEdit(banner)}
-                                        >
-                                            <PencilIcon className="size-4" />
-                                            Rediger
-                                        </Button>
-                                        <Button
-                                            variant="destructive"
-                                            size="sm"
-                                            disabled={remove.isPending}
-                                            onClick={() => handleDelete(banner)}
-                                        >
-                                            <Trash2 className="size-4" />
-                                        </Button>
+                                        {canEdit ? (
+                                            <Button
+                                                variant="outline"
+                                                size="sm"
+                                                onClick={() => onEdit(banner)}
+                                            >
+                                                <PencilIcon className="size-4" />
+                                                Rediger
+                                            </Button>
+                                        ) : null}
+                                        {canDelete ? (
+                                            <Button
+                                                variant="destructive"
+                                                size="sm"
+                                                disabled={remove.isPending}
+                                                onClick={() =>
+                                                    handleDelete(banner)
+                                                }
+                                            >
+                                                <Trash2 className="size-4" />
+                                            </Button>
+                                        ) : null}
                                     </div>
                                 </TableCell>
                             </TableRow>

--- a/apps/kvark/src/routes/admin/brukere.tsx
+++ b/apps/kvark/src/routes/admin/brukere.tsx
@@ -50,6 +50,7 @@ import { getUsersInfiniteQuery } from "#/api/queries/user";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminGroupPicker } from "#/components/admin-group-picker";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { usePermission } from "#/hooks/use-permission";
 import {
     UserSearchCombobox,
     type UserSearchOption,
@@ -146,10 +147,15 @@ function UsersAdminPage() {
      * innlogging, og API-et avviser håndredigering av dem (400). Lista vises
      * derfor uten rolle- og fjern-handlinger for slike grupper.
      */
+    // Add/remove members and role changes all require `groups:manage`
+    // GLOBALLY server-side (no scope, no leader bypass), so anything less
+    // makes the list read-only rather than showing controls that 403.
+    const canManageMembers = usePermission("groups:manage");
     const selectedGroup = groups.find((group) => group.slug === groupSlug);
     const readOnly = selectedGroup
-        ? ["study", "studyyear"].includes(selectedGroup.type.toLowerCase())
-        : false;
+        ? ["study", "studyyear"].includes(selectedGroup.type.toLowerCase()) ||
+          !canManageMembers
+        : !canManageMembers;
 
     return (
         <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">

--- a/apps/kvark/src/routes/admin/galleri.tsx
+++ b/apps/kvark/src/routes/admin/galleri.tsx
@@ -37,6 +37,7 @@ import {
 } from "#/api/queries/galleries";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import { assetPublicUrl } from "#/lib/assets";
 import { imageDropzoneLabels } from "#/lib/image";
 
@@ -58,14 +59,23 @@ export const Route = createFileRoute("/admin/galleri")({
 });
 
 function GalleryAdminPage() {
+    const canCreateGallery = useAnyScopePermission([
+        "galleries:create",
+        "galleries:manage",
+    ]);
+    const canUploadPictures = useAnyScopePermission([
+        "galleries:pictures:create",
+        "galleries:manage",
+    ]);
+
     return (
         <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
             <AdminPageHeader
                 title="Galleri"
                 description="Opprett gallerier og last opp bilder fra arrangementer."
             />
-            <CreateGalleryCard />
-            <UploadPicturesCard />
+            {canCreateGallery ? <CreateGalleryCard /> : null}
+            {canUploadPictures ? <UploadPicturesCard /> : null}
             <GalleryListCard />
         </div>
     );
@@ -360,6 +370,10 @@ function UploadPicturesCard() {
 function GalleryListCard() {
     const { data } = useSuspenseQuery(getGalleriesQuery(0));
     const deleteGallery = useMutation(deleteGalleryMutation);
+    const canDelete = useAnyScopePermission([
+        "galleries:delete",
+        "galleries:manage",
+    ]);
 
     return (
         <Card>
@@ -397,27 +411,29 @@ function GalleryListCard() {
                                         : `${gallery.pictureCount} bilder`}
                                 </span>
                             </div>
-                            <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                disabled={deleteGallery.isPending}
-                                onClick={() => {
-                                    if (
-                                        !window.confirm(
-                                            `Slette "${gallery.title}" og alle bildene i det?`,
-                                        )
-                                    ) {
-                                        return;
-                                    }
-                                    deleteGallery.mutate({
-                                        slug: gallery.slug,
-                                    });
-                                }}
-                            >
-                                <Trash2Icon className="size-4" />
-                                Slett
-                            </Button>
+                            {canDelete ? (
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={deleteGallery.isPending}
+                                    onClick={() => {
+                                        if (
+                                            !window.confirm(
+                                                `Slette "${gallery.title}" og alle bildene i det?`,
+                                            )
+                                        ) {
+                                            return;
+                                        }
+                                        deleteGallery.mutate({
+                                            slug: gallery.slug,
+                                        });
+                                    }}
+                                >
+                                    <Trash2Icon className="size-4" />
+                                    Slett
+                                </Button>
+                            ) : null}
                         </div>
                     ))
                 )}

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -37,6 +37,10 @@ import {
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import {
+    useIsGroupLeaderOf,
+    useScopedPermission,
+} from "#/hooks/use-permission";
 import { groupTypeLabel } from "#/lib/group";
 
 export const Route = createFileRoute("/admin/grupper")({
@@ -124,6 +128,12 @@ function GroupCard({
 
     const updateGroup = useMutation(updateGroupMutation);
     const { uploadImage, isUploading } = useImageUploader();
+    // The scope is known here, so this is exactly the check the API runs:
+    // `groups:update` globally or granted for this very group.
+    const canEdit = useScopedPermission(
+        ["groups:update", "groups:manage"],
+        `group:${group.slug}`,
+    );
 
     async function handleSave() {
         setError(null);
@@ -167,9 +177,15 @@ function GroupCard({
                         {group.finesActivated && (
                             <Badge variant="outline">Bøter aktivert</Badge>
                         )}
-                        <Button variant="outline" size="sm" onClick={onToggle}>
-                            {expanded ? "Lukk" : "Rediger"}
-                        </Button>
+                        {canEdit ? (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={onToggle}
+                            >
+                                {expanded ? "Lukk" : "Rediger"}
+                            </Button>
+                        ) : null}
                     </div>
                 </div>
             </CardHeader>
@@ -232,6 +248,12 @@ function MemberSigningTable({
     signatures: GroupSignatureList;
 }) {
     const revokeSignature = useMutation(revokeSignatureMutation);
+    // Mirrors revoke-signature server-side: `contracts:manage` (global or for
+    // this group) or being the group's leader.
+    const isLeader = useIsGroupLeaderOf(groupSlug);
+    const canRevoke =
+        useScopedPermission("contracts:manage", `group:${groupSlug}`) ||
+        isLeader;
 
     if (!signatures.members.length) {
         return <p>Ingen medlemmer i denne gruppen.</p>;
@@ -260,11 +282,14 @@ function MemberSigningTable({
                             key={member.userId}
                             member={member}
                             disabled={revokeSignature.isPending}
-                            onRevoke={() =>
-                                revokeSignature.mutate({
-                                    groupSlug,
-                                    userId: member.userId,
-                                })
+                            onRevoke={
+                                canRevoke
+                                    ? () =>
+                                          revokeSignature.mutate({
+                                              groupSlug,
+                                              userId: member.userId,
+                                          })
+                                    : undefined
                             }
                         />
                     ))}
@@ -281,7 +306,8 @@ function MemberRow({
 }: {
     member: GroupSignatureMember;
     disabled: boolean;
-    onRevoke: () => void;
+    /** Omitted when the viewer may not revoke — no button then. */
+    onRevoke?: () => void;
 }) {
     return (
         <TableRow>
@@ -310,7 +336,7 @@ function MemberRow({
                     : "—"}
             </TableCell>
             <TableCell>
-                {member.hasSigned && (
+                {member.hasSigned && onRevoke && (
                     <Button
                         size="sm"
                         variant="destructive"

--- a/apps/kvark/src/routes/admin/index.tsx
+++ b/apps/kvark/src/routes/admin/index.tsx
@@ -24,32 +24,51 @@ import { getEventsQuery } from "#/api/queries/events";
 import { getGroupsQuery } from "#/api/queries/groups";
 import { getJobsQuery } from "#/api/queries/jobs";
 import { getNewsQuery } from "#/api/queries/news";
+import { authClient, sessionHasPermissionInAnyScope } from "#/api/auth";
+import { useAnyScopePermission } from "#/hooks/use-permission";
+import { ADMIN_SECTION_PERMISSIONS } from "#/lib/admin-sections";
 
 export const Route = createFileRoute("/admin/")({
     component: DashboardPage,
     loader: async ({ context }) => {
+        // Only prefetch what the viewer may read. `/api/contracts` answers 403
+        // without `contracts:view`, and prefetching it unconditionally took
+        // the whole dashboard down with an error for everyone else.
+        const auth = await authClient();
+        const mayRead = (permission: string | readonly string[]) =>
+            sessionHasPermissionInAnyScope(auth?.permissions, permission);
+
         await Promise.all([
             context.queryClient.ensureQueryData(getEventsQuery(0)),
             context.queryClient.ensureQueryData(getNewsQuery(0)),
             context.queryClient.ensureQueryData(getJobsQuery(0)),
             context.queryClient.ensureQueryData(getGroupsQuery(0)),
-            context.queryClient.ensureQueryData(getContractListQuery()),
+            ...(mayRead(ADMIN_SECTION_PERMISSIONS.opptak)
+                ? [context.queryClient.ensureQueryData(getContractListQuery())]
+                : []),
         ]);
         return { breadcrumbs: "Dashboard" };
     },
 });
 
 function DashboardPage() {
+    const canCreateEvents = useAnyScopePermission([
+        "events:create",
+        "events:manage",
+    ]);
+
     return (
         <div className="container mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-8">
             <AdminPageHeader
                 title="Dashboard"
                 description="Oversikt over innhold og administrasjon i Kvark."
                 action={
-                    <Button render={<Link to="/admin/arrangementer" />}>
-                        <PlusIcon className="size-4" />
-                        Nytt arrangement
-                    </Button>
+                    canCreateEvents ? (
+                        <Button render={<Link to="/admin/arrangementer" />}>
+                            <PlusIcon className="size-4" />
+                            Nytt arrangement
+                        </Button>
+                    ) : null
                 }
             />
 
@@ -76,75 +95,142 @@ function StatsGrid() {
     const { data: news } = useSuspenseQuery(getNewsQuery(0));
     const { data: jobs } = useSuspenseQuery(getJobsQuery(0));
     const { data: groups } = useSuspenseQuery(getGroupsQuery(0));
-    const { data: contracts } = useSuspenseQuery(getContractListQuery());
+
+    // The cards are links into the admin sections, so they follow the same
+    // rule as the sidebar: no entry point to a section you cannot open.
+    const canEvents = useAnyScopePermission(
+        ADMIN_SECTION_PERMISSIONS.arrangementer,
+    );
+    const canNews = useAnyScopePermission(ADMIN_SECTION_PERMISSIONS.nyheter);
+    const canJobs = useAnyScopePermission(ADMIN_SECTION_PERMISSIONS.annonser);
+    const canGroups = useAnyScopePermission(ADMIN_SECTION_PERMISSIONS.grupper);
+    const canContracts = useAnyScopePermission(
+        ADMIN_SECTION_PERMISSIONS.opptak,
+    );
 
     return (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <AdminStatCard
-                label="Arrangementer"
-                value={events.totalCount}
-                icon={CalendarIcon}
-                link={{ to: "/admin/arrangementer" }}
-            />
-            <AdminStatCard
-                label="Nyheter"
-                value={news.totalCount}
-                icon={NewspaperIcon}
-                link={{ to: "/admin/nyheter" }}
-            />
-            <AdminStatCard
-                label="Annonser"
-                value={jobs.totalCount}
-                icon={BriefcaseBusinessIcon}
-                link={{ to: "/admin/annonser" }}
-            />
-            <AdminStatCard
-                label="Grupper"
-                value={groups.length}
-                icon={Users2Icon}
-                link={{ to: "/admin/grupper" }}
-            />
-            <AdminStatCard
-                label="Kontrakter"
-                value={contracts.length}
-                icon={FileSignatureIcon}
-                hint={
-                    contracts.some((contract) => contract.isActive)
-                        ? "Én aktiv kontrakt"
-                        : "Ingen aktiv kontrakt"
-                }
-                link={{ to: "/admin/opptak" }}
-            />
+            {canEvents ? (
+                <AdminStatCard
+                    label="Arrangementer"
+                    value={events.totalCount}
+                    icon={CalendarIcon}
+                    link={{ to: "/admin/arrangementer" }}
+                />
+            ) : null}
+            {canNews ? (
+                <AdminStatCard
+                    label="Nyheter"
+                    value={news.totalCount}
+                    icon={NewspaperIcon}
+                    link={{ to: "/admin/nyheter" }}
+                />
+            ) : null}
+            {canJobs ? (
+                <AdminStatCard
+                    label="Annonser"
+                    value={jobs.totalCount}
+                    icon={BriefcaseBusinessIcon}
+                    link={{ to: "/admin/annonser" }}
+                />
+            ) : null}
+            {canGroups ? (
+                <AdminStatCard
+                    label="Grupper"
+                    value={groups.length}
+                    icon={Users2Icon}
+                    link={{ to: "/admin/grupper" }}
+                />
+            ) : null}
+            {/* Own component: the contracts endpoint 403s without
+                contracts:view, so the query must not run at all for others. */}
+            {canContracts ? <ContractsStatCard /> : null}
         </div>
     );
 }
 
+function ContractsStatCard() {
+    const { data: contracts } = useSuspenseQuery(getContractListQuery());
+
+    return (
+        <AdminStatCard
+            label="Kontrakter"
+            value={contracts.length}
+            icon={FileSignatureIcon}
+            hint={
+                contracts.some((contract) => contract.isActive)
+                    ? "Én aktiv kontrakt"
+                    : "Ingen aktiv kontrakt"
+            }
+            link={{ to: "/admin/opptak" }}
+        />
+    );
+}
+
 function QuickActions() {
+    const canCreateNews = useAnyScopePermission(
+        ADMIN_SECTION_PERMISSIONS.nyheter,
+    );
+    const canCreateJobs = useAnyScopePermission(["jobs:create", "jobs:manage"]);
+    const canUploadContract = useAnyScopePermission([
+        "contracts:create",
+        "contracts:manage",
+    ]);
+    const canManageGroups = useAnyScopePermission(
+        ADMIN_SECTION_PERMISSIONS.grupper,
+    );
+
+    if (
+        !canCreateNews &&
+        !canCreateJobs &&
+        !canUploadContract &&
+        !canManageGroups
+    ) {
+        return null;
+    }
+
     return (
         <Card>
             <CardHeader>
                 <CardTitle>Hurtighandlinger</CardTitle>
             </CardHeader>
             <CardContent className="flex flex-wrap gap-3">
-                <Button variant="outline" render={<Link to="/admin/nyheter" />}>
-                    <NewspaperIcon className="size-4" />
-                    Ny nyhet
-                </Button>
-                <Button
-                    variant="outline"
-                    render={<Link to="/admin/annonser" />}
-                >
-                    <BriefcaseBusinessIcon className="size-4" />
-                    Ny annonse
-                </Button>
-                <Button variant="outline" render={<Link to="/admin/opptak" />}>
-                    <FileSignatureIcon className="size-4" />
-                    Last opp kontrakt
-                </Button>
-                <Button variant="outline" render={<Link to="/admin/grupper" />}>
-                    <Users2Icon className="size-4" />
-                    Administrer grupper
-                </Button>
+                {canCreateNews ? (
+                    <Button
+                        variant="outline"
+                        render={<Link to="/admin/nyheter" />}
+                    >
+                        <NewspaperIcon className="size-4" />
+                        Ny nyhet
+                    </Button>
+                ) : null}
+                {canCreateJobs ? (
+                    <Button
+                        variant="outline"
+                        render={<Link to="/admin/annonser" />}
+                    >
+                        <BriefcaseBusinessIcon className="size-4" />
+                        Ny annonse
+                    </Button>
+                ) : null}
+                {canUploadContract ? (
+                    <Button
+                        variant="outline"
+                        render={<Link to="/admin/opptak" />}
+                    >
+                        <FileSignatureIcon className="size-4" />
+                        Last opp kontrakt
+                    </Button>
+                ) : null}
+                {canManageGroups ? (
+                    <Button
+                        variant="outline"
+                        render={<Link to="/admin/grupper" />}
+                    >
+                        <Users2Icon className="size-4" />
+                        Administrer grupper
+                    </Button>
+                ) : null}
             </CardContent>
         </Card>
     );

--- a/apps/kvark/src/routes/admin/nyheter.tsx
+++ b/apps/kvark/src/routes/admin/nyheter.tsx
@@ -20,6 +20,8 @@ import { CheckCircle2, XCircle } from "lucide-react";
 import { useImageUploader } from "#/api/queries/assets";
 import { createNewsMutation } from "#/api/queries/news";
 import { AdminImageField } from "#/components/admin-image-field";
+import { AdminNoAccess } from "#/components/admin-no-access";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import { richRegistry } from "#/components/markdown/directives/presets";
 
 export const Route = createFileRoute("/admin/nyheter")({
@@ -27,6 +29,7 @@ export const Route = createFileRoute("/admin/nyheter")({
 });
 
 function NewsAdminPage() {
+    const canCreate = useAnyScopePermission(["news:create", "news:manage"]);
     const [title, setTitle] = useState("");
     const [excerpt, setExcerpt] = useState("");
     const [body, setBody] = useState("");
@@ -86,128 +89,132 @@ function NewsAdminPage() {
                 </p>
             </div>
 
-            <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Innhold</CardTitle>
-                        <CardDescription>
-                            Tittel, utdrag, og brødtekst. Brødteksten lagres som
-                            markdown i databasen.
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <FieldGroup>
-                            <Field>
-                                <FieldLabel htmlFor="news-title">
-                                    Tittel
-                                </FieldLabel>
-                                <Input
-                                    id="news-title"
-                                    type="text"
-                                    required
-                                    value={title}
-                                    onChange={(event) =>
-                                        setTitle(event.target.value)
-                                    }
-                                />
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="news-excerpt">
-                                    Utdrag
-                                </FieldLabel>
-                                <Textarea
-                                    id="news-excerpt"
-                                    rows={2}
-                                    required
-                                    value={excerpt}
-                                    onChange={(event) =>
-                                        setExcerpt(event.target.value)
-                                    }
-                                />
-                            </Field>
-                            <Field>
-                                <FieldLabel>Brødtekst</FieldLabel>
-                                <RichEditor
-                                    registry={richRegistry}
-                                    value={body}
-                                    onChange={setBody}
-                                />
-                            </Field>
-                        </FieldGroup>
-                    </CardContent>
-                </Card>
+            {!canCreate ? <AdminNoAccess action="publisere nyheter" /> : null}
 
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Forsidebilde</CardTitle>
-                        <CardDescription>
-                            Bildet vises på nyhetskortet og øverst på
-                            nyhetssiden. Forhåndsvisningen under er nøyaktig
-                            samme utsnitt som besøkende ser.
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <FieldGroup>
-                            <AdminImageField
-                                label="Bilde"
-                                preset="cover-wide"
-                                value={image}
-                                onChange={setImage}
-                            />
-                            <Field>
-                                <FieldLabel htmlFor="news-image-alt">
-                                    Bildebeskrivelse
-                                </FieldLabel>
-                                <Input
-                                    id="news-image-alt"
-                                    type="text"
-                                    maxLength={255}
-                                    placeholder="Kort beskrivelse for skjermlesere"
-                                    value={imageAlt}
-                                    onChange={(event) =>
-                                        setImageAlt(event.target.value)
-                                    }
+            {canCreate ? (
+                <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Innhold</CardTitle>
+                            <CardDescription>
+                                Tittel, utdrag, og brødtekst. Brødteksten lagres
+                                som markdown i databasen.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <FieldGroup>
+                                <Field>
+                                    <FieldLabel htmlFor="news-title">
+                                        Tittel
+                                    </FieldLabel>
+                                    <Input
+                                        id="news-title"
+                                        type="text"
+                                        required
+                                        value={title}
+                                        onChange={(event) =>
+                                            setTitle(event.target.value)
+                                        }
+                                    />
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="news-excerpt">
+                                        Utdrag
+                                    </FieldLabel>
+                                    <Textarea
+                                        id="news-excerpt"
+                                        rows={2}
+                                        required
+                                        value={excerpt}
+                                        onChange={(event) =>
+                                            setExcerpt(event.target.value)
+                                        }
+                                    />
+                                </Field>
+                                <Field>
+                                    <FieldLabel>Brødtekst</FieldLabel>
+                                    <RichEditor
+                                        registry={richRegistry}
+                                        value={body}
+                                        onChange={setBody}
+                                    />
+                                </Field>
+                            </FieldGroup>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Forsidebilde</CardTitle>
+                            <CardDescription>
+                                Bildet vises på nyhetskortet og øverst på
+                                nyhetssiden. Forhåndsvisningen under er nøyaktig
+                                samme utsnitt som besøkende ser.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <FieldGroup>
+                                <AdminImageField
+                                    label="Bilde"
+                                    preset="cover-wide"
+                                    value={image}
+                                    onChange={setImage}
                                 />
-                            </Field>
-                        </FieldGroup>
-                    </CardContent>
-                </Card>
+                                <Field>
+                                    <FieldLabel htmlFor="news-image-alt">
+                                        Bildebeskrivelse
+                                    </FieldLabel>
+                                    <Input
+                                        id="news-image-alt"
+                                        type="text"
+                                        maxLength={255}
+                                        placeholder="Kort beskrivelse for skjermlesere"
+                                        value={imageAlt}
+                                        onChange={(event) =>
+                                            setImageAlt(event.target.value)
+                                        }
+                                    />
+                                </Field>
+                            </FieldGroup>
+                        </CardContent>
+                    </Card>
 
-                {uploadError && (
-                    <Alert variant="destructive">
-                        <XCircle className="size-4" />
-                        <AlertTitle>Kunne ikke laste opp bildet</AlertTitle>
-                        <AlertDescription>{uploadError}</AlertDescription>
-                    </Alert>
-                )}
-                {createNews.isSuccess && (
-                    <Alert>
-                        <CheckCircle2 className="size-4" />
-                        <AlertTitle>Publisert</AlertTitle>
-                        <AlertDescription>
-                            Nyheten ble opprettet.
-                        </AlertDescription>
-                    </Alert>
-                )}
-                {createNews.isError && (
-                    <Alert variant="destructive">
-                        <XCircle className="size-4" />
-                        <AlertTitle>Kunne ikke publisere</AlertTitle>
-                        <AlertDescription>
-                            {createNews.error.message}
-                        </AlertDescription>
-                    </Alert>
-                )}
+                    {uploadError && (
+                        <Alert variant="destructive">
+                            <XCircle className="size-4" />
+                            <AlertTitle>Kunne ikke laste opp bildet</AlertTitle>
+                            <AlertDescription>{uploadError}</AlertDescription>
+                        </Alert>
+                    )}
+                    {createNews.isSuccess && (
+                        <Alert>
+                            <CheckCircle2 className="size-4" />
+                            <AlertTitle>Publisert</AlertTitle>
+                            <AlertDescription>
+                                Nyheten ble opprettet.
+                            </AlertDescription>
+                        </Alert>
+                    )}
+                    {createNews.isError && (
+                        <Alert variant="destructive">
+                            <XCircle className="size-4" />
+                            <AlertTitle>Kunne ikke publisere</AlertTitle>
+                            <AlertDescription>
+                                {createNews.error.message}
+                            </AlertDescription>
+                        </Alert>
+                    )}
 
-                <div className="flex justify-end">
-                    <Button
-                        type="submit"
-                        disabled={createNews.isPending || isUploading}
-                    >
-                        {isUploading ? "Laster opp bilde …" : "Publiser"}
-                    </Button>
-                </div>
-            </form>
+                    <div className="flex justify-end">
+                        <Button
+                            type="submit"
+                            disabled={createNews.isPending || isUploading}
+                        >
+                            {isUploading ? "Laster opp bilde …" : "Publiser"}
+                        </Button>
+                    </div>
+                </form>
+            ) : null}
         </div>
     );
 }

--- a/apps/kvark/src/routes/admin/oppmote.tsx
+++ b/apps/kvark/src/routes/admin/oppmote.tsx
@@ -31,6 +31,8 @@ import {
     setAttendanceMutation,
 } from "#/api/queries/events";
 import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AdminNoAccess } from "#/components/admin-no-access";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { AdminStatCard } from "#/components/admin-stat-card";
 
@@ -58,6 +60,10 @@ export const Route = createFileRoute("/admin/oppmote")({
 });
 
 function AttendanceAdminPage() {
+    const canSetAttendance = useAnyScopePermission([
+        "events:update",
+        "events:manage",
+    ]);
     const { data: events } = useSuspenseQuery(getEventsQuery(0));
     const [eventId, setEventId] = useState<string | null>(
         events.items[0]?.id ?? null,
@@ -78,49 +84,58 @@ function AttendanceAdminPage() {
                 description="Registrer hvem som møtte opp. Deltakere som fortsatt står som påmeldt når arrangementet er over, kan få prikker for no-show."
             />
 
-            <Alert>
-                <InfoIcon className="size-4" />
-                <AlertTitle>Slik gis no-show-prikker</AlertTitle>
-                <AlertDescription>
-                    Huk av dem som møtte opp. Etter at arrangementet er slutt
-                    gir systemet automatisk 2 prikker til alle som fortsatt er
-                    påmeldt – men kun for arrangementer som kan gi prikker, og
-                    kun dersom minst én er huket av.
-                </AlertDescription>
-            </Alert>
-
-            <Field className="sm:max-w-96">
-                <FieldLabel>Arrangement</FieldLabel>
-                <Select
-                    items={eventOptions}
-                    value={eventId ?? ""}
-                    onValueChange={setEventId}
-                >
-                    <SelectTrigger>
-                        <SelectValue placeholder="Velg arrangement" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        {eventOptions.map((option) => (
-                            <SelectItem key={option.value} value={option.value}>
-                                {option.label}
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
-            </Field>
-
-            {eventId ? (
-                <AttendanceSection eventId={eventId} />
+            {!canSetAttendance ? (
+                <AdminNoAccess action="registrere oppmøte" />
             ) : (
-                <Card>
-                    <CardContent>
-                        <AdminEmptyState
-                            icon={CircleCheckBigIcon}
-                            title="Ingen arrangementer"
-                            description="Det finnes ingen arrangementer å registrere oppmøte for."
-                        />
-                    </CardContent>
-                </Card>
+                <>
+                    <Alert>
+                        <InfoIcon className="size-4" />
+                        <AlertTitle>Slik gis no-show-prikker</AlertTitle>
+                        <AlertDescription>
+                            Huk av dem som møtte opp. Etter at arrangementet er
+                            slutt gir systemet automatisk 2 prikker til alle som
+                            fortsatt er påmeldt – men kun for arrangementer som
+                            kan gi prikker, og kun dersom minst én er huket av.
+                        </AlertDescription>
+                    </Alert>
+
+                    <Field className="sm:max-w-96">
+                        <FieldLabel>Arrangement</FieldLabel>
+                        <Select
+                            items={eventOptions}
+                            value={eventId ?? ""}
+                            onValueChange={setEventId}
+                        >
+                            <SelectTrigger>
+                                <SelectValue placeholder="Velg arrangement" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {eventOptions.map((option) => (
+                                    <SelectItem
+                                        key={option.value}
+                                        value={option.value}
+                                    >
+                                        {option.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </Field>
+
+                    {eventId ? (
+                        <AttendanceSection eventId={eventId} />
+                    ) : (
+                        <Card>
+                            <CardContent>
+                                <AdminEmptyState
+                                    icon={CircleCheckBigIcon}
+                                    title="Ingen arrangementer"
+                                    description="Det finnes ingen arrangementer å registrere oppmøte for."
+                                />
+                            </CardContent>
+                        </Card>
+                    )}
+                </>
             )}
         </div>
     );

--- a/apps/kvark/src/routes/admin/opptak.tsx
+++ b/apps/kvark/src/routes/admin/opptak.tsx
@@ -28,6 +28,7 @@ import { Suspense, lazy, useEffect, useState } from "react";
 
 import { uploadAssetMutation } from "#/api/queries/assets";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import {
     activateContractMutation,
     createContractMutation,
@@ -49,6 +50,14 @@ export const Route = createFileRoute("/admin/opptak")({
 function OpptakAdminPage() {
     const { data: contracts } = useSuspenseQuery(getContractListQuery());
     const activateContract = useMutation(activateContractMutation);
+    const canUpload = useAnyScopePermission([
+        "contracts:create",
+        "contracts:manage",
+    ]);
+    const canActivate = useAnyScopePermission([
+        "contracts:update",
+        "contracts:manage",
+    ]);
 
     return (
         <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
@@ -56,10 +65,14 @@ function OpptakAdminPage() {
                 title="Kontraktstyring"
                 description="Last opp og administrer frivillighetskontrakter."
             />
-            <UploadContractCard />
+            {canUpload ? <UploadContractCard /> : null}
             <ContractListCard
                 contracts={contracts}
-                onActivate={(id) => activateContract.mutate({ id })}
+                onActivate={
+                    canActivate
+                        ? (id) => activateContract.mutate({ id })
+                        : undefined
+                }
             />
         </div>
     );
@@ -227,7 +240,7 @@ function ContractListCard({
     onActivate,
 }: {
     contracts: Contract[];
-    onActivate: (id: string) => void;
+    onActivate?: (id: string) => void;
 }) {
     if (!contracts.length) {
         return (
@@ -282,7 +295,8 @@ function ContractRow({
     onActivate,
 }: {
     contract: Contract;
-    onActivate: (id: string) => void;
+    /** Omitted when the viewer may not activate contracts — no button then. */
+    onActivate?: (id: string) => void;
 }) {
     return (
         <TableRow>
@@ -299,7 +313,7 @@ function ContractRow({
                 {new Date(contract.createdAt).toLocaleDateString("nb-NO")}
             </TableCell>
             <TableCell>
-                {!contract.isActive && (
+                {!contract.isActive && onActivate && (
                     <Button
                         size="sm"
                         variant="outline"

--- a/apps/kvark/src/routes/admin/prikker.tsx
+++ b/apps/kvark/src/routes/admin/prikker.tsx
@@ -43,6 +43,7 @@ import {
 import { searchUsersQuery } from "#/api/queries/roles";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import {
     UserSearchCombobox,
     type UserSearchOption,
@@ -55,6 +56,10 @@ export const Route = createFileRoute("/admin/prikker")({
 });
 
 function StrikesAdminPage() {
+    const canCreate = useAnyScopePermission([
+        "events:strikes:create",
+        "events:manage",
+    ]);
     const [createOpen, setCreateOpen] = useState(false);
 
     return (
@@ -64,10 +69,12 @@ function StrikesAdminPage() {
                     title="Prikker"
                     description="Se og administrer prikker medlemmer har fått på arrangementer."
                 />
-                <Button onClick={() => setCreateOpen(true)}>
-                    <PlusIcon className="size-4" />
-                    Ny prikk
-                </Button>
+                {canCreate ? (
+                    <Button onClick={() => setCreateOpen(true)}>
+                        <PlusIcon className="size-4" />
+                        Ny prikk
+                    </Button>
+                ) : null}
             </div>
 
             <StrikesSection />
@@ -84,6 +91,10 @@ function StrikesSection() {
     const [page, setPage] = useState(0);
     const { data, isPending } = useQuery(getStrikesQuery(page));
     const remove = useMutation(deleteStrikeMutation);
+    const canDelete = useAnyScopePermission([
+        "events:strikes:delete",
+        "events:manage",
+    ]);
 
     if (isPending) {
         return (
@@ -173,16 +184,18 @@ function StrikesSection() {
                                     </TableCell>
                                     <TableCell>
                                         <div className="flex justify-end">
-                                            <Button
-                                                variant="destructive"
-                                                size="sm"
-                                                disabled={remove.isPending}
-                                                onClick={() =>
-                                                    handleDelete(strike)
-                                                }
-                                            >
-                                                <Trash2 className="size-4" />
-                                            </Button>
+                                            {canDelete ? (
+                                                <Button
+                                                    variant="destructive"
+                                                    size="sm"
+                                                    disabled={remove.isPending}
+                                                    onClick={() =>
+                                                        handleDelete(strike)
+                                                    }
+                                                >
+                                                    <Trash2 className="size-4" />
+                                                </Button>
+                                            ) : null}
                                         </div>
                                     </TableCell>
                                 </TableRow>

--- a/apps/kvark/src/routes/admin/roller.tsx
+++ b/apps/kvark/src/routes/admin/roller.tsx
@@ -54,6 +54,11 @@ import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminGroupPicker } from "#/components/admin-group-picker";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import {
+    useIsGroupLeaderOf,
+    usePermission,
+    useScopedPermission,
+} from "#/hooks/use-permission";
+import {
     UserSearchCombobox,
     type UserSearchOption,
 } from "#/components/user-search-combobox";
@@ -76,8 +81,33 @@ export const Route = createFileRoute("/admin/roller")({
 
 type TabValue = "verv" | "roller";
 
+/**
+ * Whether the viewer may manage the verv of `groupSlug`.
+ *
+ * Mirrors `canManagePositions` server-side for group-scoped positions:
+ * `groups:manage`/`roles:create` globally or for this group, or being the
+ * group's leader.
+ */
+function useCanManagePositions(groupSlug: string): boolean {
+    const hasScoped = useScopedPermission(
+        ["groups:manage", "roles:create"],
+        `group:${groupSlug}`,
+    );
+    const isLeader = useIsGroupLeaderOf(groupSlug);
+    return hasScoped || isLeader;
+}
+
 function RolesAdminPage() {
     const [tab, setTab] = useState<TabValue>("verv");
+    // Global roles are listed and edited with global roles:* permissions —
+    // a group leader has no business in that tab, so it is not shown.
+    const canSeeRoles = usePermission([
+        "roles:view",
+        "roles:create",
+        "roles:update",
+        "roles:delete",
+        "roles:assign",
+    ]);
 
     return (
         <div className="container mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8">
@@ -89,11 +119,17 @@ function RolesAdminPage() {
             <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
                 <TabsList>
                     <TabsTrigger value="verv">Verv</TabsTrigger>
-                    <TabsTrigger value="roller">Roller</TabsTrigger>
+                    {canSeeRoles ? (
+                        <TabsTrigger value="roller">Roller</TabsTrigger>
+                    ) : null}
                 </TabsList>
             </Tabs>
 
-            {tab === "verv" ? <PositionsSection /> : <RolesSection />}
+            {tab === "verv" || !canSeeRoles ? (
+                <PositionsSection />
+            ) : (
+                <RolesSection />
+            )}
         </div>
     );
 }
@@ -202,12 +238,12 @@ function PositionsSection() {
                         onValueChange={setGroupSlug}
                     />
                 </Field>
-                {groupSlug && (
-                    <Button onClick={() => setCreateOpen(true)}>
-                        <PlusIcon className="size-4" />
-                        Nytt verv
-                    </Button>
-                )}
+                {groupSlug ? (
+                    <NewPositionButton
+                        groupSlug={groupSlug}
+                        onClick={() => setCreateOpen(true)}
+                    />
+                ) : null}
             </div>
 
             {groupSlug ? <PositionsTable groupSlug={groupSlug} /> : null}
@@ -224,7 +260,29 @@ function PositionsSection() {
     );
 }
 
+/**
+ * Own component so the permission hook can depend on the selected group
+ * without the section re-running hooks conditionally.
+ */
+function NewPositionButton({
+    groupSlug,
+    onClick,
+}: {
+    groupSlug: string;
+    onClick: () => void;
+}) {
+    const canManage = useCanManagePositions(groupSlug);
+    if (!canManage) return null;
+    return (
+        <Button onClick={onClick}>
+            <PlusIcon className="size-4" />
+            Nytt verv
+        </Button>
+    );
+}
+
 function PositionsTable({ groupSlug }: { groupSlug: string }) {
+    const canManage = useCanManagePositions(groupSlug);
     const { data: positions, isPending } = useQuery(
         getGroupPositionsQuery(groupSlug),
     );
@@ -359,17 +417,23 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                                                     image={
                                                         position.holder.image
                                                     }
-                                                    onRemove={() =>
-                                                        unassign.mutate({
-                                                            groupSlug,
-                                                            positionId:
-                                                                position.id,
-                                                            userId: position
-                                                                .holder!.userId,
-                                                        })
+                                                    onRemove={
+                                                        canManage
+                                                            ? () =>
+                                                                  unassign.mutate(
+                                                                      {
+                                                                          groupSlug,
+                                                                          positionId:
+                                                                              position.id,
+                                                                          userId: position
+                                                                              .holder!
+                                                                              .userId,
+                                                                      },
+                                                                  )
+                                                            : undefined
                                                     }
                                                 />
-                                            ) : (
+                                            ) : canManage ? (
                                                 <UserSearchCombobox
                                                     holder={null}
                                                     emptyLabel="Ingen tildelt"
@@ -406,6 +470,10 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                                                     }
                                                     placeholder="Søk blant gruppens medlemmer…"
                                                 />
+                                            ) : (
+                                                <span className="text-sm text-muted-foreground">
+                                                    Ingen tildelt
+                                                </span>
                                             )}
                                         </div>
                                     </TableCell>
@@ -415,31 +483,35 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                                         )}
                                     </TableCell>
                                     <TableCell>
-                                        <DropdownMenu>
-                                            <DropdownMenuTrigger
-                                                aria-label="Handlinger"
-                                                className="cursor-pointer"
-                                            >
-                                                <MoreHorizontalIcon className="size-4" />
-                                            </DropdownMenuTrigger>
-                                            <DropdownMenuContent align="end">
-                                                <DropdownMenuItem
-                                                    onClick={() =>
-                                                        setEditing(position)
-                                                    }
+                                        {canManage ? (
+                                            <DropdownMenu>
+                                                <DropdownMenuTrigger
+                                                    aria-label="Handlinger"
+                                                    className="cursor-pointer"
                                                 >
-                                                    Rediger
-                                                </DropdownMenuItem>
-                                                <DropdownMenuItem
-                                                    variant="destructive"
-                                                    onClick={() =>
-                                                        handleDelete(position)
-                                                    }
-                                                >
-                                                    Slett
-                                                </DropdownMenuItem>
-                                            </DropdownMenuContent>
-                                        </DropdownMenu>
+                                                    <MoreHorizontalIcon className="size-4" />
+                                                </DropdownMenuTrigger>
+                                                <DropdownMenuContent align="end">
+                                                    <DropdownMenuItem
+                                                        onClick={() =>
+                                                            setEditing(position)
+                                                        }
+                                                    >
+                                                        Rediger
+                                                    </DropdownMenuItem>
+                                                    <DropdownMenuItem
+                                                        variant="destructive"
+                                                        onClick={() =>
+                                                            handleDelete(
+                                                                position,
+                                                            )
+                                                        }
+                                                    >
+                                                        Slett
+                                                    </DropdownMenuItem>
+                                                </DropdownMenuContent>
+                                            </DropdownMenu>
+                                        ) : null}
                                     </TableCell>
                                 </TableRow>
                             ))}

--- a/apps/kvark/src/routes/admin/soknader.tsx
+++ b/apps/kvark/src/routes/admin/soknader.tsx
@@ -26,6 +26,7 @@ import {
 } from "#/api/queries/applications";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import { AdminDetailDialog } from "#/components/soknader/admin-detail-dialog";
 import { ApplicationStatusBadge } from "#/components/soknader/status-badge";
 
@@ -93,6 +94,17 @@ function AdminApplicationsPage() {
     const navigate = Route.useNavigate();
 
     const { data: session } = useQuery(authQueryOptions);
+    // The list and the detail view need `*:view`; changing the status needs
+    // `*:manage`. Without it the dialog is read-only and the row button says
+    // "Se" instead of promising a decision the viewer cannot make.
+    const canManage = useAnyScopePermission([
+        "applications:manage",
+        "applications:expense:manage",
+        "applications:support:manage",
+        "applications:sports-support:manage",
+        "applications:hs-case:manage",
+        "applications:company-contact:manage",
+    ]);
     const visibleTabs = TYPE_TABS.filter((tab) =>
         sessionHasPermission(session?.permissions, tab.permissions),
     );
@@ -259,7 +271,9 @@ function AdminApplicationsPage() {
                                                         )
                                                     }
                                                 >
-                                                    Behandle
+                                                    {canManage
+                                                        ? "Behandle"
+                                                        : "Se"}
                                                 </Button>
                                             </div>
                                         </TableCell>
@@ -280,6 +294,7 @@ function AdminApplicationsPage() {
                 isLoading={isLoadingDetail}
                 attachmentUrls={attachmentUrls}
                 isSaving={updateStatus.isPending}
+                canManage={canManage}
                 onDownloadPdf={() => {
                     if (selectedId) void downloadPdf(selectedId);
                 }}

--- a/apps/kvark/src/routes/admin/toddel.tsx
+++ b/apps/kvark/src/routes/admin/toddel.tsx
@@ -47,6 +47,7 @@ import {
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 
 export const Route = createFileRoute("/admin/toddel")({
     component: ToddelAdminPage,
@@ -76,6 +77,7 @@ const PDF_UPLOAD_BLOCKED_NOTE =
     "Serveren avviser filer over 1 MB, og Töddel-PDF-er er større. Nye utgaver kan legges ut når grensen er hevet.";
 
 function ToddelAdminPage() {
+    const canCreate = useAnyScopePermission(["toddel:create", "toddel:manage"]);
     const [dialog, setDialog] = useState<
         { mode: "create" } | { mode: "edit"; issue: ToddelIssue } | null
     >(null);
@@ -86,13 +88,15 @@ function ToddelAdminPage() {
                 title="TÖDDEL"
                 description="Legg ut nye utgaver av studentbladet, og rediger de som allerede ligger ute."
                 action={
-                    <Button
-                        disabled={PDF_UPLOAD_BLOCKED}
-                        onClick={() => setDialog({ mode: "create" })}
-                    >
-                        <PlusIcon className="size-4" />
-                        Ny utgave
-                    </Button>
+                    canCreate ? (
+                        <Button
+                            disabled={PDF_UPLOAD_BLOCKED}
+                            onClick={() => setDialog({ mode: "create" })}
+                        >
+                            <PlusIcon className="size-4" />
+                            Ny utgave
+                        </Button>
+                    ) : null
                 }
             />
 
@@ -140,6 +144,8 @@ function TableSkeleton() {
 function IssuesTable({ onEdit }: { onEdit: (issue: ToddelIssue) => void }) {
     const { data: issues } = useSuspenseQuery(getToddelIssuesQuery());
     const remove = useMutation(deleteToddelMutation);
+    const canEdit = useAnyScopePermission(["toddel:update", "toddel:manage"]);
+    const canDelete = useAnyScopePermission(["toddel:delete", "toddel:manage"]);
 
     if (issues.length === 0) {
         return (
@@ -214,22 +220,28 @@ function IssuesTable({ onEdit }: { onEdit: (issue: ToddelIssue) => void }) {
                                 </TableCell>
                                 <TableCell>
                                     <div className="flex justify-end gap-2">
-                                        <Button
-                                            variant="outline"
-                                            size="sm"
-                                            onClick={() => onEdit(issue)}
-                                        >
-                                            <PencilIcon className="size-4" />
-                                            Rediger
-                                        </Button>
-                                        <Button
-                                            variant="destructive"
-                                            size="sm"
-                                            disabled={remove.isPending}
-                                            onClick={() => handleDelete(issue)}
-                                        >
-                                            <Trash2 className="size-4" />
-                                        </Button>
+                                        {canEdit ? (
+                                            <Button
+                                                variant="outline"
+                                                size="sm"
+                                                onClick={() => onEdit(issue)}
+                                            >
+                                                <PencilIcon className="size-4" />
+                                                Rediger
+                                            </Button>
+                                        ) : null}
+                                        {canDelete ? (
+                                            <Button
+                                                variant="destructive"
+                                                size="sm"
+                                                disabled={remove.isPending}
+                                                onClick={() =>
+                                                    handleDelete(issue)
+                                                }
+                                            >
+                                                <Trash2 className="size-4" />
+                                            </Button>
+                                        ) : null}
                                     </div>
                                 </TableCell>
                             </TableRow>

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1332,7 +1332,7 @@ export interface paths {
         put?: never;
         /**
          * Add member to group
-         * @description Add a member to a group. Requires 'groups:manage' permission.
+         * @description Add a member to a group. Requires 'groups:manage' (globally or scoped to the group), or being the group's leader.
          */
         post: operations["addGroupMember"];
         delete?: never;
@@ -1353,7 +1353,7 @@ export interface paths {
         post?: never;
         /**
          * Remove member from group
-         * @description Remove a member from a group. Requires 'groups:manage' permission.
+         * @description Remove a member from a group. Requires 'groups:manage' (globally or scoped to the group), or being the group's leader.
          */
         delete: operations["removeGroupMember"];
         options?: never;
@@ -3104,6 +3104,8 @@ export interface components {
             image: string | null;
             /** @description Alt text for the event image (nullable) */
             imageAlt: string | null;
+            /** @description Creator user ID. The creator may update and delete their own event, so clients need it to decide whether to offer those actions. */
+            createdById: string | null;
             /**
              * Format: date-time
              * @description Event creation time (ISO 8601)


### PR DESCRIPTION
## Hva

Knapper som utfører noe brukeren ikke har tilgang til, vises ikke lenger. Gjelder hele nettsiden — offentlige detaljsider, gruppesider og alle admin-seksjonene.

Den mest synlige feilen: `ADMIN_DASHBOARD_PERMISSIONS` inneholdt `fines:create`, som **hver eneste student** har globalt via `member`-rollen. `useIsAdmin` var derfor sann for alle innloggede, så «Admin»-lenken i profilmenyen og kommandopaletten ble vist til hele medlemsmassen. Admin-sidebaren hadde i tillegg tilgangskrav på kun 2 av 17 oppføringer — inkludert hele Super Admin-seksjonen.

## Hvordan

Sjekkene speiler serverens `requireAccess` i stedet for å gjette. Tre nye hjelpere i `api/auth.ts` + `hooks/use-permission.ts`:

| Hjelper | Regel | Brukes når |
|---|---|---|
| `sessionHasScopedPermission` | global **eller** eksakt scope | scopet er kjent (gruppesider, admin/grupper, verv) |
| `sessionHasPermissionInAnyScope` | grant i hvilken som helst scope | inngang til lister som blander flere grupper |
| `useCanActOnResource` | tilgangen **eller** å være oppretteren | nyheter, annonser, arrangementer |

`ADMIN_SECTION_PERMISSIONS` (ny, i `lib/admin-sections.ts`) er én kilde for hvilke tilganger som åpner hver admin-seksjon, delt av sidebar, dashboard og `useIsAdmin` — inngangspunktet kan ikke komme i utakt med menyen.

Any-scope brukes bevisst der UI-et ikke kan vite hvilket scope handlingen ender i: å skjule inngangen fra en som har tilgangen for *én* gruppe ville tatt fra dem arbeid de har lov til. API-et avviser den enkelte forespørselen.

Sider der hele siden er én privilegert handling (nyhets- og arrangementsskjemaet, oppmøteregistrering) viser «Du har ikke tilgang» i stedet for et skjema som ikke kan sendes.

## API-endringer

- **Arrangementer eksponerer `createdById`.** Uten det kunne ikke frontend se at oppretteren har lov til å redigere sitt eget arrangement, og knappen ble feilaktig skjult for dem.
- **`POST`/`DELETE /groups/:slug/members` godtar nå gruppeleder** eller `groups:manage` scopet til gruppa, ikke bare global `groups:manage`. Å legge til noen **som leder** krever fortsatt `groups:manage` — det drar med seg lederrollen og en plass i HS. Rolleendring (medlem ↔ leder) er urørt og krever fortsatt global tilgang.

## Bonus-fiks

Admin-dashboardet krasjet med 403 for alle uten `contracts:view`, fordi loaderen alltid hentet `/api/contracts`. Den henter nå bare det brukeren får lese, og kontraktkortet er skilt ut i egen komponent så spørringen ikke kjører for andre.

## Verifisering

- `typecheck` 9/9, `build` 4/4, `lint` uten nye treff.
- Nye integrasjonstester: gruppeleder får 201 når de legger til et medlem uten `groups:manage`, og 403 når de prøver å legge til en leder. Grupper-, kontrakts- og rbac-suitene: 141/141.
- Kjørt lokalt med testbrukeren nedgradert i dev-DB til rent `member`: forsiden, nyhetssiden, profilmenyen og admin ble riktig strippet. Som gruppeleder dukket «Roller og verv», «Legg til medlem» og «Gi bot» opp igjen — men «Nytt verv» kun for gruppen de leder. Som oppretter av et arrangement vises «Rediger arrangement» på det arrangementet og ikke på andre. Root ser alt som før.

## Verdt å vite for reviewer

- **Rutene er ikke vaktet.** Skriver du `/admin/brukere` direkte får du fortsatt siden, nå uten knapper. API-et beskytter dataene. Redirect kan legges på med `authClientWithPermission` i `beforeLoad` per seksjon — bevisst utelatt her fordi det er en ruteendring, og fordi vakten i så fall må bruke any-scope + leder-unntaket for ikke å låse ute gruppeledere.
- **Gruppeledere ser «Admin».** De kan administrere verv i egen gruppe, så de har én reell seksjon. Regelen er «du ser Admin hvis og bare hvis minst én seksjon er åpen for deg».
- **«Gi bot» er strengere enn API-et.** `member`-rollen har `fines:create` globalt, så API-et lar hvem som helst foreslå en bot i hvilken som helst gruppe. UI-et viser knappen kun for ledere/botsjef/admin, som før. Serverside-sjekken bør trolig scopes til gruppa — ikke gjort her.

🤖 Generated with [Claude Code](https://claude.com/claude-code)