### PR TITLE
fix(arrangementer): påmelding, kontaktperson og stavekontroll

### DIFF
--- a/apps/api/src/routes/event/get.ts
+++ b/apps/api/src/routes/event/get.ts
@@ -36,6 +36,9 @@ export const getRoute = route().get(
             with: {
                 category: true,
                 organizer: true,
+                contactPerson: {
+                    columns: { id: true, name: true, email: true },
+                },
                 reactions: {
                     columns: { userId: true, emoji: true },
                     with: { user: { columns: { name: true } } },
@@ -110,6 +113,16 @@ export const getRoute = route().get(
               }
             : null;
 
+        // Navnet er offentlig, e-posten er det ikke: adressen deles bare med
+        // innloggede medlemmer, så den ikke kan høstes fra de åpne sidene.
+        const contactPerson = event.contactPerson
+            ? {
+                  id: event.contactPerson.id,
+                  name: event.contactPerson.name,
+                  email: user ? event.contactPerson.email : null,
+              }
+            : null;
+
         const category = {
             slug: event.category.slug,
             label: event.category.label,
@@ -154,6 +167,7 @@ export const getRoute = route().get(
             cancellationDeadline:
                 event.cancellationDeadline?.toISOString() ?? null,
             organizer,
+            contactPerson,
             category,
             closed: event.isRegistrationClosed,
             requiresSigningUp: event.requiresSigningUp,

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -53,9 +53,9 @@ const eventMutationSchema = z.object({
         description:
             "Timestamp for when registrations open. If null, open immediately.",
     }),
-    registrationEnd: z.iso.datetime().meta({
+    registrationEnd: z.iso.datetime().nullable().meta({
         description:
-            "When the registration for the event ends. After this time, users cannot sign up.",
+            "When the registration for the event ends. After this time, users cannot sign up. Null for events without sign-up (requiresSigningUp false).",
     }),
     cancellationDeadline: z.iso.datetime().nullable().meta({
         description:
@@ -219,6 +219,16 @@ export const createEventSchema = Schema(
                     path: ["allowWaitlist"],
                 });
             }
+        } else if (!val.registrationEnd) {
+            // Motstykket til regelen over: `registrationEnd` er nullable for at
+            // arrangementer uten påmelding skal kunne opprettes, så et
+            // arrangement med påmelding må fortsatt oppgi en frist.
+            ctx.addIssue({
+                code: "custom",
+                message:
+                    "registrationEnd is required if requiresSigningUp is true",
+                path: ["registrationEnd"],
+            });
         }
 
         if (
@@ -232,7 +242,9 @@ export const createEventSchema = Schema(
             });
         }
 
-        if (!val.requiresSigningUp && val.capacity !== undefined) {
+        // `capacity` er et påkrevd felt, så et arrangement uten påmelding må
+        // kunne sende null. Det er bare et faktisk tak som ikke gir mening.
+        if (!val.requiresSigningUp && val.capacity != null) {
             ctx.addIssue({
                 code: "custom",
                 message: "capacity cannot be set if requiresSigningUp is false",
@@ -338,7 +350,8 @@ export const updateEventSchema = Schema(
                     path: ["allowWaitlist"],
                 });
             }
-            if (val.capacity !== undefined) {
+            // Se kommentaren i create-skjemaet: null betyr «ingen kapasitet».
+            if (val.capacity != null) {
                 ctx.addIssue({
                     code: "custom",
                     message:
@@ -511,6 +524,20 @@ export const eventDetailSchema = Schema(
             })
             .nullable()
             .meta({ description: "Event organizer (nullable)" }),
+        contactPerson: z
+            .object({
+                id: z.string().meta({ description: "Contact person user ID" }),
+                name: z.string().meta({ description: "Contact person name" }),
+                email: z.string().nullable().meta({
+                    description:
+                        "Contact person e-mail. Null for unauthenticated callers, so members' addresses are not exposed to the open internet.",
+                }),
+            })
+            .nullable()
+            .meta({
+                description:
+                    "Who to ask about the event (nullable). Set with contactPersonUserId.",
+            }),
         closed: z.boolean().meta({ description: "Is registration closed" }),
         requiresSigningUp: z.boolean().meta({
             description: "Do users need to sign up to attend the event?",

--- a/apps/api/src/test/event/contact-person.test.ts
+++ b/apps/api/src/test/event/contact-person.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+const baseEventBody = {
+    title: "Event med kontaktperson",
+    description: "Test av kontaktperson på arrangementsdetaljene",
+    categorySlug: "bedpres",
+    organizerGroupSlug: "index",
+    location: "Trondheim",
+    imageUrl: null,
+    imageAlt: null,
+    start: "2025-12-01T18:00:00Z",
+    end: "2025-12-01T20:00:00Z",
+    registrationStart: null,
+    registrationEnd: "2025-11-30T23:59:59Z",
+    cancellationDeadline: null,
+    capacity: 50,
+    isRegistrationClosed: false,
+    requiresSigningUp: true,
+    allowWaitlist: true,
+    priorityPools: null,
+    onlyAllowPrioritized: false,
+    canCauseStrikes: false,
+    enforcesPreviousStrikes: false,
+    isPaidEvent: false,
+    price: null,
+    paymentGracePeriodMinutes: null,
+    reactionsAllowed: true,
+};
+
+describe("event contact person", () => {
+    integrationTest(
+        "is returned on the event detail, with the e-mail only for authenticated callers",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.giveUserPermissions(user, ["events:create"]);
+
+            const createResponse = await client.api.event.$post({
+                json: { ...baseEventBody, contactPersonUserId: user.id },
+            });
+            expect(createResponse.status).toBe(201);
+            const { eventId } = await createResponse.json();
+
+            const detailResponse = await client.api.event[":eventId"].$get({
+                param: { eventId },
+            });
+            expect(detailResponse.status).toBe(200);
+            const detail = await detailResponse.json();
+            expect(detail).toMatchObject({
+                contactPerson: {
+                    id: user.id,
+                    name: user.name,
+                    email: user.email,
+                },
+            });
+
+            // Adressen skal ikke kunne høstes fra de åpne sidene.
+            const anonymous = ctx.utils.client();
+            const publicResponse = await anonymous.api.event[":eventId"].$get({
+                param: { eventId },
+            });
+            expect(publicResponse.status).toBe(200);
+            const publicDetail = await publicResponse.json();
+            expect(publicDetail).toMatchObject({
+                contactPerson: {
+                    id: user.id,
+                    name: user.name,
+                    email: null,
+                },
+            });
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "is null when the event has none",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.giveUserPermissions(user, ["events:create"]);
+
+            const createResponse = await client.api.event.$post({
+                json: { ...baseEventBody, contactPersonUserId: null },
+            });
+            expect(createResponse.status).toBe(201);
+            const { eventId } = await createResponse.json();
+
+            const detailResponse = await client.api.event[":eventId"].$get({
+                param: { eventId },
+            });
+            const detail = await detailResponse.json();
+            expect(detail).toMatchObject({ contactPerson: null });
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "can be set and cleared on update",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.giveUserPermissions(user, [
+                "events:create",
+                "events:update",
+            ]);
+
+            const createResponse = await client.api.event.$post({
+                json: { ...baseEventBody, contactPersonUserId: null },
+            });
+            const { eventId } = await createResponse.json();
+
+            const setResponse = await client.api.event[":id"].$put({
+                param: { id: eventId },
+                json: { contactPersonUserId: user.id },
+            });
+            expect(setResponse.status).toBe(200);
+
+            const afterSetResponse = await client.api.event[":eventId"].$get({
+                param: { eventId },
+            });
+            expect(await afterSetResponse.json()).toMatchObject({
+                contactPerson: { id: user.id },
+            });
+
+            const clearResponse = await client.api.event[":id"].$put({
+                param: { id: eventId },
+                json: { contactPersonUserId: null },
+            });
+            expect(clearResponse.status).toBe(200);
+
+            const afterClearResponse = await client.api.event[":eventId"].$get({
+                param: { eventId },
+            });
+            expect(await afterClearResponse.json()).toMatchObject({
+                contactPerson: null,
+            });
+        },
+        500_000,
+    );
+});

--- a/apps/api/src/test/event/create.test.ts
+++ b/apps/api/src/test/event/create.test.ts
@@ -185,6 +185,98 @@ describe("create event", () => {
     );
 
     integrationTest(
+        "Test that creating an event without sign-up works",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            await ctx.utils.giveUserPermissions(user, ["events:create"]);
+
+            // Arrangementer man bare møter opp på. Både frist og kapasitet må
+            // kunne være null her — ellers er de umulige å opprette.
+            const response = await client.api.event.$post({
+                json: {
+                    title: "Facebook-vegg",
+                    description: "Ingen påmelding, bare møt opp",
+                    categorySlug: "bedpres",
+                    organizerGroupSlug: "index",
+                    location: "Oslo, Norway",
+                    imageUrl: null,
+                    start: "2025-12-01T18:00:00Z",
+                    end: "2025-12-01T20:00:00Z",
+                    registrationStart: null,
+                    registrationEnd: null,
+                    cancellationDeadline: null,
+                    capacity: null,
+                    isRegistrationClosed: false,
+                    requiresSigningUp: false,
+                    allowWaitlist: false,
+                    priorityPools: null,
+                    onlyAllowPrioritized: false,
+                    canCauseStrikes: false,
+                    enforcesPreviousStrikes: false,
+                    isPaidEvent: false,
+                    price: null,
+                    paymentGracePeriodMinutes: null,
+                    contactPersonUserId: null,
+                    reactionsAllowed: true,
+                },
+            });
+
+            expect(response.status).toBe(201);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "Test that an event with sign-up must have a registration deadline",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            await ctx.utils.giveUserPermissions(user, ["events:create"]);
+
+            const response = await client.api.event.$post({
+                json: {
+                    title: "Test Event",
+                    description: "A test event description",
+                    categorySlug: "bedpres",
+                    organizerGroupSlug: "index",
+                    location: "Oslo, Norway",
+                    imageUrl: null,
+                    start: "2025-12-01T18:00:00Z",
+                    end: "2025-12-01T20:00:00Z",
+                    registrationStart: null,
+                    registrationEnd: null,
+                    cancellationDeadline: null,
+                    capacity: 50,
+                    isRegistrationClosed: false,
+                    requiresSigningUp: true,
+                    allowWaitlist: true,
+                    priorityPools: null,
+                    onlyAllowPrioritized: false,
+                    canCauseStrikes: false,
+                    enforcesPreviousStrikes: false,
+                    isPaidEvent: false,
+                    price: null,
+                    paymentGracePeriodMinutes: null,
+                    contactPersonUserId: null,
+                    reactionsAllowed: true,
+                },
+            });
+
+            expect(response.status).toBe(400);
+        },
+        500_000,
+    );
+
+    integrationTest(
         "Test that creating an event without events:create permission returns forbidden",
         async ({ ctx }) => {
             const user = await ctx.utils.createTestUser();

--- a/apps/kvark/src/api/api-client.ts
+++ b/apps/kvark/src/api/api-client.ts
@@ -240,11 +240,35 @@ class Client<Paths extends object> {
 
             return response.text();
         } catch (error) {
+            useApiErrorMessage(error);
+
             for (const hook of this.beforeAnyErrorHooks) {
                 hook(error);
             }
             throw error;
         }
+    }
+}
+
+/**
+ * Løft API-ets egen feilmelding opp i `error.message`.
+ *
+ * Uten dette blir forklaringen liggende igjen i responskroppen, og alt kallere
+ * har å vise brukeren er ky sin generiske «Request failed with status code
+ * 403». API-et svarer alltid `{ status, message }` (se `globalErrorHandler`).
+ */
+function useApiErrorMessage(error: unknown): void {
+    if (!(error instanceof Error)) return;
+
+    // ky leser kroppen selv og legger den ferdig parset på `data` — etter det
+    // er `response.json()` tom. Duck-typet i stedet for `instanceof HTTPError`,
+    // siden SSR og klienten kan ende opp med hver sin kopi av ky.
+    const data = (error as { data?: unknown }).data;
+    if (!data || typeof data !== "object") return;
+
+    const message = (data as { message?: unknown }).message;
+    if (typeof message === "string" && message) {
+        error.message = message;
     }
 }
 

--- a/apps/kvark/src/api/queries/events.ts
+++ b/apps/kvark/src/api/queries/events.ts
@@ -1,4 +1,5 @@
 import {
+    type QueryClient,
     infiniteQueryOptions,
     mutationOptions,
     queryOptions,
@@ -78,6 +79,22 @@ export const getEventByIdQuery = (eventId: string) =>
             }),
     });
 
+/**
+ * Frisk opp arrangementsdetaljene, uansett om de ligger i cachen under slug
+ * eller ID.
+ *
+ * Endepunktet tar imot begge, og de offentlige sidene slår opp på slug mens
+ * mutasjonene bare kjenner ID-en. Å invalidere på ID alene bommet derfor på
+ * nøkkelen siden faktisk brukte: påmeldingskortet ble stående uendret til
+ * brukeren lastet siden på nytt.
+ */
+function invalidateEventDetails(client: QueryClient): Promise<void> {
+    return client.invalidateQueries({
+        queryKey: [...EventQueryKeys.detail],
+        exact: false,
+    });
+}
+
 export const updateEventMutation = mutationOptions({
     mutationFn: ({
         eventId,
@@ -91,13 +108,9 @@ export const updateEventMutation = mutationOptions({
             json: data,
         }),
     onSuccess(_, __, ___, ctx) {
-        // Detaljsiden caches på slug, mens vi oppdaterer på id — og en
-        // tittelendring gir dessuten ny slug. Derfor invalideres hele
-        // detail-nøkkelen, ikke bare den ene oppføringen.
-        ctx.client.invalidateQueries({
-            queryKey: [...EventQueryKeys.detail],
-            exact: false,
-        });
+        // En tittelendring gir dessuten ny slug, så hele detail-nøkkelen må
+        // friskes opp.
+        invalidateEventDetails(ctx.client);
         ctx.client.invalidateQueries({
             queryKey: [...EventQueryKeys.list],
             exact: false,
@@ -114,8 +127,8 @@ export const deleteEventMutation = mutationOptions({
         apiClient.delete(`/api/event/{eventId}`, {
             params: { eventId: eventId },
         }),
-    onSuccess(_, vars, __, ctx) {
-        ctx.client.invalidateQueries(getEventByIdQuery(vars.eventId));
+    onSuccess(_, __, ___, ctx) {
+        invalidateEventDetails(ctx.client);
         ctx.client.invalidateQueries({
             queryKey: [...EventQueryKeys.list],
             exact: false,
@@ -255,7 +268,7 @@ export const registerForEventMutation = mutationOptions({
             queryKey: [...EventQueryKeys.registrations, vars.eventId],
             exact: false,
         });
-        ctx.client.invalidateQueries(getEventByIdQuery(vars.eventId));
+        invalidateEventDetails(ctx.client);
     },
 });
 
@@ -269,7 +282,7 @@ export const unregisterFromEventMutation = mutationOptions({
             queryKey: [...EventQueryKeys.registrations, vars.eventId],
             exact: false,
         });
-        ctx.client.invalidateQueries(getEventByIdQuery(vars.eventId));
+        invalidateEventDetails(ctx.client);
     },
 });
 

--- a/apps/kvark/src/components/event-form.tsx
+++ b/apps/kvark/src/components/event-form.tsx
@@ -28,6 +28,9 @@ import { richRegistry } from "#/components/markdown/directives/presets";
 /** Sentinel for "no institute restriction" — Select has no empty value. */
 export const ALL_INSTITUTES = "all";
 
+/** Samme grunn: Select trenger en verdi for «ingen kontaktperson». */
+const NO_CONTACT = "none";
+
 export type EventFormValues = {
     title: string;
     description: string;
@@ -39,8 +42,12 @@ export type EventFormValues = {
      * ("Digitalt", "R1") gir null, og da vises stedet uten kartlenke.
      */
     locationCoords: { label: string; lat: number; lng: number } | null;
+    /** Bruker-ID til den som skal svare på spørsmål. Tom streng = ingen valgt. */
+    contactPersonUserId: string;
     start: Date | null;
     end: Date | null;
+    /** Om arrangementet har påmelding i det hele tatt. */
+    requiresSigningUp: boolean;
     registrationEnd: Date | null;
     capacity: string;
     visibility: "public" | "members";
@@ -57,6 +64,8 @@ type EventFormProps = {
     onChange: (patch: Partial<EventFormValues>) => void;
     groups: Array<{ slug: string; name: string }>;
     institutes: Array<{ slug: string; shortName: string; name: string }>;
+    /** Medlemmene i den valgte arrangørgruppen — kandidatene til kontaktperson. */
+    contactPersonCandidates: Array<{ id: string; name: string }>;
     addressSuggestions: AddressSuggestion[];
     isSearchingAddress: boolean;
     /** Bilde som allerede ligger på arrangementet, vist til et nytt velges. */
@@ -78,6 +87,7 @@ export function EventForm({
     onChange,
     groups,
     institutes,
+    contactPersonCandidates,
     addressSuggestions,
     isSearchingAddress,
     existingImageUrl,
@@ -99,6 +109,31 @@ export function EventForm({
                     : null,
         });
     }
+
+    /**
+     * Kandidatene er medlemmene i arrangørgruppen. En kontaktperson som er
+     * lagret fra før, men ikke lenger står i lista — f.eks. etter et
+     * lederskifte — legges til, slik at redigering ikke stille nullstiller
+     * feltet.
+     */
+    const contactPersonOptions = [
+        { value: NO_CONTACT, label: "Ingen kontaktperson" },
+        ...contactPersonCandidates.map((member) => ({
+            value: member.id,
+            label: member.name,
+        })),
+        ...(values.contactPersonUserId &&
+        !contactPersonCandidates.some(
+            (member) => member.id === values.contactPersonUserId,
+        )
+            ? [
+                  {
+                      value: values.contactPersonUserId,
+                      label: "Nåværende kontaktperson",
+                  },
+              ]
+            : []),
+    ];
 
     function handleSelectAddress(suggestion: AddressSuggestion) {
         onChange({
@@ -182,6 +217,42 @@ export function EventForm({
                             </Select>
                         </Field>
                         <Field>
+                            <FieldLabel htmlFor="event-contact">
+                                Kontaktperson (valgfritt)
+                            </FieldLabel>
+                            <Select
+                                items={contactPersonOptions}
+                                value={values.contactPersonUserId || NO_CONTACT}
+                                onValueChange={(value) =>
+                                    onChange({
+                                        contactPersonUserId:
+                                            !value || value === NO_CONTACT
+                                                ? ""
+                                                : value,
+                                    })
+                                }
+                            >
+                                <SelectTrigger id="event-contact">
+                                    <SelectValue placeholder="Ingen kontaktperson" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {contactPersonOptions.map((option) => (
+                                        <SelectItem
+                                            key={option.value}
+                                            value={option.value}
+                                        >
+                                            {option.label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                            <FieldDescription>
+                                Vises på arrangementssiden, med e-post for
+                                innloggede medlemmer. Velg blant medlemmene i
+                                arrangørgruppen.
+                            </FieldDescription>
+                        </Field>
+                        <Field>
                             <FieldLabel htmlFor="event-location">
                                 Sted
                             </FieldLabel>
@@ -225,35 +296,55 @@ export function EventForm({
                                 onValueChange={(end) => onChange({ end })}
                             />
                         </Field>
-                        <Field>
-                            <FieldLabel htmlFor="event-reg-end">
-                                Påmeldingsfrist
-                            </FieldLabel>
-                            <DateTimePicker
-                                id="event-reg-end"
-                                locale={nb}
-                                placeholder="Velg påmeldingsfrist"
-                                maxDate={values.start ?? undefined}
-                                value={values.registrationEnd}
-                                onValueChange={(registrationEnd) =>
-                                    onChange({ registrationEnd })
+                        <Field orientation="horizontal" className="gap-3">
+                            <Checkbox
+                                id="event-requires-signup"
+                                checked={values.requiresSigningUp}
+                                onCheckedChange={(checked) =>
+                                    onChange({
+                                        requiresSigningUp: Boolean(checked),
+                                    })
                                 }
                             />
-                        </Field>
-                        <Field>
-                            <FieldLabel htmlFor="event-capacity">
-                                Kapasitet (valgfritt)
+                            <FieldLabel htmlFor="event-requires-signup">
+                                Arrangementet har påmelding
                             </FieldLabel>
-                            <Input
-                                id="event-capacity"
-                                type="number"
-                                min={1}
-                                value={values.capacity}
-                                onChange={(event) =>
-                                    onChange({ capacity: event.target.value })
-                                }
-                            />
                         </Field>
+                        {values.requiresSigningUp ? (
+                            <>
+                                <Field>
+                                    <FieldLabel htmlFor="event-reg-end">
+                                        Påmeldingsfrist
+                                    </FieldLabel>
+                                    <DateTimePicker
+                                        id="event-reg-end"
+                                        locale={nb}
+                                        placeholder="Velg påmeldingsfrist"
+                                        maxDate={values.start ?? undefined}
+                                        value={values.registrationEnd}
+                                        onValueChange={(registrationEnd) =>
+                                            onChange({ registrationEnd })
+                                        }
+                                    />
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-capacity">
+                                        Kapasitet (valgfritt)
+                                    </FieldLabel>
+                                    <Input
+                                        id="event-capacity"
+                                        type="number"
+                                        min={1}
+                                        value={values.capacity}
+                                        onChange={(event) =>
+                                            onChange({
+                                                capacity: event.target.value,
+                                            })
+                                        }
+                                    />
+                                </Field>
+                            </>
+                        ) : null}
                         <Field>
                             <FieldLabel htmlFor="event-visibility">
                                 Synlighet

--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -1,3 +1,4 @@
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { Badge } from "@tihlde/ui/ui/badge";
 import { Button } from "@tihlde/ui/ui/button";
 import { VippsButton } from "@tihlde/ui/ui/vipps-button";
@@ -8,6 +9,7 @@ import { Progress } from "@tihlde/ui/ui/progress";
 import {
     AlertCircle,
     Ban,
+    CalendarCheck,
     CalendarClock,
     CheckCircle2,
     CreditCard,
@@ -47,12 +49,21 @@ type EventRegistrationCardProps = {
     headerSlot?: ReactNode;
     notEligibleReason?: string;
     waitlistPosition?: number;
+    /** Satt mens en på-/avmelding er underveis, så knappen ikke kan dobbeltklikkes. */
+    isSubmitting?: boolean;
+    /**
+     * Feilmeldingen fra siste forsøk på å melde seg på eller av. Uten denne
+     * så knappen ut til å ikke gjøre noe når API-et avviste påmeldingen.
+     */
+    actionError?: string | null;
 };
 
 export function EventRegistrationCard(props: EventRegistrationCardProps) {
     const [allowPhoto, setAllowPhoto] = useState(true);
     const timeline = buildTimeline(props);
     const state = getStateRendering(props, { allowPhoto, setAllowPhoto });
+    // Uten påmelding er både tidslinjen og «0/∞ påmeldte» bare støy.
+    const showRegistrationDetails = props.registrationState !== "no-signup";
 
     return (
         <Card>
@@ -69,10 +80,12 @@ export function EventRegistrationCard(props: EventRegistrationCardProps) {
                 </div>
             </CardHeader>
             <CardContent className="flex flex-col gap-4">
-                {timeline.length >= 2 ? (
+                {showRegistrationDetails && timeline.length >= 2 ? (
                     <RegistrationTimeline points={timeline} />
                 ) : null}
-                <RegistrationStats {...props} />
+                {showRegistrationDetails ? (
+                    <RegistrationStats {...props} />
+                ) : null}
                 {state.message ? (
                     <InfoRow icon={state.icon}>
                         <span>{state.message}</span>
@@ -84,6 +97,13 @@ export function EventRegistrationCard(props: EventRegistrationCardProps) {
                     </InfoRow>
                 ) : null}
                 {state.actions}
+                {props.actionError ? (
+                    <Alert variant="destructive">
+                        <AlertCircle className="size-4" />
+                        <AlertTitle>Påmeldingen gikk ikke gjennom</AlertTitle>
+                        <AlertDescription>{props.actionError}</AlertDescription>
+                    </Alert>
+                ) : null}
             </CardContent>
         </Card>
     );
@@ -108,6 +128,20 @@ function getStateRendering(
     const state = props.registrationState;
 
     switch (state) {
+        case "no-signup":
+            return {
+                icon: CalendarCheck,
+                message: "Dette arrangementet har ikke påmelding",
+                secondary: "Bare møt opp.",
+            };
+
+        case "processing":
+            return {
+                icon: Hourglass,
+                message: "Behandler påmeldingen din …",
+                secondary: "Vi gir deg beskjed så snart plassen er klar.",
+            };
+
         case "not-open":
             return {
                 icon: AlertCircle,
@@ -237,13 +271,16 @@ function getStateRendering(
                         </Label>
                         <Button
                             className="w-full"
+                            disabled={props.isSubmitting}
                             onClick={() =>
                                 props.onRegister?.({
                                     allowPhoto: photoConsent.allowPhoto,
                                 })
                             }
                         >
-                            Meld deg på
+                            {props.isSubmitting
+                                ? "Melder deg på …"
+                                : "Meld deg på"}
                         </Button>
                     </>
                 ),

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -4,8 +4,10 @@ import { nb } from "date-fns/locale";
 // -- Shared display types (previously in mock/events) --
 
 export type EventRegistrationState =
+    | "no-signup"
     | "not-open"
     | "open"
+    | "processing"
     | "joined"
     | "awaiting-payment"
     | "on-waitlist"
@@ -44,6 +46,10 @@ type RegistrationStateInput = {
     registration: ApiRegistration;
     /** The event's own `closed` flag. */
     closed: boolean;
+    /** Whether the event has sign-up at all. */
+    requiresSigningUp: boolean;
+    /** Whether the event costs money — a pending registration then awaits payment. */
+    isPaidEvent: boolean;
     /** When registration opens. Null means "open immediately". */
     registrationStart?: string | null;
     /** Påmeldingsfristen. Null means "no deadline". */
@@ -65,20 +71,29 @@ export function deriveRegistrationState(
     {
         registration,
         closed,
+        requiresSigningUp,
+        isPaidEvent,
         registrationStart,
         registrationEnd,
         endTime,
     }: RegistrationStateInput,
     now: Date = new Date(),
 ): EventRegistrationState {
+    // Arrangementer uten påmelding har ingenting å melde seg på. Uten dette
+    // sto det en helt vanlig «Meld deg på»-knapp der, og API-et svarte 409.
+    if (!requiresSigningUp) return "no-signup";
+
     switch (registration?.status) {
         case "registered":
         case "attended":
             return "joined";
         case "waitlisted":
             return "on-waitlist";
+        // Påmeldingen ligger som «pending» til cron-en har avgjort om den ble
+        // plass eller venteliste. På et gratis arrangement er det bare noen
+        // sekunders behandling — «venter på betaling» ville vært feil.
         case "pending":
-            return "awaiting-payment";
+            return isPaidEvent ? "awaiting-payment" : "processing";
         default:
             if (closed) return "closed";
             if (endTime && new Date(endTime) < now) return "closed";
@@ -90,6 +105,44 @@ export function deriveRegistrationState(
             }
             return "open";
     }
+}
+
+/**
+ * Oversett en feil fra påmeldings-endepunktet til noe et medlem forstår.
+ *
+ * API-meldingene er engelske og skrevet for utviklere. De vanligste årsakene
+ * får en norsk forklaring; resten faller tilbake på API-meldingen, som fortsatt
+ * er langt bedre enn ingenting.
+ */
+export function registrationErrorMessage(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes("not open for registration")) {
+        return "Dette arrangementet er ikke åpent for påmelding.";
+    }
+    if (message.includes("already registered")) {
+        return "Du er allerede påmeldt. Last siden på nytt for å se påmeldingen din.";
+    }
+    if (message.includes("priority pool")) {
+        return "Dette arrangementet er forbeholdt medlemmer i en prioritert gruppe.";
+    }
+    if (message.includes("only open to students at")) {
+        const institute = message.split("only open to students at")[1]?.trim();
+        return institute
+            ? `Dette arrangementet er kun for studenter ved ${institute}.`
+            : "Dette arrangementet er kun for studenter ved ett bestemt institutt.";
+    }
+    if (message.includes("requires permission")) {
+        return "Kontoen din har ikke tilgang til å melde seg på arrangementer. Ta kontakt med Index hvis dette ser feil ut.";
+    }
+    if (message.includes("Authentication required")) {
+        return "Du må være innlogget for å melde deg på.";
+    }
+    if (message.includes("not registered")) {
+        return "Du er ikke påmeldt dette arrangementet.";
+    }
+
+    return message;
 }
 
 /**

--- a/apps/kvark/src/routes/__root.tsx
+++ b/apps/kvark/src/routes/__root.tsx
@@ -86,9 +86,13 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
     shellComponent: RootDocument,
 });
 
+/**
+ * Språket er norsk. Med `lang="en"` slo nettleseren opp all tekst i den
+ * engelske ordboka, og da fikk ingen skrivefeil rød strek i skjemaene våre.
+ */
 function RootDocument({ children }: { children: React.ReactNode }) {
     return (
-        <html lang="en" suppressHydrationWarning>
+        <html lang="nb" suppressHydrationWarning>
             <head>
                 <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
                 <HeadContent />

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -11,6 +11,7 @@ import {
     QrCode,
     Star,
     StarOff,
+    UserRound,
     UsersRound,
 } from "lucide-react";
 
@@ -45,6 +46,7 @@ import {
     formatEventDate,
     formatEventPrice,
     formatEventTime,
+    registrationErrorMessage,
 } from "#/lib/event";
 
 export const Route = createFileRoute("/_app/arrangementer/$slug")({
@@ -57,7 +59,18 @@ function EventDetailPage() {
     const { slug } = Route.useParams();
     const navigate = useNavigate();
 
-    const { data: event } = useSuspenseQuery(getEventByIdQuery(slug));
+    // En fersk påmelding ligger som «pending» til cron-en på serveren har
+    // avgjort plass eller venteliste. Vi poller til den er avklart, ellers
+    // ville brukeren blitt stående i behandling til de lastet siden på nytt.
+    const { data: event } = useSuspenseQuery({
+        ...getEventByIdQuery(slug),
+        refetchInterval: (query) =>
+            query.state.data?.registration?.status === "pending" ? 2000 : false,
+        // Pollingen står ellers stille når fanen ikke er i forgrunnen, og en
+        // bruker som bytter fane mens vi behandler ville kommet tilbake til
+        // «Behandler påmeldingen din …» som aldri gikk videre.
+        refetchIntervalInBackground: true,
+    });
     const { data: session } = useQuery(authQueryOptions);
     const { data: registrations } = useQuery(
         getEventRegistrationsQuery(event.id, 0),
@@ -89,10 +102,19 @@ function EventDetailPage() {
     const registrationState = deriveRegistrationState({
         registration: event.registration,
         closed: event.closed,
+        requiresSigningUp: event.requiresSigningUp,
+        isPaidEvent: event.isPaidEvent,
         registrationStart: event.registrationStart,
         registrationEnd: event.registrationEnd,
         endTime: event.endTime,
     });
+    // Feil fra på- eller avmelding. Uten dette så knappen ut til å ikke gjøre
+    // noe når API-et avviste forsøket.
+    const failedAction = registerMutation.error ?? unregisterMutation.error;
+    const registrationError = failedAction
+        ? registrationErrorMessage(failedAction)
+        : null;
+
     const price = formatEventPrice(event.isPaidEvent, event.payInfo?.price);
     const registeredCount = registrations?.totalCount ?? 0;
     const registrants = (registrations?.registeredUsers ?? []).map((u) => ({
@@ -258,6 +280,28 @@ function EventDetailPage() {
                                       />,
                                   ]
                                 : []),
+                            ...(event.contactPerson
+                                ? [
+                                      <DetailField
+                                          icon={UserRound}
+                                          label="Kontaktperson"
+                                          value={
+                                              // E-posten deles kun med innloggede
+                                              // medlemmer, så den mangler for
+                                              // utloggede besøkende.
+                                              event.contactPerson.email ? (
+                                                  <a
+                                                      href={`mailto:${event.contactPerson.email}`}
+                                                  >
+                                                      {event.contactPerson.name}
+                                                  </a>
+                                              ) : (
+                                                  event.contactPerson.name
+                                              )
+                                          }
+                                      />,
+                                  ]
+                                : []),
                         ]}
                     />
 
@@ -286,6 +330,11 @@ function EventDetailPage() {
                         price={price}
                         onRegister={handleRegister}
                         onUnregister={handleUnregister}
+                        isSubmitting={
+                            registerMutation.isPending ||
+                            unregisterMutation.isPending
+                        }
+                        actionError={registrationError}
                         waitlistPosition={
                             event.registration?.waitlistPosition ?? undefined
                         }

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -44,7 +44,7 @@ import {
     setAttendanceMutation,
     updateEventMutation,
 } from "#/api/queries/events";
-import { getGroupsQuery } from "#/api/queries/groups";
+import { getGroupMembersQuery, getGroupsQuery } from "#/api/queries/groups";
 import { getInstitutesQuery } from "#/api/queries/institutes";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
@@ -166,6 +166,7 @@ function valuesFromEvent(event: Event): EventFormValues {
         description: event.description,
         categorySlug: event.category.slug,
         organizerGroupSlug: event.organizer?.slug ?? "",
+        contactPersonUserId: event.contactPerson?.id ?? "",
         location,
         locationCoords:
             hasCoords && location
@@ -177,6 +178,7 @@ function valuesFromEvent(event: Event): EventFormValues {
                 : null,
         start: toDate(event.startTime),
         end: toDate(event.endTime),
+        requiresSigningUp: event.requiresSigningUp,
         registrationEnd: toDate(event.registrationEnd),
         capacity: event.capacity === null ? "" : String(event.capacity),
         visibility: event.visibility === "members" ? "members" : "public",
@@ -216,6 +218,16 @@ function DetailsTab({ eventId }: { eventId: string }) {
     const { data: addressSuggestions, isFetching: isSearchingAddress } =
         useQuery(searchAddressQuery(debouncedLocation));
 
+    // Kontaktpersonen velges blant medlemmene i arrangørgruppen.
+    const { data: organizerMembers } = useQuery({
+        ...getGroupMembersQuery(values.organizerGroupSlug, 0),
+        enabled: Boolean(values.organizerGroupSlug),
+    });
+    const contactPersonCandidates = (organizerMembers ?? []).map((member) => ({
+        id: member.user.id,
+        name: member.user.name,
+    }));
+
     const updateEvent = useMutation(updateEventMutation);
     const removeEvent = useMutation(deleteEventMutation);
     const { uploadImage, isUploading } = useImageUploader();
@@ -228,7 +240,8 @@ function DetailsTab({ eventId }: { eventId: string }) {
         formEvent.preventDefault();
         setUploadError(null);
 
-        if (!values.start || !values.end || !values.registrationEnd) return;
+        if (!values.start || !values.end) return;
+        if (values.requiresSigningUp && !values.registrationEnd) return;
 
         // Lastes opp først: en feilet opplasting skal ikke lagre resten av
         // endringene med et bilde som mangler.
@@ -259,17 +272,23 @@ function DetailsTab({ eventId }: { eventId: string }) {
             start: values.start.toISOString(),
             end: values.end.toISOString(),
             registrationStart: null,
-            registrationEnd: values.registrationEnd.toISOString(),
+            // Uten påmelding avviser API-et både frist og kapasitet.
+            registrationEnd: values.requiresSigningUp
+                ? (values.registrationEnd?.toISOString() ?? null)
+                : null,
             cancellationDeadline: null,
-            capacity: values.capacity ? Number(values.capacity) : null,
+            capacity:
+                values.requiresSigningUp && values.capacity
+                    ? Number(values.capacity)
+                    : null,
             visibility: values.visibility,
             restrictedToInstituteSlug:
                 values.instituteSlug === ALL_INSTITUTES
                     ? null
                     : values.instituteSlug,
             isRegistrationClosed: event.closed,
-            requiresSigningUp: true,
-            allowWaitlist: true,
+            requiresSigningUp: values.requiresSigningUp,
+            allowWaitlist: values.requiresSigningUp,
             priorityPools: null,
             onlyAllowPrioritized: event.onlyAllowPrioritized,
             canCauseStrikes: values.canCauseStrikes,
@@ -281,7 +300,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
                     : null,
             paymentGracePeriodMinutes:
                 event.payInfo?.paymentGracePeriodMinutes ?? null,
-            contactPersonUserId: null,
+            contactPersonUserId: values.contactPersonUserId || null,
             reactionsAllowed: false,
         };
 
@@ -323,6 +342,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
                 onChange={handleChange}
                 groups={groups}
                 institutes={institutes}
+                contactPersonCandidates={contactPersonCandidates}
                 existingImageUrl={event.image}
                 addressSuggestions={addressSuggestions ?? []}
                 isSearchingAddress={isSearchingAddress}

--- a/apps/kvark/src/routes/admin/arrangementer.ny.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.ny.tsx
@@ -9,7 +9,7 @@ import { XCircle } from "lucide-react";
 import { searchAddressQuery } from "#/api/queries/address";
 import { useImageUploader } from "#/api/queries/assets";
 import { createEventMutation } from "#/api/queries/events";
-import { getGroupsQuery } from "#/api/queries/groups";
+import { getGroupMembersQuery, getGroupsQuery } from "#/api/queries/groups";
 import { getInstitutesQuery } from "#/api/queries/institutes";
 import { AdminNoAccess } from "#/components/admin-no-access";
 import { AdminPageHeader } from "#/components/admin-page-header";
@@ -51,10 +51,12 @@ const emptyValues: EventFormValues = {
     description: "",
     categorySlug: "",
     organizerGroupSlug: "",
+    contactPersonUserId: "",
     location: "",
     locationCoords: null,
     start: null,
     end: null,
+    requiresSigningUp: true,
     registrationEnd: null,
     capacity: "",
     visibility: "public",
@@ -79,6 +81,13 @@ function NewEventPage() {
     const { data: addressSuggestions, isFetching: isSearchingAddress } =
         useQuery(searchAddressQuery(debouncedLocation));
 
+    // Kontaktpersonen velges blant medlemmene i arrangørgruppen, så lista
+    // følger gruppevalget over.
+    const { data: organizerMembers } = useQuery({
+        ...getGroupMembersQuery(values.organizerGroupSlug, 0),
+        enabled: Boolean(values.organizerGroupSlug),
+    });
+
     // Sett standardverdier på klienten for å unngå SSR-hydration-mismatch.
     useEffect(() => {
         const defaults = eventDateDefaults();
@@ -90,6 +99,11 @@ function NewEventPage() {
                 current.registrationEnd ?? defaults.registrationEnd,
         }));
     }, []);
+
+    const contactPersonCandidates = (organizerMembers ?? []).map((member) => ({
+        id: member.user.id,
+        name: member.user.name,
+    }));
 
     const createEvent = useMutation(createEventMutation);
     const { uploadImage, isUploading } = useImageUploader();
@@ -104,8 +118,12 @@ function NewEventPage() {
 
         const startIso = toIso(values.start);
         const endIso = toIso(values.end);
-        const registrationEndIso = toIso(values.registrationEnd);
-        if (!startIso || !endIso || !registrationEndIso) return;
+        // Uten påmelding avviser API-et både frist og kapasitet, så de utelates.
+        const registrationEndIso = values.requiresSigningUp
+            ? toIso(values.registrationEnd)
+            : null;
+        if (!startIso || !endIso) return;
+        if (values.requiresSigningUp && !registrationEndIso) return;
 
         // Uploaded first: a failed upload must not leave an event behind that
         // silently lost its cover.
@@ -138,15 +156,18 @@ function NewEventPage() {
                     registrationStart: null,
                     registrationEnd: registrationEndIso,
                     cancellationDeadline: null,
-                    capacity: values.capacity ? Number(values.capacity) : null,
+                    capacity:
+                        values.requiresSigningUp && values.capacity
+                            ? Number(values.capacity)
+                            : null,
                     visibility: values.visibility,
                     restrictedToInstituteSlug:
                         values.instituteSlug === ALL_INSTITUTES
                             ? null
                             : values.instituteSlug,
                     isRegistrationClosed: false,
-                    requiresSigningUp: true,
-                    allowWaitlist: true,
+                    requiresSigningUp: values.requiresSigningUp,
+                    allowWaitlist: values.requiresSigningUp,
                     priorityPools: null,
                     onlyAllowPrioritized: false,
                     canCauseStrikes: values.canCauseStrikes,
@@ -157,7 +178,7 @@ function NewEventPage() {
                             ? Number(values.price)
                             : null,
                     paymentGracePeriodMinutes: null,
-                    contactPersonUserId: null,
+                    contactPersonUserId: values.contactPersonUserId || null,
                     reactionsAllowed: false,
                 },
             },
@@ -195,6 +216,7 @@ function NewEventPage() {
                 onChange={handleChange}
                 groups={groups}
                 institutes={institutes}
+                contactPersonCandidates={contactPersonCandidates}
                 addressSuggestions={addressSuggestions ?? []}
                 isSearchingAddress={isSearchingAddress}
                 onSubmit={handleSubmit}

--- a/packages/db/src/schema/event.ts
+++ b/packages/db/src/schema/event.ts
@@ -165,6 +165,10 @@ export const eventRelations = relations(event, ({ one, many }) => ({
         fields: [event.restrictedToInstituteId],
         references: [institute.id],
     }),
+    contactPerson: one(user, {
+        fields: [event.contactPersonId],
+        references: [user.id],
+    }),
     reactions: many(eventReaction),
     pools: many(eventPriorityPool),
     favorites: many(eventFavorite),

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3075,11 +3075,8 @@ export interface components {
             end: string;
             /** @description Timestamp for when registrations open. If null, open immediately. */
             registrationStart: string | null;
-            /**
-             * Format: date-time
-             * @description When the registration for the event ends. After this time, users cannot sign up.
-             */
-            registrationEnd: string;
+            /** @description When the registration for the event ends. After this time, users cannot sign up. Null for events without sign-up (requiresSigningUp false). */
+            registrationEnd: string | null;
             /** @description Deadline timestamp for when users cannot cancel anymore. After this, no-shows may receive strikes. */
             cancellationDeadline: string | null;
             /** @description Maximum number of participants allowed. If null, no capacity limit. */
@@ -3227,11 +3224,8 @@ export interface components {
             end?: string;
             /** @description Timestamp for when registrations open. If null, open immediately. */
             registrationStart?: string | null;
-            /**
-             * Format: date-time
-             * @description When the registration for the event ends. After this time, users cannot sign up.
-             */
-            registrationEnd?: string;
+            /** @description When the registration for the event ends. After this time, users cannot sign up. Null for events without sign-up (requiresSigningUp false). */
+            registrationEnd?: string | null;
             /** @description Deadline timestamp for when users cannot cancel anymore. After this, no-shows may receive strikes. */
             cancellationDeadline?: string | null;
             /** @description Maximum number of participants allowed. If null, no capacity limit. */
@@ -3319,6 +3313,15 @@ export interface components {
                 type: string;
                 /** @description Organizer logo URL */
                 image: string | null;
+            } | null;
+            /** @description Who to ask about the event (nullable). Set with contactPersonUserId. */
+            contactPerson: {
+                /** @description Contact person user ID */
+                id: string;
+                /** @description Contact person name */
+                name: string;
+                /** @description Contact person e-mail. Null for unauthenticated callers, so members' addresses are not exposed to the open internet. */
+                email: string | null;
             } | null;
             /** @description Is registration closed */
             closed: boolean;

--- a/packages/ui/src/components/complex/markdown/rich-editor.tsx
+++ b/packages/ui/src/components/complex/markdown/rich-editor.tsx
@@ -16,6 +16,10 @@ export type RichEditorProps = {
     placeholder?: string;
     autoFocus?: boolean;
     className?: string;
+    /** Ordboken nettleseren staveretter mot. Innholdet er norsk. */
+    lang?: string;
+    /** Rød strek under skrivefeil. På som standard. */
+    spellCheck?: boolean;
 };
 
 export function RichEditor({
@@ -25,6 +29,8 @@ export function RichEditor({
     placeholder,
     autoFocus,
     className,
+    lang = "nb",
+    spellCheck = true,
 }: RichEditorProps) {
     const lastEmitted = useRef(value);
 
@@ -45,6 +51,15 @@ export function RichEditor({
         content: initialContent,
         immediatelyRender: false,
         autofocus: autoFocus ? "end" : false,
+        editorProps: {
+            attributes: {
+                // Innholdet skrives på norsk, og stavekontrollen slås på
+                // eksplisitt: teksten her ender opp på arrangementer og
+                // nyheter, der skrivefeil blir stående lenge.
+                lang,
+                spellcheck: String(spellCheck),
+            },
+        },
         onUpdate: ({ editor: instance }) => {
             const json = instance.getJSON();
             const mdast = tiptapToMdast(json, registry);


### PR DESCRIPTION
Fikser tre av tilbakemeldingene fra Mari (visepres): #405, #407 og #408.

## Påmelding (#408 → #407)

Mari fikk ikke meldt seg på, og knappen så helt normal ut. Arrangementet var «Facebook-vegg / White Lie», som ikke har påmelding på gamle TIHLDE-sida. Det viste seg å være tre feil oppå hverandre:

1. **Frontenden leste aldri `requiresSigningUp`.** Arrangementer uten påmelding fikk en helt vanlig «Meld deg på»-knapp, og API-et svarte 409. Dette gjelder **538 av 1229** arrangementer i dev-basen. Ny tilstand `no-signup` sier i stedet «Dette arrangementet har ikke påmelding — Bare møt opp», og skjuler tidslinje og påmeldingsteller.
2. **Feil ble aldri vist.** `registerForEventMutation` hadde ingen `onError`, så alt API-et avviste (403 institutt/prioritering, 409 stengt, manglende `events:registrations:create`) forsvant i stillhet. Meldingen løftes nå opp i `error.message` i api-klienten og oversettes til norsk i påmeldingskortet.
3. **Cache-invalideringen bommet på nøkkelen.** På- og avmelding invaliderte på arrangements-ID, mens de offentlige sidene cacher på slug. Kortet ble derfor stående uendret til man lastet siden på nytt — trolig hovedgrunnen til at knappen føltes helt død.

I tillegg mapper `pending` ikke lenger til «venter på betaling» på gratis arrangementer (påmeldingen ligger som pending til cron-en har avgjort plass eller venteliste), og siden poller til statusen er avklart.

> ⚠️ Verdt å merke seg for review: ky 2.x leser responskroppen selv og legger den på `error.data` — etter det er `error.response.json()` tom. Det er derfor `data` brukes og ikke responsen.

## Kontaktperson (#408)

Feltet fantes allerede i databasen, og API-et tok imot og validerte `contactPersonUserId` — men admin-skjemaet sendte hardkodet `null`, og GET-responsen tok aldri med kontaktpersonen. **680 av 1229** arrangementer hadde altså en kontaktperson lagret som aldri ble vist.

- `contactPerson` lagt til i `eventDetailSchema` og `get.ts`, med ny Drizzle-relasjon.
- Navnet er offentlig, men **e-posten deles kun med innloggede**, så adressene ikke kan høstes fra de åpne sidene.
- Admin får en velger blant medlemmene i arrangørgruppen. En kontaktperson som ikke lenger står i lista (f.eks. etter lederskifte) beholdes som eget valg, så redigering ikke stille nullstiller feltet.

## Stavekontroll (#405)

`<html lang="en">` på en norsk side gjorde at nettleseren slo opp all tekst i den engelske ordboka — derfor fikk skrivefeil aldri rød strek. Satt til `nb`, og `RichEditor` setter nå `lang` og `spellcheck` eksplisitt på Tiptap-editoren.

## Utenfor bestillingen, men nødvendig

`requiresSigningUp` var i praksis umulig å skru av: admin-skjemaet hardkodet `true` ved både oppretting og redigering (så enhver redigering av et arrangement uten påmelding ville slått den på), og API-skjemaet krevde `registrationEnd` samtidig som valideringen forbød den — samme selvmotsigelse for `capacity`. Lagt til avkrysningen «Arrangementet har påmelding» og rettet valideringen slik at `null` er lov når arrangementet ikke har påmelding.

## Testing

- `bun run typecheck`, `lint`, `format` og `build` er grønne (etter rebase på gjeldende `dev`).
- API-suiten: **430/430** (5 nye tester — kontaktperson på detaljene inkl. at e-posten holdes tilbake for utloggede, oppretting uten påmelding, og at et arrangement med påmelding fortsatt må ha frist).
- Kjørt i nettleseren mot lokal API og dev-database:
  - `<html lang="nb">` og editoren med `lang="nb" spellcheck="true"`
  - arrangement uten påmelding viser «Dette arrangementet har ikke påmelding»
  - feilende påmelding viser «Påmeldingen gikk ikke gjennom — Dette arrangementet er kun for studenter ved IIK.»
  - vellykket påmelding: «Behandler påmeldingen din …» → «Du har plass på arrangementet!» uten reload
  - kontaktperson valgt i admin, lagret og hentet tilbake; e-post `null` for utlogget kall

🤖 Generated with [Claude Code](https://claude.com/claude-code)
