### PR TITLE
fix(events): vis kun innlogget brukers favoritter

### DIFF
--- a/apps/api/src/routes/event/favorite/get.ts
+++ b/apps/api/src/routes/event/favorite/get.ts
@@ -1,3 +1,5 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
 import type z from "zod";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -26,6 +28,7 @@ export const getFavoriteEventsRoute = route().get(
 
         // Get all favorite event IDs for the user
         const favorites = await db.query.eventFavorite.findMany({
+            where: eq(schema.eventFavorite.userId, userId),
             with: {
                 event: {
                     columns: { id: true, title: true, slug: true },

--- a/apps/api/src/routes/event/index.ts
+++ b/apps/api/src/routes/event/index.ts
@@ -25,16 +25,16 @@ export const eventRoutes = route()
     .route("/", createStrikeRoute)
     .route("/", deleteStrikeRoute)
 
+    // Favorites (registered before "/:eventId" so the static /favorite path wins)
+    .route("/favorite", updateFavoriteEventsRoute)
+    .route("/favorite", getFavoriteEventsRoute)
+
     // Event routes
     .route("/", createRoute)
     .route("/", listRoute)
     .route("/", updateRoute)
     .route("/", deleteRoute)
     .route("/", getRoute)
-
-    // Favorites
-    .route("/favorite", updateFavoriteEventsRoute)
-    .route("/favorite", getFavoriteEventsRoute)
 
     // Registration
     // url prefix is delegated because we capture the :eventId there

--- a/apps/api/src/test/event/favorite.test.ts
+++ b/apps/api/src/test/event/favorite.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+describe("event favorites", () => {
+    integrationTest(
+        "only returns the favorites of the authenticated user",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const eventA = await ctx.utils.createTestEvent({
+                title: "Event A",
+                slug: `event-a-${Date.now()}`,
+            });
+            const eventB = await ctx.utils.createTestEvent({
+                title: "Event B",
+                slug: `event-b-${Date.now()}`,
+            });
+
+            const userA = await ctx.utils.createTestUser();
+            const userB = await ctx.utils.createTestUser();
+            const clientA = await ctx.utils.clientForUser(userA);
+            const clientB = await ctx.utils.clientForUser(userB);
+
+            const favoriteA = await clientA.api.event.favorite[":id"].$put({
+                param: { id: eventA.id },
+                json: { isFavorite: true },
+            });
+            expect(favoriteA.status).toBe(200);
+
+            const favoriteB = await clientB.api.event.favorite[":id"].$put({
+                param: { id: eventB.id },
+                json: { isFavorite: true },
+            });
+            expect(favoriteB.status).toBe(200);
+
+            const responseA = await clientA.api.event.favorite.$get();
+            expect(responseA.status).toBe(200);
+            const bodyA = await responseA.json();
+
+            expect(bodyA.map((f) => f.eventId)).toEqual([eventA.id]);
+
+            const responseB = await clientB.api.event.favorite.$get();
+            expect(responseB.status).toBe(200);
+            const bodyB = await responseB.json();
+
+            expect(bodyB.map((f) => f.eventId)).toEqual([eventB.id]);
+        },
+        500_000,
+    );
+});

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -589,6 +589,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/event/favorite/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update event favorite
+         * @description Mark or unmark an event as a favorite for the authenticated user
+         */
+        put: operations["updateEventFavorite"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/event/favorite": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get all my favorite events
+         * @description Retrieve a list of all events you have marked as favorite.
+         */
+        get: operations["getFavoriteEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/event": {
         parameters: {
             query?: never;
@@ -652,46 +692,6 @@ export interface paths {
          * @description Delete an event by its ID. Event creators can delete their own events. Users with 'events:delete' permission can delete any event. This action is irreversible and will remove all associated data, including registrations and feedback.
          */
         delete: operations["deleteEvent"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/event/favorite/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * Update event favorite
-         * @description Mark or unmark an event as a favorite for the authenticated user
-         */
-        put: operations["updateEventFavorite"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/event/favorite": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get all my favorite events
-         * @description Retrieve a list of all events you have marked as favorite.
-         */
-        get: operations["getFavoriteEvents"];
-        put?: never;
-        post?: never;
-        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -2852,6 +2852,26 @@ export interface components {
         DeleteStrikeResponse: {
             message: string;
         };
+        UpdateFavoriteResponse: {
+            success: boolean;
+        };
+        UpdateFavoriteEvent: {
+            /** @description Is favorite */
+            isFavorite: boolean;
+        };
+        FavoriteEvents: {
+            /** @description Event ID */
+            eventId: string;
+            /** @description Event title */
+            title: string;
+            /** @description Event slug */
+            slug: string;
+            /**
+             * Format: date-time
+             * @description When you added this event to your favorites
+             */
+            createdAt: string;
+        }[];
         CreateEventResponse: {
             /** Format: uuid */
             eventId: string;
@@ -3233,26 +3253,6 @@ export interface components {
                 attendedAt: string | null;
             } | null;
         };
-        UpdateFavoriteResponse: {
-            success: boolean;
-        };
-        UpdateFavoriteEvent: {
-            /** @description Is favorite */
-            isFavorite: boolean;
-        };
-        FavoriteEvents: {
-            /** @description Event ID */
-            eventId: string;
-            /** @description Event title */
-            title: string;
-            /** @description Event slug */
-            slug: string;
-            /**
-             * Format: date-time
-             * @description When you added this event to your favorites
-             */
-            createdAt: string;
-        }[];
         EventRegistration: {
             /** Format: uuid */
             eventId: string;
@@ -6369,6 +6369,77 @@ export interface operations {
             };
         };
     };
+    updateEventFavorite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateFavoriteEvent"];
+            };
+        };
+        responses: {
+            /** @description Updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateFavoriteResponse"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Not Found - Event not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getFavoriteEvents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of favorite events */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FavoriteEvents"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+        };
+    };
     listEvents: {
         parameters: {
             query?: {
@@ -6555,77 +6626,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
-            };
-        };
-    };
-    updateEventFavorite: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateFavoriteEvent"];
-            };
-        };
-        responses: {
-            /** @description Updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UpdateFavoriteResponse"];
-                };
-            };
-            /** @description Authentication required */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPAppException"];
-                };
-            };
-            /** @description Not Found - Event not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getFavoriteEvents: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of favorite events */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FavoriteEvents"];
-                };
-            };
-            /** @description Authentication required */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPAppException"];
-                };
             };
         };
     };


### PR DESCRIPTION
## Hva

`GET /api/event/favorite` hadde to feil:

1. **Lekkasje av andres favoritter** — `db.query.eventFavorite.findMany` manglet `where: eq(schema.eventFavorite.userId, userId)`, så den hentet hele `event_favorite`-tabellen. `userId` ble hentet ut av konteksten, men aldri brukt (oxlint flagget den ubrukte variabelen).
2. **Ruten var uansett uåpnåelig** — `GET /:eventId` var registrert før `/favorite` i `event/index.ts`, så `GET /api/event/favorite` traff event-oppslaget og svarte 404 «Event not found». Favoritt-rutene er flyttet foran `/:eventId`, med samme kommentarmønster som strikes-rutene rett over.

## Hvorfor

Punkt 1 er et personvernproblem: endepunktet skulle returnere «mine favoritter». Punkt 2 ble avdekket av den nye testen — uten den fiksen svarer endepunktet aldri.

## Test

Ny integrasjonstest `apps/api/src/test/event/favorite.test.ts`: bruker A og B favoriserer hvert sitt arrangement, og hver får kun sitt eget tilbake. Testen feiler på begge buggene hver for seg (verifisert ved å stashe fiksene én og én).

## Verifisert

- `bun run vitest run src/test/event` — 12 filer / 67 tester grønne, ingen regresjon fra ruteomrokkeringen
- `bun run typecheck` — 9/9 ok
- `bun run lint` — ingen nye advarsler i berørte filer (den ubrukte `userId` er borte)

## For reviewer

`packages/sdk/src/generated/openapi.ts` er regenerert og inneholder kun omrokkering av favoritt-stiene som følge av ruterekkefølgen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)