### PR TITLE
feat(profil): flytt bildesamtykke fra arrangement til innstillinger

### DIFF
--- a/apps/api/src/lib/user/settings.ts
+++ b/apps/api/src/lib/user/settings.ts
@@ -36,7 +36,12 @@ function emptyToNull<T extends string>(value: T | undefined) {
     return value === undefined ? undefined : value === "" ? null : value;
 }
 
-export const UpdateUserSettingsSchema = UserSettingsSchema.partial();
+// `allergies` har `.default([])`, som overlever `.partial()` og gjør feltet
+// påkrevd for klientene. Uten dette måtte enhver delvis oppdatering sende
+// allergiene på nytt — glemmer den det, tømmes de.
+export const UpdateUserSettingsSchema = UserSettingsSchema.partial().extend({
+    allergies: z.array(z.string()).optional(),
+});
 
 export type UserAllergy = z.infer<typeof UserAllergySchema>;
 export type UserSettings = z.infer<typeof UserSettingsSchema>;

--- a/apps/api/src/routes/event/registration/create.ts
+++ b/apps/api/src/routes/event/registration/create.ts
@@ -52,7 +52,7 @@ export const registerToEventRoute = route().post(
         const eventId = c.req.param("eventId");
         const userId = c.get("user").id;
         const { db } = c.get("ctx");
-        const { allowPhoto } = c.req.valid("json");
+        const body = c.req.valid("json");
 
         const event = await db.query.event.findFirst({
             where: (event, { eq }) => eq(event.id, eventId),
@@ -130,6 +130,19 @@ export const registerToEventRoute = route().post(
                 message: "User is already registered for this event",
             });
         }
+
+        // Bildesamtykket bor på profilen, ikke på arrangementet. Uten et
+        // eksplisitt felt i kallet er kontoinnstillingen fasit; brukere uten
+        // innstillinger (ikke onboardet) faller tilbake på kolonnedefaulten.
+        const allowPhoto =
+            body.allowPhoto ??
+            (
+                await db.query.userSettings.findFirst({
+                    where: (settings, { eq }) => eq(settings.userId, userId),
+                    columns: { allowsPhotosByDefault: true },
+                })
+            )?.allowsPhotosByDefault ??
+            true;
 
         // Create pending registration in database
         await db.insert(schema.eventRegistration).values({

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -407,9 +407,9 @@ export const registerSchema = Schema(
 export const createRegistrationBodySchema = Schema(
     "CreateEventRegistrationBody",
     z.object({
-        allowPhoto: z.boolean().default(true).meta({
+        allowPhoto: z.boolean().optional().meta({
             description:
-                "Photo consent for this event, overriding the account-level allowsPhotosByDefault",
+                "Photo consent for this event. Omit it to use the account-level allowsPhotosByDefault, which is where members manage their consent.",
         }),
     }),
 );

--- a/apps/api/src/test/event/event-fields.test.ts
+++ b/apps/api/src/test/event/event-fields.test.ts
@@ -136,7 +136,7 @@ describe("event imageAlt and onlyAllowPrioritized", () => {
 
 describe("registration allowPhoto", () => {
     integrationTest(
-        "allowPhoto is stored on sign-up and defaults to true",
+        "allowPhoto is stored on sign-up and defaults to true without settings",
         async ({ ctx }) => {
             await ctx.utils.setupGroups();
             await ctx.utils.setupEventCategories();
@@ -183,6 +183,48 @@ describe("registration allowPhoto", () => {
             const defaulted = rows.find((r) => r.userId === defaultUser.id);
             expect(declined?.allowPhoto).toBe(false);
             expect(defaulted?.allowPhoto).toBe(true);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "allowPhoto falls back to the account-level allowsPhotosByDefault",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent();
+
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(user, [
+                "events:registrations:create",
+            ]);
+            // Samtykket styres fra profilinnstillingene, ikke per arrangement.
+            await ctx.db.insert(schema.userSettings).values({
+                userId: user.id,
+                gender: "other",
+                allowsPhotosByDefault: false,
+                acceptsEventRules: true,
+                receiveMailCommunication: true,
+                isOnboarded: true,
+            });
+            const client = await ctx.utils.clientForUser(user);
+
+            const response = await client.api.event[
+                ":eventId"
+            ].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+            expect(response.status).toBe(200);
+            const json = await response.json();
+            expect(json.allowPhoto).toBe(false);
+
+            const row = await ctx.db.query.eventRegistration.findFirst({
+                where: (reg, { and, eq }) =>
+                    and(eq(reg.eventId, event.id), eq(reg.userId, user.id)),
+            });
+            expect(row?.allowPhoto).toBe(false);
         },
         500_000,
     );

--- a/apps/kvark/src/api/queries/events.ts
+++ b/apps/kvark/src/api/queries/events.ts
@@ -252,16 +252,12 @@ export const getEventRegistrationsQuery = (
     });
 
 export const registerForEventMutation = mutationOptions({
-    mutationFn: ({
-        eventId,
-        allowPhoto = true,
-    }: {
-        eventId: string;
-        allowPhoto?: boolean;
-    }) =>
+    // Bildesamtykket sendes ikke med: API-et bruker kontoinnstillingen
+    // (`allowsPhotosByDefault`), som medlemmene styrer fra profilen sin.
+    mutationFn: ({ eventId }: { eventId: string }) =>
         apiClient.post("/api/event/{eventId}/registration", {
             params: { eventId },
-            json: { allowPhoto },
+            json: {},
         }),
     onSuccess(_, vars, __, ctx) {
         ctx.client.invalidateQueries({

--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -3,8 +3,6 @@ import { Badge } from "@tihlde/ui/ui/badge";
 import { Button } from "@tihlde/ui/ui/button";
 import { VippsButton } from "@tihlde/ui/ui/vipps-button";
 import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
-import { Checkbox } from "@tihlde/ui/ui/checkbox";
-import { Label } from "@tihlde/ui/ui/label";
 import { Progress } from "@tihlde/ui/ui/progress";
 import {
     AlertCircle,
@@ -20,7 +18,7 @@ import {
     Users,
     type LucideIcon,
 } from "lucide-react";
-import { Fragment, type ReactNode, useState } from "react";
+import { Fragment, type ReactNode } from "react";
 
 import type {
     EventDeadline,
@@ -40,7 +38,7 @@ type EventRegistrationCardProps = {
     waitlistCount: number;
     isAdmin: boolean;
     price: EventPrice;
-    onRegister?: (opts: { allowPhoto: boolean }) => void;
+    onRegister?: () => void;
     onUnregister?: () => void;
     onJoinWaitlist?: () => void;
     onNotify?: () => void;
@@ -59,9 +57,8 @@ type EventRegistrationCardProps = {
 };
 
 export function EventRegistrationCard(props: EventRegistrationCardProps) {
-    const [allowPhoto, setAllowPhoto] = useState(true);
     const timeline = buildTimeline(props);
-    const state = getStateRendering(props, { allowPhoto, setAllowPhoto });
+    const state = getStateRendering(props);
     // Uten påmelding er både tidslinjen og «0/∞ påmeldte» bare støy.
     const showRegistrationDetails = props.registrationState !== "no-signup";
 
@@ -116,15 +113,7 @@ type StateRendering = {
     actions?: ReactNode;
 };
 
-type PhotoConsentState = {
-    allowPhoto: boolean;
-    setAllowPhoto: (allowPhoto: boolean) => void;
-};
-
-function getStateRendering(
-    props: EventRegistrationCardProps,
-    photoConsent: PhotoConsentState,
-): StateRendering {
+function getStateRendering(props: EventRegistrationCardProps): StateRendering {
     const state = props.registrationState;
 
     switch (state) {
@@ -255,34 +244,13 @@ function getStateRendering(
         case "open":
             return {
                 actions: (
-                    <>
-                        <Label className="flex items-start gap-3">
-                            <Checkbox
-                                className="shrink-0"
-                                checked={photoConsent.allowPhoto}
-                                onCheckedChange={(checked) =>
-                                    photoConsent.setAllowPhoto(checked === true)
-                                }
-                            />
-                            <span>
-                                Jeg samtykker til at bilder av meg fra
-                                arrangementet kan publiseres
-                            </span>
-                        </Label>
-                        <Button
-                            className="w-full"
-                            disabled={props.isSubmitting}
-                            onClick={() =>
-                                props.onRegister?.({
-                                    allowPhoto: photoConsent.allowPhoto,
-                                })
-                            }
-                        >
-                            {props.isSubmitting
-                                ? "Melder deg på …"
-                                : "Meld deg på"}
-                        </Button>
-                    </>
+                    <Button
+                        className="w-full"
+                        disabled={props.isSubmitting}
+                        onClick={() => props.onRegister?.()}
+                    >
+                        {props.isSubmitting ? "Melder deg på …" : "Meld deg på"}
+                    </Button>
                 ),
             };
 

--- a/apps/kvark/src/routeTree.gen.ts
+++ b/apps/kvark/src/routeTree.gen.ts
@@ -70,6 +70,7 @@ import { Route as AdminArrangementerEventIdRouteImport } from './routes/admin/ar
 import { Route as AdminArrangementerNyRouteImport } from './routes/admin/arrangementer.ny'
 import { Route as AppProfilIdIndexRouteImport } from './routes/_app/profil/$id/index'
 import { Route as AppProfilIdArrangementerRouteImport } from './routes/_app/profil/$id/arrangementer'
+import { Route as AppProfilIdInnstillingerRouteImport } from './routes/_app/profil/$id/innstillinger'
 import { Route as AppProfilIdMedlemskapRouteImport } from './routes/_app/profil/$id/medlemskap'
 import { Route as AppProfilIdPrikkerRouteImport } from './routes/_app/profil/$id/prikker'
 import { Route as AppProfilIdSporreskjemaerRouteImport } from './routes/_app/profil/$id/sporreskjemaer'
@@ -378,6 +379,12 @@ const AppProfilIdArrangementerRoute =
     path: '/arrangementer',
     getParentRoute: () => AppProfilIdRoute,
   } as any)
+const AppProfilIdInnstillingerRoute =
+  AppProfilIdInnstillingerRouteImport.update({
+    id: '/innstillinger',
+    path: '/innstillinger',
+    getParentRoute: () => AppProfilIdRoute,
+  } as any)
 const AppProfilIdMedlemskapRoute = AppProfilIdMedlemskapRouteImport.update({
   id: '/medlemskap',
   path: '/medlemskap',
@@ -452,6 +459,7 @@ export interface FileRoutesByFullPath {
   '/nyheter/': typeof AppNyheterIndexRoute
   '/admin/arrangementer/': typeof AdminArrangementerIndexRoute
   '/profil/$id/arrangementer': typeof AppProfilIdArrangementerRoute
+  '/profil/$id/innstillinger': typeof AppProfilIdInnstillingerRoute
   '/profil/$id/medlemskap': typeof AppProfilIdMedlemskapRoute
   '/profil/$id/prikker': typeof AppProfilIdPrikkerRoute
   '/profil/$id/sporreskjemaer': typeof AppProfilIdSporreskjemaerRoute
@@ -512,6 +520,7 @@ export interface FileRoutesByTo {
   '/nyheter': typeof AppNyheterIndexRoute
   '/admin/arrangementer': typeof AdminArrangementerIndexRoute
   '/profil/$id/arrangementer': typeof AppProfilIdArrangementerRoute
+  '/profil/$id/innstillinger': typeof AppProfilIdInnstillingerRoute
   '/profil/$id/medlemskap': typeof AppProfilIdMedlemskapRoute
   '/profil/$id/prikker': typeof AppProfilIdPrikkerRoute
   '/profil/$id/sporreskjemaer': typeof AppProfilIdSporreskjemaerRoute
@@ -579,6 +588,7 @@ export interface FileRoutesById {
   '/_app/nyheter/': typeof AppNyheterIndexRoute
   '/admin/arrangementer/': typeof AdminArrangementerIndexRoute
   '/_app/profil/$id/arrangementer': typeof AppProfilIdArrangementerRoute
+  '/_app/profil/$id/innstillinger': typeof AppProfilIdInnstillingerRoute
   '/_app/profil/$id/medlemskap': typeof AppProfilIdMedlemskapRoute
   '/_app/profil/$id/prikker': typeof AppProfilIdPrikkerRoute
   '/_app/profil/$id/sporreskjemaer': typeof AppProfilIdSporreskjemaerRoute
@@ -643,6 +653,7 @@ export interface FileRouteTypes {
     | '/nyheter/'
     | '/admin/arrangementer/'
     | '/profil/$id/arrangementer'
+    | '/profil/$id/innstillinger'
     | '/profil/$id/medlemskap'
     | '/profil/$id/prikker'
     | '/profil/$id/sporreskjemaer'
@@ -703,6 +714,7 @@ export interface FileRouteTypes {
     | '/nyheter'
     | '/admin/arrangementer'
     | '/profil/$id/arrangementer'
+    | '/profil/$id/innstillinger'
     | '/profil/$id/medlemskap'
     | '/profil/$id/prikker'
     | '/profil/$id/sporreskjemaer'
@@ -769,6 +781,7 @@ export interface FileRouteTypes {
     | '/_app/nyheter/'
     | '/admin/arrangementer/'
     | '/_app/profil/$id/arrangementer'
+    | '/_app/profil/$id/innstillinger'
     | '/_app/profil/$id/medlemskap'
     | '/_app/profil/$id/prikker'
     | '/_app/profil/$id/sporreskjemaer'
@@ -1211,6 +1224,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProfilIdArrangementerRouteImport
       parentRoute: typeof AppProfilIdRoute
     }
+    '/_app/profil/$id/innstillinger': {
+      id: '/_app/profil/$id/innstillinger'
+      path: '/innstillinger'
+      fullPath: '/profil/$id/innstillinger'
+      preLoaderRoute: typeof AppProfilIdInnstillingerRouteImport
+      parentRoute: typeof AppProfilIdRoute
+    }
     '/_app/profil/$id/medlemskap': {
       id: '/_app/profil/$id/medlemskap'
       path: '/medlemskap'
@@ -1237,6 +1257,7 @@ declare module '@tanstack/react-router' {
 
 interface AppProfilIdRouteChildren {
   AppProfilIdArrangementerRoute: typeof AppProfilIdArrangementerRoute
+  AppProfilIdInnstillingerRoute: typeof AppProfilIdInnstillingerRoute
   AppProfilIdMedlemskapRoute: typeof AppProfilIdMedlemskapRoute
   AppProfilIdPrikkerRoute: typeof AppProfilIdPrikkerRoute
   AppProfilIdSporreskjemaerRoute: typeof AppProfilIdSporreskjemaerRoute
@@ -1245,6 +1266,7 @@ interface AppProfilIdRouteChildren {
 
 const AppProfilIdRouteChildren: AppProfilIdRouteChildren = {
   AppProfilIdArrangementerRoute: AppProfilIdArrangementerRoute,
+  AppProfilIdInnstillingerRoute: AppProfilIdInnstillingerRoute,
   AppProfilIdMedlemskapRoute: AppProfilIdMedlemskapRoute,
   AppProfilIdPrikkerRoute: AppProfilIdPrikkerRoute,
   AppProfilIdSporreskjemaerRoute: AppProfilIdSporreskjemaerRoute,

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -144,12 +144,14 @@ function EventDetailPage() {
         end: { iso: event.endTime },
     });
 
-    function handleRegister({ allowPhoto }: { allowPhoto: boolean }) {
+    function handleRegister() {
         if (!session) {
             navigate({ to: "/login", search: { redirectTo: location.href } });
             return;
         }
-        registerMutation.mutate({ eventId: event.id, allowPhoto });
+        // Bildesamtykket ligger på profilen, så påmeldingen sender det ikke —
+        // API-et henter kontoinnstillingen selv.
+        registerMutation.mutate({ eventId: event.id });
     }
 
     function handleUnregister() {

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -17,6 +17,7 @@ import {
     LayoutGrid,
     LogOut,
     Pencil,
+    Settings,
     ShieldCheck,
     Ticket,
     UserCircle2,
@@ -166,6 +167,14 @@ function RouteComponent() {
                               icon: HelpCircle,
                               link: linkOptions({
                                   to: "/profil/$id/sporreskjemaer",
+                                  params: { id },
+                              }),
+                          },
+                          {
+                              label: "Innstillinger",
+                              icon: Settings,
+                              link: linkOptions({
+                                  to: "/profil/$id/innstillinger",
                                   params: { id },
                               }),
                           },

--- a/apps/kvark/src/routes/_app/profil/$id/innstillinger.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/innstillinger.tsx
@@ -1,0 +1,77 @@
+import {
+    authQueryOptions,
+    invalidateAuth,
+    requireOwnProfile,
+} from "#/api/auth";
+import { updateUserSettingsMutation } from "#/api/queries/user";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
+import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
+import {
+    Field,
+    FieldContent,
+    FieldDescription,
+    FieldLabel,
+} from "@tihlde/ui/ui/field";
+import { Switch } from "@tihlde/ui/ui/switch";
+import { AlertCircle } from "lucide-react";
+
+export const Route = createFileRoute("/_app/profil/$id/innstillinger")({
+    component: RouteComponent,
+    beforeLoad: ({ location, params }) =>
+        requireOwnProfile(params.id, location.href),
+});
+
+function RouteComponent() {
+    const { data: session } = useQuery(authQueryOptions);
+    const updateSettings = useMutation(updateUserSettingsMutation);
+
+    const allowsPhotos = session?.user.settings?.allowsPhotosByDefault ?? false;
+
+    async function handleAllowPhotosChange(checked: boolean) {
+        await updateSettings.mutateAsync({
+            data: { allowsPhotosByDefault: checked },
+        });
+        // Samtykket leses fra sesjonen (både her og på arrangementsiden), så
+        // den må hentes på nytt for at endringen skal vises uten refresh.
+        await invalidateAuth();
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Personvern</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+                <Field orientation="horizontal">
+                    <FieldContent>
+                        <FieldLabel htmlFor="allows-photos">
+                            Bildesamtykke
+                        </FieldLabel>
+                        <FieldDescription>
+                            Bilder av deg fra arrangementer kan publiseres.
+                            Gjelder alle arrangementer du melder deg på etter at
+                            du har endret dette.
+                        </FieldDescription>
+                    </FieldContent>
+                    <Switch
+                        id="allows-photos"
+                        checked={allowsPhotos}
+                        disabled={updateSettings.isPending}
+                        onCheckedChange={handleAllowPhotosChange}
+                    />
+                </Field>
+                {updateSettings.isError ? (
+                    <Alert variant="destructive">
+                        <AlertCircle className="size-4" />
+                        <AlertTitle>Innstillingen ble ikke lagret</AlertTitle>
+                        <AlertDescription>
+                            Prøv på nytt. Står det seg, gi beskjed til TIHLDE.
+                        </AlertDescription>
+                    </Alert>
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3435,11 +3435,8 @@ export interface components {
             allowPhoto: boolean;
         };
         CreateEventRegistrationBody: {
-            /**
-             * @description Photo consent for this event, overriding the account-level allowsPhotosByDefault
-             * @default true
-             */
-            allowPhoto: boolean;
+            /** @description Photo consent for this event. Omit it to use the account-level allowsPhotosByDefault, which is where members manage their consent. */
+            allowPhoto?: boolean;
         };
         EventRegistrationPayment: {
             /** Format: uuid */
@@ -5326,8 +5323,7 @@ export interface components {
             githubUrl?: string | "";
             linkedinUrl?: string | "";
             receiveMailCommunication?: boolean;
-            /** @default [] */
-            allergies: string[];
+            allergies?: string[];
         };
         UpdateUserSettingsInput: {
             /** @enum {string} */
@@ -5340,8 +5336,7 @@ export interface components {
             githubUrl?: string | "";
             linkedinUrl?: string | "";
             receiveMailCommunication?: boolean;
-            /** @default [] */
-            allergies: string[];
+            allergies?: string[];
         };
         Allergy: {
             /** @description Unique identifier for the allergy */


### PR DESCRIPTION
## Hva

Samtykket til å bli tatt bilde av lå som en avkrysningsboks i påmeldingskortet på arrangementsiden, med boksen huket av som standard. Nå styres det én gang fra profilen.

- **Ny side** `/profil/$id/innstillinger` («Innstillinger» i profilmenyen, kun egen profil) med et Personvern-kort og bryteren **Bildesamtykke**.
- **Fjernet** avkrysningsboksen fra `EventRegistrationCard` — kortet slutter nå på «Meld deg på».
- **API**: `allowPhoto` i påmeldings-bodyen er nå valgfri. Utelates den, henter endepunktet brukerens `allowsPhotosByDefault`. Frontend sender den ikke lenger.

Kontoinnstillingen `allowsPhotosByDefault` fantes allerede i databasen (og ble migrert fra Lepton) — den ble bare aldri brukt. Per-påmelding-kolonnen `allow_photo` er urørt, så admin-lista over påmeldte fungerer som før.

## Hvorfor det er verdt å merke seg

Effektiv standard endrer seg: før var boksen huket av (samtykke), nå kommer verdien fra kontoinnstillingen, som er `false` som standard i databasen. Migrerte Lepton-brukere har sin egen verdi, så dette treffer i praksis nye brukere og de som allerede står med `false`. Det er ønsket oppførsel — samtykke skal være aktivt valgt — men det betyr flere «nei» i påmeldingslista.

## Bonusfiks

`allergies` hadde `.default([])`, som overlevde `.partial()` og gjorde feltet påkrevd ved delvise oppdateringer av innstillinger. En klient som glemte å sende det ville tømt brukerens allergier. Nå eksplisitt valgfritt.

## Testet

- `bun run typecheck`, `bun run lint`, `bun run format`, `bun run build` — grønt
- `src/test/event` (98 tester) og `user.test.ts` (23 tester) — grønt, inkludert ny test på at påmelding følger kontoinnstillingen
- Manuelt mot lokal API + DB: skrudde av bryteren → `PATCH` 200 og `allows_photos_by_default = f` i basen → påmelding skrev `allow_photo = f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)