### PR TITLE
fix(galleri): la piltastene bla i lightboxen når fokus står på en knapp

### DIFF
--- a/apps/kvark/src/components/gallery-lightbox.tsx
+++ b/apps/kvark/src/components/gallery-lightbox.tsx
@@ -45,6 +45,16 @@ export function GalleryLightbox({
         if (openIndex === null) return;
 
         function onKeyDown(event: KeyboardEvent) {
+            // Skriving skal alltid vinne over bla-snarveien.
+            const target = event.target as HTMLElement | null;
+            if (
+                target?.isContentEditable ||
+                target instanceof HTMLInputElement ||
+                target instanceof HTMLTextAreaElement
+            ) {
+                return;
+            }
+
             if (event.key === "ArrowLeft") {
                 event.preventDefault();
                 go(-1);
@@ -54,8 +64,12 @@ export function GalleryLightbox({
             }
         }
 
-        window.addEventListener("keydown", onKeyDown);
-        return () => window.removeEventListener("keydown", onKeyDown);
+        // Capture-fasen, ikke bobling: knappene i lightboxen kommer fra Base UI,
+        // som stopper propagering av piltaster. Har du nettopp klikket på en av
+        // pilene (eller lukkeknappen) står fokus der, og en vanlig
+        // window-lytter ville aldri sett tasten.
+        window.addEventListener("keydown", onKeyDown, true);
+        return () => window.removeEventListener("keydown", onKeyDown, true);
     }, [openIndex, go]);
 
     if (!picture) return null;


### PR DESCRIPTION
## Hva

Piltastene i galleri-lightboxen sluttet å virke så snart fokus havnet på en knapp inne i dialogen.

## Hvorfor

Knappene i lightboxen kommer fra Base UI, som kaller `stopPropagation()` på piltast-eventer. Keydown-lytteren i `gallery-lightbox.tsx` lå på `window` i **bobblefasen**, og fikk derfor aldri tasten når fokus sto på en knapp i dialogen.

I praksis betyr det at piltastene var døde etter at du hadde klikket på en av skjermpilene, eller tabbet til lukkeknappen. Rett etter at lightboxen ble åpnet (fokus på `body`) virket de — derfor har feilen sett tilfeldig ut.

## Endring

- Lytteren flyttet til **capture-fasen**, som kjører før knappen rekker å stoppe eventet.
- Guard som hopper over piltaster når fokus står i et tekstfelt (`input`, `textarea`, contenteditable), så skriving alltid vinner over bla-snarveien.

## Verifisert

Manuelt i browser på `/galleri/vaargalla-2026` med ekte museklikk og ekte tastetrykk:

- Åpne bilde → klikk skjermpil (1→2) → 3× `ArrowRight` → **5/25**. Før fiksen sto telleren bom fast etter klikket.
- 6× `ArrowLeft` → stopper på **1/25**, ingen wrap eller negativ indeks.
- Tab til lukkeknappen → 2× `ArrowRight` → **3/25** (virket ikke før).
- `Escape` lukker fortsatt dialogen.
- Ingen konsollfeil.

`typecheck`, `lint`, `format` og `build` er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)