### PR TITLE
feat(kvark): bunnlinje med meny på mobil

### DIFF
--- a/apps/kvark/src/components/site-bottom-bar.tsx
+++ b/apps/kvark/src/components/site-bottom-bar.tsx
@@ -1,0 +1,164 @@
+import { Link } from "@tanstack/react-router";
+import {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger,
+} from "@tihlde/ui/ui/accordion";
+import { BottomBar, BottomBarItem } from "@tihlde/ui/ui/bottom-bar";
+import {
+    Drawer,
+    DrawerContent,
+    DrawerHeader,
+    DrawerTitle,
+    DrawerTrigger,
+} from "@tihlde/ui/ui/drawer";
+import { BriefcaseBusiness, Calendar, Menu } from "lucide-react";
+import { useState } from "react";
+
+import { TihldeLogo } from "./icons/tihlde";
+import type { NavItem, NavLink } from "./site-header";
+
+type SiteBottomBarProps = {
+    navItems: NavItem[];
+    isAuthenticated: boolean;
+};
+
+export function SiteBottomBar({
+    navItems,
+    isAuthenticated,
+}: SiteBottomBarProps) {
+    const [menuOpen, setMenuOpen] = useState(false);
+    const closeMenu = () => setMenuOpen(false);
+
+    return (
+        <BottomBar className="md:hidden">
+            <div className="flex items-stretch justify-between gap-1 px-2 py-1">
+                <BottomBarItem
+                    render={<Link to="/" activeOptions={{ exact: true }} />}
+                >
+                    <div className="size-5">
+                        <TihldeLogo />
+                    </div>
+                    Hjem
+                </BottomBarItem>
+
+                <BottomBarItem render={<Link to="/arrangementer" />}>
+                    <Calendar />
+                    Arrangementer
+                </BottomBarItem>
+
+                <BottomBarItem render={<Link to="/annonser" />}>
+                    <BriefcaseBusiness />
+                    Stillinger
+                </BottomBarItem>
+
+                <Drawer open={menuOpen} onOpenChange={setMenuOpen}>
+                    <DrawerTrigger asChild>
+                        <BottomBarItem aria-label="Åpne meny">
+                            <Menu />
+                            Meny
+                        </BottomBarItem>
+                    </DrawerTrigger>
+                    <DrawerContent>
+                        <DrawerHeader className="flex flex-row items-center gap-2">
+                            <div className="size-7">
+                                <TihldeLogo />
+                            </div>
+                            <DrawerTitle>Meny</DrawerTitle>
+                        </DrawerHeader>
+
+                        {/* min-h-0 lets the list actually scroll inside the
+                            drawer's max height instead of being clipped. */}
+                        <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto px-4 pb-8">
+                            {navItems.map((item) =>
+                                item.kind === "group" ? (
+                                    <Accordion key={item.label}>
+                                        <AccordionItem
+                                            value={item.label}
+                                            className="border-none"
+                                        >
+                                            <AccordionTrigger>
+                                                {item.label}
+                                            </AccordionTrigger>
+                                            <AccordionContent>
+                                                <div className="flex flex-col pl-2">
+                                                    {item.items.map((sub) => (
+                                                        <MenuLink
+                                                            key={sub.label}
+                                                            link={sub}
+                                                            onNavigate={
+                                                                closeMenu
+                                                            }
+                                                        />
+                                                    ))}
+                                                </div>
+                                            </AccordionContent>
+                                        </AccordionItem>
+                                    </Accordion>
+                                ) : (
+                                    <MenuLink
+                                        key={item.label}
+                                        link={item}
+                                        onNavigate={closeMenu}
+                                    />
+                                ),
+                            )}
+
+                            {isAuthenticated ? (
+                                <MenuLink
+                                    link={{
+                                        kind: "internal",
+                                        label: "Min profil",
+                                        link: {
+                                            to: "/profil/$id",
+                                            params: { id: "me" },
+                                        },
+                                    }}
+                                    onNavigate={closeMenu}
+                                />
+                            ) : (
+                                <MenuLink
+                                    link={{
+                                        kind: "internal",
+                                        label: "Logg inn",
+                                        link: { to: "/login" },
+                                    }}
+                                    onNavigate={closeMenu}
+                                />
+                            )}
+                        </div>
+                    </DrawerContent>
+                </Drawer>
+            </div>
+        </BottomBar>
+    );
+}
+
+function MenuLink({
+    link,
+    onNavigate,
+}: {
+    link: NavLink;
+    onNavigate: () => void;
+}) {
+    if (link.kind === "external") {
+        return (
+            <a
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="py-2"
+                onClick={onNavigate}
+            >
+                {link.label}
+            </a>
+        );
+    }
+
+    return (
+        <Link {...link.link} className="py-2" onClick={onNavigate}>
+            {link.label}
+        </Link>
+    );
+}

--- a/apps/kvark/src/components/site-nav-items.ts
+++ b/apps/kvark/src/components/site-nav-items.ts
@@ -1,0 +1,147 @@
+import { linkOptions } from "@tanstack/react-router";
+import { useMemo } from "react";
+
+import type { NavItem } from "#/components/site-header";
+
+/**
+ * The site navigation, shared by the header, the mobile bottom bar and the
+ * auth pages. Lives outside the layouts so every shell that shows navigation
+ * shows the same navigation.
+ */
+export function useSiteNavItems(isAuthenticated: boolean): NavItem[] {
+    // Vis "Ny student" i navmenyen fra og med juni til og med august
+    const month = new Date().getMonth();
+    const isNewStudentTime = month >= 5 && month <= 7;
+
+    const navItems = useMemo(
+        () =>
+            [
+                {
+                    kind: "group",
+                    label: "Generelt",
+                    items: [
+                        {
+                            kind: "internal",
+                            label: "Nyheter",
+                            link: linkOptions({ to: "/nyheter" }),
+                            description: "Se de siste nyhetene fra TIHLDE",
+                        },
+                        {
+                            kind: "internal",
+                            label: "TÖDDEL",
+                            link: linkOptions({ to: "/toddel" }),
+                            description: "TIHLDE sitt eget studentblad",
+                        },
+                        {
+                            kind: "internal",
+                            label: "Gruppeoversikt",
+                            link: linkOptions({ to: "/grupper" }),
+                            description:
+                                "Få oversikt over alle verv og grupper",
+                        },
+                        {
+                            kind: "external",
+                            label: "Fondet",
+                            href: "https://fondet.tihlde.org",
+                            description:
+                                "Se hvordan det ligger an med fondet vårt",
+                        },
+                    ],
+                },
+
+                ...(isNewStudentTime
+                    ? [
+                          {
+                              kind: "internal",
+                              label: "Ny student",
+                              link: linkOptions({ to: "/ny-student" }),
+                          },
+                      ]
+                    : []),
+
+                {
+                    kind: "internal",
+                    label: "Arrangementer",
+                    link: linkOptions({ to: "/arrangementer" }),
+                },
+                {
+                    kind: "external",
+                    label: "Wiki",
+                    href: "https://wiki.tihlde.org",
+                },
+                {
+                    kind: "internal",
+                    label: "Stillinger",
+                    link: linkOptions({ to: "/annonser" }),
+                },
+                ...(!isAuthenticated
+                    ? [
+                          {
+                              kind: "internal",
+                              label: "For Bedrifter",
+                              link: linkOptions({ to: "/bedrift" }),
+                          },
+                      ]
+                    : []),
+                ...(isAuthenticated
+                    ? [
+                          {
+                              kind: "group",
+                              label: "For Medlemmer",
+                              items: [
+                                  {
+                                      kind: "internal",
+                                      label: "Opptak",
+                                      link: linkOptions({ to: "/opptak" }),
+                                      description: "Søk verv hos TIHLDE",
+                                  },
+                                  {
+                                      kind: "internal",
+                                      label: "Kokebok",
+                                      link: linkOptions({ to: "/kokebok" }),
+                                      description: "Få hjelp til dine øvinger",
+                                  },
+                                  {
+                                      kind: "internal",
+                                      label: "QR koder",
+                                      link: linkOptions({ to: "/qr-koder" }),
+                                      description: "Generer dine egne QR koder",
+                                  },
+                                  {
+                                      kind: "internal",
+                                      label: "Møtetid",
+                                      link: linkOptions({ to: "/motetid" }),
+                                      description:
+                                          "Finn et tidspunkt som passer alle",
+                                  },
+                                  {
+                                      kind: "internal",
+                                      label: "Galleri",
+                                      link: linkOptions({ to: "/galleri" }),
+                                      description:
+                                          "Se alle bilder fra TIHLDE sine arrangementer",
+                                  },
+                                  {
+                                      kind: "internal",
+                                      label: "Søknader",
+                                      link: linkOptions({ to: "/soknader" }),
+                                      description:
+                                          "Send inn utlegg og søknader til TIHLDE",
+                                  },
+                                  {
+                                      kind: "external",
+                                      label: "Kontres",
+                                      href: "https://new-kontres.tihlde.org",
+                                      description:
+                                          "Reserver kontor og utstyr fra TIHLDE",
+                                  },
+                              ],
+                          },
+                      ]
+                    : []),
+            ] as NavItem[],
+        [isAuthenticated, isNewStudentTime],
+    );
+
+    return navItems;
+}

--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -1,10 +1,11 @@
-import { Outlet, createFileRoute, linkOptions } from "@tanstack/react-router";
+import { Outlet, createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 
 import { authQueryOptions } from "#/api/auth";
+import { SiteBottomBar } from "#/components/site-bottom-bar";
 import { SiteFooter } from "#/components/site-footer";
-import { SiteHeader, type NavItem } from "#/components/site-header";
-import { useMemo } from "react";
+import { SiteHeader } from "#/components/site-header";
+import { useSiteNavItems } from "#/components/site-nav-items";
 
 export const Route = createFileRoute("/_app")({ component: AppLayout });
 
@@ -21,147 +22,21 @@ function AppLayout() {
           }
         : null;
     const isAuthenticated = Boolean(currentUser);
+    const navItems = useSiteNavItems(isAuthenticated);
 
-    // Vis "Ny student" i navmenyen fra og med juni til og med august
-    const month = new Date().getMonth();
-    const isNewStudentTime = month >= 5 && month <= 7;
-
-    const navItems = useMemo(
-        () =>
-            [
-                {
-                    kind: "group",
-                    label: "Generelt",
-                    items: [
-                        {
-                            kind: "internal",
-                            label: "Nyheter",
-                            link: linkOptions({ to: "/nyheter" }),
-                            description: "Se de siste nyhetene fra TIHLDE",
-                        },
-                        {
-                            kind: "internal",
-                            label: "TÖDDEL",
-                            link: linkOptions({ to: "/toddel" }),
-                            description: "TIHLDE sitt eget studentblad",
-                        },
-                        {
-                            kind: "internal",
-                            label: "Gruppeoversikt",
-                            link: linkOptions({ to: "/grupper" }),
-                            description:
-                                "Få oversikt over alle verv og grupper",
-                        },
-                        {
-                            kind: "external",
-                            label: "Fondet",
-                            href: "https://fondet.tihlde.org",
-                            description:
-                                "Se hvordan det ligger an med fondet vårt",
-                        },
-                    ],
-                },
-
-                ...(isNewStudentTime
-                    ? [
-                          {
-                              kind: "internal",
-                              label: "Ny student",
-                              link: linkOptions({ to: "/ny-student" }),
-                          },
-                      ]
-                    : []),
-
-                {
-                    kind: "internal",
-                    label: "Arrangementer",
-                    link: linkOptions({ to: "/arrangementer" }),
-                },
-                {
-                    kind: "external",
-                    label: "Wiki",
-                    href: "https://wiki.tihlde.org",
-                },
-                {
-                    kind: "internal",
-                    label: "Stillinger",
-                    link: linkOptions({ to: "/annonser" }),
-                },
-                ...(!isAuthenticated
-                    ? [
-                          {
-                              kind: "internal",
-                              label: "For Bedrifter",
-                              link: linkOptions({ to: "/bedrift" }),
-                          },
-                      ]
-                    : []),
-                ...(isAuthenticated
-                    ? [
-                          {
-                              kind: "group",
-                              label: "For Medlemmer",
-                              items: [
-                                  {
-                                      kind: "internal",
-                                      label: "Opptak",
-                                      link: linkOptions({ to: "/opptak" }),
-                                      description: "Søk verv hos TIHLDE",
-                                  },
-                                  {
-                                      kind: "internal",
-                                      label: "Kokebok",
-                                      link: linkOptions({ to: "/kokebok" }),
-                                      description: "Få hjelp til dine øvinger",
-                                  },
-                                  {
-                                      kind: "internal",
-                                      label: "QR koder",
-                                      link: linkOptions({ to: "/qr-koder" }),
-                                      description: "Generer dine egne QR koder",
-                                  },
-                                  {
-                                      kind: "internal",
-                                      label: "Møtetid",
-                                      link: linkOptions({ to: "/motetid" }),
-                                      description:
-                                          "Finn et tidspunkt som passer alle",
-                                  },
-                                  {
-                                      kind: "internal",
-                                      label: "Galleri",
-                                      link: linkOptions({ to: "/galleri" }),
-                                      description:
-                                          "Se alle bilder fra TIHLDE sine arrangementer",
-                                  },
-                                  {
-                                      kind: "internal",
-                                      label: "Søknader",
-                                      link: linkOptions({ to: "/soknader" }),
-                                      description:
-                                          "Send inn utlegg og søknader til TIHLDE",
-                                  },
-                                  {
-                                      kind: "external",
-                                      label: "Kontres",
-                                      href: "https://new-kontres.tihlde.org",
-                                      description:
-                                          "Reserver kontor og utstyr fra TIHLDE",
-                                  },
-                              ],
-                          },
-                      ]
-                    : []),
-            ] as NavItem[],
-        [isAuthenticated, isNewStudentTime],
-    );
     return (
-        <div className="flex min-h-screen flex-col">
+        // The bottom padding keeps the footer clear of the fixed bottom bar,
+        // which only exists below md.
+        <div className="flex min-h-screen flex-col pb-16 md:pb-0">
             <SiteHeader navItems={navItems} user={currentUser} />
             <main className="flex flex-1 flex-col">
                 <Outlet />
             </main>
             <SiteFooter />
+            <SiteBottomBar
+                navItems={navItems}
+                isAuthenticated={isAuthenticated}
+            />
         </div>
     );
 }

--- a/apps/kvark/src/routes/_auth.tsx
+++ b/apps/kvark/src/routes/_auth.tsx
@@ -1,12 +1,22 @@
 import { Link, Outlet, createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
 
+import { authQueryOptions } from "#/api/auth";
 import { TihldeLogo } from "#/components/icons/tihlde";
+import { SiteBottomBar } from "#/components/site-bottom-bar";
+import { useSiteNavItems } from "#/components/site-nav-items";
 
 export const Route = createFileRoute("/_auth")({ component: AuthLayout });
 
 function AuthLayout() {
+    const { data: session } = useQuery(authQueryOptions);
+    const isAuthenticated = Boolean(session?.user);
+    const navItems = useSiteNavItems(isAuthenticated);
+
     return (
-        <div className="flex min-h-screen flex-col items-center justify-center gap-8 px-4 py-12">
+        // These pages have no header, so on mobile the bottom bar is the only
+        // way out of them — hence the padding that keeps it off the form.
+        <div className="flex min-h-screen flex-col items-center justify-center gap-8 px-4 py-12 pb-28 md:pb-12">
             <Link
                 to="/"
                 className="flex items-center gap-1"
@@ -22,6 +32,10 @@ function AuthLayout() {
             <div className="w-full max-w-md">
                 <Outlet />
             </div>
+            <SiteBottomBar
+                navItems={navItems}
+                isAuthenticated={isAuthenticated}
+            />
         </div>
     );
 }

--- a/packages/ui/src/components/ui/accordion.tsx
+++ b/packages/ui/src/components/ui/accordion.tsx
@@ -71,8 +71,13 @@ function AccordionContent({
             {...props}
         >
             <div
+                // Link styling is scoped to prose: a link sitting in a
+                // paragraph needs the underline to be findable mid-sentence,
+                // while a panel used as a list of links (a nav menu, a set of
+                // shortcuts) should look like the links around it, not like
+                // running text.
                 className={cn(
-                    "pt-0 pb-2.5 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+                    "pt-0 pb-2.5 [&_p_a]:underline [&_p_a]:underline-offset-3 [&_p_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
                     className,
                 )}
             >

--- a/packages/ui/src/components/ui/bottom-bar.tsx
+++ b/packages/ui/src/components/ui/bottom-bar.tsx
@@ -1,0 +1,41 @@
+import { useRender } from "@base-ui/react/use-render";
+import * as React from "react";
+
+import { cn } from "#/lib/utils";
+
+function BottomBar({ className, ...props }: React.ComponentProps<"nav">) {
+    return (
+        <nav
+            data-slot="bottom-bar"
+            className={cn(
+                // `pb-safe` keeps the row clear of the iOS home indicator, which
+                // otherwise sits right on top of the labels.
+                "fixed inset-x-0 bottom-0 z-40 border-t bg-background/90 pb-[env(safe-area-inset-bottom)] backdrop-blur supports-backdrop-filter:bg-background/70",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+type BottomBarItemProps = React.ComponentProps<"button"> & {
+    render?: useRender.RenderProp;
+};
+
+function BottomBarItem({ className, render, ...props }: BottomBarItemProps) {
+    return useRender({
+        render: render ?? <button type="button" />,
+        props: {
+            "data-slot": "bottom-bar-item",
+            className: cn(
+                // TanStack Router marks the matching link with data-status=active;
+                // anything else (the menu button) simply never gets the attribute.
+                "flex flex-1 cursor-pointer flex-col items-center gap-1 rounded-lg px-2 py-1.5 text-[0.6875rem] font-medium text-muted-foreground outline-none transition-colors select-none hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50 data-[status=active]:text-foreground [&_svg]:size-5 [&_svg]:shrink-0",
+                className,
+            ),
+            ...props,
+        },
+    });
+}
+
+export { BottomBar, BottomBarItem };


### PR DESCRIPTION
## Hva

Legger til en fast bunnlinje på mobil (`md:hidden`) med **Hjem, Arrangementer, Stillinger** og en **Meny**-knapp som åpner hele navigasjonen i en drawer. Modellert etter bunnlinja i Kvark-repoet.

## Hvorfor

Under `md` er headerens `NavigationMenu` skjult, så på mobil var det ingen vei til nyheter, grupper, galleri, opptak osv. — bare logo, temabryter og profil.

## Endringer

- **`packages/ui/src/components/ui/bottom-bar.tsx`** (ny): `BottomBar` (fixed nederst, blur, `env(safe-area-inset-bottom)`) og `BottomBarItem` (ikon + label, aktiv-tilstand via TanStack Routers `data-status=active`). All farge/typografi ligger her, i tråd med at Kvark-appen kun gjør layout.
- **`apps/kvark/src/components/site-bottom-bar.tsx`** (ny): komposisjonen — snarveier + Meny-drawer. Grupper er accordions, enkeltlenker ligger flatt, og Min profil / Logg inn nederst.
- **`apps/kvark/src/components/site-nav-items.ts`** (ny): nav-lista flyttet ut av `_app`-layouten til `useSiteNavItems(isAuthenticated)`, så header, bunnlinje og auth-sidene deler samme kilde.
- **`_app.tsx` / `_auth.tsx`**: rendrer bunnlinja og får bunnmarg så footer/skjema ikke havner under den. Auth-sidene har ingen header, så uten den er de en blindvei på mobil.
- **`packages/ui/src/components/ui/accordion.tsx`**: lenkestylingen i panelet er snevret fra `[&_a]` til `[&_p_a]`. Den understreket alle lenker — riktig midt i en tekst, men det gjorde at menylenkene skilte seg fra de andre i samme drawer.

## Utenfor scope

- **`/admin`** har allerede egen mobilmeny (sidebar-trigger i admin-headeren), så bunnlinja er ikke lagt til der.
- `_dev` (form-test) er intern og har ikke navigasjonsbehov.

## Testing

Verifisert i browser-preview på 375×812 mot lokal API:

- Bunnlinja vises på forsiden, `/arrangementer`, `/login` og `/register`; aktiv-markeringen følger ruta.
- Meny-drawer'en åpner, «Generelt» folder seg ut med animasjon på første klikk og viser alle punktene; klikk på en lenke navigerer og lukker drawer'en.
- Alle lenker i drawer'en har `text-decoration: none`.
- Footer (748 px) ligger klar av linja (751 px); innloggingskortet likeså.
- På 1280 px er bunnlinja `display: none` på både `_app`- og `_auth`-sidene.

`bun run typecheck`, `bun run lint`, `bun run format` og `bun run build` er grønne.

## Til reviewer

TanStack-devtools-merket nede i høyre hjørne ligger oppå «Meny»-knappen i dev-modus. Det er kun lokalt — merket finnes ikke i produksjonsbygget — men gjør knappen vanskelig å treffe når du tester.

🤖 Generated with [Claude Code](https://claude.com/claude-code)