### PR TITLE
fix(kvark): vis riktig bruker på /profil/$id

### DIFF
--- a/apps/api/src/routes/user/get.ts
+++ b/apps/api/src/routes/user/get.ts
@@ -1,0 +1,110 @@
+import { HTTPException } from "hono/http-exception";
+import { describeRoute } from "~/lib/openapi";
+import { route } from "~/lib/route";
+import { requireAuth } from "~/middleware/auth";
+import { userProfileSchema } from "./schema";
+
+/**
+ * Another member's profile.
+ *
+ * Deliberately narrower than the session: bio, links, study and group
+ * memberships are what a profile page shows, while e-mail, gender, allergies
+ * and the notification settings stay private. Any signed-in member may look up
+ * any other — the group member lists already link here.
+ */
+export const getUserRoute = route().get(
+    "/:id",
+    describeRoute({
+        tags: ["users"],
+        summary: "Get user profile",
+        operationId: "getUserProfile",
+        description:
+            "Public profile of a single user: name, bio, links, study programme and group memberships. Requires being signed in.",
+    })
+        .schemaResponse({
+            statusCode: 200,
+            schema: userProfileSchema,
+            description: "User profile",
+        })
+        .notFound({ description: "User not found" })
+        .build(),
+    requireAuth,
+    async (c) => {
+        const { db } = c.get("ctx");
+        const id = c.req.param("id");
+
+        const user = await db.query.user.findFirst({
+            where: (user, { eq }) => eq(user.id, id),
+            columns: {
+                id: true,
+                name: true,
+                username: true,
+                image: true,
+                createdAt: true,
+            },
+        });
+
+        if (!user) {
+            throw new HTTPException(404, {
+                message: `User with id "${id}" not found`,
+            });
+        }
+
+        const [settings, memberships] = await Promise.all([
+            db.query.userSettings.findFirst({
+                where: (s, { eq }) => eq(s.userId, id),
+                columns: {
+                    imageUrl: true,
+                    bioDescription: true,
+                    githubUrl: true,
+                    linkedinUrl: true,
+                },
+            }),
+            db.query.groupMembership.findMany({
+                where: (gm, { eq }) => eq(gm.userId, id),
+                with: { group: true },
+            }),
+        ]);
+
+        /**
+         * Study programme and cohort mirror `listUsers`: they are a projection
+         * of Feide onto ordinary groups (types STUDY/STUDYYEAR), not
+         * `studyProgramMembership` — that table only gets rows from a Feide
+         * login, so everyone migrated from Lepton is missing there. The type is
+         * stored in UPPERCASE from Lepton, hence the case-insensitive compare.
+         */
+        const study = memberships.find(
+            (m) => m.group.type.toLowerCase() === "study",
+        );
+
+        // Several cohorts can linger on one account (a bachelor who continued
+        // into a master). The most recent one is the useful one.
+        const startYears = memberships
+            .filter((m) => m.group.type.toLowerCase() === "studyyear")
+            .map((m) => Number.parseInt(m.group.name, 10))
+            .filter((year) => Number.isFinite(year));
+
+        return c.json({
+            id: user.id,
+            name: user.name,
+            username: user.username ?? null,
+            // The uploaded avatar wins over the one Feide handed us, same as
+            // the session's `settings.imageUrl ?? user.image`.
+            image: settings?.imageUrl ?? user.image ?? null,
+            bio: settings?.bioDescription ?? null,
+            githubUrl: settings?.githubUrl ?? null,
+            linkedinUrl: settings?.linkedinUrl ?? null,
+            studyProgram: study?.group.name ?? null,
+            studyStartYear:
+                startYears.length > 0 ? Math.max(...startYears) : null,
+            groups: memberships.map((m) => ({
+                slug: m.groupSlug,
+                name: m.group.name,
+                type: m.group.type,
+                imageUrl: m.group.imageUrl ?? null,
+                role: m.role,
+            })),
+            createdAt: user.createdAt.toISOString(),
+        });
+    },
+);

--- a/apps/api/src/routes/user/index.ts
+++ b/apps/api/src/routes/user/index.ts
@@ -1,5 +1,6 @@
 import { route } from "~/lib/route";
 import { allergyRoutes } from "./allergy";
+import { getUserRoute } from "./get";
 import { listUsersRoute } from "./list";
 import { meRoutes } from "./me";
 import { searchUsersRoute } from "./search";
@@ -8,4 +9,6 @@ export const userRoutes = route()
     .route("/me", meRoutes)
     .route("/allergy", allergyRoutes)
     .route("/", searchUsersRoute)
-    .route("/", listUsersRoute);
+    .route("/", listUsersRoute)
+    // Last: `/:id` is a catch-all and would otherwise swallow `/search`.
+    .route("/", getUserRoute);

--- a/apps/api/src/routes/user/schema.ts
+++ b/apps/api/src/routes/user/schema.ts
@@ -107,3 +107,55 @@ export const userListResponseSchema = Schema(
         items: z.array(userListItemSchema),
     }),
 );
+
+/**
+ * What one member may see about another. Deliberately excludes e-mail, gender,
+ * allergies and notification settings — those belong to the session, not to a
+ * profile page someone else is looking at.
+ */
+export const userProfileSchema = Schema(
+    "UserProfile",
+    z.object({
+        id: z.string().meta({ description: "User ID" }),
+        name: z.string().meta({ description: "User display name" }),
+        username: z.string().nullable().meta({ description: "Username" }),
+        image: z.string().nullable().meta({
+            description:
+                "Profile image URL — the uploaded avatar when there is one, otherwise the one from Feide",
+        }),
+        bio: z.string().nullable().meta({ description: "Free-text bio" }),
+        githubUrl: z
+            .string()
+            .nullable()
+            .meta({ description: "Link to the user's GitHub profile" }),
+        linkedinUrl: z
+            .string()
+            .nullable()
+            .meta({ description: "Link to the user's LinkedIn profile" }),
+        studyProgram: z.string().nullable().meta({
+            description:
+                "Name of the user's study programme, derived from their STUDY group membership. Null when they have none.",
+        }),
+        studyStartYear: z.number().int().nullable().meta({
+            description:
+                "The year the user started studying (kull), derived from their STUDYYEAR group membership. Null when unknown.",
+        }),
+        groups: z
+            .array(
+                z.object({
+                    slug: z.string(),
+                    name: z.string(),
+                    type: z.string(),
+                    imageUrl: z.string().nullable(),
+                    role: z.string(),
+                }),
+            )
+            .meta({
+                description:
+                    "Every group the user belongs to, including the derived STUDY/STUDYYEAR groups",
+            }),
+        createdAt: z
+            .string()
+            .meta({ description: "Account creation timestamp" }),
+    }),
+);

--- a/apps/kvark/src/api/auth.ts
+++ b/apps/kvark/src/api/auth.ts
@@ -223,6 +223,27 @@ export async function authClientWithRedirect(url: string) {
 }
 
 /**
+ * Snarveien menyene bruker for «min profil», i stedet for å slå opp
+ * bruker-ID-en på hvert kallsted. `/_app/profil/$id` bytter den ut med den
+ * ekte ID-en før noe annet kjører.
+ */
+export const OWN_PROFILE_ALIAS = "me";
+
+/**
+ * Guards the personal sub-pages of a profile (favoritter, prikker,
+ * spørreskjemaer). They all read "me"-scoped endpoints, so on someone else's
+ * profile they would show the *viewer's* own data under a stranger's name.
+ * Anyone landing there by URL is sent to that profile's public overview.
+ */
+export async function requireOwnProfile(profileId: string, url: string) {
+    const auth = await authClientWithRedirect(url);
+    if (profileId !== OWN_PROFILE_ALIAS && auth.user.id !== profileId) {
+        throw redirect({ to: "/profil/$id", params: { id: profileId } });
+    }
+    return auth;
+}
+
+/**
  * Returns the URL to redirect to the login page with the current URL as the redirect target
  * @param request the current request object
  * @returns URL string to redirect to the login page

--- a/apps/kvark/src/api/queries/user.ts
+++ b/apps/kvark/src/api/queries/user.ts
@@ -10,6 +10,7 @@ const UserQueryKeys = {
     settings: ["user", "settings"] as const,
     allergies: ["user", "allergies"] as const,
     listInfinite: ["user", "list-infinite"] as const,
+    profile: ["user", "profile"] as const,
 } as const;
 
 const DEFAULT_PAGE_SIZE = 50;
@@ -47,6 +48,18 @@ export const getUsersInfiniteQuery = (
             }),
         initialPageParam: 0,
         getNextPageParam: (lastPage) => lastPage.nextPage,
+    });
+
+/**
+ * Another member's profile. Narrower than the session on purpose — it carries
+ * no e-mail, allergies or settings — so use the session when the profile being
+ * shown is the viewer's own.
+ */
+export const getUserProfileQuery = (userId: string) =>
+    queryOptions({
+        queryKey: [...UserQueryKeys.profile, userId],
+        queryFn: () =>
+            apiClient.get("/api/user/{id}", { params: { id: userId } }),
     });
 
 export const getUserSettingsQuery = () =>

--- a/apps/kvark/src/components/profile-header.tsx
+++ b/apps/kvark/src/components/profile-header.tsx
@@ -9,11 +9,13 @@ import { initials } from "#/lib/utils";
 export type ProfileLink = {
     kind: "github" | "linkedin";
     label: string;
+    url?: string;
 };
 
 export type ProfileHeaderUser = {
     name: string;
-    email: string;
+    /** Bare satt på egen profil — e-post er ikke en del av den offentlige profilen. */
+    email?: string;
     programme?: string;
     avatarUrl?: string;
     links: ProfileLink[];
@@ -22,7 +24,10 @@ export type ProfileHeaderUser = {
 type ProfileHeaderProps = {
     user: ProfileHeaderUser;
     actions?: ReactNode;
-    /** Åpner dialogen der GitHub-/LinkedIn-lenker redigeres. */
+    /**
+     * Åpner dialogen der GitHub-/LinkedIn-lenker redigeres. Utelates på andres
+     * profiler, som også skjuler «Legg til lenke».
+     */
     onAddLink?: () => void;
 };
 
@@ -54,13 +59,15 @@ export function ProfileHeader({
                             {user.programme}
                         </p>
                     ) : null}
-                    <a
-                        href={`mailto:${user.email}`}
-                        className="flex w-fit items-center gap-1.5 text-sm text-muted-foreground"
-                    >
-                        <Mail className="size-3.5 shrink-0" />
-                        {user.email}
-                    </a>
+                    {user.email ? (
+                        <a
+                            href={`mailto:${user.email}`}
+                            className="flex w-fit items-center gap-1.5 text-sm text-muted-foreground"
+                        >
+                            <Mail className="size-3.5 shrink-0" />
+                            {user.email}
+                        </a>
+                    ) : null}
                 </div>
             }
             badges={
@@ -70,19 +77,32 @@ export function ProfileHeader({
                             key={link.kind}
                             variant="outline"
                             className="gap-1.5"
+                            render={
+                                link.url ? (
+                                    <a
+                                        href={link.url}
+                                        target="_blank"
+                                        rel="noreferrer noopener"
+                                    />
+                                ) : undefined
+                            }
                         >
                             {link.kind === "github" ? <Github /> : <Linkedin />}
                             {link.label}
                         </Badge>
                     ))}
-                    <Badge
-                        variant="secondary"
-                        className="gap-1.5"
-                        render={<button type="button" onClick={onAddLink} />}
-                    >
-                        <Plus />
-                        Legg til lenke
-                    </Badge>
+                    {onAddLink ? (
+                        <Badge
+                            variant="secondary"
+                            className="gap-1.5"
+                            render={
+                                <button type="button" onClick={onAddLink} />
+                            }
+                        >
+                            <Plus />
+                            Legg til lenke
+                        </Badge>
+                    ) : null}
                 </>
             }
             actions={actions}

--- a/apps/kvark/src/components/profile-links-section.tsx
+++ b/apps/kvark/src/components/profile-links-section.tsx
@@ -5,9 +5,19 @@ import type { ProfileLink } from "#/components/profile-header";
 
 type ProfileLinksSectionProps = {
     links: ProfileLink[];
+    /**
+     * Åpner dialogen der lenkene redigeres. Utelates på andres profiler, som
+     * også skjuler «Legg til lenke».
+     */
+    onAddLink?: () => void;
 };
 
-export function ProfileLinksSection({ links }: ProfileLinksSectionProps) {
+export function ProfileLinksSection({
+    links,
+    onAddLink,
+}: ProfileLinksSectionProps) {
+    if (links.length === 0 && !onAddLink) return null;
+
     return (
         <div className="flex flex-col gap-3 md:hidden">
             <h3 className="text-xs text-muted-foreground">LENKER</h3>
@@ -17,15 +27,30 @@ export function ProfileLinksSection({ links }: ProfileLinksSectionProps) {
                         key={link.kind}
                         variant="outline"
                         className="gap-1.5"
+                        render={
+                            link.url ? (
+                                <a
+                                    href={link.url}
+                                    target="_blank"
+                                    rel="noreferrer noopener"
+                                />
+                            ) : undefined
+                        }
                     >
                         {link.kind === "github" ? <Github /> : <Linkedin />}
                         {link.label}
                     </Badge>
                 ))}
-                <Badge variant="secondary" className="gap-1.5">
-                    <Plus />
-                    add link
-                </Badge>
+                {onAddLink ? (
+                    <Badge
+                        variant="secondary"
+                        className="gap-1.5"
+                        render={<button type="button" onClick={onAddLink} />}
+                    >
+                        <Plus />
+                        Legg til lenke
+                    </Badge>
+                ) : null}
             </div>
         </div>
     );

--- a/apps/kvark/src/components/profile-overview-header.tsx
+++ b/apps/kvark/src/components/profile-overview-header.tsx
@@ -3,11 +3,14 @@ import { Bell } from "lucide-react";
 
 type ProfileOverviewHeaderProps = {
     name: string;
+    /** Velkomsthilsen og varsler gir bare mening på ens egen profil. */
+    isOwnProfile?: boolean;
     notifications?: number;
 };
 
 export function ProfileOverviewHeader({
     name,
+    isOwnProfile = true,
     notifications = 0,
 }: ProfileOverviewHeaderProps) {
     const firstName = name.split(" ")[0] ?? name;
@@ -16,14 +19,18 @@ export function ProfileOverviewHeader({
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
             <div className="flex flex-col gap-1">
                 <h2 className="text-2xl">Oversikt</h2>
-                <p className="text-sm text-muted-foreground">
-                    Velkommen tilbake, {firstName}
-                </p>
+                {isOwnProfile ? (
+                    <p className="text-sm text-muted-foreground">
+                        Velkommen tilbake, {firstName}
+                    </p>
+                ) : null}
             </div>
-            <Badge variant="outline" className="gap-1.5">
-                <Bell />
-                {notifications} nye varsler
-            </Badge>
+            {isOwnProfile ? (
+                <Badge variant="outline" className="gap-1.5">
+                    <Bell />
+                    {notifications} nye varsler
+                </Badge>
+            ) : null}
         </div>
     );
 }

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -4,10 +4,11 @@ import {
     type LinkOptions,
     linkOptions,
     Outlet,
+    redirect,
     useMatchRoute,
     useNavigate,
 } from "@tanstack/react-router";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Button } from "@tihlde/ui/ui/button";
 import { Separator } from "@tihlde/ui/ui/separator";
 import {
@@ -27,8 +28,12 @@ import {
     authQueryOptions,
     invalidateAuth,
     logoutUser,
+    OWN_PROFILE_ALIAS,
 } from "#/api/auth";
-import { updateUserSettingsMutation } from "#/api/queries/user";
+import {
+    getUserProfileQuery,
+    updateUserSettingsMutation,
+} from "#/api/queries/user";
 import { useIsAdmin } from "#/hooks/use-permission";
 import { EditBioDialog } from "#/components/edit-bio-dialog";
 import { MembershipQrDialog } from "#/components/membership-qr-dialog";
@@ -41,7 +46,22 @@ import { deriveStudy } from "#/lib/utils";
 
 export const Route = createFileRoute("/_app/profil/$id")({
     component: RouteComponent,
-    beforeLoad: ({ location }) => authClientWithRedirect(location.href),
+    beforeLoad: async ({ location, params }) => {
+        const auth = await authClientWithRedirect(location.href);
+        // Menyene lenker til /profil/me som en snarvei til «min profil».
+        // Alt nedenfor forventer en ekte bruker-ID, så aliaset byttes ut med
+        // den innloggede brukerens ID her.
+        if (params.id === OWN_PROFILE_ALIAS) {
+            throw redirect({
+                to: "/profil/$id",
+                params: { id: auth.user.id },
+                replace: true,
+            });
+        }
+        return auth;
+    },
+    loader: ({ context, params }) =>
+        context.queryClient.ensureQueryData(getUserProfileQuery(params.id)),
 });
 
 type ProfileNavItem = {
@@ -61,8 +81,10 @@ function buildProfileLinks(
     linkedinUrl?: string | null,
 ): ProfileLink[] {
     const links: ProfileLink[] = [];
-    if (githubUrl) links.push({ kind: "github", label: "github" });
-    if (linkedinUrl) links.push({ kind: "linkedin", label: "linkedin" });
+    if (githubUrl)
+        links.push({ kind: "github", label: "github", url: githubUrl });
+    if (linkedinUrl)
+        links.push({ kind: "linkedin", label: "linkedin", url: linkedinUrl });
     return links;
 }
 
@@ -70,23 +92,30 @@ function RouteComponent() {
     const { id } = Route.useParams();
     const navigate = useNavigate();
 
+    // Everything on screen comes from the profile endpoint, so the page renders
+    // the same whoever is being looked at. The session only decides whether the
+    // viewer gets the edit affordances.
+    const { data: profile } = useSuspenseQuery(getUserProfileQuery(id));
     const { data: session } = useQuery(authQueryOptions);
+    const isOwnProfile = session?.user.id === id;
     const isAdmin = useIsAdmin();
     const updateSettings = useMutation(updateUserSettingsMutation);
     const [bioOpen, setBioOpen] = useState(false);
 
     const settings = session?.user.settings;
-    const { programme, classYear } = deriveStudy(session?.groups ?? []);
+    const { programme, classYear } = deriveStudy(profile.groups);
     const studyLabel =
         [programme, classYear ? `${classYear}. klasse` : null]
             .filter(Boolean)
             .join(" · ") || undefined;
     const user: ProfileHeaderUser = {
-        name: session?.user.name ?? "",
-        email: session?.user.email ?? "",
-        avatarUrl: settings?.imageUrl ?? session?.user.image ?? undefined,
+        name: profile.name,
+        // E-post er ikke en del av den offentlige profilen — den vises bare for
+        // deg selv, der den uansett ligger i sesjonen.
+        email: isOwnProfile ? (session?.user.email ?? undefined) : undefined,
+        avatarUrl: profile.image ?? undefined,
         programme: studyLabel,
-        links: buildProfileLinks(settings?.githubUrl, settings?.linkedinUrl),
+        links: buildProfileLinks(profile.githubUrl, profile.linkedinUrl),
     };
 
     async function handleLogout() {
@@ -94,6 +123,8 @@ function RouteComponent() {
         await navigate({ to: "/" });
     }
 
+    // Prikker, spørreskjemaer og admin er den innloggede brukerens egne ting og
+    // gir ingen mening på en annens profil.
     const navGroups: ProfileNavGroup[] = [
         {
             id: "main",
@@ -104,14 +135,18 @@ function RouteComponent() {
                     link: linkOptions({ to: "/profil/$id", params: { id } }),
                     exact: true,
                 },
-                {
-                    label: "Arrangementer",
-                    icon: CalendarDays,
-                    link: linkOptions({
-                        to: "/profil/$id/arrangementer",
-                        params: { id },
-                    }),
-                },
+                ...(isOwnProfile
+                    ? [
+                          {
+                              label: "Arrangementer",
+                              icon: CalendarDays,
+                              link: linkOptions({
+                                  to: "/profil/$id/arrangementer",
+                                  params: { id },
+                              }),
+                          },
+                      ]
+                    : []),
                 {
                     label: "Medlemskap",
                     icon: UserCircle2,
@@ -120,26 +155,30 @@ function RouteComponent() {
                         params: { id },
                     }),
                 },
-                {
-                    label: "Prikker",
-                    icon: Ticket,
-                    link: linkOptions({
-                        to: "/profil/$id/prikker",
-                        params: { id },
-                    }),
-                },
-                {
-                    label: "Spørreskjemaer",
-                    icon: HelpCircle,
-                    link: linkOptions({
-                        to: "/profil/$id/sporreskjemaer",
-                        params: { id },
-                    }),
-                },
+                ...(isOwnProfile
+                    ? [
+                          {
+                              label: "Prikker",
+                              icon: Ticket,
+                              link: linkOptions({
+                                  to: "/profil/$id/prikker",
+                                  params: { id },
+                              }),
+                          },
+                          {
+                              label: "Spørreskjemaer",
+                              icon: HelpCircle,
+                              link: linkOptions({
+                                  to: "/profil/$id/sporreskjemaer",
+                                  params: { id },
+                              }),
+                          },
+                      ]
+                    : []),
             ],
         },
         // Admin entry point — only for admins. The API still enforces access.
-        ...(isAdmin
+        ...(isOwnProfile && isAdmin
             ? [
                   {
                       id: "secondary",
@@ -159,44 +198,51 @@ function RouteComponent() {
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
             <ProfileHeader
                 user={user}
-                onAddLink={() => setBioOpen(true)}
+                onAddLink={isOwnProfile ? () => setBioOpen(true) : undefined}
                 actions={
-                    <>
-                        <MembershipQrDialog
-                            name={user.name}
-                            userId={session?.user.id}
-                        />
-                        <Button onClick={() => setBioOpen(true)}>
-                            <Pencil />
-                            Rediger bio
-                        </Button>
-                    </>
+                    isOwnProfile ? (
+                        <>
+                            <MembershipQrDialog
+                                name={user.name}
+                                userId={session?.user.id}
+                            />
+                            <Button onClick={() => setBioOpen(true)}>
+                                <Pencil />
+                                Rediger bio
+                            </Button>
+                        </>
+                    ) : null
                 }
             />
             {/* Dialogen styres herfra slik at både «Rediger bio» og
                 «Legg til lenke» i headeren åpner den samme dialogen. */}
-            <EditBioDialog
-                open={bioOpen}
-                onOpenChange={setBioOpen}
-                defaultValues={{
-                    bio: settings?.bioDescription ?? "",
-                    github: settings?.githubUrl ?? "",
-                    linkedin: settings?.linkedinUrl ?? "",
-                }}
-                onSubmit={async (values) => {
-                    await updateSettings.mutateAsync({
-                        data: {
-                            bioDescription: values.bio || undefined,
-                            githubUrl: values.github || undefined,
-                            linkedinUrl: values.linkedin || undefined,
-                            allergies: settings?.allergies ?? [],
-                        },
-                    });
-                    await invalidateAuth();
-                }}
-            />
+            {isOwnProfile ? (
+                <EditBioDialog
+                    open={bioOpen}
+                    onOpenChange={setBioOpen}
+                    defaultValues={{
+                        bio: settings?.bioDescription ?? "",
+                        github: settings?.githubUrl ?? "",
+                        linkedin: settings?.linkedinUrl ?? "",
+                    }}
+                    onSubmit={async (values) => {
+                        await updateSettings.mutateAsync({
+                            data: {
+                                bioDescription: values.bio || undefined,
+                                githubUrl: values.github || undefined,
+                                linkedinUrl: values.linkedin || undefined,
+                                allergies: settings?.allergies ?? [],
+                            },
+                        });
+                        await invalidateAuth();
+                    }}
+                />
+            ) : null}
             <div className="grid gap-6 md:grid-cols-[16rem_1fr]">
-                <ProfileNav navGroups={navGroups} onLogout={handleLogout} />
+                <ProfileNav
+                    navGroups={navGroups}
+                    onLogout={isOwnProfile ? handleLogout : undefined}
+                />
                 <section className="flex min-w-0 flex-col gap-6">
                     <Outlet />
                 </section>
@@ -226,6 +272,7 @@ function NavButton({
             variant={isActive ? "default" : "ghost"}
             size={size}
             className={className}
+            nativeButton={false}
             render={<Link {...item.link} />}
         >
             <item.icon />
@@ -239,7 +286,7 @@ function ProfileNav({
     onLogout,
 }: {
     navGroups: ProfileNavGroup[];
-    onLogout: () => void;
+    onLogout?: () => void;
 }) {
     const flatItems = navGroups.flatMap((g) => g.items);
 
@@ -274,15 +321,19 @@ function ProfileNav({
                             </ul>
                         </Fragment>
                     ))}
-                    <Separator className="my-2" />
-                    <Button
-                        variant="ghost"
-                        className="justify-start"
-                        onClick={onLogout}
-                    >
-                        <LogOut />
-                        Logg ut
-                    </Button>
+                    {onLogout ? (
+                        <>
+                            <Separator className="my-2" />
+                            <Button
+                                variant="ghost"
+                                className="justify-start"
+                                onClick={onLogout}
+                            >
+                                <LogOut />
+                                Logg ut
+                            </Button>
+                        </>
+                    ) : null}
                 </nav>
             </aside>
         </>

--- a/apps/kvark/src/routes/_app/profil/$id/arrangementer.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/arrangementer.tsx
@@ -1,3 +1,4 @@
+import { requireOwnProfile } from "#/api/auth";
 import { getFavoriteEventsQuery } from "#/api/queries/events";
 import { useQuery } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
@@ -14,6 +15,8 @@ import { CalendarDays, Star } from "lucide-react";
 
 export const Route = createFileRoute("/_app/profil/$id/arrangementer")({
     component: RouteComponent,
+    beforeLoad: ({ location, params }) =>
+        requireOwnProfile(params.id, location.href),
 });
 
 function RouteComponent() {

--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -1,9 +1,10 @@
 import { authQueryOptions } from "#/api/auth";
+import { getUserProfileQuery } from "#/api/queries/user";
 import { ProfileLinksSection } from "#/components/profile-links-section";
 import { ProfileOverviewHeader } from "#/components/profile-overview-header";
 import { ProfileStatCard } from "#/components/profile-stat-card";
 import type { ProfileLink } from "#/components/profile-header";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import type { SignatureStatus } from "@tihlde/sdk";
 import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
@@ -21,30 +22,52 @@ export const Route = createFileRoute("/_app/profil/$id/")({
     component: RouteComponent,
 });
 
+/** Grupper som ikke er reelle medlemskap — de er avledet av Feide-dataene. */
+const DERIVED_GROUP_TYPES = ["study", "studyyear", "tihlde"];
+
 function RouteComponent() {
+    const { id } = Route.useParams();
+    const { data: profile } = useSuspenseQuery(getUserProfileQuery(id));
     const { data: session } = useQuery(authQueryOptions);
-    const settings = session?.user.settings;
+    const isOwnProfile = session?.user.id === id;
 
     const links: ProfileLink[] = [];
-    if (settings?.githubUrl) links.push({ kind: "github", label: "github" });
-    if (settings?.linkedinUrl)
-        links.push({ kind: "linkedin", label: "linkedin" });
+    if (profile.githubUrl)
+        links.push({ kind: "github", label: "github", url: profile.githubUrl });
+    if (profile.linkedinUrl)
+        links.push({
+            kind: "linkedin",
+            label: "linkedin",
+            url: profile.linkedinUrl,
+        });
 
-    const groups = session?.groups ?? [];
-    const membershipTitle = groups.length > 0 ? "Aktiv" : "Ingen medlemskap";
+    const memberships = profile.groups.filter(
+        (g) => !DERIVED_GROUP_TYPES.includes(g.type.toLowerCase()),
+    );
+    const membershipTitle =
+        memberships.length > 0 ? "Aktiv" : "Ingen medlemskap";
     const membershipDescription =
-        groups.length > 0
-            ? `${groups.length} ${groups.length === 1 ? "gruppe" : "grupper"}`
-            : "Du er ikke medlem i noen grupper";
+        memberships.length > 0
+            ? `${memberships.length} ${memberships.length === 1 ? "gruppe" : "grupper"}`
+            : isOwnProfile
+              ? "Du er ikke medlem i noen grupper"
+              : "Ikke medlem i noen grupper";
 
     return (
         <>
             <ProfileOverviewHeader
-                name={session?.user.name ?? ""}
+                name={profile.name}
+                isOwnProfile={isOwnProfile}
                 notifications={0}
             />
+            {profile.bio ? (
+                <div className="flex flex-col gap-2">
+                    <h3 className="text-xs text-muted-foreground">OM</h3>
+                    <p className="whitespace-pre-line text-sm">{profile.bio}</p>
+                </div>
+            ) : null}
             <ProfileLinksSection links={links} />
-            <ContractBanner signature={null} />
+            {isOwnProfile ? <ContractBanner signature={null} /> : null}
 
             <div className="grid gap-4 md:grid-cols-3">
                 <ProfileStatCard
@@ -54,37 +77,45 @@ function RouteComponent() {
                 />
             </div>
 
-            <div className="flex flex-col gap-3">
-                <h3>KOMMENDE</h3>
-                <Empty>
-                    <EmptyHeader>
-                        <EmptyMedia variant="icon">
-                            <CalendarDays />
-                        </EmptyMedia>
-                        <EmptyTitle>Ingen kommende arrangementer</EmptyTitle>
-                        <EmptyDescription>
-                            Påmeldingene dine vises her når du melder deg på et
-                            arrangement.
-                        </EmptyDescription>
-                    </EmptyHeader>
-                </Empty>
-            </div>
+            {/* Kommende arrangementer og oppgaver er personlige og vises kun på
+                egen profil. */}
+            {isOwnProfile ? (
+                <>
+                    <div className="flex flex-col gap-3">
+                        <h3>KOMMENDE</h3>
+                        <Empty>
+                            <EmptyHeader>
+                                <EmptyMedia variant="icon">
+                                    <CalendarDays />
+                                </EmptyMedia>
+                                <EmptyTitle>
+                                    Ingen kommende arrangementer
+                                </EmptyTitle>
+                                <EmptyDescription>
+                                    Påmeldingene dine vises her når du melder
+                                    deg på et arrangement.
+                                </EmptyDescription>
+                            </EmptyHeader>
+                        </Empty>
+                    </div>
 
-            <div className="flex flex-col gap-3">
-                <h3>MÅ GJØRES</h3>
-                <Empty>
-                    <EmptyHeader>
-                        <EmptyMedia variant="icon">
-                            <ListTodo />
-                        </EmptyMedia>
-                        <EmptyTitle>Ingenting å gjøre</EmptyTitle>
-                        <EmptyDescription>
-                            Oppgaver som spørreskjemaer og evalueringer dukker
-                            opp her.
-                        </EmptyDescription>
-                    </EmptyHeader>
-                </Empty>
-            </div>
+                    <div className="flex flex-col gap-3">
+                        <h3>MÅ GJØRES</h3>
+                        <Empty>
+                            <EmptyHeader>
+                                <EmptyMedia variant="icon">
+                                    <ListTodo />
+                                </EmptyMedia>
+                                <EmptyTitle>Ingenting å gjøre</EmptyTitle>
+                                <EmptyDescription>
+                                    Oppgaver som spørreskjemaer og evalueringer
+                                    dukker opp her.
+                                </EmptyDescription>
+                            </EmptyHeader>
+                        </Empty>
+                    </div>
+                </>
+            ) : null}
         </>
     );
 }

--- a/apps/kvark/src/routes/_app/profil/$id/medlemskap.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/medlemskap.tsx
@@ -1,6 +1,7 @@
 import { authQueryOptions } from "#/api/auth";
+import { getUserProfileQuery } from "#/api/queries/user";
 import { groupTypeLabel } from "#/lib/group";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
 import { Badge } from "@tihlde/ui/ui/badge";
@@ -19,13 +20,16 @@ export const Route = createFileRoute("/_app/profil/$id/medlemskap")({
 });
 
 function RouteComponent() {
+    const { id } = Route.useParams();
+    const { data: profile } = useSuspenseQuery(getUserProfileQuery(id));
     const { data: session } = useQuery(authQueryOptions);
-    const groups = session?.groups ?? [];
+    const isOwnProfile = session?.user.id === id;
+
     // study/studyyear er avledede grupper (projeksjon av Feide-data) og vises
     // ved profilbildet, ikke i medlemskapslisten. TIHLDE er ingen gruppe man
     // melder seg inn i – alle er med – så den skal heller ikke vises her.
     // Typen er UPPERCASE i DB.
-    const memberships = groups.filter(
+    const memberships = profile.groups.filter(
         (g) => !["study", "studyyear", "tihlde"].includes(g.type.toLowerCase()),
     );
 
@@ -38,7 +42,9 @@ function RouteComponent() {
                     </EmptyMedia>
                     <EmptyTitle>Ingen medlemskap</EmptyTitle>
                     <EmptyDescription>
-                        Du er ikke medlem i noen grupper ennå.
+                        {isOwnProfile
+                            ? "Du er ikke medlem i noen grupper ennå."
+                            : `${profile.name} er ikke medlem i noen grupper.`}
                     </EmptyDescription>
                 </EmptyHeader>
             </Empty>

--- a/apps/kvark/src/routes/_app/profil/$id/prikker.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/prikker.tsx
@@ -1,3 +1,4 @@
+import { requireOwnProfile } from "#/api/auth";
 import { createFileRoute } from "@tanstack/react-router";
 import {
     Empty,
@@ -10,6 +11,8 @@ import { Ticket } from "lucide-react";
 
 export const Route = createFileRoute("/_app/profil/$id/prikker")({
     component: RouteComponent,
+    beforeLoad: ({ location, params }) =>
+        requireOwnProfile(params.id, location.href),
 });
 
 function RouteComponent() {

--- a/apps/kvark/src/routes/_app/profil/$id/sporreskjemaer.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/sporreskjemaer.tsx
@@ -1,3 +1,4 @@
+import { requireOwnProfile } from "#/api/auth";
 import { createFileRoute } from "@tanstack/react-router";
 import {
     Empty,
@@ -10,6 +11,8 @@ import { HelpCircle } from "lucide-react";
 
 export const Route = createFileRoute("/_app/profil/$id/sporreskjemaer")({
     component: RouteComponent,
+    beforeLoad: ({ location, params }) =>
+        requireOwnProfile(params.id, location.href),
 });
 
 function RouteComponent() {

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2213,6 +2213,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/user/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get user profile
+         * @description Public profile of a single user: name, bio, links, study programme and group memberships. Requires being signed in.
+         */
+        get: operations["getUserProfile"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -5038,6 +5058,36 @@ export interface components {
             /** @description The next page number that can be fetched */
             nextPage: number | null;
             items: components["schemas"]["UserListItem"][];
+        };
+        UserProfile: {
+            /** @description User ID */
+            id: string;
+            /** @description User display name */
+            name: string;
+            /** @description Username */
+            username: string | null;
+            /** @description Profile image URL — the uploaded avatar when there is one, otherwise the one from Feide */
+            image: string | null;
+            /** @description Free-text bio */
+            bio: string | null;
+            /** @description Link to the user's GitHub profile */
+            githubUrl: string | null;
+            /** @description Link to the user's LinkedIn profile */
+            linkedinUrl: string | null;
+            /** @description Name of the user's study programme, derived from their STUDY group membership. Null when they have none. */
+            studyProgram: string | null;
+            /** @description The year the user started studying (kull), derived from their STUDYYEAR group membership. Null when unknown. */
+            studyStartYear: number | null;
+            /** @description Every group the user belongs to, including the derived STUDY/STUDYYEAR groups */
+            groups: {
+                slug: string;
+                name: string;
+                type: string;
+                imageUrl: string | null;
+                role: string;
+            }[];
+            /** @description Account creation timestamp */
+            createdAt: string;
         };
     };
     responses: never;
@@ -11086,6 +11136,44 @@ export interface operations {
             };
             /** @description Forbidden - Requires users:view */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getUserProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description User profile */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserProfile"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Not Found - User not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/sdk/src/generated/schemas.ts
+++ b/packages/sdk/src/generated/schemas.ts
@@ -189,6 +189,7 @@ export type UpdateUserSettingsInput = Schemas["UpdateUserSettingsInput"];
 export type UploadResponse = Schemas["UploadResponse"];
 export type UserList = Schemas["UserList"];
 export type UserListItem = Schemas["UserListItem"];
+export type UserProfile = Schemas["UserProfile"];
 export type UserSearchResult = Schemas["UserSearchResult"];
 export type UserSettings = Schemas["UserSettings"];
 export type UserSettingsBase = Schemas["UserSettingsBase"];


### PR DESCRIPTION
Fikser #325.

## Problem

`/profil/$id` leste alt fra den innloggede sesjonen (`authQueryOptions`) og brukte aldri `$id`-parameteren. To synlige konsekvenser:

- Trykket man på et medlem i en gruppe, havnet man på sin egen profil.
- Det var umulig å se andre brukeres bio — bio-feltet hadde i praksis ingen funksjon.

Det fantes heller ikke noe API for å hente en annen bruker enn seg selv.

## Endringer

**Backend** — nytt `GET /api/user/{id}` (`apps/api/src/routes/user/get.ts`) som returnerer navn, brukernavn, bilde, bio, GitHub-/LinkedIn-lenker, studieprogram, kull og gruppemedlemskap. E-post, kjønn, allergier og varslingsinnstillinger er bevisst utelatt — de hører til sesjonen, ikke til en profilside noen andre ser på. Ruten registreres sist i `user/index.ts` fordi `/:id` ellers sluker `/search`.

**Frontend** — profilsiden og undersidene henter fra `$id`. Sesjonen brukes kun til å avgjøre om den besøkende ser sin egen profil:

- «Rediger bio», medlemsbevis, «Legg til lenke» og «Logg ut» vises bare på egen profil.
- Bioen rendres nå faktisk (den ble aldri vist noe sted før), og GitHub-/LinkedIn-merkene er ekte lenker.

## Verdt å vite for review

To ting som dukket opp underveis og måtte håndteres for at fiksen skulle være trygg:

- **`me`-scopede undersider.** Favoritter, prikker og spørreskjemaer leser endepunkter som alltid gjelder innlogget bruker. Uten en guard ville de vist den besøkendes egne data under en annens navn — samme klasse feil som issuen handler om. De er nå skjult i menyen på andres profiler, og `requireOwnProfile` redirigerer til profilens oversikt om man åpner URL-en direkte.
- **`/profil/me`-snarveien.** Fem kallsteder (site-header, admin-header, kommandomeny, spørreskjema, forsiden) lenker til `/profil/me`. Det fungerte kun fordi `$id` ble ignorert, og ville blitt 404 etter denne endringen. `beforeLoad` bytter nå aliaset mot den ekte bruker-ID-en og normaliserer URL-en, så kallstedene er urørt.

I tillegg: `NavButton` manglet `nativeButton={false}` og logget en Base UI-feil ved hver rendring. Den lå der fra før, men er fikset her siden filen uansett ble skrevet om.

`packages/sdk/src/generated/*` er regenerert med `bun run codegen`.

## Verifisering

Kjørt mot ekte stack, ikke bare typecheck.

API:
- Egen profil og en annen bruker returnerer riktige data (bio, lenker, studieprogram, grupper).
- `401` uinnlogget, `404` på ukjent ID.
- `GET /api/user/search` svarer fortsatt `200` — ikke slukt av `/:id`.

Nettleser, innlogget som testbruker:
- `/profil/<annen bruker>` viser den andre brukeren med bio og lenker, kun «Oversikt» og «Medlemskap» i menyen, ingen redigeringsknapper. Eneste `mailto` på siden er footerens `hs@tihlde.org` — ingen e-post lekker.
- Egen profil uendret: e-post, medlemsbevis, «Rediger bio», full meny.
- `/profil/<annen bruker>/prikker` redirigerer til oversikten.
- `/profil/me` normaliserer til ekte ID.
- Null konsollfeil etter endringen.

`bun run typecheck`, `lint`, `format` og `build` passerer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)