### PR TITLE
fix(jobs): la ?expired=false faktisk ekskludere utløpte annonser

### DIFF
--- a/apps/api/src/routes/job/schema.ts
+++ b/apps/api/src/routes/job/schema.ts
@@ -160,7 +160,11 @@ export const jobListFilterSchema = PaginationSchema.extend({
     search: z.string().optional().meta({
         description: "Search term to filter by title or company name",
     }),
-    expired: z.coerce.boolean().optional().meta({
+    // stringbool parses the "true"/"false" a query string actually carries;
+    // z.coerce.boolean() turned "false" into true. The meta type keeps it a
+    // boolean in OpenAPI, where that encoding is implied.
+    expired: z.stringbool().optional().meta({
+        type: "boolean",
         description: "Include expired job postings (default: false)",
     }),
     jobType: z.enum(schema.jobTypeVariants).optional().meta({

--- a/apps/api/src/test/job/jobs.test.ts
+++ b/apps/api/src/test/job/jobs.test.ts
@@ -166,6 +166,20 @@ describe("Job Postings System", () => {
             );
             expect(expiredJobInList?.expired).toBe(true);
 
+            // 8b. `expired=false` must behave like omitting the filter.
+            // z.coerce.boolean() made every non-empty string true, so the
+            // explicit opt-out returned expired ads — the opposite of the ask.
+            const listWithoutExpiredResponse = await userClient.api.jobs.$get({
+                query: { expired: "false" },
+            });
+
+            expect(listWithoutExpiredResponse.status).toBe(200);
+            const withoutExpired = await listWithoutExpiredResponse.json();
+            expect(withoutExpired.items.length).toBe(2);
+            expect(
+                withoutExpired.items.find((j) => j.id === expiredJob.id),
+            ).toBeUndefined();
+
             // 9. Search by title
             const searchByTitleResponse = await userClient.api.jobs.$get({
                 query: { search: "Developer" },


### PR DESCRIPTION
## Hva

`jobListFilterSchema` brukte `z.coerce.boolean()` på `expired`. Query-parametre kommer inn som strenger, og JS gjør enhver ikke-tom streng til `true` — så `"false"` ble `true`, `showExpired` ble satt i [list.ts:35](apps/api/src/routes/job/list.ts#L35), og `GET /api/job?expired=false` returnerte utløpte annonser. Stikk motsatt av det kallet ber om.

Bytter til `z.stringbool()`, som er mønsteret resten av repoet allerede bruker for boolske query-parametre (se `apps/api/src/routes/event/schema.ts` og `notification/schema.ts`).

## Hvorfor det ikke endrer API-kontrakten

`meta({ type: "boolean" })` holder OpenAPI-typen uendret, akkurat som i event-schemaet. Jeg kjørte `bun run --filter @tihlde/sdk codegen` — **null diff i `packages/sdk`**. Det var bare runtime-parsingen som var feil.

## Test

Ny integrasjonstest (steg 8b) i `apps/api/src/test/job/jobs.test.ts` som sjekker at `?expired=false` gir samme resultat som å utelate filteret.

- Testen feiler på gammel kode: jeg reverterte schemaet midlertidig og kjørte jobbtesten → `AssertionError: expected 3 to be 2`.
- Med fiksen: 1 passed.
- Full suite: **376 passed** (50 filer). `typecheck` og `format` grønne; `lint` viser bare de samme pre-eksisterende warningene i urelaterte filer.

## Andre boolske query-parametre

`grep -rn "z.coerce.boolean" apps/api/src` gir nå null treff — dette var det eneste tilfellet i API-et.

Ett treff utenfor API-et som jeg **lot stå**: `apps/kvark/src/routes/_auth/koble-feide.tsx:31` bruker `z.coerce.boolean()` i `validateSearch`. Ikke en bug i praksis — den eneste som setter parameteren er `callbackURL: "/koble-feide?linked=1"` i samme fil, og verdien brukes kun som truthy-sjekk. Ingen kode sender `linked=false`. Si fra om den bør strammes inn uansett for konsistens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)