### PR TITLE
feat(kvark,ui): gi innhold bevegelse på load og hover

### DIFF
--- a/apps/kvark/src/components/list-card.tsx
+++ b/apps/kvark/src/components/list-card.tsx
@@ -31,6 +31,10 @@ export function ListCard({
     return useRender({
         render: render ?? <div />,
         props: {
+            // Hover/press motion for this row lives in @tihlde/ui's styles.css
+            // and is keyed off this slot, so it stays with the rest of the
+            // motion system instead of as animation classes in this app.
+            "data-slot": "list-card",
             className:
                 "flex flex-col gap-3 overflow-hidden rounded-2xl bg-card sm:flex-row sm:gap-3 sm:overflow-visible sm:bg-transparent sm:p-2 sm:transition-colors sm:hover:bg-muted/50",
             children: (

--- a/apps/kvark/src/routes/_app/annonser.index.tsx
+++ b/apps/kvark/src/routes/_app/annonser.index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
 import { useState } from "react";
 
 import { getJobsQuery } from "#/api/queries/jobs";
@@ -42,12 +43,12 @@ function JobsPage() {
 
     return (
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
-            <div className="flex flex-col gap-1">
+            <Reveal render={<div className="flex flex-col gap-1" />}>
                 <h1 className="text-3xl">Stillingsannonser</h1>
                 <p className="text-muted-foreground">
                     Finn relevante jobber for studenter
                 </p>
-            </div>
+            </Reveal>
 
             <div className="grid gap-6 md:grid-cols-[20rem_1fr]">
                 <aside>
@@ -63,7 +64,9 @@ function JobsPage() {
                     <p className="text-sm text-muted-foreground">
                         {data.totalCount} stillinger funnet
                     </p>
-                    <ul className="flex flex-col gap-4 sm:gap-1">
+                    <Stagger
+                        render={<ul className="flex flex-col gap-4 sm:gap-1" />}
+                    >
                         {jobs.map((job) => (
                             <li key={job.id}>
                                 <JobCard
@@ -83,7 +86,7 @@ function JobsPage() {
                                 />
                             </li>
                         ))}
-                    </ul>
+                    </Stagger>
                 </section>
             </div>
         </div>

--- a/apps/kvark/src/routes/_app/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
 import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import { useDeferredValue, useMemo, useState } from "react";
 import z from "zod";
@@ -161,12 +162,12 @@ function EventsPage() {
 
     return (
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
-            <div className="flex flex-col gap-1">
+            <Reveal render={<div className="flex flex-col gap-1" />}>
                 <h1 className="text-3xl">Arrangementer</h1>
                 <p className="text-muted-foreground">
                     Finn arrangementer for våren 2026
                 </p>
-            </div>
+            </Reveal>
 
             <div className="grid gap-6 md:grid-cols-[20rem_1fr]">
                 <aside>
@@ -226,7 +227,11 @@ function EventsPage() {
                             }))}
                         />
                     ) : (
-                        <ul className="flex flex-col gap-4 sm:gap-1">
+                        <Stagger
+                            render={
+                                <ul className="flex flex-col gap-4 sm:gap-1" />
+                            }
+                        >
                             {events.map((event) => (
                                 <li key={event.id}>
                                     <EventCard
@@ -243,7 +248,7 @@ function EventsPage() {
                                     />
                                 </li>
                             ))}
-                        </ul>
+                        </Stagger>
                     )}
                 </section>
             </div>

--- a/apps/kvark/src/routes/_app/galleri.index.tsx
+++ b/apps/kvark/src/routes/_app/galleri.index.tsx
@@ -1,6 +1,7 @@
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Empty, EmptyDescription, EmptyTitle } from "@tihlde/ui/ui/empty";
+import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
 
 import { getGalleriesInfiniteQuery } from "#/api/queries/galleries";
 import { GalleryCard } from "#/components/gallery-card";
@@ -22,12 +23,12 @@ function GalleriesPage() {
 
     return (
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
-            <div className="flex flex-col gap-1">
+            <Reveal render={<div className="flex flex-col gap-1" />}>
                 <h1 className="text-3xl">Galleri</h1>
                 <p className="text-muted-foreground">
                     Bilder fra arrangementene våre
                 </p>
-            </div>
+            </Reveal>
 
             {galleries.length === 0 ? (
                 <Empty>
@@ -38,7 +39,11 @@ function GalleriesPage() {
                     </EmptyDescription>
                 </Empty>
             ) : (
-                <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <Stagger
+                    render={
+                        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" />
+                    }
+                >
                     {galleries.map((gallery) => (
                         <li key={gallery.id}>
                             <GalleryCard
@@ -50,7 +55,7 @@ function GalleriesPage() {
                             />
                         </li>
                     ))}
-                </ul>
+                </Stagger>
             )}
 
             {hasNextPage && (

--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -2,6 +2,7 @@ import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { Button } from "@tihlde/ui/ui/button";
 import { EventCalendar } from "@tihlde/ui/complex/event-calendar";
+import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import { Plus } from "lucide-react";
@@ -119,7 +120,7 @@ function EventsSection() {
                 <TabsTrigger value="calendar">Kalender</TabsTrigger>
             </TabsList>
             <TabsContent value="list">
-                <div className="grid gap-4 md:grid-cols-2">
+                <Stagger render={<div className="grid gap-4 md:grid-cols-2" />}>
                     {events.slice(0, LIST_PREVIEW_COUNT).map((event) => (
                         <EventCard
                             key={event.id}
@@ -133,7 +134,7 @@ function EventsSection() {
                             imageAlt={event.imageAlt || undefined}
                         />
                     ))}
-                </div>
+                </Stagger>
             </TabsContent>
             <TabsContent value="calendar">
                 <EventCalendar
@@ -161,7 +162,11 @@ function NewsSection() {
     if (news.length === 0) return null;
 
     return (
-        <ul className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Stagger
+            render={
+                <ul className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3" />
+            }
+        >
             {news.map((item) => (
                 <li key={item.id}>
                     <NewsCard
@@ -173,7 +178,7 @@ function NewsSection() {
                     />
                 </li>
             ))}
-        </ul>
+        </Stagger>
     );
 }
 
@@ -204,7 +209,13 @@ function Hero() {
     return (
         <div className="relative">
             <HeroSectionBackground className="h-full text-primary -z-50" />
-            <section className="container mx-auto flex w-full flex-col items-center gap-6 px-4 py-50 text-center">
+            {/* Logo, blurb and actions are the section's three direct children,
+             * so Stagger walks them in that reading order on its own. */}
+            <Stagger
+                render={
+                    <section className="container mx-auto flex w-full flex-col items-center gap-6 px-4 py-50 text-center" />
+                }
+            >
                 <div
                     className="flex items-center gap-1"
                     style={{ color: "var(--color-logo, currentColor)" }}
@@ -222,7 +233,7 @@ function Hero() {
                     transformasjon og Informasjonsbehandling ved NTNU.
                 </p>
                 <HeroActions />
-            </section>
+            </Stagger>
         </div>
     );
 }
@@ -273,7 +284,9 @@ function SectionHeader({
     actionLabel?: string;
 }) {
     return (
-        <div className="flex items-center justify-between gap-4">
+        <Reveal
+            render={<div className="flex items-center justify-between gap-4" />}
+        >
             <h2 className="text-2xl">{title}</h2>
             {actionLabel ? (
                 <Button variant="ghost" size="sm">
@@ -281,6 +294,6 @@ function SectionHeader({
                     {actionLabel}
                 </Button>
             ) : null}
-        </div>
+        </Reveal>
     );
 }

--- a/apps/kvark/src/routes/_app/nyheter.index.tsx
+++ b/apps/kvark/src/routes/_app/nyheter.index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
+import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
+
 import { getNewsQuery } from "#/api/queries/news";
 import { NewsCard } from "#/components/news-card";
 import { formatNewsDateRelative } from "#/lib/news";
@@ -17,14 +19,18 @@ function NewsPage() {
 
     return (
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
-            <div className="flex flex-col gap-1">
+            <Reveal render={<div className="flex flex-col gap-1" />}>
                 <h1 className="text-3xl">Nyheter</h1>
                 <p className="text-muted-foreground">
                     Siste nytt fra TIHLDE og undergruppene
                 </p>
-            </div>
+            </Reveal>
 
-            <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            <Stagger
+                render={
+                    <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4" />
+                }
+            >
                 {news.map((item) => (
                     <li key={item.id}>
                         <NewsCard
@@ -36,7 +42,7 @@ function NewsPage() {
                         />
                     </li>
                 ))}
-            </ul>
+            </Stagger>
         </div>
     );
 }

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -4,7 +4,13 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "#/lib/utils";
 
 const buttonVariants = cva(
-    "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow,translate] duration-150 outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+    // The press state pairs a 1px drop with a 0.97 scale: the nudge alone is
+    // easy to miss, and the scale is what actually reads as "the button heard
+    // you". Both are skipped on popup triggers (aria-haspopup) — those stay
+    // visually pressed for as long as their menu is open, so animating the
+    // press there fights the open state. `translate` and `scale` are separate
+    // CSS properties in Tailwind v4, so the two compose instead of clobbering.
+    "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow,translate,scale] duration-150 outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px active:not-aria-[haspopup]:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
     {
         variants: {
             variant: {

--- a/packages/ui/src/components/ui/motion.tsx
+++ b/packages/ui/src/components/ui/motion.tsx
@@ -1,0 +1,69 @@
+import { useRender } from "@base-ui/react/use-render";
+import * as React from "react";
+
+import { cn } from "#/lib/utils";
+
+/**
+ * Entrance motion for content that mounts.
+ *
+ * Both components are markup-free: they render *as* the element you pass to
+ * `render`, so dropping one around an existing `<ul className="grid …">`
+ * changes no layout and adds no wrapper node. The animation itself lives in
+ * `styles.css` next to the easing tokens, keyed off the `data-slot` these set
+ * — that keeps timing in one place and keeps consuming apps free of animation
+ * classes (see apps/kvark/CLAUDE.md, which forbids them outright).
+ *
+ * These re-run whenever the element mounts, which is what makes them work with
+ * Suspense and with client-side navigation: a section that streams in late
+ * animates when its data lands, not when the document first parsed.
+ */
+
+type MotionProps = React.ComponentProps<"div"> & {
+    render?: useRender.RenderProp;
+};
+
+/**
+ * Fades a single element up on mount.
+ *
+ * ```tsx
+ * <Reveal render={<section className="flex flex-col gap-4" />}>…</Reveal>
+ * ```
+ *
+ * Tune per instance with `--reveal-duration` / `--reveal-distance`.
+ */
+function Reveal({ className, render, ...props }: MotionProps) {
+    return useRender({
+        render: render ?? <div />,
+        props: {
+            "data-slot": "reveal",
+            className: cn(className),
+            ...props,
+        },
+    });
+}
+
+/**
+ * Fades this element's direct children up on mount, each a beat after the one
+ * before it. Use it on the list or grid itself so the children it staggers are
+ * the cards:
+ *
+ * ```tsx
+ * <Stagger render={<ul className="grid gap-4 sm:grid-cols-2" />}>
+ *     {items.map((item) => <li key={item.id}>…</li>)}
+ * </Stagger>
+ * ```
+ *
+ * The step is 40ms, capped at 8 children; `--reveal-step` overrides it.
+ */
+function Stagger({ className, render, ...props }: MotionProps) {
+    return useRender({
+        render: render ?? <div />,
+        props: {
+            "data-slot": "stagger",
+            className: cn(className),
+            ...props,
+        },
+    });
+}
+
+export { Reveal, Stagger };

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -216,6 +216,122 @@
         var(--tw-animation-fill-mode, none);
 }
 
+/* ── Entrance motion ──────────────────────────────────────────────────────
+   Content that mounts — a page section, a grid of cards — fades up instead of
+   snapping in. `<Reveal>` and `<Stagger>` (components/ui/motion.tsx) are the
+   only entry points; the timing lives here so it sits next to the easing
+   tokens above rather than drifting per component.
+
+   Three deliberate choices:
+
+   1. The keyframe declares only `from`. The implicit `to` is the element's own
+      computed style, so this composes with any layout without restating it —
+      the same trick tw-animate-css uses for its `enter` keyframe.
+   2. `backwards`, not `both`. A `both` animation keeps filling after it
+      finishes, which leaves `transform` permanently applied — and a
+      transformed element is a containing block for `position: fixed`
+      descendants forever. `backwards` covers the stagger delay and then
+      releases the element completely.
+   3. Movement is 0.5rem. Entrances are seen on every navigation, so this is
+      deliberately small: enough to read as motion, not enough to feel slow. */
+@keyframes reveal-in {
+    from {
+        opacity: 0;
+        transform: translate3d(0, var(--reveal-distance, 0.5rem), 0);
+    }
+}
+
+[data-slot="reveal"] {
+    animation: reveal-in var(--reveal-duration, 0.26s) var(--ease-out) backwards;
+}
+
+/* Stagger: children enter 40ms apart, capped at 5 steps (200ms). The cap does
+   double duty. Without it a 24-card grid would still be animating a second
+   after it rendered; and because the rule also covers children appended
+   later, the cap is exactly how long a "last inn mer" batch stays invisible
+   before it fades in — 200ms after a network round-trip is unnoticeable,
+   500ms would read as the button not working.
+
+   Every direct child gets an explicit index, including the first, because
+   `--reveal-index` inherits: leaving `:nth-child(1)` to the default would let
+   a nested <Stagger> pick up its parent's offset. */
+[data-slot="stagger"] > * {
+    animation: reveal-in var(--reveal-duration, 0.26s) var(--ease-out)
+        calc(var(--reveal-step, 0.04s) * var(--reveal-index, 0)) backwards;
+}
+[data-slot="stagger"] > *:nth-child(1) {
+    --reveal-index: 0;
+}
+[data-slot="stagger"] > *:nth-child(2) {
+    --reveal-index: 1;
+}
+[data-slot="stagger"] > *:nth-child(3) {
+    --reveal-index: 2;
+}
+[data-slot="stagger"] > *:nth-child(4) {
+    --reveal-index: 3;
+}
+[data-slot="stagger"] > *:nth-child(5) {
+    --reveal-index: 4;
+}
+[data-slot="stagger"] > *:nth-child(n + 6) {
+    --reveal-index: 5;
+}
+
+/* ── Interactive surfaces ─────────────────────────────────────────────────
+   A card that navigates should answer the pointer. Keyed off `data-slot`
+   rather than a class so every current and future link-card (news, gallery,
+   …) gets the same treatment without opting in — apps/kvark is not allowed to
+   add visual classes of its own, so the default has to be right here.
+
+   The lift and the shadow carry this on their own — the cover image is
+   deliberately left alone. Zooming artwork on hover fights the content: it
+   crops the poster the designer framed, and on a wall of cards the movement
+   competes with the card that is actually being pointed at.
+
+   `@media (hover: hover)` is mandatory on hand-written rules. Tailwind wraps
+   its own `hover:` utilities in this guard, but plain CSS gets no such help,
+   and on a touch device an unguarded `:hover` sticks after a tap until the
+   user taps somewhere else. */
+:is(a, button)[data-slot="card"],
+[data-slot="list-card"] {
+    transition:
+        translate 0.2s var(--ease-out),
+        box-shadow 0.2s var(--ease-out);
+}
+
+@media (hover: hover) {
+    :is(a, button)[data-slot="card"]:hover,
+    [data-slot="list-card"]:hover {
+        translate: 0 -2px;
+    }
+    /* Card carries `ring-1`, so its `box-shadow` is already Tailwind's stack
+       of `var(--tw-*)` slots. Feeding the elevation through `--tw-shadow`
+       layers it *under* that ring; setting `box-shadow` here would drop the
+       ring instead. ListCard has no ring — nothing declares `box-shadow` on
+       it — so `--tw-shadow` would go nowhere and it needs the real property.
+       Same visual result, two different plumbing paths. */
+    :is(a, button)[data-slot="card"]:hover {
+        --tw-shadow: 0 10px 24px -14px oklch(0 0 0 / 0.45);
+    }
+    /* Only from `sm` up, matching the breakpoint where ListCard stops being a
+       filled card and becomes a transparent row. A drop shadow under a
+       transparent row reads as a rendering artefact. */
+    @media (width >= 40rem) {
+        [data-slot="list-card"]:hover {
+            box-shadow: 0 10px 24px -14px oklch(0 0 0 / 0.45);
+        }
+    }
+}
+
+/* Press settles the card back down, faster than it rose — the system
+   responding should always outpace the user deciding. */
+:is(a, button)[data-slot="card"]:active,
+[data-slot="list-card"]:active {
+    translate: 0 0;
+    transition-duration: 0.1s;
+}
+
 @layer base {
     * {
         @apply border-border outline-ring/50;
@@ -289,5 +405,12 @@
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;
         scroll-behavior: auto !important;
+        /* Delays must go too, not just durations. A staggered entrance fills
+           `backwards` — opacity 0 — for the whole delay, so an untouched
+           320ms delay would leave the last cards in a grid blank for a third
+           of a second before snapping in. That reads as a loading bug, which
+           is the opposite of what reduced motion is asking for. */
+        animation-delay: 0ms !important;
+        transition-delay: 0ms !important;
     }
 }


### PR DESCRIPTION
## Hva

Motion-systemet i `@tihlde/ui` hadde bare easing-tokens fra før — `--ease-out`, `--ease-drawer` og en reduced-motion-guard. **Ingenting brukte dem**, så verken sider eller kort beveget seg på load eller hover. Denne PR-en kobler på forbrukerne.

## Entrance

To nye komponenter i `@tihlde/ui/ui/motion`:

- `<Reveal>` — toner ett element opp ved mount
- `<Stagger>` — toner elementets direkte barn opp, 40ms fra hverandre

Begge rendres *som* elementet de får via `render`, så de kan legges rundt et eksisterende `<ul className="grid …">` uten wrapper-div og uten layoutendring. Selve animasjonen ligger i `styles.css` ved siden av easing-tokenene, så timingen bor ett sted.

Fordi de trigges på mount virker de også med Suspense og klientnavigasjon: en seksjon som streames inn sent animerer når dataene lander, ikke når dokumentet ble parset.

**Tre valg verdt en ekstra titt i review:**

| Valg | Hvorfor |
| --- | --- |
| `fill-mode: backwards`, ikke `both` | En `both`-animasjon fortsetter å fylle etter at den er ferdig, som lar `transform` bli hengende permanent — og et transformert element er containing block for `position: fixed` for alltid |
| Stagger-tak på 5 steg (200ms) | Taket gjelder også elementer som legges til senere, så det er nøyaktig hvor lenge en «last inn mer»-batch er usynlig før den tones inn |
| reduced-motion nuller nå også `delay` | Ellers ville bakerste kort i et grid stått usynlige i 200ms — som leses som en lastebug, altså det motsatte av hva reduced motion ber om |

## Hover

Kort som navigerer løftes 2px og får en skygge. Regelen er keyet på `data-slot` framfor en klasse, så alle nåværende og framtidige lenkekort arver den uten å melde seg på — `apps/kvark` har ikke lov til å legge inn egne visuelle klasser (se `apps/kvark/CLAUDE.md`), så standarden må være riktig i UI-pakken.

To ulike rør for samme resultat, kommentert i koden: `Card` har `ring-1`, så skyggen mates gjennom Tailwinds egen `--tw-shadow`-slot for å legge seg *under* ringen — å sette `box-shadow` direkte hadde slettet ringen. `ListCard` har ingen ring, og trenger den ekte propertyen.

Coverbildet står med vilje i ro — zoom på hover beskjærer plakaten designeren har rammet inn.

Knapper får `scale(.97)` ved trykk i tillegg til 1px-nudgen som fantes fra før. `translate` og `scale` er separate properties i Tailwind v4, så de komponerer i stedet for å overskrive hverandre.

## Sider som har fått entrance

`/`, `/nyheter`, `/arrangementer`, `/annonser`, `/galleri`. Hover gjelder alle lenkekort og listerader automatisk, også på sider som ikke er rørt her.

## Verifisert

Kjørt mot lokal dev-server, ikke bare typecheck:

- **Load** — 26 `reveal-in`-animasjoner på `/nyheter` med delays `[0, 40, 80, 120, 160, 200]`, varighet 260ms, kurve `cubic-bezier(0.22, 1, 0.36, 1)`. Frosset midtveis: kort 1 på 31% opacity / 5.4px, kort 2–6 fortsatt på 0 — kaskaden stemmer.
- **Settled state** — etter `.finish()` er alle 26 på `opacity: 1` og `transform: none`. Ingen hengende transform (dette er regresjonen `both` ville gitt).
- **Hover** — ekte peker på både `ListCard` og `Card`: `translate: 0px -2px`, skyggen legger seg etter ringen (`rgb(9,31,73) 0 0 0 1px, oklch(0 0 0/.45) 0 10px 24px -14px`), naboene rører seg ikke. `imgScale: none` og rendret bildestørrelse = layout-boks, altså ingen skalering.
- **Bygget CSS** — reglene overlever minifisering, inkludert `animation-delay:0s!important` i reduced-motion-blokka.

typecheck ✅ · build ✅ · format ✅ · lint uten funn i `apps/kvark` og `packages/ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)