### PR TITLE
fix(kvark): vis faktisk antall uleste varsler på profilen

### DIFF
--- a/apps/api/src/routes/notification/list.ts
+++ b/apps/api/src/routes/notification/list.ts
@@ -1,16 +1,15 @@
 import { schema } from "@photon/db";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import type { z } from "zod";
 import { describeRoute } from "~/lib/openapi";
-import {
-    PaginationSchema,
-    getPageOffset,
-    getTotalPages,
-} from "~/middleware/pagination";
+import { getPageOffset, getTotalPages } from "~/middleware/pagination";
 import { route } from "../../lib/route";
 import { requireAuth } from "../../middleware/auth";
-import { notificationListResponseSchema } from "./schema";
+import {
+    notificationListQuerySchema,
+    notificationListResponseSchema,
+} from "./schema";
 
 export const listNotificationsRoute = route().get(
     "/",
@@ -19,7 +18,7 @@ export const listNotificationsRoute = route().get(
         summary: "List notifications for authenticated user",
         operationId: "listNotifications",
         description:
-            "Returns paginated list of notifications for the authenticated user, ordered by most recent first",
+            "Returns paginated list of notifications for the authenticated user, ordered by most recent first. Pass isRead=false to count unread ones: totalCount answers that without fetching the notifications themselves.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -28,14 +27,19 @@ export const listNotificationsRoute = route().get(
         })
         .build(),
     requireAuth,
-    validator("query", PaginationSchema),
+    validator("query", notificationListQuerySchema),
     async (c) => {
         const { db } = c.get("ctx");
         const userId = c.get("user").id;
-        const { pageSize, page } = c.req.valid("query");
+        const { pageSize, page, isRead } = c.req.valid("query");
         const pageOffset = getPageOffset(page, pageSize);
 
-        const notificationFilter = eq(schema.notification.userId, userId);
+        const notificationFilter = and(
+            eq(schema.notification.userId, userId),
+            isRead === undefined
+                ? undefined
+                : eq(schema.notification.isRead, isRead),
+        );
 
         const notificationCount = await db.$count(
             schema.notification,

--- a/apps/api/src/routes/notification/schema.ts
+++ b/apps/api/src/routes/notification/schema.ts
@@ -1,8 +1,21 @@
 import z from "zod";
 import { Schema } from "~/lib/openapi";
-import { PagniationResponseSchema } from "~/middleware/pagination";
+import {
+    PagniationResponseSchema,
+    PaginationSchema,
+} from "~/middleware/pagination";
 
 // ===== INPUT SCHEMAS =====
+
+export const notificationListQuerySchema = PaginationSchema.extend({
+    // stringbool parses the "true"/"false" a query string actually carries;
+    // z.coerce.boolean() would read "false" as true.
+    isRead: z.stringbool().optional().meta({
+        type: "boolean",
+        description:
+            "Filter on read state. False returns only unread notifications, true only read ones. Omit to return both.",
+    }),
+});
 
 export const markReadSchema = Schema(
     "MarkNotificationRead",

--- a/apps/api/src/test/notification.test.ts
+++ b/apps/api/src/test/notification.test.ts
@@ -1,0 +1,82 @@
+import { schema } from "@photon/db";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+describe("notification list", () => {
+    integrationTest(
+        "filters on read state and counts unread without fetching them",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+
+            await ctx.db.insert(schema.notification).values([
+                {
+                    userId: user.id,
+                    title: "Ulest 1",
+                    description: "",
+                    isRead: false,
+                },
+                {
+                    userId: user.id,
+                    title: "Ulest 2",
+                    description: "",
+                    isRead: false,
+                },
+                {
+                    userId: user.id,
+                    title: "Lest",
+                    description: "",
+                    isRead: true,
+                },
+            ]);
+
+            const all = await client.api.notification.$get({ query: {} });
+            expect(all.status).toBe(200);
+            expect((await all.json()).totalCount).toBe(3);
+
+            /**
+             * The profile badge asks for a single row and reads totalCount, so
+             * the count must reflect the filter and not the page size. A
+             * `z.coerce.boolean()` query param would read "false" as true and
+             * make this return the read one instead.
+             */
+            const unread = await client.api.notification.$get({
+                query: { isRead: "false", pageSize: "1" },
+            });
+            const unreadBody = await unread.json();
+            expect(unreadBody.totalCount).toBe(2);
+            expect(unreadBody.items).toHaveLength(1);
+            expect(unreadBody.items[0]?.isRead).toBe(false);
+
+            const read = await client.api.notification.$get({
+                query: { isRead: "true" },
+            });
+            const readBody = await read.json();
+            expect(readBody.totalCount).toBe(1);
+            expect(readBody.items[0]?.title).toBe("Lest");
+        },
+    );
+
+    integrationTest(
+        "counts only the caller's notifications",
+        async ({ ctx }) => {
+            const mine = await ctx.utils.createTestUser();
+            const theirs = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(mine);
+
+            await ctx.db.insert(schema.notification).values([
+                {
+                    userId: theirs.id,
+                    title: "Ikke min",
+                    description: "",
+                    isRead: false,
+                },
+            ]);
+
+            const unread = await client.api.notification.$get({
+                query: { isRead: "false" },
+            });
+            expect((await unread.json()).totalCount).toBe(0);
+        },
+    );
+});

--- a/apps/kvark/src/api/queries/notifications.ts
+++ b/apps/kvark/src/api/queries/notifications.ts
@@ -9,6 +9,7 @@ import type { QueryParamsHelper } from "@tihlde/sdk/types";
 const NotificationQueryKeys = {
     listInfinite: ["notifications", "list-infinite"] as const,
     list: ["notifications", "list-paged"] as const,
+    unreadCount: ["notifications", "unread-count"] as const,
 } as const;
 
 const DEFAULT_PAGE_SIZE = 25;
@@ -33,6 +34,20 @@ export const getNotificationsQuery = (
                     ...filters,
                 },
             }),
+    });
+
+/**
+ * Antall uleste varsler. Henter én rad og leser `totalCount` — serveren teller
+ * med samme filter, så vi slipper å laste ned varslene for å telle dem.
+ */
+export const getUnreadNotificationCountQuery = () =>
+    queryOptions({
+        queryKey: NotificationQueryKeys.unreadCount,
+        queryFn: () =>
+            apiClient.get("/api/notification", {
+                searchParams: { page: 0, pageSize: 1, isRead: false },
+            }),
+        select: (data) => data.totalCount,
     });
 
 export const getNotificationsInfiniteQuery = (
@@ -67,6 +82,10 @@ export const deleteNotificationMutation = mutationOptions({
             queryKey: [...NotificationQueryKeys.listInfinite],
             exact: false,
         });
+        // Både lesing og sletting endrer antallet uleste.
+        ctx.client.invalidateQueries({
+            queryKey: NotificationQueryKeys.unreadCount,
+        });
     },
 });
 
@@ -90,6 +109,10 @@ export const markNotificationReadMutation = mutationOptions({
         ctx.client.invalidateQueries({
             queryKey: [...NotificationQueryKeys.listInfinite],
             exact: false,
+        });
+        // Både lesing og sletting endrer antallet uleste.
+        ctx.client.invalidateQueries({
+            queryKey: NotificationQueryKeys.unreadCount,
         });
     },
 });

--- a/apps/kvark/src/components/profile-overview-header.tsx
+++ b/apps/kvark/src/components/profile-overview-header.tsx
@@ -28,7 +28,9 @@ export function ProfileOverviewHeader({
             {isOwnProfile ? (
                 <Badge variant="outline" className="gap-1.5">
                     <Bell />
-                    {notifications} nye varsler
+                    {notifications === 1
+                        ? "1 nytt varsel"
+                        : `${notifications} nye varsler`}
                 </Badge>
             ) : null}
         </div>

--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -1,4 +1,5 @@
 import { authQueryOptions } from "#/api/auth";
+import { getUnreadNotificationCountQuery } from "#/api/queries/notifications";
 import { getUserProfileQuery } from "#/api/queries/user";
 import { ProfileLinksSection } from "#/components/profile-links-section";
 import { ProfileOverviewHeader } from "#/components/profile-overview-header";
@@ -31,6 +32,13 @@ function RouteComponent() {
     const { data: session } = useQuery(authQueryOptions);
     const isOwnProfile = session?.user.id === id;
 
+    // Varselmerket vises bare på egen profil, så andres profiler skal heller
+    // ikke koste et kall til det innloggede-scopede endepunktet.
+    const { data: unreadNotifications } = useQuery({
+        ...getUnreadNotificationCountQuery(),
+        enabled: isOwnProfile,
+    });
+
     const links: ProfileLink[] = [];
     if (profile.githubUrl)
         links.push({ kind: "github", label: "github", url: profile.githubUrl });
@@ -58,7 +66,7 @@ function RouteComponent() {
             <ProfileOverviewHeader
                 name={profile.name}
                 isOwnProfile={isOwnProfile}
-                notifications={0}
+                notifications={unreadNotifications}
             />
             {profile.bio ? (
                 <div className="flex flex-col gap-2">

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1174,7 +1174,7 @@ export interface paths {
         };
         /**
          * List notifications for authenticated user
-         * @description Returns paginated list of notifications for the authenticated user, ordered by most recent first
+         * @description Returns paginated list of notifications for the authenticated user, ordered by most recent first. Pass isRead=false to count unread ones: totalCount answers that without fetching the notifications themselves.
          */
         get: operations["listNotifications"];
         put?: never;
@@ -8262,6 +8262,8 @@ export interface operations {
                 pageSize?: number;
                 /** @description Number of items to skip */
                 page?: number;
+                /** @description Filter on read state. False returns only unread notifications, true only read ones. Omit to return both. */
+                isRead?: boolean;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
Varselmerket på profiloversikten fikk `notifications={0}` hardkodet, så det sto «0 nye varsler» uansett hvor mange uleste man hadde. Varsel-API-et (`GET /api/notification` med mark-read og delete) og query-laget i Kvark fantes allerede — det var bare aldri koblet sammen. Dette er det ene uavklarte punktet under **Communication** i #40.

## Endringer

- `GET /api/notification` tar nå `isRead` som filter. Frontenden ber om én rad og leser `totalCount`, så antallet uleste koster ikke en nedlasting av varslene.
- Filteret bruker `z.stringbool()`, ikke `z.coerce.boolean()`: en query-streng er alltid en streng, og coerce ville lest `"false"` som `true` og telt de leste i stedet. Testen dekker nettopp det tilfellet — den feiler på `z.coerce.boolean()` med «expected 1 to be 2».
- Både «marker som lest» og sletting invaliderer det nye antallet.
- Merket henter ikke på andres profiler: det vises uansett bare på ens egen, og endepunktet er scopet til innlogget bruker.
- «1 nye varsler» er rettet til «1 nytt varsel».

## Verifisering

- `bun run typecheck` 9/9, `bun run build` 4/4, `bun run format` rent, `bun run lint` uten nye advarsler
- Ny integrasjonstest (`apps/api/src/test/notification.test.ts`, 2 tester): filtrering på lest/ulest, at `totalCount` følger filteret og ikke sidestørrelsen, og at man ikke teller andres varsler
- Lokalt i nettleseren: 3 uleste + 1 lest gir «3 nye varsler»; etter at to merkes lest står det «1 nytt varsel»; en annens profil skjuler merket og gjør ingen kall til `/api/notification` (bekreftet i API-loggen)

Fant også i forbifarten at `expired` på `/api/job` har den `z.coerce.boolean()`-feilen denne PR-en unngår — `?expired=false` inkluderer utløpte annonser. Ikke rørt her.