### PR TITLE
feat(kvark): vis de 3 nyeste nyhetene på forsiden

### DIFF
--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -10,13 +10,15 @@ import { Suspense } from "react";
 import { authQueryOptions } from "#/api/auth";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 import { getEventsQuery } from "#/api/queries/events";
+import { getNewsQuery } from "#/api/queries/news";
 import { getVisibleBannersQuery } from "#/api/queries/banners";
 import { EventCard } from "#/components/event-card";
 import { InfoBanner } from "#/components/info-banner";
-import { NewsCard, type NewsCardProps } from "#/components/news-card";
+import { NewsCard } from "#/components/news-card";
 import { TihldeLogo } from "#/components/icons/tihlde";
 import { HeroSectionBackground } from "#/components/hero-section";
 import { formatEventDateTime } from "#/lib/event";
+import { formatNewsDateRelative } from "#/lib/news";
 
 /** Enough events to fill a month in the calendar; the list shows a slice. */
 const EVENTS_PAGE_SIZE = 50;
@@ -27,32 +29,20 @@ const upcomingEventsQuery = () =>
 
 const LIST_PREVIEW_COUNT = 4;
 
+/** The three newest news items, ordered by the API. */
+const NEWS_PREVIEW_COUNT = 3;
+const latestNewsQuery = () => getNewsQuery(0, {}, NEWS_PREVIEW_COUNT);
+
 export const Route = createFileRoute("/_app/")({
     component: Home,
     loader: async ({ context }) => {
         await Promise.all([
             context.queryClient.ensureQueryData(upcomingEventsQuery()),
             context.queryClient.ensureQueryData(getVisibleBannersQuery()),
+            context.queryClient.ensureQueryData(latestNewsQuery()),
         ]);
     },
 });
-
-const NEWS: NewsCardProps[] = [
-    {
-        slug: "how-to-notion",
-        title: "How to Notion",
-        excerpt:
-            "Opplæring til Promo? Bruk Notion! Les vår nye guide om hvordan vi bruker Notion i undergrupper.",
-        publishedAt: "3 dager siden",
-    },
-    {
-        slug: "trivselsundersokelse-v26",
-        title: "TIHLDE Trivselsundersøkelse V26",
-        excerpt:
-            "Vinn gavekort ved å svare på den årlige trivselsundersøkelsen. Din stemme teller!",
-        publishedAt: "1 uke siden",
-    },
-];
 
 function Home() {
     // Admin-only shortcuts — the API enforces these permissions server-side
@@ -90,12 +80,9 @@ function Home() {
                     title="Nyheter"
                     actionLabel={canCreateNews ? "Ny nyhet" : undefined}
                 />
-                <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                    {NEWS.map((item) => (
-                        // TODO: replace with a unique id field once wired up to the backend
-                        <NewsCard key={item.title} {...item} />
-                    ))}
-                </div>
+                <Suspense fallback={<NewsSkeleton />}>
+                    <NewsSection />
+                </Suspense>
             </section>
         </>
     );
@@ -164,6 +151,39 @@ function EventsSection() {
                 />
             </TabsContent>
         </Tabs>
+    );
+}
+
+function NewsSection() {
+    const { data } = useSuspenseQuery(latestNewsQuery());
+    const news = data.items;
+
+    if (news.length === 0) return null;
+
+    return (
+        <ul className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {news.map((item) => (
+                <li key={item.id}>
+                    <NewsCard
+                        slug={item.id}
+                        title={item.title}
+                        excerpt={item.header ?? ""}
+                        publishedAt={formatNewsDateRelative(item.createdAt)}
+                        imageUrl={item.imageUrl || undefined}
+                    />
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+function NewsSkeleton() {
+    return (
+        <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: NEWS_PREVIEW_COUNT }, (_, i) => (
+                <Skeleton key={i} className="h-64 w-full" />
+            ))}
+        </div>
     );
 }
 


### PR DESCRIPTION
## Hva

Nyhetsseksjonen på forsiden henter nå de **3 nyeste nyhetene** fra API-et i stedet for to hardkodede eksempler.

## Hvorfor

Forsiden viste to statiske placeholder-nyheter («How to Notion», «TIHLDE Trivselsundersøkelse V26») med falske relative datoer og slugs som ikke pekte på ekte artikler — klikk endte på en nyhet som ikke finnes.

## Endringer

Alt ligger i `apps/kvark/src/routes/_app/index.tsx`:

- `latestNewsQuery()` = `getNewsQuery(0, {}, 3)`. `GET /api/news` sorterer allerede `desc(createdAt)` (`apps/api/src/routes/news/list.ts:40`), så side 0 med `pageSize: 3` gir de tre nyeste.
- Prefetches i route-loaderen sammen med arrangementer og bannere, så SSR har dataene.
- Ny `NewsSection` bruker `useSuspenseQuery` bak en `<Suspense>` med `NewsSkeleton` — samme mønster som arrangementsseksjonen.
- Mapping er identisk med `/nyheter`-lista: `slug={item.id}`, `header` som excerpt, `formatNewsDateRelative(createdAt)`, `imageUrl`.
- Fjernet `NEWS`-konstanten og den tilhørende TODO-en.

## Verifisert

Kjørt lokalt mot dev-API + dev-database:

- Forsiden rendrer 3 kort med ekte data, i samme rekkefølge som `GET /api/news?page=0&pageSize=3`.
- Lenkene peker på `/nyheter/<id>`, bildene lastes, ingen konsollfeil.
- `bun run typecheck` og `bun run format` grønne. `lint` viser kun eksisterende advarsler i `apps/api/src/test/asset/asset.test.ts` (urørt av denne PR-en).

**Forbehold:** skjermbilder fra browser-panelet kom ut blanke (panelet rapporterer `clientWidth: 0` for denne appen — kjent lokalt problem), så visuell layout er verifisert via DOM, ikke bilde. Grid-klassene er de samme som på den fungerende `/nyheter`-siden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)