### PR TITLE
fix(kvark): gjør det tydelig hvilken e-post som skal bekreftes

### DIFF
--- a/apps/kvark/src/components/feide-sign-in-issue.tsx
+++ b/apps/kvark/src/components/feide-sign-in-issue.tsx
@@ -29,6 +29,14 @@ export type FeideSignInIssueProps = {
     onSendVerification: (email: string) => void;
     verificationSending?: boolean;
     verificationSent?: boolean;
+    /**
+     * Set when the request itself failed. Not "wrong address": the endpoint
+     * answers 200 either way, on purpose. Without this the form would sit
+     * there looking unpressed whenever the call did not go through.
+     */
+    verificationError?: string;
+    /** Clears the sent state so a wrong address can be corrected. */
+    onTryAnotherEmail?: () => void;
 
     onRequestHelp: (input: AccountLinkHelpInput) => void;
     helpSending?: boolean;
@@ -76,7 +84,9 @@ export function FeideSignInIssue(props: FeideSignInIssueProps) {
                 onSend={props.onSendVerification}
                 sending={props.verificationSending ?? false}
                 sent={props.verificationSent ?? false}
+                error={props.verificationError}
                 onNeedHelp={() => setStep("help")}
+                onTryAnother={props.onTryAnotherEmail}
             />
         );
     }
@@ -123,12 +133,16 @@ function VerifyEmailPrompt({
     onSend,
     sending,
     sent,
+    error,
     onNeedHelp,
+    onTryAnother,
 }: {
     onSend: (email: string) => void;
     sending: boolean;
     sent: boolean;
+    error?: string;
     onNeedHelp: () => void;
+    onTryAnother?: () => void;
 }) {
     const [email, setEmail] = useState("");
 
@@ -140,15 +154,39 @@ function VerifyEmailPrompt({
                     Finnes adressen hos oss, har vi sendt en lenke. Åpne den, så
                     kobler vi kontoen til Feide.
                 </AlertDescription>
+                {/* The endpoint answers the same whether or not the address
+                    exists, so a member who guessed wrong just sees nothing
+                    arrive. Without a way back they are stuck on a screen that
+                    looks like success. */}
+                <div className="mt-3 flex flex-col gap-2">
+                    {onTryAnother && (
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={onTryAnother}
+                        >
+                            Kom ingen e-post? Prøv en annen adresse
+                        </Button>
+                    )}
+                    <Button type="button" variant="link" onClick={onNeedHelp}>
+                        Husker du ikke e-posten?
+                    </Button>
+                </div>
             </Alert>
         );
     }
 
     return (
         <Alert>
-            <AlertTitle>Bekreft e-posten din</AlertTitle>
+            {/* Asking which account, rather than "bekreft e-posten din",
+                because the mistake to prevent is answering with the address
+                they use today. Most migrated accounts predate the member
+                having an NTNU address at all: 986 of 1685 carry a private
+                one, so @stud.ntnu.no is the likeliest wrong answer and is
+                worth naming outright. */}
+            <AlertTitle>Hvilken e-post hadde den gamle brukeren?</AlertTitle>
             <AlertDescription>
-                Skriv inn e-posten du brukte på den gamle brukeren din.
+                Som regel en privat adresse — ikke @stud.ntnu.no.
             </AlertDescription>
             <form
                 className="mt-3 flex flex-col gap-2"
@@ -175,6 +213,7 @@ function VerifyEmailPrompt({
                         "Send lenke"
                     )}
                 </Button>
+                {error && <p className="text-sm text-destructive">{error}</p>}
                 <Button type="button" variant="link" onClick={onNeedHelp}>
                     Husker du ikke e-posten?
                 </Button>

--- a/apps/kvark/src/routes/_auth/login.tsx
+++ b/apps/kvark/src/routes/_auth/login.tsx
@@ -160,6 +160,16 @@ function LoginPage() {
                         }
                         verificationSending={verificationMutation.isPending}
                         verificationSent={verificationMutation.isSuccess}
+                        // The endpoint answers 200 whether or not the address
+                        // exists, so a failure here is never "wrong address" —
+                        // it is the request itself not getting through. Say
+                        // only that, rather than guessing at a cause.
+                        verificationError={
+                            verificationMutation.isError
+                                ? "Fikk ikke sendt lenken. Prøv igjen."
+                                : undefined
+                        }
+                        onTryAnotherEmail={() => verificationMutation.reset()}
                         onRequestHelp={(data) => helpMutation.mutate({ data })}
                         helpSending={helpMutation.isPending}
                         helpSent={helpMutation.isSuccess}


### PR DESCRIPTION
Ble liggende igjen da #318 ble merget før denne commiten rakk å bli pushet. Samme endring, ny PR.

## Problemet

Steget der et migrert medlem bekrefter e-posten sin spurte «Bekreft e-posten din» og ba om «e-posten du brukte på den gamle brukeren». Det leses lett som *din* e-post — altså den man bruker i dag.

For **986 av 1685** migrerte kontoer er den riktige adressen privat, ikke `@stud.ntnu.no`. Embret Roås koblet kontoen sin med en outlook-adresse, så feilen er reell og ikke hypotetisk.

**Nå:** «Hvilken e-post hadde den gamle brukeren?» / «Som regel en privat adresse — ikke @stud.ntnu.no.»

Spørsmålet peker på *hvilken konto* i stedet for på «din e-post», og linja under navngir det sannsynlige feilsvaret direkte.

## Feil adresse så ut som suksess

Testet endepunktet utlogget mot både en kjent og en ukjent adresse — **begge svarer 200**. Det er bevisst, så ingen kan kartlegge hvem som har konto. Men konsekvensen er at skriver du feil adresse får du «Sjekk innboksen din», og så kommer det aldri noe.

Uten en vei ut var medlemmet fast der. Lagt til **«Kom ingen e-post? Prøv en annen adresse»** på kvitteringsskjermen.

## Ingen feiltilstand fantes

Komponenten hadde bare `sending` og `sent`. Feilet kallet, sto skjemaet uendret og uten et ord. Viser nå «Fikk ikke sendt lenken. Prøv igjen.» — formulert som en overføringsfeil, ikke som «ukjent adresse», siden endepunktet aldri sier det.

## Verifisert

I nettleser mot lokal API og database: begge skjermbildene, feiltilstanden og tilbake-knappen. `bun run typecheck`, `lint` og `format` grønt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)