### PR TITLE
fix(kvark,api): rett opp elleve punkter fra Sanders gjennomgang

### DIFF
--- a/apps/api/src/routes/event/favorite/get.ts
+++ b/apps/api/src/routes/event/favorite/get.ts
@@ -31,18 +31,30 @@ export const getFavoriteEventsRoute = route().get(
             where: eq(schema.eventFavorite.userId, userId),
             with: {
                 event: {
-                    columns: { id: true, title: true, slug: true },
+                    columns: {
+                        id: true,
+                        title: true,
+                        slug: true,
+                        start: true,
+                        end: true,
+                    },
                 },
             },
         });
 
-        const returnFavorites: z.infer<typeof favoriteEventsSchema> =
-            favorites.map((fav) => ({
+        // Sorted by when the event happens, not by when it was favorited: the
+        // list is read as a calendar, and the client needs the times to tell a
+        // favorite that is still coming up from one that is over.
+        const returnFavorites: z.infer<typeof favoriteEventsSchema> = favorites
+            .map((fav) => ({
                 eventId: fav.eventId,
                 slug: fav.event.slug,
                 title: fav.event.title,
+                startTime: fav.event.start.toISOString(),
+                endTime: fav.event.end.toISOString(),
                 createdAt: fav.createdAt.toISOString(),
-            }));
+            }))
+            .sort((a, b) => a.startTime.localeCompare(b.startTime));
 
         return c.json(returnFavorites, 200);
     },

--- a/apps/api/src/routes/event/favorite/update.ts
+++ b/apps/api/src/routes/event/favorite/update.ts
@@ -47,11 +47,16 @@ export const updateFavoriteRoute = route().put(
         }
 
         if (body.isFavorite) {
-            // Add to favorites
-            await db.insert(schema.eventFavorite).values({
-                eventId,
-                userId,
-            });
+            // Add to favorites. (user_id, event_id) is the primary key, so a
+            // repeated "favorite" — a double tap, or a stale UI state — would
+            // otherwise fail on the unique violation rather than being a no-op.
+            await db
+                .insert(schema.eventFavorite)
+                .values({
+                    eventId,
+                    userId,
+                })
+                .onConflictDoNothing();
         } else {
             // Remove from favorites
             await db

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -728,6 +728,12 @@ export const favoriteEventsSchema = Schema(
             eventId: z.string().meta({ description: "Event ID" }),
             title: z.string().meta({ description: "Event title" }),
             slug: z.string().meta({ description: "Event slug" }),
+            startTime: z.iso.datetime().meta({
+                description: "When the event starts (ISO 8601)",
+            }),
+            endTime: z.iso.datetime().meta({
+                description: "When the event ends (ISO 8601)",
+            }),
             createdAt: z.iso.datetime().meta({
                 description: "When you added this event to your favorites",
             }),

--- a/apps/kvark/src/api/queries/events.ts
+++ b/apps/kvark/src/api/queries/events.ts
@@ -24,6 +24,7 @@ const EventQueryKeys = {
     forms: ["events", "forms"] as const,
     strikes: ["events", "strikes"] as const,
     myHistory: ["events", "my-history"] as const,
+    myHistoryInfinite: ["events", "my-history-infinite"] as const,
 } as const;
 
 const DEFAULT_PAGE_SIZE = 25;
@@ -166,6 +167,23 @@ export const getMyEventHistoryQuery = (
             apiClient.get("/api/event/my-registrations", {
                 searchParams: { page, pageSize },
             }),
+    });
+
+/**
+ * Samme liste som `getMyEventHistoryQuery`, men side for side — profilen viste
+ * bare de 25 nyeste og hadde ingen vei til resten.
+ */
+export const getMyEventHistoryInfiniteQuery = (
+    pageSize: number = DEFAULT_PAGE_SIZE,
+) =>
+    infiniteQueryOptions({
+        queryKey: [...EventQueryKeys.myHistoryInfinite, pageSize] as const,
+        queryFn: ({ pageParam }) =>
+            apiClient.get("/api/event/my-registrations", {
+                searchParams: { page: pageParam, pageSize },
+            }),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) => lastPage.nextPage,
     });
 
 export const updateFavoriteEventMutation = mutationOptions({

--- a/apps/kvark/src/components/group-fine-row.tsx
+++ b/apps/kvark/src/components/group-fine-row.tsx
@@ -12,11 +12,21 @@ type GroupFineRowProps = {
 
 export function GroupFineRow({ fine, index, onOpen }: GroupFineRowProps) {
     return (
+        // Raden er et klikkbart kort, ikke en <button>, så den må selv si fra
+        // at den kan få tastaturfokus og svare på Enter/mellomrom. Uten dette
+        // var botlisten helt utilgjengelig med tastatur.
         <Card
             size="sm"
             className="flex-row items-center gap-3 px-3 py-2 cursor-pointer"
             onClick={onOpen}
             role="button"
+            tabIndex={0}
+            onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    onOpen();
+                }
+            }}
         >
             <span className="w-6 text-center font-medium">{index}</span>
             <div className="flex min-w-0 flex-1 flex-col">

--- a/apps/kvark/src/components/group-fines-tab.tsx
+++ b/apps/kvark/src/components/group-fines-tab.tsx
@@ -65,6 +65,12 @@ export function GroupFinesTab({
         return map;
     }, [filtered]);
 
+    /** Åpner den første boten i en persons gruppe av bøter. */
+    function openGrouped(list: Fine[]) {
+        const index = filtered.findIndex((f) => f.id === (list[0]?.id ?? ""));
+        if (index >= 0) setOpenIndex(index);
+    }
+
     const stats = useMemo(() => {
         const ikkeGodkjent = fines
             .filter((f) => !f.approved)
@@ -162,11 +168,16 @@ export function GroupFinesTab({
                                     size="sm"
                                     className="flex-row items-center gap-3 px-3 py-2 cursor-pointer"
                                     role="button"
-                                    onClick={() => {
-                                        const i = filtered.findIndex(
-                                            (f) => f.id === (list[0]?.id ?? ""),
-                                        );
-                                        setOpenIndex(i);
+                                    tabIndex={0}
+                                    onClick={() => openGrouped(list)}
+                                    onKeyDown={(event) => {
+                                        if (
+                                            event.key === "Enter" ||
+                                            event.key === " "
+                                        ) {
+                                            event.preventDefault();
+                                            openGrouped(list);
+                                        }
                                     }}
                                 >
                                     <Avatar className="size-10">

--- a/apps/kvark/src/components/share-button.tsx
+++ b/apps/kvark/src/components/share-button.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@tihlde/ui/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@tihlde/ui/ui/tooltip";
-import { Check, Share2 } from "lucide-react";
+import { Check, Copy, Share2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 type ShareButtonProps = {
@@ -16,6 +16,10 @@ type ShareButtonProps = {
  * Deler en lenke: mobil får den native delingsmenyen, alt annet får lenken
  * kopiert til utklippstavlen. Knappen hadde ingen standardhandling før, så
  * «Del»-knappene på nyheter, arrangementer og stillinger gjorde ingenting.
+ *
+ * Ikonet følger handlingen: et dele-ikon der nettleseren faktisk åpner en
+ * delingsmeny, ellers et kopier-ikon — «del» på en knapp som bare kopierer
+ * lover mer enn den holder.
  */
 export function ShareButton({
     url,
@@ -25,6 +29,15 @@ export function ShareButton({
 }: ShareButtonProps) {
     const [copied, setCopied] = useState(false);
     const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Sjekkes etter hydrering: `navigator` finnes ikke under SSR, og server og
+    // klient må rendre det samme ikonet i første pass.
+    const [canShareNatively, setCanShareNatively] = useState(false);
+
+    useEffect(() => {
+        setCanShareNatively(
+            typeof navigator !== "undefined" && !!navigator.share,
+        );
+    }, []);
 
     useEffect(
         () => () => {
@@ -56,7 +69,9 @@ export function ShareButton({
         }
     }
 
-    const tooltip = copied ? "Lenke kopiert" : label;
+    const actionLabel = canShareNatively ? label : "Kopier lenke";
+    const tooltip = copied ? "Lenke kopiert" : actionLabel;
+    const Icon = canShareNatively ? Share2 : Copy;
 
     return (
         <Tooltip>
@@ -66,10 +81,10 @@ export function ShareButton({
                         variant="outline"
                         size={showLabel ? "sm" : "icon"}
                         onClick={share}
-                        aria-label={label}
+                        aria-label={actionLabel}
                     >
-                        {copied ? <Check /> : <Share2 />}
-                        {showLabel ? (copied ? "Kopiert" : label) : null}
+                        {copied ? <Check /> : <Icon />}
+                        {showLabel ? (copied ? "Kopiert" : actionLabel) : null}
                     </Button>
                 }
             />

--- a/apps/kvark/src/hooks/use-go-back.ts
+++ b/apps/kvark/src/hooks/use-go-back.ts
@@ -1,0 +1,25 @@
+import { useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router";
+import { useCallback } from "react";
+
+/**
+ * En tilbake-knapp som faktisk går tilbake.
+ *
+ * Sider man kommer til fra flere steder — et spørreskjema nås både fra
+ * profilen, en e-post og en gruppeside — pleide å ha en hardkodet lenke hjem,
+ * som sendte deg et helt annet sted enn der du kom fra. Går til `fallback`
+ * bare når det ikke finnes noe å gå tilbake til (åpnet i ny fane, eller
+ * direkte fra en e-postlenke).
+ */
+export function useGoBack(fallback: string = "/"): () => void {
+    const router = useRouter();
+    const canGoBack = useCanGoBack();
+    const navigate = useNavigate();
+
+    return useCallback(() => {
+        if (canGoBack) {
+            router.history.back();
+            return;
+        }
+        navigate({ to: fallback });
+    }, [canGoBack, router, navigate, fallback]);
+}

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -39,19 +39,36 @@ type ApiRegistration = {
         | "pending";
 } | null;
 
+type RegistrationStateInput = {
+    /** The authenticated user's own registration, if any. */
+    registration: ApiRegistration;
+    /** The event's own `closed` flag. */
+    closed: boolean;
+    /** When registration opens. Null means "open immediately". */
+    registrationStart?: string | null;
+    /** Påmeldingsfristen. Null means "no deadline". */
+    registrationEnd?: string | null;
+    /** When the event itself ends. */
+    endTime?: string | null;
+};
+
 /**
- * Derive the UI registration state from the API event's `registration`
- * (the authenticated user's own registration), whether registration is
- * closed, and when it opens.
+ * Derive the UI registration state from the authenticated user's own
+ * registration and the event's registration window.
  *
- * `registrationStart` matters even though the API rejects an early sign-up:
- * without it the card showed an inviting "Meld deg på" for events whose
- * registration had not opened yet. Null means "open immediately".
+ * Every bound matters even though the API rejects a sign-up outside the
+ * window: without them the card showed an inviting "Meld deg på" both before
+ * registration opened and — for `registrationEnd`/`endTime` — long after the
+ * event was over, since `closed` is a manual flag arrangørene sjelden setter.
  */
 export function deriveRegistrationState(
-    registration: ApiRegistration,
-    closed: boolean,
-    registrationStart?: string | null,
+    {
+        registration,
+        closed,
+        registrationStart,
+        registrationEnd,
+        endTime,
+    }: RegistrationStateInput,
     now: Date = new Date(),
 ): EventRegistrationState {
     switch (registration?.status) {
@@ -64,6 +81,10 @@ export function deriveRegistrationState(
             return "awaiting-payment";
         default:
             if (closed) return "closed";
+            if (endTime && new Date(endTime) < now) return "closed";
+            if (registrationEnd && new Date(registrationEnd) < now) {
+                return "closed";
+            }
             if (registrationStart && new Date(registrationStart) > now) {
                 return "not-open";
             }

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -76,16 +76,23 @@ const GROUP_TYPE_LABELS: Record<string, string> = {
     COMMITTEE: "Komité",
     BOARD: "Styre",
     INTERESTGROUP: "Interessegruppe",
+    SPORTSTEAM: "Idrettslag",
     STUDYYEAR: "Klassetrinn",
     STUDY: "Studie",
     TIHLDE: "TIHLDE",
     PRIVATE: "Privat",
 };
 
-/** Norsk visningsnavn for en gruppetype fra databasen (f.eks. "SUBGROUP"). */
+/**
+ * Norsk visningsnavn for en gruppetype fra databasen (f.eks. "SUBGROUP").
+ *
+ * Oppslaget er case-insensitivt: typen er en fritekstkolonne, og en gruppe
+ * lagret med annen skrivemåte skal ikke falle tilbake til det engelske ordet
+ * — det var slik idrettslagene endte opp som «Sportsteam».
+ */
 export function groupTypeLabel(type: string): string {
     return (
-        GROUP_TYPE_LABELS[type] ??
+        GROUP_TYPE_LABELS[type.toUpperCase()] ??
         type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
     );
 }

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -9,6 +9,8 @@ import {
     MapPin,
     PencilLine,
     QrCode,
+    Star,
+    StarOff,
     UsersRound,
 } from "lucide-react";
 
@@ -16,8 +18,10 @@ import { authQueryOptions } from "#/api/auth";
 import {
     getEventByIdQuery,
     getEventRegistrationsQuery,
+    getFavoriteEventsQuery,
     registerForEventMutation,
     unregisterFromEventMutation,
+    updateFavoriteEventMutation,
 } from "#/api/queries/events";
 import { DetailDateRange } from "#/components/detail-date-range";
 import { DetailField } from "#/components/detail-field";
@@ -61,6 +65,18 @@ function EventDetailPage() {
 
     const registerMutation = useMutation(registerForEventMutation);
     const unregisterMutation = useMutation(unregisterFromEventMutation);
+    const favoriteMutation = useMutation(updateFavoriteEventMutation);
+
+    // Arrangementet sier ikke selv om det er en favoritt, så favorittlisten —
+    // som uansett ligger i cachen fra profilen — avgjør det.
+    const { data: favorites } = useQuery({
+        ...getFavoriteEventsQuery(),
+        enabled: Boolean(session),
+    });
+    const isFavorite = Boolean(
+        favorites?.some((favorite) => favorite.eventId === event.id),
+    );
+    const organizerSlug = event.organizer?.slug;
 
     // Same rule as the API: the permission (a group-scoped one counts), or
     // having created the event.
@@ -70,11 +86,13 @@ function EventDetailPage() {
         "events:delete",
     ])(event.createdById);
 
-    const registrationState = deriveRegistrationState(
-        event.registration,
-        event.closed,
-        event.registrationStart,
-    );
+    const registrationState = deriveRegistrationState({
+        registration: event.registration,
+        closed: event.closed,
+        registrationStart: event.registrationStart,
+        registrationEnd: event.registrationEnd,
+        endTime: event.endTime,
+    });
     const price = formatEventPrice(event.isPaidEvent, event.payInfo?.price);
     const registeredCount = registrations?.totalCount ?? 0;
     const registrants = (registrations?.registeredUsers ?? []).map((u) => ({
@@ -140,11 +158,42 @@ function EventDetailPage() {
             header={
                 <>
                     <div className="flex items-center justify-between gap-2">
-                        <DetailIdentity
-                            name={event.organizer?.name ?? "TIHLDE"}
-                            logoUrl={event.organizer?.image ?? undefined}
-                        />
+                        {organizerSlug ? (
+                            <Link
+                                to="/grupper/$slug"
+                                params={{ slug: organizerSlug }}
+                                className="flex min-w-0"
+                            >
+                                <DetailIdentity
+                                    name={event.organizer?.name ?? "TIHLDE"}
+                                    logoUrl={
+                                        event.organizer?.image ?? undefined
+                                    }
+                                />
+                            </Link>
+                        ) : (
+                            <DetailIdentity
+                                name={event.organizer?.name ?? "TIHLDE"}
+                                logoUrl={event.organizer?.image ?? undefined}
+                            />
+                        )}
                         <div className="flex items-center gap-1">
+                            {session ? (
+                                <IconActionButton
+                                    icon={isFavorite ? StarOff : Star}
+                                    label={
+                                        isFavorite
+                                            ? "Fjern fra favoritter"
+                                            : "Legg til i favoritter"
+                                    }
+                                    onClick={() =>
+                                        favoriteMutation.mutate({
+                                            eventId: event.id,
+                                            data: { isFavorite: !isFavorite },
+                                        })
+                                    }
+                                />
+                            ) : null}
                             <ShareButton label="Del arrangement" />
                             {isAdmin ? (
                                 <IconActionButton

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -130,7 +130,12 @@ function GroupDetailPage() {
     // Bøter og lovverk er lesbart for gruppens medlemmer, botsjefen og
     // fines:view for denne gruppen — samme regel som GET-endepunktene. Uten
     // dette sto fanene der for alle og spørringene svarte alltid 403.
-    const canViewFines = isMember || isFinesAdmin || hasFinesView;
+    //
+    // `finesActivated` avgjør først: en gruppe som ikke bruker botsystemet har
+    // verken lovverk eller bøter å vise, og fanene sto likevel der for alle
+    // medlemmene.
+    const canViewFines =
+        apiGroup.finesActivated && (isMember || isFinesAdmin || hasFinesView);
 
     const { data: apiFines } = useQuery({
         ...getGroupFinesQuery(slug, 0),

--- a/apps/kvark/src/routes/_app/grupper.index.tsx
+++ b/apps/kvark/src/routes/_app/grupper.index.tsx
@@ -92,12 +92,12 @@ function buildTreeInput(groups: ApiGroup[]): GroupTreeInput {
         // Sports teams sit alongside interest groups rather than inside them:
         // same level in the organisation, but a category of their own. They
         // come first because they reach the widest — and the label carries
-        // IDKOM, since the chart otherwise reads as if the teams were their
-        // own top-level category rather than IDKOM's.
+        // IdKom, since the chart otherwise reads as if the teams were their
+        // own top-level category rather than IdKom's.
         branches: [
             sectionFrom(
                 "idrettslag",
-                "Idrettslag (IDKOM)",
+                "Idrettslag (IdKom)",
                 2,
                 groups,
                 "SPORTSTEAM",

--- a/apps/kvark/src/routes/_app/opptak.tsx
+++ b/apps/kvark/src/routes/_app/opptak.tsx
@@ -27,9 +27,18 @@ type ApiGroup = {
     imageUrl: string | null;
 };
 
+/**
+ * Grupper man ikke søker seg inn i, og som derfor ikke hører hjemme på
+ * opptakssiden. Hovedstyret velges på generalforsamlingen.
+ */
+const NOT_OPEN_FOR_ADMISSION = new Set(["hs"]);
+
 function toAdmissionGroups(groups: ApiGroup[], type: string): AdmissionGroup[] {
     return groups
-        .filter((group) => group.type === type)
+        .filter(
+            (group) =>
+                group.type === type && !NOT_OPEN_FOR_ADMISSION.has(group.slug),
+        )
         .map((group) => ({
             name: group.name,
             slug: group.slug,

--- a/apps/kvark/src/routes/_app/profil/$id/arrangementer.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/arrangementer.tsx
@@ -1,9 +1,9 @@
 import { requireOwnProfile } from "#/api/auth";
 import {
     getFavoriteEventsQuery,
-    getMyEventHistoryQuery,
+    getMyEventHistoryInfiniteQuery,
 } from "#/api/queries/events";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { Badge } from "@tihlde/ui/ui/badge";
 import { Card } from "@tihlde/ui/ui/card";
@@ -17,6 +17,7 @@ import {
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import { CalendarDays, Star } from "lucide-react";
 
+import { LoadMoreButton } from "#/components/load-more-button";
 import { formatEventDate } from "#/lib/event";
 
 export const Route = createFileRoute("/_app/profil/$id/arrangementer")({
@@ -27,6 +28,13 @@ export const Route = createFileRoute("/_app/profil/$id/arrangementer")({
 
 function RouteComponent() {
     const { data: favorites, isPending } = useQuery(getFavoriteEventsQuery());
+
+    // Favoritter er en huskeliste over noe som skal skje. Et arrangement som
+    // er over hører ikke hjemme der — det står allerede under «Tidligere».
+    const now = Date.now();
+    const upcomingFavorites = (favorites ?? []).filter(
+        (event) => new Date(event.endTime).getTime() >= now,
+    );
 
     return (
         <div className="flex flex-col gap-6">
@@ -40,9 +48,9 @@ function RouteComponent() {
                             </li>
                         ))}
                     </ul>
-                ) : favorites && favorites.length > 0 ? (
+                ) : upcomingFavorites.length > 0 ? (
                     <ul className="flex flex-col gap-3">
-                        {favorites.map((event) => (
+                        {upcomingFavorites.map((event) => (
                             <li key={event.eventId}>
                                 <Card
                                     size="sm"
@@ -58,6 +66,9 @@ function RouteComponent() {
                                         <span className="truncate font-medium">
                                             {event.title}
                                         </span>
+                                        <span className="truncate text-sm text-muted-foreground">
+                                            {formatEventDate(event.startTime)}
+                                        </span>
                                     </div>
                                     <Star className="size-4 shrink-0" />
                                 </Card>
@@ -72,8 +83,8 @@ function RouteComponent() {
                             </EmptyMedia>
                             <EmptyTitle>Ingen favorittarrangementer</EmptyTitle>
                             <EmptyDescription>
-                                Arrangementer du markerer som favoritt vises
-                                her.
+                                Kommende arrangementer du markerer som favoritt
+                                vises her.
                             </EmptyDescription>
                         </EmptyHeader>
                     </Empty>
@@ -93,8 +104,9 @@ const STATUS_LABELS: Record<string, string> = {
 
 /** Arrangementene man har vært påmeldt, nyeste først. */
 function PastEventsSection() {
-    const { data, isPending } = useQuery(getMyEventHistoryQuery(0));
-    const events = data?.events ?? [];
+    const { data, isPending, hasNextPage, fetchNextPage, isFetchingNextPage } =
+        useInfiniteQuery(getMyEventHistoryInfiniteQuery());
+    const events = data?.pages.flatMap((page) => page.events) ?? [];
 
     return (
         <section className="flex flex-col gap-3">
@@ -136,6 +148,14 @@ function PastEventsSection() {
                             </Card>
                         </li>
                     ))}
+                    {hasNextPage ? (
+                        <li className="flex justify-center">
+                            <LoadMoreButton
+                                onClick={() => fetchNextPage()}
+                                isLoading={isFetchingNextPage}
+                            />
+                        </li>
+                    ) : null}
                 </ul>
             ) : (
                 <Empty>

--- a/apps/kvark/src/routes/_app/sporreskjema.$id.tsx
+++ b/apps/kvark/src/routes/_app/sporreskjema.$id.tsx
@@ -22,6 +22,7 @@ import {
     getFormByIdQuery,
 } from "#/api/queries/forms";
 import { formHandlers, useAppForm } from "#/hooks/form";
+import { useGoBack } from "#/hooks/use-go-back";
 import { formatEventDate } from "#/lib/event";
 
 export const Route = createFileRoute("/_app/sporreskjema/$id")({
@@ -46,17 +47,13 @@ function byType(fields: FormField[], type: FormField["type"]) {
 function FormPage() {
     const { id } = Route.useParams();
     const { data: form } = useSuspenseQuery(getFormByIdQuery(id));
+    const goBack = useGoBack();
 
     return (
         <div className="container mx-auto flex max-w-3xl flex-col gap-6 px-4 py-12">
-            <Button
-                variant="outline"
-                className="self-start"
-                nativeButton={false}
-                render={<Link to="/" />}
-            >
+            <Button variant="outline" className="self-start" onClick={goBack}>
                 <ArrowLeft />
-                Til forsiden
+                Tilbake
             </Button>
             <Card>
                 <CardHeader>

--- a/packages/db/src/schema/org.ts
+++ b/packages/db/src/schema/org.ts
@@ -100,6 +100,12 @@ export const studyProgramMembership = pgTable(
     (t) => [primaryKey({ columns: [t.userId, t.studyProgramId] })],
 );
 
+/**
+ * NB: `group.type` is a `varchar`, not this enum, and holds upper-case values
+ * from the Lepton migration — including `SPORTSTEAM`, which is not listed
+ * here. Treat this list as indicative, compare types case-insensitively, and
+ * never assume a group's type is one of these values.
+ */
 export const groupType = pgEnum("org_group_type", [
     "studyyear",
     "interestgroup",

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2999,6 +2999,16 @@ export interface components {
             slug: string;
             /**
              * Format: date-time
+             * @description When the event starts (ISO 8601)
+             */
+            startTime: string;
+            /**
+             * Format: date-time
+             * @description When the event ends (ISO 8601)
+             */
+            endTime: string;
+            /**
+             * Format: date-time
              * @description When you added this event to your favorites
              */
             createdAt: string;


### PR DESCRIPTION
Tar de små/mellomstore punktene fra Sanders siste gjennomgang. De større (paragraf på bøter, tidligere grupper på profil, kort bio) er lagt som egne issues.

## Arrangement
- **«Meld deg på» på arrangementer som var over.** `deriveRegistrationState` så bare på `closed` — et manuelt flagg arrangørene sjelden setter — og ignorerte både påmeldingsfristen og at arrangementet var ferdig.
- **Favorittknapp.** Endepunktet fantes, knappen manglet. Tilstanden leses fra favorittlista, så arrangement-endepunktet er urørt.
- **Arrangøren er nå en lenke** til gruppesiden.
- `PUT /api/event/favorite/:id` fikk `onConflictDoNothing` — (user_id, event_id) er primærnøkkel, så et dobbelttrykk ga 500 før.

## Profil
- **Favoritter viste arrangementer som var over**, uten dato. `GET /api/event/favorite` returnerer nå start- og sluttidspunkt og sorterer på dato; klienten viser bare det som ikke er ferdig.
- **«Tidligere» viste bare de 25 nyeste.** API-et paginerte allerede; frontend hentet aldri side 2. Nå «Last inn mer».

## Grupper
- **Bøter- og Lovverk-fanene sto der også for grupper uten botsystem.** `canViewFines` sjekket medlemskap og rettigheter, men aldri `finesActivated`.
- **Idrettslag ble vist som «Sportsteam».** `SPORTSTEAM` manglet i labeltabellen. Oppslaget er nå case-insensitivt, siden `group.type` er en fritekstkolonne med store bokstaver fra Lepton-migreringen — det er dokumentert på `groupType`-enumen, som kolonnen faktisk ikke bruker.
- **«IDKOM» → «IdKom»** i hierarkiet. Gruppenavnet i databasen var allerede riktig; bare den hardkodede etiketten var feil.

## Ellers
- **Søk verv:** Hovedstyret lå i lista, men velges på generalforsamlingen.
- **Spørreskjema:** tilbake-knappen gikk til forsiden. Ny `useGoBack`-hook går faktisk tilbake, med forsiden som fallback når det ikke finnes historikk (åpnet fra en e-postlenke).
- **Bøter:** radene er klikkbare kort med `role="button"`, men hadde verken `tabIndex` eller tastaturhåndtering — botlista var utilgjengelig med tastatur.

## Verifisert
`bun run typecheck`, `bun run lint` og `bun run build` er grønne. Kjørt gjennom i nettleseren mot lokal dev, innlogget:

- gammelt arrangement viser «Påmelding er stengt»
- favorittknapp lagrer til `event_favorite` og bytter til «Fjern fra favoritter»
- arrangør lenker til `/grupper/sosialen`
- favoritt som er over vises ikke på profilen; kommende vises med dato
- «Last inn mer» henter side 2 og forsvinner når lista er tom (25 → 30 rader)
- Bøter/Lovverk forsvinner når `fines_activated` slås av, og er der når den er på
- Enter på en botrad åpner dialogen
- tilbake-knappen i spørreskjema lander på siden man kom fra, og på forsiden ved direktelenke
- Hovedstyret borte fra opptak, Forvaltningsgruppen står igjen

Testdata i dev-basen er ryddet opp igjen. Ingen konsollfeil.

Merk: **galleri-piltaster og delingsikonet var allerede fikset** i `6eba5b7` (30. juli), som ligger i både `dev` og `main` — Sander testet trolig en eldre prod-build. Denne PR-en justerer bare ikonet på desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)