### PR TITLE
fix(auth): synkroniser Feide-data også når kontoen kobles

### DIFF
--- a/apps/api/src/routes/account-link/index.ts
+++ b/apps/api/src/routes/account-link/index.ts
@@ -1,4 +1,7 @@
 import { route } from "~/lib/route";
 import { accountLinkHelpRoute } from "./help";
+import { accountLinkSyncRoute } from "./sync";
 
-export const accountLinkRoutes = route().route("/", accountLinkHelpRoute);
+export const accountLinkRoutes = route()
+    .route("/", accountLinkHelpRoute)
+    .route("/", accountLinkSyncRoute);

--- a/apps/api/src/routes/account-link/schema.ts
+++ b/apps/api/src/routes/account-link/schema.ts
@@ -30,6 +30,13 @@ export const accountLinkHelpSchema = Schema(
     }),
 );
 
+export const accountLinkSyncResponseSchema = Schema(
+    "AccountLinkSyncResponse",
+    z.object({
+        success: z.boolean(),
+    }),
+);
+
 export const accountLinkHelpResponseSchema = Schema(
     "AccountLinkHelpResponse",
     z.object({

--- a/apps/api/src/routes/account-link/sync.ts
+++ b/apps/api/src/routes/account-link/sync.ts
@@ -1,0 +1,86 @@
+import { NoFeideAccountError, syncFeideForUser } from "@photon/auth/feide";
+import { HTTPException } from "hono/http-exception";
+import { describeRoute } from "~/lib/openapi";
+import { route } from "~/lib/route";
+import { requireAuth } from "~/middleware/auth";
+import { accountLinkSyncResponseSchema } from "./schema";
+
+/**
+ * Finish an account link by pulling the member's study data from Feide.
+ *
+ * Linking cannot do this itself. Better Auth's `/oauth2/callback` has two
+ * branches, and the link branch writes the account row and redirects without
+ * ever calling `setSessionCookie` — the member was already signed in, so no
+ * new session is minted. `syncFeideHook` keys on that new session to learn who
+ * logged in, so for a link it has nobody to sync and returns early.
+ *
+ * The result in production on 2026-07-30: five members linked Feide and kept a
+ * complete-looking account with no study programme, campus or cohort. Nothing
+ * was lost — the next Feide sign-in fills it in — but until then they sit
+ * outside every priority pool that selects on a study or cohort group, and
+ * they have no way to know.
+ *
+ * So the page they land on afterwards calls this instead. It has the session
+ * the callback lacked, which is all that was ever missing.
+ *
+ * Idempotent: the underlying writes are additive and conflict-tolerant, so a
+ * member may call it as often as they like. That also makes it the repair tool
+ * for the five already in this state.
+ */
+export const accountLinkSyncRoute = route().post(
+    "/sync",
+    describeRoute({
+        tags: ["account-link"],
+        summary: "Sync study data from Feide for the current user",
+        operationId: "syncFeideAccount",
+        description:
+            "Reads the caller's study programmes, cohort and campus from Feide and applies them, including derived study groups and the member/alumni role. Run after linking a Feide account, which cannot sync on its own. Safe to repeat.",
+    })
+        .schemaResponse({
+            statusCode: 200,
+            schema: accountLinkSyncResponseSchema,
+            description: "Study data synced",
+        })
+        .response({
+            statusCode: 409,
+            description: "No Feide account is linked to this user",
+        })
+        .response({
+            statusCode: 502,
+            description: "Feide could not be reached",
+        })
+        .build(),
+    requireAuth,
+    async (c) => {
+        const user = c.get("user");
+        const { db } = c.get("ctx");
+        const logger = c.get("logger");
+
+        try {
+            await syncFeideForUser(db, user.id);
+        } catch (error) {
+            if (error instanceof NoFeideAccountError) {
+                throw new HTTPException(409, {
+                    message: "Ingen Feide-konto er koblet til denne brukeren.",
+                });
+            }
+
+            /**
+             * Never fatal to the member: the link itself already succeeded and
+             * they are signed in. Their study data is filled in by the next
+             * Feide sign-in, so the caller is expected to say so and move on
+             * rather than trap them here.
+             */
+            logger.error(
+                { err: error, userId: user.id },
+                "Feide sync failed after account link",
+            );
+            throw new HTTPException(502, {
+                message:
+                    "Fikk ikke hentet studieopplysningene fra Feide. De hentes neste gang du logger inn.",
+            });
+        }
+
+        return c.json({ success: true }, 200);
+    },
+);

--- a/apps/api/src/test/feide/account-link-sync.test.ts
+++ b/apps/api/src/test/feide/account-link-sync.test.ts
@@ -1,0 +1,227 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, vi } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * The endpoint that finishes an account link.
+ *
+ * Better Auth's `/oauth2/callback` has two branches. Signing in mints a
+ * session; linking writes the account row and redirects without one, because
+ * the member was already signed in. `syncFeideHook` keys on that new session to
+ * learn who to sync, so a link syncs nobody — and the member ends up with a
+ * working Feide login and no study programme, campus or cohort.
+ *
+ * Five members reached exactly that state in production on 2026-07-30. This
+ * endpoint is what the post-link page calls to close the gap, using the session
+ * the callback never had.
+ */
+
+const dataportenGroups = [
+    {
+        id: "fc:fs:fs:kull:ntnu.no:BIDATA:2026H",
+        type: "fc:fs:kull",
+        displayName: "Kull for Høst 2026 BIDATA",
+        membership: { active: true },
+    },
+    {
+        id: "fc:fs:fs:emne:ntnu.no:IDATT1003:1",
+        type: "fc:fs:emne",
+        displayName: "IDATT1003",
+        membership: { active: true },
+    },
+];
+
+/**
+ * Stand in for Dataporten. The sync reaches the network through a bare
+ * `fetch`, so this is the seam — and stubbing it also keeps the suite from
+ * depending on Feide being up.
+ */
+const stubDataporten = (groups: unknown = dataportenGroups) => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes("groups-api.dataporten.no")) {
+            return new Response(JSON.stringify(groups), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch in test: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+};
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("POST /api/account-link/sync", () => {
+    integrationTest("rejects a caller without a session", async ({ ctx }) => {
+        const client = ctx.utils.client();
+        const res = await client.api["account-link"].sync.$post();
+
+        expect(res.status).toBe(401);
+    });
+
+    integrationTest(
+        "answers 409 when the user has never linked Feide",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+
+            const res = await client.api["account-link"].sync.$post();
+
+            // Distinct from a Feide outage on purpose: nothing is wrong, they
+            // simply have no Feide account for us to read.
+            expect(res.status).toBe(409);
+        },
+    );
+
+    integrationTest(
+        "writes the study programme a link never got around to",
+        async ({ ctx }) => {
+            stubDataporten();
+
+            const user = await ctx.utils.createTestUser();
+
+            await ctx.db.insert(schema.group).values({
+                slug: "dataingenior",
+                name: "Dataingeniør",
+                type: "STUDY",
+                finesInfo: "",
+                finesActivated: false,
+            });
+            await ctx.db.insert(schema.studyProgram).values({
+                slug: "dataingenior",
+                feideCode: "BIDATA",
+                displayName: "Dataingeniør",
+                type: "bachelor",
+            });
+            await ctx.db
+                .insert(schema.role)
+                .values([{ name: "member" }, { name: "alumni" }])
+                .onConflictDoNothing();
+
+            // What linking leaves behind: an account row with a token, and
+            // nothing else.
+            await ctx.db.insert(schema.account).values({
+                id: "acc-feide-test",
+                userId: user.id,
+                providerId: "feide",
+                accountId: "feide-user-1",
+                accessToken: "token-from-the-link",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api["account-link"].sync.$post();
+
+            expect(res.status).toBe(200);
+
+            const [membership] = await ctx.db
+                .select({
+                    startYear: schema.studyProgramMembership.startYear,
+                    campus: schema.studyProgramMembership.confirmedCampus,
+                })
+                .from(schema.studyProgramMembership)
+                .where(eq(schema.studyProgramMembership.userId, user.id));
+
+            expect(membership?.startYear).toBe(2026);
+            expect(membership?.campus).toBe("trondheim");
+
+            const groups = await ctx.db
+                .select({ slug: schema.groupMembership.groupSlug })
+                .from(schema.groupMembership)
+                .where(eq(schema.groupMembership.userId, user.id));
+
+            // Both groups event priority selects on.
+            expect(groups.map((g) => g.slug).sort()).toEqual([
+                "2026",
+                "dataingenior",
+            ]);
+        },
+    );
+
+    integrationTest(
+        "can be run twice without duplicating anything",
+        async ({ ctx }) => {
+            stubDataporten();
+
+            const user = await ctx.utils.createTestUser();
+
+            await ctx.db.insert(schema.group).values({
+                slug: "dataingenior",
+                name: "Dataingeniør",
+                type: "STUDY",
+                finesInfo: "",
+                finesActivated: false,
+            });
+            await ctx.db.insert(schema.studyProgram).values({
+                slug: "dataingenior",
+                feideCode: "BIDATA",
+                displayName: "Dataingeniør",
+                type: "bachelor",
+            });
+            await ctx.db
+                .insert(schema.role)
+                .values([{ name: "member" }, { name: "alumni" }])
+                .onConflictDoNothing();
+
+            await ctx.db.insert(schema.account).values({
+                id: "acc-feide-test-2",
+                userId: user.id,
+                providerId: "feide",
+                accountId: "feide-user-2",
+                accessToken: "token-from-the-link",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+
+            const client = await ctx.utils.clientForUser(user);
+
+            // A reload of the post-link page, or a member pressing back, must
+            // cost nothing — this is the repair tool for the five already in
+            // the broken state, so it will be run more than once on purpose.
+            expect((await client.api["account-link"].sync.$post()).status).toBe(
+                200,
+            );
+            expect((await client.api["account-link"].sync.$post()).status).toBe(
+                200,
+            );
+
+            const memberships = await ctx.db
+                .select({ userId: schema.studyProgramMembership.userId })
+                .from(schema.studyProgramMembership)
+                .where(eq(schema.studyProgramMembership.userId, user.id));
+
+            expect(memberships).toHaveLength(1);
+        },
+    );
+
+    integrationTest(
+        "answers 502 when Dataporten cannot be reached",
+        async ({ ctx }) => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () => new Response("nope", { status: 503 })),
+            );
+
+            const user = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.account).values({
+                id: "acc-feide-test-3",
+                userId: user.id,
+                providerId: "feide",
+                accountId: "feide-user-3",
+                accessToken: "token-from-the-link",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api["account-link"].sync.$post();
+
+            // Separated from the 409 so the page can say "we'll get it next
+            // login" rather than "you have not linked Feide".
+            expect(res.status).toBe(502);
+        },
+    );
+});

--- a/apps/kvark/src/api/queries/account-link.ts
+++ b/apps/kvark/src/api/queries/account-link.ts
@@ -15,3 +15,19 @@ export const requestAccountLinkHelpMutation = mutationOptions({
             json: data,
         }),
 });
+
+/**
+ * Pulls the caller's study programme, cohort and campus from Feide.
+ *
+ * Needed because linking cannot do it: Better Auth's link branch attaches the
+ * account without minting a session, and the sync hook keys on that session to
+ * know who signed in. So a freshly linked member has a working login and no
+ * study data — and therefore no study or cohort group, which is what event
+ * priority is decided by.
+ *
+ * Called from `/koble-feide` once the link returns. Idempotent, so a retry or
+ * a stray reload costs nothing.
+ */
+export const syncFeideAccountMutation = mutationOptions({
+    mutationFn: () => apiClient.post("/api/account-link/sync"),
+});

--- a/apps/kvark/src/components/feide-sign-in-issue.tsx
+++ b/apps/kvark/src/components/feide-sign-in-issue.tsx
@@ -179,14 +179,19 @@ function VerifyEmailPrompt({
     return (
         <Alert>
             {/* Asking which account, rather than "bekreft e-posten din",
-                because the mistake to prevent is answering with the address
-                they use today. Most migrated accounts predate the member
-                having an NTNU address at all: 986 of 1685 carry a private
-                one, so @stud.ntnu.no is the likeliest wrong answer and is
-                worth naming outright. */}
+                because the mistake to prevent is answering with whatever
+                address they happen to use today.
+
+                Deliberately does NOT steer towards either kind. An earlier
+                version said the address was "as a rule private, not
+                @stud.ntnu.no" — true of the majority, but prod holds 1006
+                private addresses against 689 @stud.ntnu.no ones, so it told
+                two in five members the wrong thing. The first member to hit it
+                had an NTNU address, followed the hint, typed a private one and
+                got silence. Name both, and let the retry button carry them. */}
             <AlertTitle>Hvilken e-post hadde den gamle brukeren?</AlertTitle>
             <AlertDescription>
-                Som regel en privat adresse — ikke @stud.ntnu.no.
+                Privat adresse eller @stud.ntnu.no — begge deler er vanlig.
             </AlertDescription>
             <form
                 className="mt-3 flex flex-col gap-2"

--- a/apps/kvark/src/routes/_auth/koble-feide.tsx
+++ b/apps/kvark/src/routes/_auth/koble-feide.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
+import { Suspense, useEffect, useRef } from "react";
+import { z } from "zod";
 import { Button } from "@tihlde/ui/ui/button";
 import {
     Card,
@@ -13,6 +14,7 @@ import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import { Spinner } from "@tihlde/ui/ui/spinner";
 
 import { authQueryOptions, linkFeideMutationOptions } from "#/api/auth";
+import { syncFeideAccountMutation } from "#/api/queries/account-link";
 
 /**
  * Where a member lands after confirming their email address.
@@ -24,6 +26,9 @@ import { authQueryOptions, linkFeideMutationOptions } from "#/api/auth";
  */
 export const Route = createFileRoute("/_auth/koble-feide")({
     component: LinkFeidePage,
+    // Feide sends the member back here with ?linked, which is what tells this
+    // page to finish the job the callback could not.
+    validateSearch: z.object({ linked: z.coerce.boolean().optional() }),
 });
 
 function LinkFeidePage() {
@@ -31,6 +36,45 @@ function LinkFeidePage() {
         <Suspense fallback={<LinkFeideSkeleton />}>
             <LinkFeideCard />
         </Suspense>
+    );
+}
+
+/**
+ * The step that only exists because linking cannot sync.
+ *
+ * Better Auth's link branch writes the account row and redirects without
+ * minting a session, and the sync hook keys on that session to learn who
+ * logged in — so a linked member ends up with a working login and no study
+ * programme, campus or cohort. Five members reached exactly that state in
+ * production on 2026-07-30, and nothing in the UI told them.
+ *
+ * Failure is deliberately not fatal. The link succeeded and they are signed
+ * in; the next Feide login syncs them anyway. Trapping them on an error screen
+ * over data they will get regardless would be the worse outcome, so this moves
+ * them on either way.
+ */
+function FinishLink({ onDone }: { onDone: () => void }) {
+    const syncMutation = useMutation(syncFeideAccountMutation);
+    const started = useRef(false);
+
+    useEffect(() => {
+        // Guarded: React runs effects twice in development, and syncing is a
+        // network round trip to Feide, not a cheap no-op.
+        if (started.current) return;
+        started.current = true;
+        syncMutation.mutate(undefined, { onSettled: onDone });
+    }, [syncMutation, onDone]);
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Henter studieopplysningene dine</CardTitle>
+                <CardDescription>Ett øyeblikk.</CardDescription>
+            </CardHeader>
+            <CardContent>
+                <Spinner />
+            </CardContent>
+        </Card>
     );
 }
 
@@ -51,8 +95,13 @@ function LinkFeideSkeleton() {
 
 function LinkFeideCard() {
     const { data: auth } = useSuspenseQuery(authQueryOptions);
+    const { linked } = Route.useSearch();
     const navigate = useNavigate();
     const linkMutation = useMutation(linkFeideMutationOptions);
+
+    if (linked && auth?.user) {
+        return <FinishLink onDone={() => navigate({ to: "/" })} />;
+    }
 
     if (!auth?.user) {
         return (
@@ -88,7 +137,14 @@ function LinkFeideCard() {
                 <Button
                     className="w-full"
                     disabled={linkMutation.isPending}
-                    onClick={() => linkMutation.mutate({ callbackURL: "/" })}
+                    // Back here rather than to the front page: this is where
+                    // the study data gets pulled, since the link itself
+                    // cannot. See FinishLink.
+                    onClick={() =>
+                        linkMutation.mutate({
+                            callbackURL: "/koble-feide?linked=1",
+                        })
+                    }
                 >
                     {linkMutation.isPending ? (
                         <>

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -259,138 +259,188 @@ export const syncFeideHook: (
         const session = middlewareContext.context.newSession;
         if (!session) {
             /**
-             * The callback did NOT authenticate anyone — an expired or reused
-             * state ("State mismatch: verification not found"), a denied
-             * consent, a provider error. Better Auth has already produced its
-             * own error response (and redirects to the sign-in's
+             * No *new* session, which happens for two very different reasons.
+             *
+             * The callback may have failed to authenticate anyone — an expired
+             * or reused state ("State mismatch: verification not found"), a
+             * denied consent, a provider error. Better Auth has already
+             * produced its own error response (and redirects to the sign-in's
              * errorCallbackURL when one was given); throwing here replaced
              * that with a bare 500 and an empty body, which is exactly what
              * users hit on photon.tihlde.org/api/auth/oauth2/callback/feide.
-             * There is nothing to sync, so leave the response alone.
+             *
+             * Or this was an account *link*, where the member was already
+             * signed in. Better Auth's link branch writes the account row and
+             * redirects without ever calling `setSessionCookie`, so there is
+             * no new session by construction — and this hook has no way to
+             * learn who was linked. Five members reached exactly this state in
+             * production on 2026-07-30: linked, but with no study programme,
+             * campus or cohort until they signed in with Feide again.
+             *
+             * The link case is therefore finished off from the outside, by
+             * `/koble-feide` calling the account-link sync endpoint, which runs
+             * {@link syncFeideForUser} for the session it does have.
              */
             console.warn(
-                "Feide callback finished without a session; skipping sync.",
+                "Feide callback finished without a new session; skipping sync. If this was an account link, /koble-feide completes it.",
             );
             return;
         }
 
-        const userId = session.user.id;
-
-        // Must filter by providerId: a user who also has an email/password
-        // account has multiple `account` rows, and only the Feide one carries
-        // the Dataporten access token needed below.
-        const feideAccount = await ctx.db
-            .select({ accessToken: account.accessToken })
-            .from(account)
-            .where(
-                and(
-                    eq(account.userId, userId),
-                    eq(account.providerId, FEIDE_PROVIDER_ID),
-                ),
-            )
-            .limit(1);
-
-        const token = feideAccount[0]?.accessToken;
-
-        if (!token) {
-            throw new Error("No Feide account linked to user");
-        }
-
-        const { programs, campus } = await fetchValidStudyPrograms(token);
-        const { allowed, campusRejected } = partitionByCampus(programs, campus);
-
-        if (needsCampusFollowUp(allowed, campus)) {
-            /**
-             * The user was let into a multi-campus programme without us being
-             * able to tell which campus they attend — see partitionByCampus for
-             * why that is allowed. Named here so the case can actually be
-             * followed up on: the pure parser has no user to point at.
-             */
-            console.warn(
-                `Could not resolve campus for user ${userId} (${session.user.username ?? "no username"}) on ${allowed.map((p) => p.code).join(", ")}; allowing.`,
-            );
-        }
-
-        // Add user to all valid study programs
-        await ctx.db.transaction(async (tx) => {
-            /**
-             * Campus only decides who gets *in*. A member whose reading came
-             * out as another campus this semester — an exchange, or courses
-             * taken at another campus — keeps the programme they already
-             * belong to, so the gate can never take away access it once gave.
-             */
-            const groups = [
-                ...allowed,
-                ...(await keepExistingMemberships(
-                    tx,
-                    userId,
-                    campusRejected,
-                    session.user.username ?? null,
-                )),
-            ];
-
-            for (const feideGroup of groups) {
-                const sp = await tx
-                    .select({ id: studyProgram.id, slug: studyProgram.slug })
-                    .from(studyProgram)
-                    .where(eq(studyProgram.feideCode, feideGroup.code))
-                    .limit(1);
-
-                if (!sp[0]) {
-                    console.warn(
-                        `User is part of unknown study program ${feideGroup}, skipping`,
-                    );
-                    continue;
-                }
-
-                const { id: studyProgramId, slug: programSlug } = sp[0];
-
-                /**
-                 * Additive by design: an existing row is left exactly as it
-                 * is, start year included. Feide only reports ACTIVE
-                 * memberships, so graduating removes the group from the
-                 * response — access history survives because rows are never
-                 * rewritten or deleted here. Baseline roles (member/alumni)
-                 * are what actually gate participation; see
-                 * syncBaselineRoles.
-                 */
-                await tx
-                    .insert(studyProgramMembership)
-                    .values({
-                        userId,
-                        studyProgramId,
-                        startYear: feideGroup.startYear,
-                        confirmedCampus: campus,
-                    })
-                    .onConflictDoNothing();
-
-                await confirmCampus(tx, userId, studyProgramId, campus);
-
-                await syncDerivedStudyGroups(
-                    tx,
-                    userId,
-                    programSlug,
-                    feideGroup.startYear,
-                );
-            }
-
-            /**
-             * Baseline roles follow the Feide result: active students get
-             * "member", former members get "alumni", strangers get neither.
-             *
-             * Keyed on `active`, not on how many groups came back. With
-             * `showAll=true` a member who finished years ago still has their
-             * old groups in the response, so counting groups would call
-             * everyone an active student forever.
-             */
-            await syncBaselineRoles(
-                tx,
-                userId,
-                groups.some((g) => g.active),
-            );
-        });
+        await syncFeideForUser(ctx.db, session.user.id);
     }
 };
+
+/**
+ * Raised when the user has no Feide account to read study data from.
+ *
+ * Its own type because the callers treat it as an expected outcome rather than
+ * a fault: the sync endpoint answers "you have not linked Feide yet", which is
+ * a different thing from Dataporten being unreachable.
+ */
+export class NoFeideAccountError extends Error {
+    constructor() {
+        super("No Feide account linked to user");
+        this.name = "NoFeideAccountError";
+    }
+}
+
+/**
+ * Bring a user's study programme, groups and baseline role in line with what
+ * Feide reports, using the access token stored on their Feide account.
+ *
+ * Extracted from {@link syncFeideHook} so the account-link flow can run the
+ * exact same work: linking produces no new session, so the hook cannot see who
+ * to sync, while the page the member lands on afterwards can.
+ */
+export async function syncFeideForUser(
+    db: AuthCreateContext["db"],
+    userId: string,
+): Promise<void> {
+    /**
+     * Must filter by providerId: a user who also has an email/password account
+     * has multiple `account` rows, and only the Feide one carries the
+     * Dataporten access token needed below.
+     *
+     * The username comes along for the ride purely so the warnings further
+     * down can name who they are about — worth the join, because those
+     * warnings are the only trace of a member who was let in without a
+     * resolved campus.
+     */
+    const [feideAccount] = await db
+        .select({ accessToken: account.accessToken, username: user.username })
+        .from(account)
+        .innerJoin(user, eq(user.id, account.userId))
+        .where(
+            and(
+                eq(account.userId, userId),
+                eq(account.providerId, FEIDE_PROVIDER_ID),
+            ),
+        )
+        .limit(1);
+
+    const token = feideAccount?.accessToken;
+
+    if (!token) {
+        throw new NoFeideAccountError();
+    }
+
+    const username = feideAccount.username;
+
+    const { programs, campus } = await fetchValidStudyPrograms(token);
+    const { allowed, campusRejected } = partitionByCampus(programs, campus);
+
+    if (needsCampusFollowUp(allowed, campus)) {
+        /**
+         * The user was let into a multi-campus programme without us being
+         * able to tell which campus they attend — see partitionByCampus for
+         * why that is allowed. Named here so the case can actually be
+         * followed up on: the pure parser has no user to point at.
+         */
+        console.warn(
+            `Could not resolve campus for user ${userId} (${username ?? "no username"}) on ${allowed.map((p) => p.code).join(", ")}; allowing.`,
+        );
+    }
+
+    // Add user to all valid study programs
+    await db.transaction(async (tx) => {
+        /**
+         * Campus only decides who gets *in*. A member whose reading came
+         * out as another campus this semester — an exchange, or courses
+         * taken at another campus — keeps the programme they already
+         * belong to, so the gate can never take away access it once gave.
+         */
+        const groups = [
+            ...allowed,
+            ...(await keepExistingMemberships(
+                tx,
+                userId,
+                campusRejected,
+                username,
+            )),
+        ];
+
+        for (const feideGroup of groups) {
+            const sp = await tx
+                .select({ id: studyProgram.id, slug: studyProgram.slug })
+                .from(studyProgram)
+                .where(eq(studyProgram.feideCode, feideGroup.code))
+                .limit(1);
+
+            if (!sp[0]) {
+                console.warn(
+                    `User is part of unknown study program ${feideGroup}, skipping`,
+                );
+                continue;
+            }
+
+            const { id: studyProgramId, slug: programSlug } = sp[0];
+
+            /**
+             * Additive by design: an existing row is left exactly as it
+             * is, start year included. Feide only reports ACTIVE
+             * memberships, so graduating removes the group from the
+             * response — access history survives because rows are never
+             * rewritten or deleted here. Baseline roles (member/alumni)
+             * are what actually gate participation; see
+             * syncBaselineRoles.
+             */
+            await tx
+                .insert(studyProgramMembership)
+                .values({
+                    userId,
+                    studyProgramId,
+                    startYear: feideGroup.startYear,
+                    confirmedCampus: campus,
+                })
+                .onConflictDoNothing();
+
+            await confirmCampus(tx, userId, studyProgramId, campus);
+
+            await syncDerivedStudyGroups(
+                tx,
+                userId,
+                programSlug,
+                feideGroup.startYear,
+            );
+        }
+
+        /**
+         * Baseline roles follow the Feide result: active students get
+         * "member", former members get "alumni", strangers get neither.
+         *
+         * Keyed on `active`, not on how many groups came back. With
+         * `showAll=true` a member who finished years ago still has their
+         * old groups in the response, so counting groups would call
+         * everyone an active student forever.
+         */
+        await syncBaselineRoles(
+            tx,
+            userId,
+            groups.some((g) => g.active),
+        );
+    });
+}
 
 /**
  * Keep a user's baseline RBAC role ("member" / "alumni") in sync with what

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -505,6 +505,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/account-link/sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sync study data from Feide for the current user
+         * @description Reads the caller's study programmes, cohort and campus from Feide and applies them, including derived study groups and the member/alumni role. Run after linking a Feide account, which cannot sync on its own. Safe to repeat.
+         */
+        post: operations["syncFeideAccount"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/company/contact": {
         parameters: {
             query?: never;
@@ -2727,6 +2747,9 @@ export interface components {
             contactEmail: string;
             /** @description What they remember about the old account */
             note?: string;
+        };
+        AccountLinkSyncResponse: {
+            success: boolean;
         };
         CompanyContactResponse: {
             success: boolean;
@@ -6144,6 +6167,49 @@ export interface operations {
             };
             /** @description Too many requests from this client */
             429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    syncFeideAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Study data synced */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountLinkSyncResponse"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description No Feide account is linked to this user */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Feide could not be reached */
+            502: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/sdk/src/generated/schemas.ts
+++ b/packages/sdk/src/generated/schemas.ts
@@ -9,6 +9,7 @@ export type SchemaOf<TName extends SchemaNames> = Schemas[TName];
 
 export type AccountLinkHelp = Schemas["AccountLinkHelp"];
 export type AccountLinkHelpResponse = Schemas["AccountLinkHelpResponse"];
+export type AccountLinkSyncResponse = Schemas["AccountLinkSyncResponse"];
 export type ActivateContractResponse = Schemas["ActivateContractResponse"];
 export type ActiveContract = Schemas["ActiveContract"];
 export type AddGroupMember = Schemas["AddGroupMember"];


### PR DESCRIPTION
## Feilen

Better Auths `/oauth2/callback` har to grener. Innlogging lager en sesjon; **kobling skriver kontoraden og redirecter uten en** — medlemmet er jo allerede innlogget:

```js
if (link) {
    …createAccount({ userId: link.userId, … })
    throw ctx.redirect(toRedirectTo);     // ← ingen setSessionCookie
}
await setSessionCookie(ctx, { session, user });   // bare her
```

`syncFeideHook` leser `context.newSession` for å vite hvem som logget inn. Ved kobling finnes den ikke, så synkroniseringen hopper over — og medlemmet får fungerende innlogging uten studieprogram, campus eller kull.

**Fem medlemmer havnet i den tilstanden i prod 30. juli.** Bekreftet i Loki: `POST /oauth2/link` på nøyaktig deres tidspunkter, og ingen «Feide returned N groups»-linje for noen av dem — vi spurte aldri Feide.

Ingenting gikk tapt; neste Feide-innlogging fyller det inn. Men inntil da står de utenfor alle **279 prioriteringspooler** som selekterer på studie- eller kullgruppe, uten å vite det.

## Fiksen

`syncFeideForUser` trekkes ut av hooken og eksponeres bak et autentisert `POST /account-link/sync`. `/koble-feide` kaller det når koblingen er ferdig — den siden har sesjonen callbacken manglet.

Valgt fremfor å lese sesjonscookien i hooken, som ville bundet oss til Better Auths cookienavn og signaturformat.

Endepunktet er **idempotent**, så det er samtidig reparasjonsverktøyet for de fem.

Feiler synkroniseringen, blokkeres ikke medlemmet: koblingen er gjort og de er innlogget, så de sendes videre.

For brukeren: samme antall klikk, ett kort «Henter studieopplysningene dine» før de er fremme.

## Retter også teksten fra #320

Den sa at adressen «som regel» er privat og ikke `@stud.ntnu.no`. Prod:

| | |
|---|---|
| privat | 1006 |
| @stud.ntnu.no | **689** |

Feil for to av fem. Den første som traff skjermbildet hadde NTNU-adresse, fulgte hintet, skrev en privat adresse og fikk stillhet. Teksten navngir nå begge uten å styre.

## Verifisert

`bun run test` (350 tester, 46 filer), `typecheck`, `lint`, `format` grønt. Fem nye tester på endepunktet: 401 uten sesjon, 409 uten Feide-konto, 200 som skriver studieprogram + begge gruppene, kjøring to ganger uten duplikater, og 502 når Dataporten er nede.

🤖 Generated with [Claude Code](https://claude.com/claude-code)