### PR TITLE
fix(kvark): vis bio-endringer uten refresh og la lenker fjernes

### DIFF
--- a/apps/api/src/lib/user/settings.ts
+++ b/apps/api/src/lib/user/settings.ts
@@ -10,17 +10,31 @@ export const UserAllergySchema = z.object({
     description: z.string().optional(),
 });
 
+/**
+ * A profile link the user can clear again. Omitting the field leaves it
+ * untouched; an empty string is an explicit "remove this link" and is stored as
+ * NULL — without it there would be no way to undo a link once it was set.
+ */
+const clearableUrl = z
+    .union([z.url({ message: "Must be a valid URL" }), z.literal("")])
+    .optional();
+
 export const UserSettingsSchema = z.object({
     gender: z.enum(genderVariants),
     allowsPhotosByDefault: z.boolean(),
     acceptsEventRules: z.boolean(),
     imageUrl: z.url({ message: "Must be a valid URL" }).optional(),
     bioDescription: z.string().optional(),
-    githubUrl: z.url({ message: "Must be a valid URL" }).optional(),
-    linkedinUrl: z.url({ message: "Must be a valid URL" }).optional(),
+    githubUrl: clearableUrl,
+    linkedinUrl: clearableUrl,
     receiveMailCommunication: z.boolean(),
     allergies: z.array(z.string()).default([]),
 });
+
+/** Tomme strenger lagres som NULL, så «tømt felt» ikke blir en tom verdi i DB. */
+function emptyToNull<T extends string>(value: T | undefined) {
+    return value === undefined ? undefined : value === "" ? null : value;
+}
 
 export const UpdateUserSettingsSchema = UserSettingsSchema.partial();
 
@@ -79,9 +93,9 @@ export async function createUserSettings(
             allowsPhotosByDefault: settings.allowsPhotosByDefault,
             acceptsEventRules: settings.acceptsEventRules,
             imageUrl: settings.imageUrl ?? null,
-            bioDescription: settings.bioDescription ?? null,
-            githubUrl: settings.githubUrl ?? null,
-            linkedinUrl: settings.linkedinUrl ?? null,
+            bioDescription: emptyToNull(settings.bioDescription) ?? null,
+            githubUrl: emptyToNull(settings.githubUrl) ?? null,
+            linkedinUrl: emptyToNull(settings.linkedinUrl) ?? null,
             receiveMailCommunication: settings.receiveMailCommunication,
             isOnboarded: true, // Mark as onboarded when creating
         });
@@ -121,9 +135,9 @@ export async function updateUserSettings(
                 .set({
                     ...settingsUpdates,
                     imageUrl: settingsUpdates.imageUrl ?? undefined,
-                    bioDescription: settingsUpdates.bioDescription ?? undefined,
-                    githubUrl: settingsUpdates.githubUrl ?? undefined,
-                    linkedinUrl: settingsUpdates.linkedinUrl ?? undefined,
+                    bioDescription: emptyToNull(settingsUpdates.bioDescription),
+                    githubUrl: emptyToNull(settingsUpdates.githubUrl),
+                    linkedinUrl: emptyToNull(settingsUpdates.linkedinUrl),
                 })
                 .where(eq(userSettings.userId, userId));
         }

--- a/apps/api/src/test/user.test.ts
+++ b/apps/api/src/test/user.test.ts
@@ -1,4 +1,5 @@
 import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
 import { describe, expect } from "vitest";
 import { integrationTest } from "~/test/config/integration";
 
@@ -664,6 +665,44 @@ describe("user endpoints", () => {
             });
 
             expect(response.status).toBe(400);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "clears a profile link when an empty string is sent",
+        async ({ ctx }) => {
+            const { db } = ctx;
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+
+            await db.insert(schema.userSettings).values({
+                userId: user.id,
+                gender: "male",
+                allowsPhotosByDefault: false,
+                acceptsEventRules: true,
+                receiveMailCommunication: true,
+                isOnboarded: true,
+                githubUrl: "https://github.com/testuser",
+                linkedinUrl: "https://linkedin.com/in/testuser",
+            });
+
+            const response = await client.api.user.me.settings.$patch({
+                json: { githubUrl: "" },
+            });
+
+            expect(response.status).toBe(200);
+
+            const settings = await db.query.userSettings.findFirst({
+                where: eq(schema.userSettings.userId, user.id),
+            });
+
+            // Tømt felt lagres som NULL, ikke tom streng — og feltene som ikke
+            // ble sendt med står urørt.
+            expect(settings?.githubUrl).toBeNull();
+            expect(settings?.linkedinUrl).toBe(
+                "https://linkedin.com/in/testuser",
+            );
         },
         500_000,
     );

--- a/apps/kvark/src/api/queries/user.ts
+++ b/apps/kvark/src/api/queries/user.ts
@@ -91,6 +91,12 @@ export const updateUserSettingsMutation = mutationOptions({
             queryKey: [...UserQueryKeys.settings],
             exact: false,
         });
+        // Bio og lenker vises fra profil-endepunktet, ikke fra settings, så
+        // profilen må hentes på nytt for at endringene skal vises uten refresh.
+        ctx.client.invalidateQueries({
+            queryKey: [...UserQueryKeys.profile],
+            exact: false,
+        });
     },
 });
 

--- a/apps/kvark/src/components/edit-bio-dialog.tsx
+++ b/apps/kvark/src/components/edit-bio-dialog.tsx
@@ -19,15 +19,21 @@ import {
 import { Input } from "@tihlde/ui/ui/input";
 import { Textarea } from "@tihlde/ui/ui/textarea";
 import { Pencil } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 
 const BIO_MAX = 500;
 
+/** Tomt felt betyr «fjern lenken», alt annet må være en gyldig URL. */
+const linkField = z.union([
+    z.url({ message: "Må være en gyldig URL" }),
+    z.literal(""),
+]);
+
 const editBioSchema = z.object({
     bio: z.string().max(BIO_MAX, `Maks ${BIO_MAX} tegn`),
-    github: z.string(),
-    linkedin: z.string(),
+    github: linkField,
+    linkedin: linkField,
 });
 
 type EditBioValues = z.infer<typeof editBioSchema>;
@@ -59,18 +65,25 @@ export function EditBioDialog({
         onOpenChange?.(next);
     }
 
+    const bio = defaultValues?.bio ?? "";
+    const github = defaultValues?.github ?? "";
+    const linkedin = defaultValues?.linkedin ?? "";
+
     const form = useForm({
-        defaultValues: {
-            bio: defaultValues?.bio ?? "",
-            github: defaultValues?.github ?? "",
-            linkedin: defaultValues?.linkedin ?? "",
-        } satisfies EditBioValues,
+        defaultValues: { bio, github, linkedin } satisfies EditBioValues,
         validators: { onChange: editBioSchema },
         onSubmit: async ({ value }) => {
             await onSubmit?.(value);
             setOpen(false);
         },
     });
+
+    // Dialogen monteres én gang og beholder skjemastaten sin, så feltene må
+    // fylles på nytt hver gang den åpnes — ellers viser den verdiene fra da
+    // komponenten ble montert, ikke de sist lagrede.
+    useEffect(() => {
+        if (open) form.reset({ bio, github, linkedin });
+    }, [open, bio, github, linkedin, form]);
 
     return (
         <Dialog open={open} onOpenChange={setOpen}>
@@ -193,7 +206,7 @@ export function EditBioDialog({
                         >
                             {({ canSubmit, isSubmitting }) => (
                                 <Button type="submit" disabled={!canSubmit}>
-                                    {isSubmitting ? "Lagrer..." : "Opprett"}
+                                    {isSubmitting ? "Lagrer..." : "Lagre"}
                                 </Button>
                             )}
                         </form.Subscribe>

--- a/apps/kvark/src/components/profile-header.tsx
+++ b/apps/kvark/src/components/profile-header.tsx
@@ -1,6 +1,6 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
 import { Badge } from "@tihlde/ui/ui/badge";
-import { Github, GraduationCap, Linkedin, Mail, Plus } from "lucide-react";
+import { Github, GraduationCap, Linkedin, Mail } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { DetailHeader } from "#/components/detail-layout";
@@ -24,18 +24,9 @@ export type ProfileHeaderUser = {
 type ProfileHeaderProps = {
     user: ProfileHeaderUser;
     actions?: ReactNode;
-    /**
-     * Åpner dialogen der GitHub-/LinkedIn-lenker redigeres. Utelates på andres
-     * profiler, som også skjuler «Legg til lenke».
-     */
-    onAddLink?: () => void;
 };
 
-export function ProfileHeader({
-    user,
-    actions,
-    onAddLink,
-}: ProfileHeaderProps) {
+export function ProfileHeader({ user, actions }: ProfileHeaderProps) {
     return (
         <DetailHeader
             avatar={
@@ -91,18 +82,6 @@ export function ProfileHeader({
                             {link.label}
                         </Badge>
                     ))}
-                    {onAddLink ? (
-                        <Badge
-                            variant="secondary"
-                            className="gap-1.5"
-                            render={
-                                <button type="button" onClick={onAddLink} />
-                            }
-                        >
-                            <Plus />
-                            Legg til lenke
-                        </Badge>
-                    ) : null}
                 </>
             }
             actions={actions}

--- a/apps/kvark/src/components/profile-links-section.tsx
+++ b/apps/kvark/src/components/profile-links-section.tsx
@@ -1,22 +1,14 @@
 import { Badge } from "@tihlde/ui/ui/badge";
-import { Github, Linkedin, Plus } from "lucide-react";
+import { Github, Linkedin } from "lucide-react";
 
 import type { ProfileLink } from "#/components/profile-header";
 
 type ProfileLinksSectionProps = {
     links: ProfileLink[];
-    /**
-     * Åpner dialogen der lenkene redigeres. Utelates på andres profiler, som
-     * også skjuler «Legg til lenke».
-     */
-    onAddLink?: () => void;
 };
 
-export function ProfileLinksSection({
-    links,
-    onAddLink,
-}: ProfileLinksSectionProps) {
-    if (links.length === 0 && !onAddLink) return null;
+export function ProfileLinksSection({ links }: ProfileLinksSectionProps) {
+    if (links.length === 0) return null;
 
     return (
         <div className="flex flex-col gap-3 md:hidden">
@@ -41,16 +33,6 @@ export function ProfileLinksSection({
                         {link.label}
                     </Badge>
                 ))}
-                {onAddLink ? (
-                    <Badge
-                        variant="secondary"
-                        className="gap-1.5"
-                        render={<button type="button" onClick={onAddLink} />}
-                    >
-                        <Plus />
-                        Legg til lenke
-                    </Badge>
-                ) : null}
             </div>
         </div>
     );

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -82,9 +82,9 @@ function buildProfileLinks(
 ): ProfileLink[] {
     const links: ProfileLink[] = [];
     if (githubUrl)
-        links.push({ kind: "github", label: "github", url: githubUrl });
+        links.push({ kind: "github", label: "GitHub", url: githubUrl });
     if (linkedinUrl)
-        links.push({ kind: "linkedin", label: "linkedin", url: linkedinUrl });
+        links.push({ kind: "linkedin", label: "LinkedIn", url: linkedinUrl });
     return links;
 }
 
@@ -194,7 +194,6 @@ function RouteComponent() {
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
             <ProfileHeader
                 user={user}
-                onAddLink={isOwnProfile ? () => setBioOpen(true) : undefined}
                 actions={
                     isOwnProfile ? (
                         <>
@@ -210,8 +209,8 @@ function RouteComponent() {
                     ) : null
                 }
             />
-            {/* Dialogen styres herfra slik at både «Rediger bio» og
-                «Legg til lenke» i headeren åpner den samme dialogen. */}
+            {/* Dialogen styres herfra slik at «Rediger bio» i headeren kan
+                åpne den. */}
             {isOwnProfile ? (
                 <EditBioDialog
                     open={bioOpen}
@@ -224,9 +223,12 @@ function RouteComponent() {
                     onSubmit={async (values) => {
                         await updateSettings.mutateAsync({
                             data: {
-                                bioDescription: values.bio || undefined,
-                                githubUrl: values.github || undefined,
-                                linkedinUrl: values.linkedin || undefined,
+                                // Tomme strenger må sendes med — `undefined`
+                                // betyr «ikke endre», så feltene kunne aldri
+                                // tømmes igjen. API-et lagrer tomt som NULL.
+                                bioDescription: values.bio,
+                                githubUrl: values.github,
+                                linkedinUrl: values.linkedin,
                                 allergies: settings?.allergies ?? [],
                             },
                         });

--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -41,11 +41,11 @@ function RouteComponent() {
 
     const links: ProfileLink[] = [];
     if (profile.githubUrl)
-        links.push({ kind: "github", label: "github", url: profile.githubUrl });
+        links.push({ kind: "github", label: "GitHub", url: profile.githubUrl });
     if (profile.linkedinUrl)
         links.push({
             kind: "linkedin",
-            label: "linkedin",
+            label: "LinkedIn",
             url: profile.linkedinUrl,
         });
 

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -5148,10 +5148,8 @@ export interface components {
             /** Format: uri */
             imageUrl?: string;
             bioDescription?: string;
-            /** Format: uri */
-            githubUrl?: string;
-            /** Format: uri */
-            linkedinUrl?: string;
+            githubUrl?: string | "";
+            linkedinUrl?: string | "";
             receiveMailCommunication: boolean;
             /** @default [] */
             allergies: string[];
@@ -5166,10 +5164,8 @@ export interface components {
             /** Format: uri */
             imageUrl?: string;
             bioDescription?: string;
-            /** Format: uri */
-            githubUrl?: string;
-            /** Format: uri */
-            linkedinUrl?: string;
+            githubUrl?: string | "";
+            linkedinUrl?: string | "";
             receiveMailCommunication: boolean;
             /** @default [] */
             allergies: string[];
@@ -5182,10 +5178,8 @@ export interface components {
             /** Format: uri */
             imageUrl?: string;
             bioDescription?: string;
-            /** Format: uri */
-            githubUrl?: string;
-            /** Format: uri */
-            linkedinUrl?: string;
+            githubUrl?: string | "";
+            linkedinUrl?: string | "";
             receiveMailCommunication: boolean;
             /** @default [] */
             allergies: string[];
@@ -5198,10 +5192,8 @@ export interface components {
             /** Format: uri */
             imageUrl?: string;
             bioDescription?: string;
-            /** Format: uri */
-            githubUrl?: string;
-            /** Format: uri */
-            linkedinUrl?: string;
+            githubUrl?: string | "";
+            linkedinUrl?: string | "";
             receiveMailCommunication?: boolean;
             /** @default [] */
             allergies: string[];
@@ -5214,10 +5206,8 @@ export interface components {
             /** Format: uri */
             imageUrl?: string;
             bioDescription?: string;
-            /** Format: uri */
-            githubUrl?: string;
-            /** Format: uri */
-            linkedinUrl?: string;
+            githubUrl?: string | "";
+            linkedinUrl?: string | "";
             receiveMailCommunication?: boolean;
             /** @default [] */
             allergies: string[];


### PR DESCRIPTION
## Hva

Bio- og lenkeendringer på profilen vises nå med én gang du lagrer, og lenker kan fjernes igjen.

## Hvorfor

Bio og lenker rendres fra `/api/user/{id}`, men lagringen invaliderte bare `user/settings` og sesjonen — profilspørringen ble aldri hentet på nytt, så du måtte refreshe for å se endringen.

## Endringer

- **Invalidering**: `updateUserSettingsMutation` invaliderer nå også profil-nøkkelen.
- **«Legg til lenke» fjernet**: badge-knappen er borte fra både headeren og LENKER-seksjonen. «Rediger bio» er eneste inngang til dialogen.
- **Dialogen resettes ved åpning**: den er montert hele tiden, så skjemaet viste verdiene fra første render — nå fylles feltene på nytt hver gang den åpnes.
- **Tomme felt kan lagres**: `undefined` betyr «ikke endre», så verken bio eller lenker kunne tømmes. API-et godtar nå tom streng for `githubUrl`/`linkedinUrl` og lagrer den som `NULL`; utelatt felt står fortsatt urørt. Klienten validerer «gyldig URL eller tomt», så en feilskrevet URL gir feilmelding i feltet i stedet for en stille 400.
- **Tekst**: lagre-knappen het «Opprett» → «Lagre»; lenkemerkene sto som `github`/`linkedin` → «GitHub»/«LinkedIn».
- `packages/sdk/src/generated/openapi.ts` er regenerert siden API-skjemaet endret seg.

## Testing

- Ny integrasjonstest: tomt felt gir `NULL` i DB, mens felt som ikke sendes med står urørt. `user.test.ts` 23/23 grønn (inkludert den eksisterende testen som fortsatt avviser ugyldige URL-er).
- Manuelt mot lokal API: endret bio → oppdatert umiddelbart uten refresh; tømte bio → «OM»-seksjonen forsvant; tømte GitHub-lenken → badgen forsvant og `/api/user/{id}` returnerer `null`; ugyldig URL → feilmelding i feltet og deaktivert lagre-knapp.
- `typecheck`, `lint` og `format` grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)