### PR TITLE
feat(kvark): sorter arrangementer i admin fra neste som skal skje

### DIFF
--- a/apps/api/src/routes/event/list.ts
+++ b/apps/api/src/routes/event/list.ts
@@ -1,5 +1,16 @@
 import { schema } from "@photon/db";
-import { and, eq, gte, ilike, inArray, lt, lte, sql } from "drizzle-orm";
+import {
+    and,
+    asc,
+    desc,
+    eq,
+    gte,
+    ilike,
+    inArray,
+    lt,
+    lte,
+    sql,
+} from "drizzle-orm";
 import { validator } from "hono-openapi";
 import type z from "zod";
 import { describeRoute } from "~/lib/openapi";
@@ -11,6 +22,39 @@ import {
     type eventListItemSchema,
     eventListResponseSchema,
 } from "./schema";
+
+type EventOrdering = z.infer<typeof eventListFilterSchema>["ordering"];
+
+/**
+ * Ordering for the event list.
+ *
+ * `upcoming` is what an admin wants by default: whatever is happening right now
+ * or next sits on top, and everything already held follows below it with the
+ * most recent first. A plain `asc(start)` cannot do that, since an ongoing event
+ * started in the past — so the first key splits held from not-yet-held events,
+ * and the two groups are then sorted in opposite directions.
+ *
+ * Without `ordering` the legacy behaviour is kept: ascending when the caller
+ * asked for upcoming events only, descending otherwise.
+ */
+function buildOrderBy(ordering: EventOrdering, expired: boolean | undefined) {
+    switch (ordering) {
+        case "newest":
+            return [desc(schema.event.start)];
+        case "oldest":
+            return [asc(schema.event.start)];
+        case "upcoming":
+            return [
+                sql`${schema.event.end} < NOW()`,
+                sql`CASE WHEN ${schema.event.end} >= NOW() THEN ${schema.event.start} END ASC NULLS LAST`,
+                desc(schema.event.start),
+            ];
+        default:
+            return expired === false
+                ? [asc(schema.event.start)]
+                : [desc(schema.event.start)];
+    }
+}
 
 export const listRoute = route().get(
     "/",
@@ -31,8 +75,15 @@ export const listRoute = route().get(
     validator("query", eventListFilterSchema),
     async (c) => {
         const { db } = c.get("ctx");
-        const { page, pageSize, search, expired, openSignUp, category } =
-            c.req.valid("query");
+        const {
+            page,
+            pageSize,
+            search,
+            expired,
+            openSignUp,
+            category,
+            ordering,
+        } = c.req.valid("query");
 
         // Members-only events are hidden from unauthenticated (non-member)
         // callers. Any authenticated user counts as a member.
@@ -67,9 +118,7 @@ export const listRoute = route().get(
         const totalPages = getTotalPages(eventCount, pageSize);
 
         const events = await db.query.event.findMany({
-            // Upcoming events read best soonest-first; past events most-recent-first.
-            orderBy: (event, { asc, desc }) =>
-                expired === false ? [asc(event.start)] : [desc(event.start)],
+            orderBy: buildOrderBy(ordering, expired),
             with: {
                 organizer: true,
                 category: true,

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -449,6 +449,10 @@ export const eventListFilterSchema = PaginationSchema.extend({
         type: "boolean",
         description: "Whether to include only events with open sign-ups",
     }),
+    ordering: z.enum(["upcoming", "newest", "oldest"]).optional().meta({
+        description:
+            "How to order the result. 'upcoming' puts ongoing and future events first, soonest first, with past events after them most-recent-first. 'newest' and 'oldest' sort every event by start time, descending and ascending respectively. Omit to keep the legacy default: ascending when expired=false, descending otherwise.",
+    }),
 });
 
 // ===== RESPONSE SCHEMAS =====

--- a/apps/kvark/src/routes/admin/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.index.tsx
@@ -3,7 +3,7 @@ import { Link, createFileRoute } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { nb } from "date-fns/locale";
 import { CalendarDaysIcon, PlusIcon } from "lucide-react";
-import { Suspense, useMemo, useState } from "react";
+import { Suspense, startTransition, useState } from "react";
 
 import { Badge } from "@tihlde/ui/ui/badge";
 import { Button } from "@tihlde/ui/ui/button";
@@ -11,6 +11,13 @@ import { Card, CardContent } from "@tihlde/ui/ui/card";
 import { Checkbox } from "@tihlde/ui/ui/checkbox";
 import { Input } from "@tihlde/ui/ui/input";
 import { Label } from "@tihlde/ui/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@tihlde/ui/ui/select";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import {
     Table,
@@ -24,12 +31,39 @@ import {
 import { getEventsQuery } from "#/api/queries/events";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { useDebouncedValue } from "#/hooks/use-debounced-value";
 import { useAnyScopePermission } from "#/hooks/use-permission";
+
+const PAGE_SIZE = 25;
+const SEARCH_DEBOUNCE_MS = 300;
+
+type EventSort = "upcoming" | "newest" | "oldest";
+
+const SORT_OPTIONS: { value: EventSort; label: string }[] = [
+    { value: "upcoming", label: "Neste først" },
+    { value: "newest", label: "Nyeste til eldste" },
+    { value: "oldest", label: "Eldste til nyeste" },
+];
+
+const DEFAULT_SORT: EventSort = "upcoming";
+
+/**
+ * Søk, tidsrom og rekkefølge avgjøres server-side. Listen er paginert, så et
+ * klientfilter ville bare skjult treff på siden du står på — og «eldste først»
+ * ville gitt det eldste av de nyeste 25.
+ */
+const toFilters = (search: string, showPast: boolean, sort: EventSort) => ({
+    search: search.trim() || undefined,
+    ordering: sort,
+    ...(showPast ? {} : { expired: false }),
+});
 
 export const Route = createFileRoute("/admin/arrangementer/")({
     component: EventsAdminPage,
     loader: async ({ context }) => {
-        await context.queryClient.ensureQueryData(getEventsQuery(0));
+        await context.queryClient.ensureQueryData(
+            getEventsQuery(0, toFilters("", false, DEFAULT_SORT), PAGE_SIZE),
+        );
         return { breadcrumbs: "Arrangementer" };
     },
 });
@@ -38,6 +72,14 @@ function EventsAdminPage() {
     const canCreate = useAnyScopePermission(["events:create", "events:manage"]);
     const [search, setSearch] = useState("");
     const [showPast, setShowPast] = useState(false);
+    const [sort, setSort] = useState<EventSort>(DEFAULT_SORT);
+    const [page, setPage] = useState(0);
+
+    const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_MS);
+
+    // Et filterbytte gjør sidetallet meningsløst — treff nummer 26 med det
+    // gamle filteret er sjelden treff nummer 26 med det nye.
+    const resetPage = () => setPage(0);
 
     return (
         <div className="container mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8">
@@ -63,16 +105,45 @@ function EventsAdminPage() {
                             type="search"
                             placeholder="Søk etter tittel"
                             value={search}
-                            onChange={(e) => setSearch(e.target.value)}
+                            onChange={(e) => {
+                                setSearch(e.target.value);
+                                resetPage();
+                            }}
                         />
                     </div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-col gap-2 sm:w-56">
+                        <Label htmlFor="event-sort">Sorter</Label>
+                        <Select
+                            items={SORT_OPTIONS}
+                            value={sort}
+                            onValueChange={(next) => {
+                                setSort((next as EventSort) ?? DEFAULT_SORT);
+                                resetPage();
+                            }}
+                        >
+                            <SelectTrigger id="event-sort" className="w-full">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {SORT_OPTIONS.map((option) => (
+                                    <SelectItem
+                                        key={option.value}
+                                        value={option.value}
+                                    >
+                                        {option.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="flex items-center gap-2 sm:pb-2">
                         <Checkbox
                             id="event-show-past"
                             checked={showPast}
-                            onCheckedChange={(checked) =>
-                                setShowPast(Boolean(checked))
-                            }
+                            onCheckedChange={(checked) => {
+                                setShowPast(Boolean(checked));
+                                resetPage();
+                            }}
                         />
                         <Label htmlFor="event-show-past">
                             Vis tidligere arrangementer
@@ -82,7 +153,13 @@ function EventsAdminPage() {
             </Card>
 
             <Suspense fallback={<TableSkeleton />}>
-                <EventsTable search={search} showPast={showPast} />
+                <EventsTable
+                    search={debouncedSearch}
+                    showPast={showPast}
+                    sort={sort}
+                    page={page}
+                    onPageChange={setPage}
+                />
             </Suspense>
         </div>
     );
@@ -91,25 +168,21 @@ function EventsAdminPage() {
 function EventsTable({
     search,
     showPast,
+    sort,
+    page,
+    onPageChange,
 }: {
     search: string;
     showPast: boolean;
+    sort: EventSort;
+    page: number;
+    onPageChange: (page: number) => void;
 }) {
-    const { data } = useSuspenseQuery(getEventsQuery(0, {}, 100));
+    const { data } = useSuspenseQuery(
+        getEventsQuery(page, toFilters(search, showPast, sort), PAGE_SIZE),
+    );
 
-    const events = useMemo(() => {
-        const now = Date.now();
-        const term = search.trim().toLowerCase();
-        return data.items.filter((event) => {
-            if (!showPast && new Date(event.endTime).getTime() < now) {
-                return false;
-            }
-            if (term && !event.title.toLowerCase().includes(term)) {
-                return false;
-            }
-            return true;
-        });
-    }, [data.items, search, showPast]);
+    const events = data.items;
 
     if (events.length === 0) {
         return (
@@ -125,69 +198,111 @@ function EventsTable({
         );
     }
 
+    // Sidebytte i en transition, slik at tabellen blir stående mens neste side
+    // hentes i stedet for å falle tilbake til skjelettet.
+    const goToPage = (next: number) =>
+        startTransition(() => onPageChange(next));
+
     return (
-        <Card>
-            <CardContent className="p-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Tittel</TableHead>
-                            <TableHead>Dato</TableHead>
-                            <TableHead>Arrangør</TableHead>
-                            <TableHead>Status</TableHead>
-                            <TableHead className="text-right">
-                                Handlinger
-                            </TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {events.map((event) => (
-                            <TableRow key={event.id}>
-                                <TableCell>{event.title}</TableCell>
-                                <TableCell>
-                                    {formatDateTime(event.startTime)}
-                                </TableCell>
-                                <TableCell>
-                                    {event.organizer?.name ?? "—"}
-                                </TableCell>
-                                <TableCell>
-                                    <EventStatusBadge
-                                        endTime={event.endTime}
-                                        closed={event.closed}
-                                    />
-                                </TableCell>
-                                <TableCell className="text-right">
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        render={
-                                            <Link
-                                                to="/admin/arrangementer/$eventId"
-                                                params={{ eventId: event.id }}
-                                            />
-                                        }
-                                    >
-                                        Administrer
-                                    </Button>
-                                </TableCell>
+        <>
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Tittel</TableHead>
+                                <TableHead>Dato</TableHead>
+                                <TableHead>Arrangør</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead className="text-right">
+                                    Handlinger
+                                </TableHead>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </CardContent>
-        </Card>
+                        </TableHeader>
+                        <TableBody>
+                            {events.map((event) => (
+                                <TableRow key={event.id}>
+                                    <TableCell>{event.title}</TableCell>
+                                    <TableCell>
+                                        {formatDateTime(event.startTime)}
+                                    </TableCell>
+                                    <TableCell>
+                                        {event.organizer?.name ?? "—"}
+                                    </TableCell>
+                                    <TableCell>
+                                        <EventStatusBadge
+                                            startTime={event.startTime}
+                                            endTime={event.endTime}
+                                            closed={event.closed}
+                                        />
+                                    </TableCell>
+                                    <TableCell className="text-right">
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            render={
+                                                <Link
+                                                    to="/admin/arrangementer/$eventId"
+                                                    params={{
+                                                        eventId: event.id,
+                                                    }}
+                                                />
+                                            }
+                                        >
+                                            Administrer
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+
+            {data.pages > 1 ? (
+                <div className="flex items-center justify-end gap-2">
+                    <span>
+                        Side {page + 1} av {data.pages}
+                    </span>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={page === 0}
+                        onClick={() => goToPage(page - 1)}
+                    >
+                        Forrige
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={data.nextPage == null}
+                        onClick={() => goToPage(page + 1)}
+                    >
+                        Neste
+                    </Button>
+                </div>
+            ) : null}
+        </>
     );
 }
 
 function EventStatusBadge({
+    startTime,
     endTime,
     closed,
 }: {
+    startTime: string;
     endTime: string;
     closed: boolean;
 }) {
-    if (new Date(endTime).getTime() < Date.now()) {
+    const now = Date.now();
+    if (new Date(endTime).getTime() < now) {
         return <Badge variant="secondary">Avholdt</Badge>;
+    }
+    // Et arrangement som er i gang havner øverst i «Neste først» fordi det
+    // startet før alt annet som ennå ikke er over — badgen forklarer hvorfor.
+    if (new Date(startTime).getTime() <= now) {
+        return <Badge>Pågår nå</Badge>;
     }
     if (closed) {
         return <Badge variant="secondary">Påmelding stengt</Badge>;

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -6843,6 +6843,8 @@ export interface operations {
                 expired?: boolean;
                 /** @description Whether to include only events with open sign-ups */
                 openSignUp?: boolean;
+                /** @description How to order the result. 'upcoming' puts ongoing and future events first, soonest first, with past events after them most-recent-first. 'newest' and 'oldest' sort every event by start time, descending and ascending respectively. Omit to keep the legacy default: ascending when expired=false, descending otherwise. */
+                ordering?: "upcoming" | "newest" | "oldest";
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## Hva

Arrangementene på admin-siden sto i omvendt rekkefølge, og det fantes ingen måte å endre den på.

Årsaken: siden hentet de 100 arrangementene med *seneste* starttid — `/api/event` sorterer synkende når `expired` ikke er satt — og filtrerte deretter bort avholdte i nettleseren.

## Endringer

**Backend** — `/api/event` får en `ordering`-parameter:

| Verdi | Rekkefølge |
| --- | --- |
| `upcoming` | Pågående og kommende først, nærmest i tid øverst; avholdte etter, nyeste først |
| `newest` | Alt på starttid, synkende |
| `oldest` | Alt på starttid, stigende |

`upcoming` deler først på om arrangementet er over, sorterer det som ikke er over stigende og resten synkende. Det er derfor et arrangement som pågår nå havner øverst selv om det startet i fortiden — noe `asc(start)` alene ikke får til. Uten parameteren er oppførselen uendret, så de andre kallerne (forsiden, arrangementslista) er urørt.

**Frontend** — admin-siden `/admin/arrangementer`:

- «Sorter»-nedtrekk: **Neste først** (standard), Nyeste til eldste, Eldste til nyeste
- «Pågår nå»-badge på arrangementer som kjører akkurat nå, så det er tydelig hvorfor et av dem ligger øverst
- Søk og tidsrom går nå til serveren i stedet for å filtreres i nettleseren, og lista er paginert (25 per side). Uten det ville «Eldste til nyeste» bare gitt det eldste av de 25 nyeste, og søk ville bare truffet sida du står på
- Loaderen prefetcher nå den samme spørringen som komponenten faktisk bruker (den hentet tidligere en annen sidestørrelse uten filtre, så prefetchen bommet)

`packages/sdk/src/generated/openapi.ts` er regenerert med `bun run codegen`.

## Verifisert

Mot lokal API + dev-DB (1229 arrangementer):

- Standardsortering starter på nærmeste kommende (11. aug 2026 med dagens dato 2. aug 2026)
- Et arrangement jeg midlertidig satte til å pågå la seg øverst med «Pågår nå»-badge — og ble stilt tilbake etterpå
- Side 2 viser overgangen riktig: siste kommende (Julebord, 14. nov 2026) etterfulgt av nyeste avholdte (13. juni 2026) synkende
- «Eldste til nyeste» starter på 2019, «Nyeste til eldste» på nov 2026
- Søk på «julebord» finner alle 9 på tvers av år — tidligere ville søket bare sett de 100 nyeste
- Sidebytte nullstilles ved filter-/sorteringsendring

`bun run typecheck`, `lint`, `format` og `build` går grønt.

## Verdt å vite for reviewer

Sorteringen ligger i komponent-state, ikke i URL-en, så den nullstilles ved refresh. Kan flyttes til søkeparametere hvis det er ønskelig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)