### PR TITLE
fix(grupper): rett rollehåndtering og slug-fallback i medlemshistorikk

### DIFF
--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -156,16 +156,12 @@ export function mapMember(member: ApiGroupMember): Member {
 }
 
 /**
- * Norske navn på rollene et avsluttet medlemskap kan ha hatt. Photon har bare
- * member/leader, men historikken er backfilt fra Lepton, som lagret styreverv
- * i samme felt og i STORE BOKSTAVER.
+ * Norske navn på rollene et avsluttet medlemskap kan ha hatt. Både Photon og
+ * Lepton-historikken kjenner bare member/leader — kolonnen er fritekst, så en
+ * ukjent verdi vises som den er i stedet for å bli borte.
  */
 const MEMBER_ROLE_LABELS: Record<string, string> = {
     leader: "Leder",
-    deputy_leader: "Nestleder",
-    treasurer: "Økonomiansvarlig",
-    chairman: "Styreleder",
-    vice_chairman: "Nestleder",
 };
 
 /**

--- a/packages/db/src/schema/org.ts
+++ b/packages/db/src/schema/org.ts
@@ -238,10 +238,11 @@ export const groupMembershipRelations = relations(
  * can join, leave and rejoin a group repeatedly, and each stint is its own
  * period.
  *
- * `role` is stored as free text rather than the enum: Lepton's history
- * (which this table is backfilled from) recorded board positions like
- * "TREASURER" that Photon's two-value enum has no room for, and the value is
- * only ever displayed.
+ * `role` is stored as free text rather than the enum on purpose. This is an
+ * append-only record of what was true at the time, so it should not move when
+ * `groupMembershipRole` gains or loses a value — a stint that ended as a role
+ * Photon no longer offers still ended as that role. The value is only ever
+ * displayed, never matched on.
  */
 export const groupMembershipHistory = pgTable(
     "group_membership_history",

--- a/packages/lepton-migration/data/.gitignore
+++ b/packages/lepton-migration/data/.gitignore
@@ -2,6 +2,7 @@
 # committed. It is refetched from Lepton's export endpoint on demand.
 lepton-users.json
 lepton-memberships.json
+lepton-membership-histories.json
 
 # Table dumps from the photon-table-export endpoint: registrations, fines,
 # payments and form answers for real members. Refetch on demand.

--- a/packages/lepton-migration/import-membership-histories.ts
+++ b/packages/lepton-migration/import-membership-histories.ts
@@ -86,9 +86,16 @@ const main = async () => {
 
     for (const [leptonSlug, list] of Object.entries(histories)) {
         // Lepton's slug is not always Photon's — `kontkom` is `kok` here.
-        // Photon's own group list is the authority, so a slug the main
-        // migration excluded falls back to itself rather than being dropped.
-        const slug = resolveGroupSlug(leptonSlug) ?? leptonSlug;
+        // Photon's own group list is the authority: a slug the main migration
+        // excluded falls back to itself, and so does a remap whose target does
+        // not exist in this database. The rename only ever happened in prod,
+        // so without that second fallback a run against dev silently drops
+        // every kontkom row.
+        const mapped = resolveGroupSlug(leptonSlug) ?? leptonSlug;
+        const slug =
+            knownGroups.has(mapped) || !knownGroups.has(leptonSlug)
+                ? mapped
+                : leptonSlug;
         if (!knownGroups.has(slug)) {
             if (list.length > 0) {
                 unknownGroup += list.length;


### PR DESCRIPTION
Oppfølging av #359. Etter at PR-en ble merget hentet og kjørte jeg backfillen mot ekte Lepton-data (1248 avsluttede medlemskap i 58 grupper), og det avdekket tre ting.

## Rollene fantes ikke

Jeg skrev at Lepton lagret styreverv som `TREASURER` i `membership_type`. Det stemmer ikke — `NativeMembershipType` har bare `LEADER` og `MEMBER`, og dataene bekrefter det: **1120 MEMBER, 128 LEADER**. De oppdiktede etikettene for treasurer/chairman/nestleder er fjernet.

At `role` er fritekst og ikke enumen står, men begrunnelsen er skrevet om: historikk er en append-only oversikt over hva som var sant den gangen, og skal ikke flytte seg når `groupMembershipRole` får eller mister en verdi.

## Importen mistet 38 rader

Tørrkjøring mot dev droppet alle `kontkom`-radene. Mappingen `kontkom→kok` stemmer bare i prod — dev har fortsatt den gamle sluggen. Importen faller nå tilbake til original-sluggen når remap-målet ikke finnes i basen, så den gir samme resultat mot begge. Etter fiksen: **1248 klare, 0 ukjente brukere, 0 ukjente grupper, 0 ugyldige datoer.**

## Cache-fil med persondata var ikke ignorert

`lepton-membership-histories.json` inneholder e-post for 1248 medlemmer, men manglet i `data/.gitignore` — i motsetning til `lepton-users.json` og `lepton-memberships.json` som begge er der. Den var én `git add -A` unna å havne i repoet.

## Verifisert

- `bun run typecheck` og `bun run format` grønt.
- 24 tester i `members.test.ts` passerer, inkludert de fire for historikken.
- Backfill kjørt mot dev-DB: 1248 rader inn, ny kjøring setter inn 0.
- Sjekket i grensesnittet: `pythons-gutter-a` viser «Tidligere medlemmer (77)» ved siden av «Medlemmer (99)» — de 35 øvrige radene er rollebytter for folk som fortsatt er medlemmer, og filtreres bort som de skal.

Prod er ikke rørt. Backfillen kjøres etter at migrasjon 0037 er deployet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)