### PR TITLE
fix(kvark): mobilfikser fra Betas rapport — dialoghøyde, medlemssortering, fanenavbar

### DIFF
--- a/apps/kvark/src/components/detail-layout.tsx
+++ b/apps/kvark/src/components/detail-layout.tsx
@@ -73,7 +73,10 @@ export function DetailLayoutNav<K extends string>({
     const flatItems = sections.flat();
 
     return (
-        <nav className="-mx-4 min-w-0 overflow-x-auto px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        // overflow-y-hidden er ikke overflødig: per CSS-spec beregnes den andre
+        // aksen til `auto` når én akse settes, så `overflow-x-auto` alene gjør
+        // fanene til en vertikal scrollcontainer og lar dem rubberband-e på iOS.
+        <nav className="-mx-4 min-w-0 overflow-x-auto overflow-y-hidden px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
             <Tabs
                 value={active}
                 onValueChange={(value) => onSelect(value as K)}

--- a/apps/kvark/src/components/group-law-form-dialog.tsx
+++ b/apps/kvark/src/components/group-law-form-dialog.tsx
@@ -142,7 +142,7 @@ export function GroupLawFormDialog({
                         </Field>
                         <Field>
                             <FieldLabel htmlFor="law-amount">
-                                Veiledende antall bøter *
+                                Veiledende antall bøter
                             </FieldLabel>
                             <Input
                                 id="law-amount"
@@ -152,7 +152,8 @@ export function GroupLawFormDialog({
                             />
                             <p className="text-xs text-muted-foreground">
                                 Brukes for å forhåndsutfylle antall bøter når
-                                det lages en ny
+                                det lages en ny. Sett 0 for overskrifter og
+                                forklaringer — da vises ingen bøteteller.
                             </p>
                         </Field>
                     </FieldGroup>

--- a/apps/kvark/src/components/group-law-item.tsx
+++ b/apps/kvark/src/components/group-law-item.tsx
@@ -18,9 +18,14 @@ export function GroupLawItem({ law, onEdit }: GroupLawItemProps) {
                 <h3 className="font-medium">
                     {law.paragraph} - {law.title}
                 </h3>
-                <span className="text-sm text-muted-foreground">
-                    Bøter: {law.amount}
-                </span>
+                {/* 0 bøter brukes for overskrifter og forklarende paragrafer.
+                    «Bøter: 0» leser da som en paragraf man kan bøtelegges
+                    etter — skjul tellingen helt i stedet. */}
+                {law.amount > 0 ? (
+                    <span className="text-sm text-muted-foreground">
+                        Bøter: {law.amount}
+                    </span>
+                ) : null}
             </div>
             <p className="pl-6 text-sm text-muted-foreground">
                 {law.description}

--- a/apps/kvark/src/components/law-combobox.tsx
+++ b/apps/kvark/src/components/law-combobox.tsx
@@ -39,9 +39,14 @@ export function LawCombobox({ items, value, onValueChange }: LawComboboxProps) {
                                     <span className="min-w-0 flex-1 break-words">
                                         {item.paragraph} - {item.title}
                                     </span>
-                                    <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
-                                        {item.amount} bøter
-                                    </span>
+                                    {/* Se GroupLawItem: 0 bøter betyr
+                                        overskrift/forklaring, ikke «null
+                                        bøter». */}
+                                    {item.amount > 0 ? (
+                                        <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
+                                            {item.amount} bøter
+                                        </span>
+                                    ) : null}
                                 </span>
                             </ComboboxItem>
                         )}

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -143,6 +143,26 @@ export function mapMember(member: ApiGroupMember): Member {
 }
 
 /**
+ * Medlemsendepunktet har ingen `orderBy`, så radene kommer i den rekkefølgen
+ * Postgres finner dem — i praksis innsettingsrekkefølge. Det ser nesten
+ * alfabetisk ut fordi Lepton-importen la dem inn slik, mens alle som er meldt
+ * inn etterpå havner bakerst.
+ *
+ * Sorteringen gjøres her og ikke i SQL fordi Postgres' standardkollasjon
+ * sorterer Æ, Ø og Å før Z. `Intl.Collator("nb")` gir riktig norsk rekkefølge:
+ * Zara, Ærlend, Øystein, Åse.
+ */
+const memberNameCollator = new Intl.Collator("nb");
+
+export function sortMembersByName<T extends { name: string }>(
+    members: T[],
+): T[] {
+    return [...members].sort((a, b) =>
+        memberNameCollator.compare(a.name, b.name),
+    );
+}
+
+/**
  * Norske navn på rollene et avsluttet medlemskap kan ha hatt. Både Photon og
  * Lepton-historikken kjenner bare member/leader — kolonnen er fritekst, så en
  * ukjent verdi vises som den er i stedet for å bli borte.

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -51,6 +51,7 @@ import {
     mapGroup,
     mapLaw,
     mapMember,
+    sortMembersByName,
 } from "#/lib/group";
 
 const searchSchema = z.object({
@@ -159,7 +160,7 @@ function GroupDetailPage() {
     });
 
     const members = useMemo(
-        () => (apiMembers ?? []).map(mapMember),
+        () => sortMembersByName((apiMembers ?? []).map(mapMember)),
         [apiMembers],
     );
     const leader = useMemo(

--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { Link, createFileRoute } from "@tanstack/react-router";
+import { Link, type LinkProps, createFileRoute } from "@tanstack/react-router";
 import { Button } from "@tihlde/ui/ui/button";
 import { EventCalendar } from "@tihlde/ui/complex/event-calendar";
 import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
@@ -70,6 +70,7 @@ function Home() {
                     actionLabel={
                         canCreateEvent ? "Nytt arrangement" : undefined
                     }
+                    actionTo="/admin/arrangementer/ny"
                 />
                 <Suspense fallback={<EventsSkeleton />}>
                     <EventsSection />
@@ -80,6 +81,7 @@ function Home() {
                 <SectionHeader
                     title="Nyheter"
                     actionLabel={canCreateNews ? "Ny nyhet" : undefined}
+                    actionTo="/admin/nyheter"
                 />
                 <Suspense fallback={<NewsSkeleton />}>
                     <NewsSection />
@@ -274,17 +276,24 @@ function HeroActions() {
 function SectionHeader({
     title,
     actionLabel,
+    actionTo,
 }: {
     title: string;
     actionLabel?: string;
+    /** Målruta for handlingsknappen. Uten den rendres ingen knapp. */
+    actionTo?: LinkProps["to"];
 }) {
     return (
         <Reveal
             render={<div className="flex items-center justify-between gap-4" />}
         >
             <h2 className="text-2xl">{title}</h2>
-            {actionLabel ? (
-                <Button variant="ghost" size="sm">
+            {actionLabel && actionTo ? (
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    render={<Link to={actionTo} />}
+                >
                     <Plus />
                     {actionLabel}
                 </Button>

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -291,7 +291,9 @@ function ProfileNav({
     return (
         <>
             {/* Mobile: horizontal scroll */}
-            <nav className="-mx-4 min-w-0 overflow-x-auto px-4 [scrollbar-width:none] md:hidden [&::-webkit-scrollbar]:hidden">
+            {/* overflow-y-hidden: se DetailLayoutNav — én akse satt gjør den
+                andre til `auto`, og fanene blir vertikalt scrollbare. */}
+            <nav className="-mx-4 min-w-0 overflow-x-auto overflow-y-hidden px-4 [scrollbar-width:none] md:hidden [&::-webkit-scrollbar]:hidden">
                 <ul className="flex w-max gap-2">
                     {flatItems.map((item) => (
                         <li key={item.label} className="shrink-0">

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -51,7 +51,13 @@ function DialogContent({
             <DialogPrimitive.Popup
                 data-slot="dialog-content"
                 className={cn(
-                    "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+                    // max-h + overflow: uten dem vokser popupen symmetrisk ut
+                    // over begge skjermkanter når innholdet er høyere enn
+                    // viewporten — tittel og lukkeknapp havner over toppen,
+                    // handlingsknappene under bunnen, og siden er `fixed` kan
+                    // ingen av dem nås. overscroll-contain hindrer at siden bak
+                    // tar over scrollingen når popupen når enden.
+                    "fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto overscroll-contain rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
                     className,
                 )}
                 {...props}


### PR DESCRIPTION
Fikser de trygge punktene fra Ola Syrstad Bergs mobilrapport. Punktene som er større, uverifiserte eller egentlig designvalg er meldt som issues i stedet — se nederst.

## Endringer

| Fil | Endring |
|---|---|
| `packages/ui/…/dialog.tsx` | `max-h-[calc(100dvh-2rem)]` + `overflow-y-auto` + `overscroll-contain` på `DialogContent` |
| `apps/kvark/src/lib/group.ts` | Ny `sortMembersByName` med `Intl.Collator("nb")` |
| `apps/kvark/…/grupper.$slug.tsx` | Tar i bruk sorteringen |
| `apps/kvark/…/detail-layout.tsx`, `profil/$id.tsx` | `overflow-y-hidden` på fanenavbarene |
| `apps/kvark/…/group-law-item.tsx`, `law-combobox.tsx`, `group-law-form-dialog.tsx` | Skjuler bøtetelling når antallet er 0 |
| `apps/kvark/…/index.tsx` | Kobler opp «Nytt arrangement» og «Ny nyhet» |

## Verifisering

**Dialogen** — A/B i kjørende app på 375×812, dialoginnholdet gjort like høyt som Ola beskriver:

| | Før | Etter |
|---|---|---|
| Høyde vs. 812px skjerm | 1154px, stikker utenfor | 780px, får plass |
| Scroll inni dialogen | nei | ja |
| X-knapp | top −134, **ikke nåbar** | top 43, nåbar |
| Avbryt / Opprett | bunn 954, **ikke nåbar** | nåbar etter scroll |

Kort dialog («Logg inn») er uendret — 375px, sentrert, ingen scrollbar. Ingen regresjon.

**Sortering** — kjørt mot ekte API-data: 21 Beta-medlemmer sortert riktig, input muteres ikke. Norsk kollasjon bekreftet: `Anna, Zara, Ærlend, Øystein, Åse` mot naiv `.sort()` som gir `Anna, Zara, Åse, Ærlend, Øystein`.

**Navbaren** — `overflow-y` er nå `hidden`, horisontal scroll intakt (scrollWidth 511 > clientWidth 375), ingenting klippes visuelt.

`typecheck`, `lint`, `format` og `build` passerer.

Ikke kjørt i nettleser: lovverk-endringene og forsideknappene krever innlogging, som kun går via Feide. For forsideknappene er typecheck likevel sterkt bevis — `LinkProps["to"]` er en streng union, så at bygget passerer betyr at begge rutene finnes.

## To avvik fra den opprinnelige planen

**Tidligere medlemmer sorteres ikke.** `members/history.ts:43` har `orderBy: [desc(endedAt)]` — nyest avsluttet først er et bevisst valg, og klagen gjaldt den aktive lista.

**Olas diagnose av sorteringsbuggen stemte ikke.** Han antok en kollasjonsfeil på Æ/Ø/Å. Det fantes ingen sortering i det hele tatt. Fiksen bruker uansett norsk kollasjon, så bekymringen hans er dekket.

## Meldt som issues i stedet

- #397 — `DialogBody` for låst header/footer. Krever at `DialogContent` bytter fra `grid` til `flex flex-col`, som treffer alle 37 dialogene.
- #398 — iOS-tastatur/dialog. Ikke reprodusert i Chromium; trenger fysisk enhet.
- #399 — gruppens arrangementsfane. Krever nytt organizer-filter i API-et + SDK-regen.
- #400 — hero-animasjonen. 32 blur-filterpass per frame; målt 29 → 56 fps ved å flytte blur til gruppenivå.
- #401 — varselmerket på profilen.
- #402 — avklaring: skal fanenavigasjonen kuttes i linje med innholdet, eller beholde edge-to-edge? Dette er et bevisst designvalg, ikke en bug, så det er ikke endret her.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
