### PR TITLE
fix(ui): eget --link-token så lenketekst leses som CTA-blåen i mørk modus

### DIFF
--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -18,7 +18,7 @@ const badgeVariants = cva(
                 outline:
                     "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
                 ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
-                link: "text-primary underline-offset-4 hover:underline",
+                link: "text-link underline-offset-4 hover:underline",
             },
         },
         defaultVariants: {

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
                 ghost: "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
                 destructive:
                     "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-                link: "text-primary underline-offset-4 hover:underline",
+                link: "text-link underline-offset-4 hover:underline",
             },
             size: {
                 default:

--- a/packages/ui/src/components/ui/empty.tsx
+++ b/packages/ui/src/components/ui/empty.tsx
@@ -76,7 +76,7 @@ function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
         <div
             data-slot="empty-description"
             className={cn(
-                "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+                "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-link",
                 className,
             )}
             {...props}

--- a/packages/ui/src/components/ui/field.tsx
+++ b/packages/ui/src/components/ui/field.tsx
@@ -142,7 +142,7 @@ function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
             className={cn(
                 "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
                 "last:mt-0 nth-last-2:-mt-1",
-                "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+                "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-link",
                 className,
             )}
             {...props}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -49,6 +49,10 @@
     --popover-foreground: oklch(0.145 0 0);
     --primary: var(--logo);
     --primary-foreground: oklch(0.985 0 0);
+    /* Tekstlenker følger --primary i lys modus — den mørke logoblåen har rikelig
+       kontrast mot hvitt (9.27:1) og leses fint som tynn tekst. Egen token
+       likevel, fordi mørk modus må avvike; se overstyringen i `.dark`. */
+    --link: var(--primary);
     --secondary: oklch(0.97 0 0);
     --secondary-foreground: oklch(0.205 0 0);
     --muted: oklch(0.97 0 0);
@@ -90,6 +94,13 @@
     --popover-foreground: #f5f7f9;
     --primary: #1b61e4;
     --primary-foreground: #ffffff;
+    /* Her kan ikke lenker følge --primary: som tekst gir #1b61e4 bare 3.34:1 mot
+       --card (#061532), under WCAG AA. Dessuten leses en stor fylt flate lysere
+       enn tynne 14px-bokstaver i samme hex, så CTA-fyllet og lenketeksten ser
+       ulike ut. Neste trinn i navy-skalaen (hsl(219°, 75%, 60%)) løser begge:
+       5.30:1 mot --background og 4.87:1 mot --card. (Mot --popover, #091f49,
+       blir det 4.34:1 — så vidt under AA, men lenker i popovers er sjeldne.) */
+    --link: #4d82e6;
     --secondary: #0d3172;
     --secondary-foreground: #f5f7f9;
     --muted: #0d3172;
@@ -136,6 +147,7 @@
     --color-popover-foreground: var(--popover-foreground);
     --color-primary: var(--primary);
     --color-primary-foreground: var(--primary-foreground);
+    --color-link: var(--link);
     --color-secondary: var(--secondary);
     --color-secondary-foreground: var(--secondary-foreground);
     --color-muted: var(--muted);
@@ -242,7 +254,7 @@
     --tw-prose-body: var(--foreground);
     --tw-prose-headings: var(--foreground);
     --tw-prose-lead: var(--muted-foreground);
-    --tw-prose-links: var(--primary);
+    --tw-prose-links: var(--link);
     --tw-prose-bold: var(--foreground);
     --tw-prose-counters: var(--muted-foreground);
     --tw-prose-bullets: var(--muted-foreground);


### PR DESCRIPTION
## Hva

Innfører `--link` som egen design-token, brukt av alle tekstlenke-flater i `@tihlde/ui`.

| Modus | `--link` | Endring |
|---|---|---|
| Lys | `var(--primary)` (`#1c458a`) | Ingen — identisk med før |
| Mørk | `#4d82e6` | Ett trinn lysere enn `--primary` på samme 219°-hue |

## Hvorfor

Utgangspunktet var at «Les mer»-lenkene på `/bedrift` så ut til å ha en annen blå enn CTA-knappen. Måling i browseren viste at de allerede var **byte-identiske** — begge `var(--primary)`, uten `opacity`/`filter`/`mix-blend-mode` noe sted i forelder-kjeden:

| Element | Tag | Fyll | Tekst |
|---|---|---|---|
| Meld interesse | `<a>` | `rgb(27,97,228)` | hvit |
| Les mer | `<a>` | — | `rgb(27,97,228)` |
| Send inn | `<button>` | `rgb(27,97,228)` | hvit |

Men inntrykket er reelt: en stor fylt flate leses lysere og mer mettet enn samme farge som tynne 14px-bokstaver (simultankontrast + antialiasing som tynner ut fargen). Det er nettopp derfor designsystemer bruker en lysere tint til lenketekst enn til knappefyll.

Målingen avdekket samtidig en faktisk feil: i mørk modus ga `#1b61e4` som tekst bare **3.34:1** mot kortflaten (`#061532`) — under WCAG AA sitt krav på 4.5:1. Ny verdi gir 5.30:1 mot `--background` og 4.87:1 mot `--card`.

## Filer

- `packages/ui/src/styles.css` — token i `:root` + `.dark`, `--color-link` i `@theme inline`, og `--tw-prose-links` peker nå på den
- `button.tsx`, `badge.tsx` — `link`-varianten: `text-primary` → `text-link`
- `field.tsx`, `empty.tsx` — hover-lenker: `text-primary` → `text-link`

Alle tekstlenke-flater peker på samme token, så en `Button variant="link"` ikke kan drifte fra en markdown-lenke. Prose-lenker hadde forøvrig samme AA-problem i mørk modus.

## For reviewer

- **Lys modus er bevisst uendret.** `--link: var(--primary)` er der rent gjennomgangsledd. Konsekvens: endrer noen `--logo` senere, følger lenkefargen med i lys modus, men ikke i mørk. Tilsiktet, men verdt å vite.
- **Kjent begrensning:** mot `--popover` (`#091f49`) blir det 4.34:1, så vidt under AA. Å gå lysere ville kollidert med `--muted-foreground` (`#5d8bdf`), og lenker inni popovers er sjeldne her.

## Verifisering

`format`, `typecheck` (exit 0), `lint` (exit 0) og `build` (exit 0) passerer. Produksjonsbundelen inneholder `--link:var(--primary)` og `--link:#4d82e6`.

Målt live på `/bedrift` i begge modus:

| Modus | «Les mer»-tekst | CTA-fyll |
|---|---|---|
| Lys | `rgb(28,69,138)` | `rgb(28,69,138)` |
| Mørk | `rgb(77,130,230)` | `rgb(27,97,228)` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)