### PR TITLE
feat(ui): demp footer-linje og card-flater i mørkt tema

### DIFF
--- a/apps/kvark/src/components/site-footer.tsx
+++ b/apps/kvark/src/components/site-footer.tsx
@@ -5,7 +5,7 @@ import { Facebook, Instagram, Linkedin } from "lucide-react";
 export function SiteFooter() {
     return (
         <footer className="w-full">
-            <Separator />
+            <Separator variant="subtle" />
             <div className="container mx-auto grid gap-8 px-4 py-10 md:grid-cols-3">
                 <div className="flex flex-col gap-2">
                     <h3 className="font-heading text-sm font-semibold">
@@ -83,7 +83,7 @@ export function SiteFooter() {
                     </a>
                 </div>
             </div>
-            <Separator />
+            <Separator variant="subtle" />
             <div className="container mx-auto flex flex-col items-center justify-between gap-2 px-4 py-6 md:flex-row">
                 <p>© {new Date().getFullYear()} TIHLDE</p>
                 <Link to="/personvern">Personvernerklæring</Link>

--- a/packages/ui/src/components/complex/event-calendar/event-calendar.tsx
+++ b/packages/ui/src/components/complex/event-calendar/event-calendar.tsx
@@ -132,7 +132,7 @@ export function EventCalendar({
     return (
         <div
             className={cn(
-                "flex w-full flex-col gap-4 overflow-hidden rounded-xl bg-card p-3 ring-1 ring-foreground/10 sm:p-4",
+                "flex w-full flex-col gap-4 overflow-hidden rounded-xl bg-card p-3 ring-1 ring-card-border sm:p-4",
                 className,
             )}
         >

--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -18,7 +18,7 @@ function Card({ className, size = "default", render, ...props }: CardProps) {
                 // `card-media` gets the same flush-to-the-edge treatment as a
                 // bare `img`, so a cover and its placeholder line up instead of
                 // the placeholder sitting inset below a strip of card.
-                "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 has-[>[data-slot=card-media]:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl *:[[data-slot=card-media]:first-child]:rounded-t-xl *:[[data-slot=card-media]:last-child]:rounded-b-xl",
+                "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-card-border has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 has-[>[data-slot=card-media]:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl *:[[data-slot=card-media]:first-child]:rounded-t-xl *:[[data-slot=card-media]:last-child]:rounded-b-xl",
                 className,
             ),
             ...props,

--- a/packages/ui/src/components/ui/separator.tsx
+++ b/packages/ui/src/components/ui/separator.tsx
@@ -4,17 +4,26 @@ import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
 
 import { cn } from "#/lib/utils";
 
+type SeparatorProps = SeparatorPrimitive.Props & {
+    /**
+     * `subtle` demper linjen slik at den skiller seksjoner uten å trekke blikket.
+     */
+    variant?: "default" | "subtle";
+};
+
 function Separator({
     className,
     orientation = "horizontal",
+    variant = "default",
     ...props
-}: SeparatorPrimitive.Props) {
+}: SeparatorProps) {
     return (
         <SeparatorPrimitive
             data-slot="separator"
             orientation={orientation}
             className={cn(
                 "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+                variant === "subtle" && "bg-border-subtle",
                 className,
             )}
             {...props}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -58,6 +58,10 @@
     --destructive: oklch(0.577 0.245 27.325);
     --destructive-foreground: oklch(0.577 0.245 27.325);
     --border: oklch(0.922 0 0);
+    /* Dempet skillelinje for seksjoner som ikke skal trekke blikket (footer o.l.) */
+    --border-subtle: oklch(0.97 0 0);
+    /* Omrisset rundt card-flater */
+    --card-border: oklch(0.922 0 0);
     --input: oklch(0.922 0 0);
     --ring: var(--logo);
     --chart-1: oklch(0.87 0 0);
@@ -80,7 +84,7 @@
     /* Navy palette generated from A (#030B1A) — hsl(219°) scale */
     --background: #030b1a;
     --foreground: #f5f7f9;
-    --card: #091f49;
+    --card: #061532;
     --card-foreground: #f5f7f9;
     --popover: #091f49;
     --popover-foreground: #f5f7f9;
@@ -95,6 +99,13 @@
     --destructive: oklch(0.704 0.191 22.216);
     --destructive-foreground: oklch(0.637 0.237 25.331);
     --border: #0d3172;
+    /* Nytt trinn i navy-skalaen (L 11%), midt mellom --background (L 5.7%) og
+       #091f49 (L 16.1%). Så vidt synlig mot bakgrunnen. Merk: samme verdi som
+       --card, så en subtle separator inni et card blir usynlig. */
+    --border-subtle: #061532;
+    /* Ett trinn over --card i navy-skalaen, så omrisset skiller kortet fra
+       bakgrunnen uten den lyse ring-foreground/10-kanten. */
+    --card-border: #091f49;
     --input: #0d3172;
     --ring: #1b61e4;
     --chart-1: #5d8bdf;
@@ -120,6 +131,7 @@
     --color-foreground: var(--foreground);
     --color-card: var(--card);
     --color-card-foreground: var(--card-foreground);
+    --color-card-border: var(--card-border);
     --color-popover: var(--popover);
     --color-popover-foreground: var(--popover-foreground);
     --color-primary: var(--primary);
@@ -133,6 +145,7 @@
     --color-destructive: var(--destructive);
     --color-destructive-foreground: var(--destructive-foreground);
     --color-border: var(--border);
+    --color-border-subtle: var(--border-subtle);
     --color-input: var(--input);
     --color-ring: var(--ring);
     --color-chart-1: var(--chart-1);


### PR DESCRIPTION
Skillelinjene i footeren og omrisset rundt cards brukte de mest fremtredende fargene i paletten. Denne PR-en innfører to nye tokens i navy-skalaen, slik at flatene kan dempes uten å endre `--border` globalt.

## Endringer

| Token | Mørkt | Lyst |
|---|---|---|
| `--border-subtle` (ny) | `#061532` | `oklch(0.97 0 0)` |
| `--card-border` (ny) | `#091f49` | `oklch(0.922 0 0)` |
| `--card` (endret) | `#091f49` → `#061532` | uendret |

- `Separator` får en `variant`-prop; `subtle` bruker `bg-border-subtle`. Standardoppførselen er uendret.
- Footeren bruker `variant="subtle"` på begge skillelinjene.
- `Card` og `EventCalendar` bytter `ring-foreground/10` (en lys hvit kant) til `ring-card-border`.

`#061532` er et nytt trinn på den eksisterende hsl(219°, ~78 %)-skalaen, midt mellom `--background` (L 5.7 %) og `#091f49` (L 16.1 %). Øvrige verdier er hentet fra paletten slik den er.

Lyst tema er praktisk talt uendret — begge nye tokens ligger i den eksisterende nøytrale gråskalaen, og `oklch(0.922)` ligger så nær gamle `foreground/10` at forskjellen ikke er synlig.

## Verifisert

- Dev-server, begge temaer: footer-linjer `rgb(6, 21, 50)`, card-bakgrunn `rgb(6, 21, 50)`, card-ring `rgb(9, 31, 73)` mot bakgrunn `rgb(3, 11, 26)`. Lyst tema gir `oklch(0.97)` / `oklch(0.922)`.
- `bun run typecheck`, `bun run build --force` og `bun run format` passerer.

## Merk

- `--popover` og `--sidebar` står fortsatt på `#091f49`, så de er nå lysere enn cards. Bevisst for popovers, men sidebaren bør kanskje følge etter.
- `--border-subtle` og `--card` har samme verdi, så en `subtle` separator inni et card blir usynlig. Kommentert i CSS-en. Ingen slike brukssteder i dag.
- Dialog, popover, dropdown, select, menubar, combobox og navigation-menu bruker fortsatt `ring-foreground/10`, men de sitter på `bg-popover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)