### PR TITLE
fix(kvark): klipp korttitler til én linje med ellipsis

### DIFF
--- a/apps/kvark/src/components/list-card.tsx
+++ b/apps/kvark/src/components/list-card.tsx
@@ -38,7 +38,7 @@ export function ListCard({
                     {/*
                      * `self-start` keeps the media at its 16/7 ratio: as a
                      * flex child it would otherwise stretch to the row height,
-                     * making covers taller on cards with two-line titles.
+                     * making covers taller on cards with more meta rows.
                      */}
                     <div
                         className={`relative ${IMAGE_PRESETS["cover-wide"].aspectClassName} w-full shrink-0 overflow-hidden rounded-t-2xl bg-muted sm:w-52 sm:self-start sm:rounded-lg`}
@@ -55,7 +55,12 @@ export function ListCard({
                         ) : null}
                     </div>
                     <div className="flex min-w-0 flex-1 flex-col gap-2 px-3 pb-3 sm:p-0">
-                        <h3 className="line-clamp-2 text-lg sm:text-xl">
+                        {/*
+                         * `line-clamp-1` over `truncate`: nowrap would let a
+                         * long title set the row's max-content width and push
+                         * the list wider than the viewport.
+                         */}
+                        <h3 className="line-clamp-1 text-lg sm:text-xl">
                             {title}
                         </h3>
                         <div className="flex flex-col gap-1 text-sm text-muted-foreground">


### PR DESCRIPTION
## Hva

Titler i `ListCard` klippes nå til én linje med `…` (`line-clamp-2` → `line-clamp-1`).

## Hvorfor

Kort med tittel over to linjer ble høyere enn nabokortene, så arrangementslistene så skjeve ut (se f.eks. «Bedpres med DNV for nye 1. og 4. Klasse»).

## For reviewer

- `ListCard` brukes av både `event-card.tsx` og `job-card.tsx` — begge får samme oppførsel.
- Jeg prøvde `truncate` først, men `white-space: nowrap` lar en lang tittel sette radens max-content-bredde og dytte lista bredere enn viewporten. `line-clamp-1` klipper uten nowrap. Grunnen er dokumentert i en kommentar i koden.
- Verifisert i dev-preview på desktop / 768px / 375px: lik korthøyde, ellipsis der tittelen er for lang, ingen ny horisontal overflyt (`document.scrollWidth` er identisk før og etter endringen).
- `typecheck`, `lint` og `format` er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)