### PR TITLE
refactor(kvark): fjern om-tekst i gruppeheaderen

### DIFF
--- a/apps/kvark/src/components/group-detail-header.tsx
+++ b/apps/kvark/src/components/group-detail-header.tsx
@@ -5,7 +5,7 @@ import { Crown, HandCoins, Mail } from "lucide-react";
 
 import { DetailHeader } from "#/components/detail-layout";
 import { GroupEditDialog } from "#/components/group-edit-dialog";
-import { groupDescriptionExcerpt, type Group } from "#/lib/group";
+import type { Group } from "#/lib/group";
 import { initials } from "#/lib/utils";
 
 type GroupDetailHeaderProps = {
@@ -42,11 +42,6 @@ export function GroupDetailHeader({
                         {group.contactEmail}
                     </a>
                 </div>
-            }
-            subtitle={
-                <p className="text-sm text-muted-foreground">
-                    {groupDescriptionExcerpt(group.description)}
-                </p>
             }
             badges={
                 <>

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -105,30 +105,6 @@ export function formatGroupDate(iso: string): string {
 }
 
 /**
- * Reduce a markdown group description to a short plain-text excerpt, for use
- * as a one-line subtitle. Strips headings, emphasis, links (keeping the link
- * text), images and horizontal rules, then truncates on a word boundary.
- */
-export function groupDescriptionExcerpt(
-    markdown: string,
-    maxLength = 160,
-): string {
-    const text = markdown
-        .replace(/!\[[^\]]*\]\([^)]*\)/g, "") // images
-        .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // links -> link text
-        .replace(/^#{1,6}\s+/gm, "") // headings
-        .replace(/^(-{3,}|\*{3,})\s*$/gm, "") // horizontal rules
-        .replace(/(\*\*|__|\*|_|`)/g, "") // emphasis/code markers
-        .replace(/^[-*+]\s+/gm, "") // list bullets
-        .replace(/&nbsp;/g, " ")
-        .replace(/\s+/g, " ")
-        .trim();
-    if (text.length <= maxLength) return text;
-    const cut = text.slice(0, maxLength);
-    return `${cut.slice(0, cut.lastIndexOf(" "))}…`;
-}
-
-/**
  * Map an API group (detail response) to the display shape used by the header
  * and about tab. The list/detail endpoints do not expose a leader name, so
  * `leader` is left undefined unless supplied by the caller.


### PR DESCRIPTION
## Hva

Fjerner beskrivelsesutdraget som ble vist ved siden av gruppelogoen øverst på gruppesiden. Hele beskrivelsen ligger fortsatt under «Om»-fanen.

- `group-detail-header.tsx`: fjernet `subtitle`-prop-en
- `lib/group.ts`: slettet `groupDescriptionExcerpt`, som nå var ubrukt

## Verifisert

- `bun run typecheck` — 9/9 tasks OK
- `bun run lint` — exit 0 (kun eksisterende warnings)
- Sjekket `/grupper/index` i preview: headeren viser logo, navn, leder, e-post og knapper, ingen om-tekst, ingen konsollfeil fra gruppesiden

🤖 Generated with [Claude Code](https://claude.com/claude-code)