### PR TITLE
fix(db): fang opp migrasjoner Drizzle hopper stille over

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
             - name: Check linting
               run: bun run lint
 
+            # Drizzle applies migrations by journal timestamp, not by index, and
+            # silently skips any that are not newer than the last one applied.
+            - name: Check migration order
+              run: bun run db:check-order
+
             - name: Check types
               run: bun run typecheck
 

--- a/apps/api/src/migrate.ts
+++ b/apps/api/src/migrate.ts
@@ -1,5 +1,10 @@
 import { env } from "@photon/core/env";
 import { createDb } from "@photon/db";
+import {
+    findSkippedMigrations,
+    readMigrationJournal,
+} from "@photon/db/migration-journal";
+import { sql } from "drizzle-orm";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 
 /**
@@ -17,11 +22,55 @@ import { migrate } from "drizzle-orm/node-postgres/migrator";
  */
 const MIGRATIONS_FOLDER = "./drizzle";
 
+/**
+ * Fails when a migration in the journal never reached the database.
+ *
+ * `migrate()` picks what to run by comparing each migration's journal timestamp
+ * against the single newest `created_at` already in the ledger, and skips
+ * anything older *without saying so* — it still resolves successfully. A
+ * migration generated on one branch but merged after a newer one is therefore
+ * passed over in silence.
+ *
+ * That is how `0039_exotic_human_fly` never reached production on 2026-08-01:
+ * it was generated before `0038_lonely_the_hand` but merged after it, so
+ * migrate() reported success, the API booted, and every query touching
+ * `org_group` failed on the missing `logo_url` column. Comparing the whole
+ * ledger against the journal turns that silent skip into an aborted boot, which
+ * is what the ENTRYPOINT already assumes happens.
+ */
+async function assertNoMigrationsSkipped(
+    db: ReturnType<typeof createDb>,
+): Promise<void> {
+    const journal = readMigrationJournal(MIGRATIONS_FOLDER);
+    const applied = await db.execute<{ hash: string }>(
+        sql`select hash from drizzle.__drizzle_migrations`,
+    );
+
+    const skipped = findSkippedMigrations(
+        journal,
+        applied.rows.map((row) => row.hash),
+    );
+
+    if (skipped.length === 0) {
+        return;
+    }
+
+    const names = skipped.map((migration) => migration.tag).join(", ");
+
+    throw new Error(
+        `${skipped.length} migration(s) were silently skipped and are missing from the database: ${names}. ` +
+            "This happens when a migration's journal timestamp is older than one that already ran. " +
+            "Apply the SQL manually in a transaction and insert its ledger row " +
+            "(hash = sha256 of the .sql file, created_at = its `when` from meta/_journal.json).",
+    );
+}
+
 console.log(`Applying database migrations from ${MIGRATIONS_FOLDER}`);
 
 try {
     const db = createDb({ connectionString: env.DATABASE_URL });
     await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+    await assertNoMigrationsSkipped(db);
     console.log("Database migrations applied");
     process.exit(0);
 } catch (error) {

--- a/apps/api/src/test/migration-journal.test.ts
+++ b/apps/api/src/test/migration-journal.test.ts
@@ -1,0 +1,89 @@
+import {
+    type JournalMigration,
+    findOutOfOrderMigrations,
+    findSkippedMigrations,
+} from "@photon/db/migration-journal";
+import { describe, expect, it } from "vitest";
+
+function migration(tag: string, when: number, idx: number): JournalMigration {
+    return { idx, tag, when, hash: `hash-${tag}` };
+}
+
+/**
+ * These two guards exist because Drizzle picks migrations by journal timestamp
+ * rather than index, and silently skips anything not newer than the newest one
+ * already applied — while still reporting success. The fixtures below are the
+ * real 2026-08-01 incident: 0039 was generated before 0038 but merged after it,
+ * so it never ran and `org_group.logo_url` was missing in production.
+ */
+const ZEROED_38 = migration("0038_lonely_the_hand", 1785578436273, 38);
+const ZEROED_39 = migration("0039_exotic_human_fly", 1785506586548, 39);
+
+describe("findOutOfOrderMigrations", () => {
+    it("accepts a journal whose timestamps increase with the index", () => {
+        const journal = [
+            migration("0001_a", 100, 1),
+            migration("0002_b", 200, 2),
+            migration("0003_c", 300, 3),
+        ];
+
+        expect(findOutOfOrderMigrations(journal)).toEqual([]);
+    });
+
+    it("flags a migration merged out of timestamp order", () => {
+        const outOfOrder = findOutOfOrderMigrations([ZEROED_38, ZEROED_39]);
+
+        expect(outOfOrder).toHaveLength(1);
+        expect(outOfOrder[0]?.migration.tag).toBe("0039_exotic_human_fly");
+        expect(outOfOrder[0]?.blockedBy.tag).toBe("0038_lonely_the_hand");
+    });
+
+    it("compares against the newest timestamp so far, not the previous entry", () => {
+        const journal = [
+            migration("0001_a", 300, 1),
+            migration("0002_b", 100, 2),
+            // Newer than 0002 but still shadowed by 0001, so Drizzle skips it.
+            migration("0003_c", 200, 3),
+        ];
+
+        expect(
+            findOutOfOrderMigrations(journal).map((it) => it.migration.tag),
+        ).toEqual(["0002_b", "0003_c"]);
+    });
+
+    it("flags a duplicate timestamp, which Drizzle also skips", () => {
+        const journal = [
+            migration("0001_a", 100, 1),
+            migration("0002_b", 100, 2),
+        ];
+
+        expect(
+            findOutOfOrderMigrations(journal).map((it) => it.migration.tag),
+        ).toEqual(["0002_b"]);
+    });
+});
+
+describe("findSkippedMigrations", () => {
+    it("returns nothing when every migration reached the ledger", () => {
+        const journal = [ZEROED_38, ZEROED_39];
+        const applied = journal.map((it) => it.hash);
+
+        expect(findSkippedMigrations(journal, applied)).toEqual([]);
+    });
+
+    it("reports a migration missing from the ledger", () => {
+        const journal = [ZEROED_38, ZEROED_39];
+
+        const skipped = findSkippedMigrations(journal, [ZEROED_38.hash]);
+
+        expect(skipped.map((it) => it.tag)).toEqual(["0039_exotic_human_fly"]);
+    });
+
+    it("ignores ledger rows with no matching journal entry", () => {
+        const journal = [ZEROED_38];
+
+        expect(
+            findSkippedMigrations(journal, [ZEROED_38.hash, "hash-removed"]),
+        ).toEqual([]);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "format": "oxfmt --check",
         "format:fix": "oxfmt .",
         "db:push": "turbo db:push",
+        "db:check-order": "turbo db:check-order",
         "db:generate": "turbo db:generate",
         "db:migrate": "turbo db:migrate",
         "db:studio": "turbo db:studio",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,9 +6,11 @@
     "exports": {
         ".": "./src/index.ts",
         "./schema": "./src/schema/index.ts",
-        "./timestamps": "./src/timestamps.ts"
+        "./timestamps": "./src/timestamps.ts",
+        "./migration-journal": "./src/migration-journal.ts"
     },
     "scripts": {
+        "db:check-order": "bun run ./scripts/check-migration-order.ts",
         "db:generate": "drizzle-kit generate",
         "db:migrate": "drizzle-kit migrate",
         "db:push": "drizzle-kit push",

--- a/packages/db/scripts/check-migration-order.ts
+++ b/packages/db/scripts/check-migration-order.ts
@@ -1,0 +1,65 @@
+import {
+    findOutOfOrderMigrations,
+    readMigrationJournal,
+} from "../src/migration-journal";
+
+/**
+ * Fails when a migration's journal timestamp is not newer than every migration
+ * before it.
+ *
+ * Drizzle decides what to apply by comparing a migration's `when` against the
+ * newest `created_at` already in `drizzle.__drizzle_migrations` — never against
+ * the index. Anything not strictly newer is skipped in silence, and migrate()
+ * still reports success. Ordering the journal by time is therefore the property
+ * that actually makes migrations run.
+ *
+ * The hazard is created at merge time, not generate time: a migration cut from
+ * an older branch keeps its original timestamp, so merging it after a
+ * newer-but-lower-numbered one leaves it permanently unapplied. Catching that
+ * here blocks the PR instead of the deploy.
+ *
+ * Regenerate the migration (`bun run db:generate`) so it picks up a current
+ * timestamp, or raise its `when` in `meta/_journal.json` above every entry
+ * before it — but only if it has not already run anywhere, otherwise it will be
+ * re-applied against databases that already have it.
+ */
+const MIGRATIONS_FOLDER = new URL("../drizzle", import.meta.url).pathname;
+
+/**
+ * Inversions that predate this check and are already reconciled by hand.
+ *
+ * `0039_exotic_human_fly` was generated on 2026-07-31 but merged after
+ * `0038_lonely_the_hand` (generated 2026-08-01), so it was skipped on every
+ * deploy and `org_group.logo_url` never existed in production — new.tihlde.org
+ * returned HTTP 500 on everything joining groups until it was applied manually
+ * on 2026-08-01. Its timestamp is deliberately left alone: production's ledger
+ * row records the original `when`, and raising it would make Drizzle re-apply a
+ * migration that has already run. Nothing should ever be added to this list.
+ */
+const KNOWN_INVERSIONS = new Set(["0039_exotic_human_fly"]);
+
+const journal = readMigrationJournal(MIGRATIONS_FOLDER);
+const inversions = findOutOfOrderMigrations(journal).filter(
+    ({ migration }) => !KNOWN_INVERSIONS.has(migration.tag),
+);
+
+if (inversions.length > 0) {
+    const details = inversions
+        .map(
+            ({ migration, blockedBy }) =>
+                `  ${migration.tag} (when=${migration.when}) is not newer than ${blockedBy.tag} (when=${blockedBy.when})`,
+        )
+        .join("\n");
+
+    console.error(
+        `${inversions.length} migration(s) would be silently skipped by Drizzle:\n${details}\n\n` +
+            "Drizzle applies a migration only when its journal `when` is newer than every migration\n" +
+            "already recorded in the database, so these would never run. Regenerate them with\n" +
+            "`bun run db:generate` so they get a current timestamp.",
+    );
+    process.exit(1);
+}
+
+console.log(
+    `Migration journal is correctly ordered (${journal.length} entries)`,
+);

--- a/packages/db/src/migration-journal.ts
+++ b/packages/db/src/migration-journal.ts
@@ -1,0 +1,101 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * A single entry from `drizzle/meta/_journal.json`, paired with the hash
+ * Drizzle records for it in `drizzle.__drizzle_migrations`.
+ */
+export type JournalMigration = {
+    idx: number;
+    tag: string;
+    /**
+     * Millisecond timestamp from the journal. Drizzle calls this `folderMillis`
+     * and uses it — not the index — to decide what still needs applying.
+     */
+    when: number;
+    /** sha256 of the `.sql` file, matching `readMigrationFiles` in drizzle-orm. */
+    hash: string;
+};
+
+type JournalFile = {
+    entries: Array<{ idx: number; tag: string; when: number }>;
+};
+
+/**
+ * Reads the migration journal and hashes each migration exactly the way
+ * drizzle-orm does, so the results can be compared against the rows in
+ * `drizzle.__drizzle_migrations`.
+ */
+export function readMigrationJournal(
+    migrationsFolder: string,
+): JournalMigration[] {
+    const journalPath = join(migrationsFolder, "meta", "_journal.json");
+    const journal = JSON.parse(
+        readFileSync(journalPath, "utf8"),
+    ) as JournalFile;
+
+    return journal.entries.map((entry) => {
+        const sql = readFileSync(
+            join(migrationsFolder, `${entry.tag}.sql`),
+            "utf8",
+        );
+
+        return {
+            idx: entry.idx,
+            tag: entry.tag,
+            when: entry.when,
+            hash: createHash("sha256").update(sql).digest("hex"),
+        };
+    });
+}
+
+/**
+ * Returns the journal migrations that are absent from Drizzle's ledger.
+ *
+ * A non-empty result means `migrate()` skipped them without reporting it: it
+ * only runs migrations whose `when` is newer than the single newest
+ * `created_at` already recorded, so one merged out of timestamp order is passed
+ * over for good while migrate() still resolves successfully.
+ */
+export function findSkippedMigrations(
+    journal: JournalMigration[],
+    appliedHashes: Iterable<string>,
+): JournalMigration[] {
+    const applied = new Set(appliedHashes);
+
+    return journal.filter((migration) => !applied.has(migration.hash));
+}
+
+/** A migration Drizzle will never run, and the one whose timestamp shadows it. */
+export type OutOfOrderMigration = {
+    migration: JournalMigration;
+    blockedBy: JournalMigration;
+};
+
+/**
+ * Returns migrations whose `when` is not newer than every migration before
+ * them, which is precisely the set Drizzle will skip once the earlier ones have
+ * been applied.
+ *
+ * Compares against the newest timestamp seen so far rather than the previous
+ * entry, mirroring how Drizzle compares against `max(created_at)` in the
+ * ledger.
+ */
+export function findOutOfOrderMigrations(
+    journal: JournalMigration[],
+): OutOfOrderMigration[] {
+    const outOfOrder: OutOfOrderMigration[] = [];
+    let newest: JournalMigration | undefined;
+
+    for (const migration of journal) {
+        if (newest && migration.when <= newest.when) {
+            outOfOrder.push({ migration, blockedBy: newest });
+            continue;
+        }
+
+        newest = migration;
+    }
+
+    return outOfOrder;
+}

--- a/turbo.json
+++ b/turbo.json
@@ -55,6 +55,7 @@
             "cache": false,
             "interactive": true
         },
+        "db:check-order": {},
         "db:generate": { "cache": false },
         "db:migrate": {
             "dependsOn": ["@photon/docker#dev:up"],


### PR DESCRIPTION
## Bakgrunn

`new.tihlde.org` var nede 1. august med HTTP 500 på alt som joiner mot grupper. Årsaken var ikke infra, men at migrasjonen `0039_exotic_human_fly` aldri hadde kjørt mot prod — `org_group.logo_url` fantes ikke, mens koden fra #376 spurte etter den.

Grunnen til at ingen oppdaget det: **Drizzle hoppet over migrasjonen i stillhet, og meldte suksess.**

Den velger hvilke migrasjoner som skal kjøres ved å sammenligne journalens `when` mot den nyeste `created_at` i ledgeren — aldri mot indeksen ([`pg-core/dialect.js`](https://github.com/drizzle-team/drizzle-orm)):

```js
select ... from __drizzle_migrations order by created_at desc limit 1
if (!lastDbMigration || Number(lastDbMigration.created_at) < migration.folderMillis) { ...apply... }
```

`0039` ble generert 31. juli 14:03, men merget etter `0038` som ble generert 1. august 10:00. Dermed var den «eldre enn siste kjørte», ble hoppet over, og `migrate()` returnerte vellykket.

Verre: `Dockerfile` kjører `migrate.js && index.js` nettopp for at en mislykket migrasjon skal stoppe oppstart. Men en *hoppet over* migrasjon er ingen feil — så API-et bootet mot feil skjema.

## Hva denne PR-en gjør

**1. Vakt ved oppstart** — `assertNoMigrationsSkipped` i `apps/api/src/migrate.ts` sammenligner hele journalen mot ledgeren (via sha256, samme hash Drizzle bruker) etter `migrate()`. Mangler noe, aborterer boot — akkurat det ENTRYPOINT allerede forutsetter.

**2. CI-sjekk** — `bun run db:check-order` feiler når en migrasjons `when` ikke er nyere enn alle før den. Den stopper PR-en som *skaper* fella, ikke deployen som utløser den.

Fella oppstår ved merge, ikke ved generering: en migrasjon klippet fra en eldre branch beholder timestampen sin, så merges den etter en nyere-men-lavere-nummerert blir den permanent ukjørt.

## Verifisering

Hendelsen reprodusert fra bunnen mot en kastbar Postgres 17:

| Steg | migrate() sier | ledger | `logo_url` | vakt |
|---|---|---|---|---|
| Før den dårlige mergen | SUCCESS | 39 | nei | passerer |
| **0039 merget inn med gammel timestamp** | **SUCCESS** | **39** | **nei** | **ABORTERER** |
| Etter manuell retting | SUCCESS | 40 | ja | passerer |

Steg 2 er hendelsen, nøyaktig. CI-sjekken er testet mot `main` sin journal med baseline slått av, og fanger inversjonen med exit 1.

I tillegg: 7 enhetstester på den rene logikken. `lint`, `typecheck`, `format` og `build` er grønne.

## Merk

`0039_exotic_human_fly` ligger i en dokumentert `KNOWN_INVERSIONS`-liste. Timestampen er bevisst ikke rettet: prod-ledgeren har den opprinnelige verdien, så å heve `when` ville få Drizzle til å kjøre migrasjonen på nytt — `ADD COLUMN` på en kolonne som finnes, altså krasj ved oppstart.

Miljøer som fortsatt mangler 0039 vil nå nekte å starte i stedet for å kjøre videre i stillhet. Det er meningen, og feilmeldingen forklarer hvordan man retter det.

🤖 Generated with [Claude Code](https://claude.com/claude-code)