### PR TITLE
fix(ui): gjør aktiv tab synlig i dark mode

### DIFF
--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -26,7 +26,11 @@ const tabsListVariants = cva(
     {
         variants: {
             variant: {
-                default: "bg-muted",
+                /* I dark mode har --muted samme verdi som --input, så en
+                   muted-liste ville fått nøyaktig samme farge som den aktive
+                   indikatoren. Legg listen ett trinn ned i navy-skalaen
+                   (--popover) så den aktive fanen skiller seg ut. */
+                default: "bg-muted dark:bg-popover",
                 line: "gap-1 bg-transparent",
             },
         },
@@ -62,7 +66,7 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
             className={cn(
                 "relative inline-flex h-[calc(100%-1px)] flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-[color,background-color,border-color,box-shadow] group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
                 "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
-                "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+                "data-active:bg-background data-active:text-foreground dark:data-active:border-primary/40 dark:data-active:bg-input dark:data-active:text-foreground",
                 "group-has-data-[slot=tabs-indicator]/tabs-list:data-active:bg-transparent group-has-data-[slot=tabs-indicator]/tabs-list:data-active:shadow-none dark:group-has-data-[slot=tabs-indicator]/tabs-list:data-active:border-transparent dark:group-has-data-[slot=tabs-indicator]/tabs-list:data-active:bg-transparent",
                 "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
                 className,
@@ -78,7 +82,7 @@ function TabsIndicator({ className, ...props }: TabsPrimitive.Indicator.Props) {
             data-slot="tabs-indicator"
             renderBeforeHydration
             className={cn(
-                "absolute top-0 left-0 h-[var(--active-tab-height)] w-[var(--active-tab-width)] translate-x-[var(--active-tab-left)] translate-y-[var(--active-tab-top)] rounded-md bg-background shadow-sm transition-[translate,width,height] duration-300 ease-out dark:border dark:border-input dark:bg-input/30",
+                "absolute top-0 left-0 h-[var(--active-tab-height)] w-[var(--active-tab-width)] translate-x-[var(--active-tab-left)] translate-y-[var(--active-tab-top)] rounded-md bg-background shadow-sm transition-[translate,width,height] duration-300 ease-out dark:border dark:border-primary/40 dark:bg-input",
                 className,
             )}
             {...props}


### PR DESCRIPTION
## Hva

Retter fargene på `Tabs`-komponenten i dark mode, slik at den aktive fanen (slideren) faktisk er synlig.

## Hvorfor

I dark mode er `--muted`, `--input` og `--border` alle satt til samme verdi (`#0d3172`) i navy-paletten. Tabs-listen brukte `bg-muted`, mens den aktive indikatoren brukte `bg-input/30` med `border-input` — altså **samme farge som underlaget, både på flate og kant**. Effekten var at det så ut som slideren manglet i dark mode, og at man uansett ikke kunne se hvilken fane som var aktiv.

Slideren i seg selv fungerte hele tiden — den var bare usynlig.

## Endringer

Alt i `packages/ui/src/components/ui/tabs.tsx`:

- **`TabsList`** (default-variant): `bg-muted` → `bg-muted dark:bg-popover`. Legger listen ett trinn ned i navy-skalaen (`#091f49`), samme «senket flate»-idé som `--card` bruker.
- **`TabsIndicator`**: `dark:bg-input/30` → `dark:bg-input` (solid i stedet for 30 % opacity), og `dark:border-input` → `dark:border-primary/40` så kanten faktisk vises.
- **`TabsTrigger`**: samme fargeretting på fallbacken som brukes når `TabsList` rendres uten indikator.

## Verifisert

Kjørt mot dev-server i browser-preview på `/arrangementer`:

- **Dark:** liste `rgb(9,31,73)` vs. indikator `rgb(13,49,114)` — tydelig kontrast, med synlig blå kant.
- **Slider:** animerer korrekt ved klikk (translate `3px` → `118.47px`, bredde `115px` → `82.7px` over 300 ms).
- **Light mode uendret:** liste `oklch(0.97 0 0)`, indikator `oklch(1 0 0)`, ingen border.
- `bun run typecheck` — 9/9 ✓
- `bun run format` — ✓
- `bun run lint` — ingen nye funn på `tabs.tsx`

## For reviewer

Endringen treffer alle tabs i appen siden den ligger i den delte UI-pakka. Verdt en rask titt på tabs som ligger **inni** et card (`--card` = `#061532`) — `--popover` (`#091f49`) er fortsatt et synlig steg opp derfra, men det er stedet en eventuell svakhet ville dukket opp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)