### PR TITLE
fix(grupper): vis logo, ikke gruppebilde, i kort og avatarer

### DIFF
--- a/apps/api/src/routes/event/get.ts
+++ b/apps/api/src/routes/event/get.ts
@@ -104,7 +104,9 @@ export const getRoute = route().get(
                   name: event.organizer.name,
                   slug: event.organizer.slug,
                   type: event.organizer.type,
-                  image: event.organizer.imageUrl,
+                  // The organizer is rendered as a round avatar, so this is the
+                  // logo — the gruppebilde belongs on the group's about tab.
+                  image: event.organizer.logoUrl,
               }
             : null;
 

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -503,7 +503,7 @@ export const eventDetailSchema = Schema(
                 image: z
                     .url()
                     .nullable()
-                    .meta({ description: "Organizer image URL" }),
+                    .meta({ description: "Organizer logo URL" }),
             })
             .nullable()
             .meta({ description: "Event organizer (nullable)" }),

--- a/apps/kvark/src/routes/_app/grupper.index.tsx
+++ b/apps/kvark/src/routes/_app/grupper.index.tsx
@@ -57,7 +57,7 @@ type ApiGroup = {
     slug: string;
     type: string;
     contactEmail: string | null;
-    imageUrl: string | null;
+    logoUrl: string | null;
 };
 
 function sectionFrom(
@@ -77,7 +77,7 @@ function sectionFrom(
                 name: g.name,
                 slug: g.slug,
                 email: g.contactEmail ?? undefined,
-                logoUrl: g.imageUrl ?? undefined,
+                logoUrl: g.logoUrl ?? undefined,
             })),
     };
 }

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3290,7 +3290,7 @@ export interface components {
                 slug: string;
                 /** @description Organizer type */
                 type: string;
-                /** @description Organizer image URL */
+                /** @description Organizer logo URL */
                 image: string | null;
             } | null;
             /** @description Is registration closed */


### PR DESCRIPTION
## Hva

To steder viste gruppas **gruppebilde** der **logoen** skal vises:

1. `/grupper` — gruppekortene mappet `imageUrl` inn i kortets logo-felt ([grupper.index.tsx](apps/kvark/src/routes/_app/grupper.index.tsx)). Siden de fleste gruppene ikke har noe gruppebilde, viste kortene i praksis ingenting.
2. Arrangementssiden — API-et sendte `organizer.imageUrl` som arrangørens `image` ([event/get.ts](apps/api/src/routes/event/get.ts)), og frontend rendrer det som den runde avataren over arrangementet. La en gruppe inn et gruppebilde, ble det bildet gruppas «profilbilde» på alle arrangementene deres.

Begge bruker nå `logoUrl`. Gruppebildet vises kun øverst på gruppas Om-fane, som tiltenkt i #375.

## Verifisert

Lokalt med API + kvark mot dev-databasen, med et distinkt gruppebilde satt på `nok`, `index` og `promo`:

- `/grupper` (liste + hierarki): kortene laster `group-logos/*.png`
- `/grupper/nok`: sirkelen = logo, gruppebildet kun i Om-fanen
- `/arrangementer/bedpres-med-hemit-1404`: arrangør-avataren = `nok.png`; API-et returnerer logoen i `organizer.image`
- `/opptak`: uendret, brukte allerede logoen

`typecheck` og `format` passerer; `lint` viser bare eksisterende advarsler i testfiler.

## Til reviewer

Endringen i `packages/sdk/src/generated/openapi.ts` er kun en oppdatert feltbeskrivelse fra OpenAPI-schemaet.

Merk at én gruppe i prod (`nok`) har en dataflis her: `logoUrl` peker på nøyaktig samme fil som `imageUrl` (identisk SHA1, 2560×1710-foto av gjengen). Det er ikke noe denne PR-en kan fikse — logoen må lastes opp på nytt i Logo-feltet i adminpanelet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)