### PR TITLE
fix(ui): animer åpning og lukking av accordion og collapsible

### DIFF
--- a/packages/ui/src/components/ui/accordion.tsx
+++ b/packages/ui/src/components/ui/accordion.tsx
@@ -60,12 +60,19 @@ function AccordionContent({
     return (
         <AccordionPrimitive.Panel
             data-slot="accordion-content"
-            className="overflow-hidden text-sm data-open:animate-accordion-down data-closed:animate-accordion-up"
+            // The panel itself carries the height so it can transition between
+            // 0 and its measured size. Base UI publishes that size as
+            // `--accordion-panel-height` and flags the open/close boundary with
+            // data-starting-style / data-ending-style — the two frames where
+            // height must read 0 for the roll to have somewhere to travel.
+            // (tw-animate-css's accordion keyframes are Radix-shaped and
+            // resolve to `height: auto` here, which cannot interpolate.)
+            className="h-(--accordion-panel-height) overflow-hidden text-sm transition-[height] duration-200 ease-out data-ending-style:h-0 data-starting-style:h-0"
             {...props}
         >
             <div
                 className={cn(
-                    "h-(--accordion-panel-height) pt-0 pb-2.5 data-ending-style:h-0 data-starting-style:h-0 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+                    "pt-0 pb-2.5 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
                     className,
                 )}
             >

--- a/packages/ui/src/components/ui/collapsible.tsx
+++ b/packages/ui/src/components/ui/collapsible.tsx
@@ -24,20 +24,13 @@ function CollapsibleContent({
         <CollapsiblePrimitive.Panel
             data-slot="collapsible-content"
             // Mirror the accordion so expand/collapse feels identical across the
-            // library: tw-animate-css drives the height keyframe, and the inner
-            // wrapper carries the measured panel height (0 at the open/close
-            // boundary) so the reveal reads as a smooth roll rather than a pop.
-            className="overflow-hidden text-sm data-open:animate-collapsible-down data-closed:animate-collapsible-up"
+            // library: the panel transitions its own height between 0 and the
+            // measured `--collapsible-panel-height`, so the reveal reads as a
+            // smooth roll rather than a pop.
+            className="h-(--collapsible-panel-height) overflow-hidden text-sm transition-[height] duration-200 ease-out data-ending-style:h-0 data-starting-style:h-0"
             {...props}
         >
-            <div
-                className={cn(
-                    "h-(--collapsible-panel-height) data-ending-style:h-0 data-starting-style:h-0",
-                    className,
-                )}
-            >
-                {children}
-            </div>
+            <div className={cn(className)}>{children}</div>
         </CollapsiblePrimitive.Panel>
     );
 }


### PR DESCRIPTION
## Problem

Accordions og collapsibles — blant annet gruppekortene på `/opptak` — sprettet opp og igjen uten animasjon.

Panelene brukte `data-open:animate-accordion-down` / `data-closed:animate-accordion-up` fra tw-animate-css. Disse keyframene leser panelhøyden fra Radix-formede variabler (`--radix-accordion-content-height` m.fl.). Base UI publiserer høyden som `--accordion-panel-height` / `--collapsible-panel-height`, så ingen av variablene traff, og keyframene falt tilbake på `height: auto` — som ikke kan interpoleres.

Den indre wrapperen vekslet riktignok mellom `h-0` og målt høyde på `data-starting-style` / `data-ending-style`, men hadde ingen `transition`-klasse i det hele tatt. Så uansett hvilken av de to mekanismene som skulle drevet bevegelsen: ingen av dem kunne det.

## Løsning

Høyden flyttes opp på selve panelet, med `transition-[height] duration-200 ease-out`, og nullstilles på `data-starting-style` / `data-ending-style` — mønsteret Base UI selv dokumenterer. Den indre wrapperen beholder kun innholdsstiling.

Redusert bevegelse trengte ingen ny kode: den globale `prefers-reduced-motion`-regelen i `styles.css` nuller ut `transition-duration`.

## Verifisert

- `bun run typecheck`, `bun run lint` (exit 0, kun eksisterende warnings), `bun run format`, `bun run build` — alle grønne.
- Kjørte `/opptak` lokalt og målte panelet midt i bevegelsen. Begge retninger gir en levende `CSSTransition`:
  - lukking: `height` 152px → fanget på 37px, `dur: 200`, `easing: cubic-bezier(0.22, 1, 0.36, 1)`, `state: running`
  - åpning: fanget på 37px mot mål 96px, `running`
  - Før endringen fantes ingen slik transition.
- Accordion-komponenten har ingen forbruker i kvark ennå, så den er ikke verifisert i nettleser — den fikk identisk fiks som collapsible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)