### PR TITLE
feat(stavekontroll): norsk stavekontroll i editoren

### DIFF
--- a/apps/kvark/.gitignore
+++ b/apps/kvark/.gitignore
@@ -12,3 +12,5 @@ dist-ssr
 __unconfig*
 todos.json
 .tmp
+# Ordboka kopieres inn av scripts/copy-dictionary.ts
+public/dictionaries/

--- a/apps/kvark/package.json
+++ b/apps/kvark/package.json
@@ -6,8 +6,8 @@
         "#/*": "./src/*"
     },
     "scripts": {
-        "dev": "vite dev --port 3000",
-        "build": "vite build",
+        "dev": "bun run scripts/copy-dictionary.ts && vite dev --port 3000",
+        "build": "bun run scripts/copy-dictionary.ts && vite build",
         "preview": "vite preview",
         "typecheck": "tsc --noEmit",
         "format": "oxfmt .",
@@ -30,7 +30,7 @@
         "@tanstack/react-router-devtools": "latest",
         "@tanstack/react-router-ssr-query": "latest",
         "@tanstack/react-start": "latest",
-        "@tanstack/react-table": "latest",
+        "@tanstack/react-table": "^8.21.3",
         "@tanstack/router-plugin": "^1.132.0",
         "@tihlde/sdk": "workspace:*",
         "@tihlde/ui": "workspace:*",
@@ -41,6 +41,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
+        "dictionary-nb": "^3.0.0",
         "ky": "^2.0.2",
         "lucide-react": "^0.577.0",
         "nitro": "latest",

--- a/apps/kvark/scripts/copy-dictionary.ts
+++ b/apps/kvark/scripts/copy-dictionary.ts
@@ -1,0 +1,53 @@
+/**
+ * Legg den norske ordboka ut som statisk fil.
+ *
+ * `dictionary-nb` leser filene sine med `node:fs` og sperrer for direkte
+ * import av dem, så de kan ikke hentes gjennom bundleren. I stedet kopieres de
+ * hit før dev og build, og stavekontrollen henter dem med `fetch` når noen
+ * åpner en editor. Filene er store og uforanderlige, så de ligger i
+ * `.gitignore` i stedet for i repoet.
+ */
+import { createRequire } from "node:module";
+import { copyFile, mkdir, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/**
+ * `.txt`-endelsen er med vilje: filene serveres da som `text/plain`, og både
+ * Vercel og vanlige webservere komprimerer den typen automatisk. Ordboka går
+ * fra 5,3 MB til rundt 1,4 MB over nett. Med `.dic` ville den blitt sendt som
+ * ukjent binærtype, altså ukomprimert.
+ */
+const FILES = [
+    { from: "index.aff", to: "index.aff.txt" },
+    { from: "index.dic", to: "index.dic.txt" },
+];
+const TARGET_DIR = join(
+    import.meta.dirname,
+    "..",
+    "public",
+    "dictionaries",
+    "nb",
+);
+
+const require = createRequire(import.meta.url);
+// Pakken eksporterer bare inngangspunktet sitt, men ordbokfilene ligger ved
+// siden av det.
+const sourceDir = dirname(require.resolve("dictionary-nb"));
+
+await mkdir(TARGET_DIR, { recursive: true });
+
+for (const file of FILES) {
+    const from = join(sourceDir, file.from);
+    const to = join(TARGET_DIR, file.to);
+
+    // Ordboka endrer seg bare når pakken oppgraderes, så vi hopper over
+    // kopieringen når filen allerede ligger der i riktig størrelse.
+    const [source, existing] = await Promise.all([
+        stat(from),
+        stat(to).catch(() => null),
+    ]);
+    if (existing && existing.size === source.size) continue;
+
+    await copyFile(from, to);
+    console.log(`ordbok: ${file.to} (${Math.round(source.size / 1024)} kB)`);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
         "@tanstack/react-router-devtools": "latest",
         "@tanstack/react-router-ssr-query": "latest",
         "@tanstack/react-start": "latest",
-        "@tanstack/react-table": "latest",
+        "@tanstack/react-table": "^8.21.3",
         "@tanstack/router-plugin": "^1.132.0",
         "@tihlde/sdk": "workspace:*",
         "@tihlde/ui": "workspace:*",
@@ -91,6 +91,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
+        "dictionary-nb": "^3.0.0",
         "ky": "^2.0.2",
         "lucide-react": "^0.577.0",
         "nitro": "latest",
@@ -263,6 +264,7 @@
         "lucide-react": "^0.577.0",
         "mdast-util-directive": "^3.1.0",
         "next-themes": "^0.4.6",
+        "nspell": "^2.1.5",
         "pdfjs-dist": "5.4.296",
         "qrcode.react": "^4.2.0",
         "react-day-picker": "^9.14.0",
@@ -285,6 +287,7 @@
       },
       "devDependencies": {
         "@types/mdast": "^4.0.4",
+        "@types/nspell": "^2.1.6",
         "@types/react": "catalog:frontend",
         "@types/react-dom": "catalog:frontend",
         "tailwindcss": "catalog:frontend",
@@ -1267,13 +1270,13 @@
 
     "@tanstack/devtools-vite": ["@tanstack/devtools-vite@0.8.3", "", { "dependencies": { "@tanstack/devtools-bundler-core": "0.1.1", "@tanstack/devtools-client": "0.0.8", "@tanstack/devtools-event-bus": "0.4.2", "chalk": "^5.6.2" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-MqqE4/rdQUG55Y8Zux1Jj1I2wIBHdqYgjAJzP1grMUtFqSZ2XIDB7BHEV9UW/vrbhK7ocl4yFgVaJWROv0zeDA=="],
 
-    "@tanstack/form-core": ["@tanstack/form-core@1.33.2", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1", "@tanstack/pacer-lite": "^0.1.1", "@tanstack/store": "^0.11.0" } }, "sha512-F60zJd15bGrXKonc1kpRYnNRNfiES7F+hgvrPMrsZznPLqZtO2DIg76OU6R25kCYkqYQY5xvuKteuWcUsc587A=="],
+    "@tanstack/form-core": ["@tanstack/form-core@1.33.3", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1", "@tanstack/pacer-lite": "^0.1.1", "@tanstack/store": "^0.11.0" } }, "sha512-htLxe/50GpUxbi2arJleh6uQkw72UOy+3Q0d1AadO3lfBTjs1e51GzyrKk/w8I7qXSkaSnF/JbYlyE+cwbJGNw=="],
 
     "@tanstack/history": ["@tanstack/history@1.162.0", "", {}, "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA=="],
 
     "@tanstack/hotkeys": ["@tanstack/hotkeys@0.7.1", "", { "dependencies": { "@tanstack/store": "^0.9.3" } }, "sha512-YHVO1z6wnvUCu7bg870Kv5k2D+FIuIOSIcbN0dAmTTsJ3mLMDLwcTVx0qVaq+SZp1B514JJTqGVstvUp85yIpQ=="],
 
-    "@tanstack/match-sorter-utils": ["@tanstack/match-sorter-utils@8.19.4", "", { "dependencies": { "remove-accents": "0.5.0" } }, "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg=="],
+    "@tanstack/match-sorter-utils": ["@tanstack/match-sorter-utils@9.0.0", "", { "dependencies": { "remove-accents": "0.5.0" } }, "sha512-6oZrlzBw/hZGFhIomyN9WyFwoaRkI/Neu2OJhYblbHNMzIbcJDDtXN2SEpICZm+fh+MALUmwOaX8YWaH+E1dMg=="],
 
     "@tanstack/pacer-lite": ["@tanstack/pacer-lite@0.1.1", "", {}, "sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w=="],
 
@@ -1283,7 +1286,7 @@
 
     "@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.9", "", { "dependencies": { "@tanstack/devtools": "0.13.0" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-lS6mtccEmUaodsWiRORGM/MGKT0jgzcy5v+eY6pzOPxEgzTHUDhca+WGxShFqKxmF4oneRxXjww1gkvMrWq6uw=="],
 
-    "@tanstack/react-form": ["@tanstack/react-form@1.33.2", "", { "dependencies": { "@tanstack/form-core": "1.33.2", "@tanstack/react-store": "^0.11.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-nEfayOu+27q5cZ5E0G5dmnddqLcLjdFCatbL/LCs/iLD469a1o1yYJlr8RISV3GfnqsBpm0hf+8kM4okh5fPCw=="],
+    "@tanstack/react-form": ["@tanstack/react-form@1.33.3", "", { "dependencies": { "@tanstack/form-core": "1.33.3", "@tanstack/react-store": "^0.11.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-lkzI/y15fHC8lKvzsLXFLLqGWroa+okvV2cKRCGAL+d0Kdf040fdMZbKh6uCXDMc08Ngpl8G3VZFnZ5KVUkUIw=="],
 
     "@tanstack/react-hotkeys": ["@tanstack/react-hotkeys@0.9.1", "", { "dependencies": { "@tanstack/hotkeys": "0.7.1", "@tanstack/react-store": "^0.9.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-/qdQUUVkYAHAWRGdFXqFgWpW/S+a6OzkvxWNWKLLDHQODJlO6EPBPa073CglaafBfzig58RK07T09ET+NnZhpg=="],
 
@@ -1297,13 +1300,13 @@
 
     "@tanstack/react-router-ssr-query": ["@tanstack/react-router-ssr-query@1.167.1", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.169.1" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/react-query": ">=5.90.0", "@tanstack/react-router": ">=1.127.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-W9j5JPnBikyafvuUfykFfHIWod58OAbAAa5leNkXBcoDoocghMmu6w9uZOmUZvAWT7CSvgj5tBUtF7CM2OoHXQ=="],
 
-    "@tanstack/react-start": ["@tanstack/react-start@1.168.32", "", { "dependencies": { "@tanstack/react-router": "1.170.18", "@tanstack/react-start-client": "1.168.16", "@tanstack/react-start-rsc": "0.1.31", "@tanstack/react-start-server": "1.167.22", "@tanstack/router-utils": "1.162.2", "@tanstack/start-client-core": "1.170.14", "@tanstack/start-plugin-core": "1.171.24", "@tanstack/start-server-core": "1.169.17", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-y1WXHo+jPfHxiuuN1m+br06IcriiBQnEWryBdbKdEOS5vw2PmnOj+Cgf1/YcGOqtSougScWFeE2rL1FXWvsLLg=="],
+    "@tanstack/react-start": ["@tanstack/react-start@1.168.35", "", { "dependencies": { "@tanstack/react-router": "1.170.18", "@tanstack/react-start-client": "1.168.16", "@tanstack/react-start-rsc": "0.1.34", "@tanstack/react-start-server": "1.167.23", "@tanstack/router-utils": "1.162.2", "@tanstack/start-client-core": "1.170.14", "@tanstack/start-plugin-core": "1.171.26", "@tanstack/start-server-core": "1.169.18", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-Do6cFns980nYL0WKle1aCU+CrN2wxDMWv3wJpY4o9E5xajgrrXKmbaIKleZFhyIvdQsCHwXpdIy4Caz4f1ztfQ=="],
 
     "@tanstack/react-start-client": ["@tanstack/react-start-client@1.168.16", "", { "dependencies": { "@tanstack/react-router": "1.170.18", "@tanstack/router-core": "1.171.15", "@tanstack/start-client-core": "1.170.14" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-1OfHgy0wpHwe2tlB3FxMeA+IMX6Il/QAMf+8UdXuimReIc2Lz3BkMLBL38k4GIxBguX9sI8EMLO5jlTZ4e1olw=="],
 
-    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.1.31", "", { "dependencies": { "@tanstack/react-router": "1.170.18", "@tanstack/router-core": "1.171.15", "@tanstack/router-utils": "1.162.2", "@tanstack/start-client-core": "1.170.14", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-plugin-core": "1.171.24", "@tanstack/start-server-core": "1.169.17", "@tanstack/start-storage-context": "1.167.17", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-WxjkXYflq550vTNJpdPyMaPC+Vyh88L5wOL+SiDTjPMGne9ad7FZmoJxqfCFEv1e7HVKMH/mMoE8619TsTNVzQ=="],
+    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.1.34", "", { "dependencies": { "@tanstack/react-router": "1.170.18", "@tanstack/router-core": "1.171.15", "@tanstack/router-utils": "1.162.2", "@tanstack/start-client-core": "1.170.14", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-plugin-core": "1.171.26", "@tanstack/start-storage-context": "1.167.17", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.30", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-KHFZUS0DySJU+dU0NWNLnfXa3dJKrHWULqCa85RcQiavtSuKTGD2znuU9ZRLfcGVn99Nkcv9Xt8UMk+1BUGI7A=="],
 
-    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.167.22", "", { "dependencies": { "@tanstack/react-router": "1.170.18", "@tanstack/router-core": "1.171.15", "@tanstack/start-server-core": "1.169.17" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-eH2PeHuLfL3R5YzE9+y2FfcE4Ld1LNV2ZfrCNVPJMMJFt+9nXDaRHg9BsEmc+JkTAGzz3FKLyQEoWwpbG6Ehqg=="],
+    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.167.23", "", { "dependencies": { "@tanstack/react-router": "1.170.18", "@tanstack/router-core": "1.171.15", "@tanstack/start-server-core": "1.169.18" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-dtA7XEzK0YowtIiMNRAb1s54FV7vjprK4z8pyAd0Z75QQgu3BPdR+uMunI0ZjzP1xc1yfVNDcLT+rukZrBU88A=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.11.0", "", { "dependencies": { "@tanstack/store": "0.11.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w=="],
 
@@ -1325,9 +1328,9 @@
 
     "@tanstack/start-fn-stubs": ["@tanstack/start-fn-stubs@1.162.0", "", {}, "sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ=="],
 
-    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.171.24", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.15", "@tanstack/router-generator": "1.167.21", "@tanstack/router-plugin": "1.168.23", "@tanstack/router-utils": "1.162.2", "@tanstack/start-server-core": "1.169.17", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.4", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-l/tm+T0ntXHeIzr9kJDTJ2IDNZC0yFazjkvbEVeZsDOrJ8F+HiZmY+tXYqI5/nDYkwxY0DVQr+kGsTRVb6y2Jw=="],
+    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.171.26", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.15", "@tanstack/router-generator": "1.167.21", "@tanstack/router-plugin": "1.168.23", "@tanstack/router-utils": "1.162.2", "@tanstack/start-server-core": "1.169.18", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.4", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-X0980UEPP1CYMcQt/BRYW1ncElas/3ZNnYgGfhI36XZNWcROJkfS4AHbAqZ94Y3ocFjK3EcUkaFWDIAqrpwPmA=="],
 
-    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.169.17", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/router-core": "1.171.15", "@tanstack/start-client-core": "1.170.14", "@tanstack/start-storage-context": "1.167.17", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.4" } }, "sha512-u0N+PHJhMHnzfnlXYI9F+A/qweDe3E2X0mfkORPGIEkNQgvS548RA9fjwvixR2en5b848CfpEqUzwFhm/tQ40Q=="],
+    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.169.18", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/router-core": "1.171.15", "@tanstack/start-client-core": "1.170.14", "@tanstack/start-storage-context": "1.167.17", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.4" } }, "sha512-/ESLR7fCGAhaypuRGPfoHaFW6AkcF8RNj1/HcQOedutF3LBi9MdGaEiENg89ivQSqnPNi5cZbtrsrJ6regHhrA=="],
 
     "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.167.17", "", { "dependencies": { "@tanstack/router-core": "1.171.15" } }, "sha512-ntkDyGx0PE0opIlWNAMpkMb8qkjR4uyCUOfC0CiT0STM25+EcwPuwYNfDXXeVObMrTAPgsQ4yOj3xdY0Xr4ptw=="],
 
@@ -1486,6 +1489,8 @@
     "@types/nodemailer": ["@types/nodemailer@7.0.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-80vKwiIsVSyFA1rRovH59jNPLBOuc6dRZIHEu40gXTkBkZnQv8vog1xSGEb9j5q/tdMAs5ivvDR2pLTU0hGHXA=="],
 
     "@types/normalize-path": ["@types/normalize-path@3.0.2", "", {}, "sha512-DO++toKYPaFn0Z8hQ7Tx+3iT9t77IJo/nDiqTXilgEP+kPNIYdpS9kh3fXuc53ugqwp9pxC1PVjCpV1tQDyqMA=="],
+
+    "@types/nspell": ["@types/nspell@2.1.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-PnWYqrBZhkKAreX2kIZDJcBeigZJzXC8VmSuNiXeILUNreczBZHLxGEv/pRT+zL8rsXLxT5bRbiIF9wuh6cGgg=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
@@ -1925,6 +1930,8 @@
 
     "dfa": ["dfa@1.2.0", "", {}, "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="],
 
+    "dictionary-nb": ["dictionary-nb@3.0.0", "", {}, "sha512-YemD394r1z5BrC1HUsV7iF6zLIalFBbcDfMCn4OV+KP3fRqC5VBLuohGBGmKnCmwwXSJmhOjmzaQY2cbK61iFw=="],
+
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
@@ -2234,6 +2241,8 @@
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
 
     "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
 
@@ -2598,6 +2607,8 @@
     "normalize-svg-path": ["normalize-svg-path@1.1.0", "", { "dependencies": { "svg-arc-to-cubic-bezier": "^3.0.0" } }, "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg=="],
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "nspell": ["nspell@2.1.5", "", { "dependencies": { "is-buffer": "^2.0.0" } }, "sha512-PSStyugKMiD9mHmqI/CR5xXrSIGejUXPlo88FBRq5Og1kO5QwQ5Ilu8D8O5I/SHpoS+mibpw6uKA8rd3vXd2Sg=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,6 +45,7 @@
         "lucide-react": "^0.577.0",
         "mdast-util-directive": "^3.1.0",
         "next-themes": "^0.4.6",
+        "nspell": "^2.1.5",
         "pdfjs-dist": "5.4.296",
         "qrcode.react": "^4.2.0",
         "react-day-picker": "^9.14.0",
@@ -67,6 +68,7 @@
     },
     "devDependencies": {
         "@types/mdast": "^4.0.4",
+        "@types/nspell": "^2.1.6",
         "@types/react": "catalog:frontend",
         "@types/react-dom": "catalog:frontend",
         "tailwindcss": "catalog:frontend",

--- a/packages/ui/src/components/complex/markdown/internal/spellcheck-extension.ts
+++ b/packages/ui/src/components/complex/markdown/internal/spellcheck-extension.ts
@@ -1,0 +1,122 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+
+import { loadSpeller, type Speller } from "./speller";
+
+const spellcheckKey = new PluginKey<DecorationSet>("norsk-stavekontroll");
+
+/**
+ * Ord skilles på alt som ikke er bokstav, bindestrek eller apostrof, slik at
+ * «e-post» og «TIHLDEs» holdes samlet. `\p{L}` fanger æ, ø og å.
+ */
+const WORD_PATTERN = /[\p{L}][\p{L}'’-]*/gu;
+
+/** Ord med tall eller versaler i seg — koder, forkortelser, TIHLDE-slang. */
+function shouldSkip(word: string): boolean {
+    if (word.length < 3) return true;
+    // ALLEVERSALER og CamelCase er som regel navn og forkortelser, ikke feil.
+    if (word === word.toUpperCase()) return true;
+    return false;
+}
+
+function buildDecorations(doc: ProseMirrorNode, speller: Speller) {
+    const decorations: Decoration[] = [];
+
+    doc.descendants((node, position) => {
+        if (!node.isText || !node.text) return;
+
+        for (const match of node.text.matchAll(WORD_PATTERN)) {
+            const word = match[0];
+            if (match.index === undefined || shouldSkip(word)) continue;
+            if (!speller.isMisspelled(word)) continue;
+
+            const from = position + match.index;
+            decorations.push(
+                Decoration.inline(from, from + word.length, {
+                    class: "spelling-error",
+                }),
+            );
+        }
+    });
+
+    return DecorationSet.create(doc, decorations);
+}
+
+/**
+ * Marker skrivefeil med rød bølgestrek, på samme måte som nettleseren ville
+ * gjort om brukeren hadde norsk ordbok installert.
+ *
+ * Ordboka lastes i bakgrunnen. Fram til den er klar — og hvis den aldri blir
+ * det — ligger dekorasjonene tomme, og nettleserens egen stavekontroll står
+ * for det den måtte klare.
+ */
+export const NorwegianSpellcheck = Extension.create({
+    name: "norwegianSpellcheck",
+
+    addProseMirrorPlugins() {
+        let speller: Speller | null = null;
+
+        return [
+            new Plugin<DecorationSet>({
+                key: spellcheckKey,
+
+                view(editorView) {
+                    let cancelled = false;
+
+                    void loadSpeller().then((loaded) => {
+                        if (cancelled || !loaded) return;
+                        speller = loaded;
+                        // Ordboka kom etter at teksten ble lagt inn, så
+                        // gjennomgangen må trigges på nytt.
+                        editorView.dispatch(
+                            editorView.state.tr.setMeta(spellcheckKey, true),
+                        );
+                    });
+
+                    return {
+                        destroy() {
+                            cancelled = true;
+                        },
+                    };
+                },
+
+                state: {
+                    init(_, state: EditorState) {
+                        return speller
+                            ? buildDecorations(state.doc, speller)
+                            : DecorationSet.empty;
+                    },
+                    apply(
+                        transaction: Transaction,
+                        current: DecorationSet,
+                    ): DecorationSet {
+                        if (!speller) return DecorationSet.empty;
+
+                        // Uendret tekst: flytt eksisterende markeringer i takt
+                        // med endringen i stedet for å gå gjennom alt på nytt.
+                        if (
+                            !transaction.docChanged &&
+                            !transaction.getMeta(spellcheckKey)
+                        ) {
+                            return current.map(
+                                transaction.mapping,
+                                transaction.doc,
+                            );
+                        }
+
+                        return buildDecorations(transaction.doc, speller);
+                    },
+                },
+
+                props: {
+                    decorations(state) {
+                        return spellcheckKey.getState(state);
+                    },
+                },
+            }),
+        ];
+    },
+});

--- a/packages/ui/src/components/complex/markdown/internal/speller.ts
+++ b/packages/ui/src/components/complex/markdown/internal/speller.ts
@@ -1,0 +1,161 @@
+/**
+ * Norsk stavekontroll i appen.
+ *
+ * Nettleserens egen stavekontroll krever at hver enkelt bruker har lagt til
+ * norsk under språkinnstillingene sine, og utvidelser som Grammarly slår den
+ * av på feltene de kobler seg på. Resultatet var at skrivefeil i arrangementer
+ * og nyheter aldri ble fanget opp. Denne modulen tar jobben selv, slik at alle
+ * arrangører får rød strek uansett nettleser.
+ *
+ * Ordboka er stor (5,3 MB), så den lastes først når noen faktisk åpner en
+ * editor — aldri på de offentlige sidene.
+ */
+
+/** Hvor kort en del av et sammensatt ord får være. */
+const MIN_COMPOUND_PART = 3;
+
+/**
+ * Ord ordboka ikke kjenner, men som er riktige hos oss. Uten disse ville
+ * navnet på foreningen fått rød strek i annethvert arrangement.
+ */
+const CUSTOM_WORDS = [
+    "TIHLDE",
+    "Index",
+    "Drift",
+    "Sosialen",
+    "Promo",
+    "KoK",
+    "NoK",
+    "Fondet",
+    "Plask",
+    "Jubkom",
+    "Turkom",
+    "Redaksjonen",
+    "bedpres",
+    "bedpresen",
+    "vors",
+    "nachspiel",
+    "fadder",
+    "faddere",
+    "fadderuke",
+    "fadderuka",
+    "immatrikuleringsball",
+    "linjeforening",
+    "linjeforeningen",
+    "dataingeniør",
+    "dataingeniører",
+    "drikkelek",
+    "drikkeleker",
+    "kontoret",
+    "kontorvakt",
+    "soundboks",
+    "Vipps",
+    "NTNU",
+    "Kalvskinnet",
+    "Gløshaugen",
+    "kull",
+    "kullet",
+];
+
+export type Speller = {
+    /** True når ordet ikke finnes i ordboka og heller ikke er en sammensetning. */
+    isMisspelled: (word: string) => boolean;
+    /** Forslag til retting, tom liste når ordboka ikke har noen. */
+    suggest: (word: string) => string[];
+};
+
+type NSpell = {
+    correct: (word: string) => boolean;
+    suggest: (word: string) => string[];
+    add: (word: string) => void;
+};
+
+/**
+ * Hvor de kopierte ordbokfilene ligger. `apps/kvark/scripts/copy-dictionary.ts`
+ * legger dem her før dev og build.
+ */
+const DEFAULT_DICTIONARY_URL = "/dictionaries/nb";
+
+let pending: Promise<Speller | null> | null = null;
+
+/**
+ * Last ordboka én gang per side. Feiler lastingen — ordboka mangler, eller
+ * nettet er nede — svarer vi null, og editoren faller tilbake på nettleserens
+ * egen stavekontroll i stedet for å vise ingenting.
+ */
+export function loadSpeller(
+    baseUrl: string = DEFAULT_DICTIONARY_URL,
+): Promise<Speller | null> {
+    pending ??= createSpeller(baseUrl).catch((error) => {
+        console.warn("Kunne ikke laste den norske ordboka:", error);
+        return null;
+    });
+    return pending;
+}
+
+async function createSpeller(baseUrl: string): Promise<Speller> {
+    // Begge filene er UTF-8 (`SET UTF-8` øverst i index.aff), og nspell tar
+    // imot dem som tekst.
+    const [{ default: nspell }, aff, dic] = await Promise.all([
+        import("nspell"),
+        fetchDictionaryFile(`${baseUrl}/index.aff.txt`),
+        fetchDictionaryFile(`${baseUrl}/index.dic.txt`),
+    ]);
+
+    const spell = nspell(aff, dic) as unknown as NSpell;
+    for (const word of CUSTOM_WORDS) spell.add(word);
+
+    // Det samme ordet står gjerne mange ganger i en tekst, og hvert oppslag
+    // koster. Cachen gjør at hvert unike ord bare sjekkes én gang.
+    const cache = new Map<string, boolean>();
+
+    function isKnown(word: string): boolean {
+        return spell.correct(word) || spell.correct(word.toLowerCase());
+    }
+
+    /**
+     * Norsk setter sammen ord fritt, og ordboka har ikke alle sammensetningene.
+     * Uten dette fikk «bedriftspresentasjon» og «fadderuke» rød strek — verre
+     * enn ingen stavekontroll, for da lærer man seg å overse strekene.
+     */
+    function isCompound(word: string): boolean {
+        if (word.length < MIN_COMPOUND_PART * 2) return false;
+
+        for (
+            let i = MIN_COMPOUND_PART;
+            i <= word.length - MIN_COMPOUND_PART;
+            i++
+        ) {
+            const head = word.slice(0, i);
+            const tail = word.slice(i);
+            if (!isKnown(tail)) continue;
+            if (isKnown(head)) return true;
+            // Bindebokstav: bedrift-s-presentasjon, barn-e-hage.
+            if (/[se]$/.test(head) && isKnown(head.slice(0, -1))) return true;
+        }
+        return false;
+    }
+
+    return {
+        isMisspelled(word) {
+            const cached = cache.get(word);
+            if (cached !== undefined) return cached;
+
+            const lower = word.toLowerCase();
+            const misspelled = !isKnown(word) && !isCompound(lower);
+            cache.set(word, misspelled);
+            return misspelled;
+        },
+        suggest(word) {
+            return spell.suggest(word).slice(0, 5);
+        },
+    };
+}
+
+async function fetchDictionaryFile(url: string): Promise<string> {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`${url} svarte ${response.status}`);
+    }
+    return response.text();
+}

--- a/packages/ui/src/components/complex/markdown/internal/tiptap-extensions.ts
+++ b/packages/ui/src/components/complex/markdown/internal/tiptap-extensions.ts
@@ -15,11 +15,14 @@ import type {
     DirectiveRegistry,
 } from "../directive";
 
+import { NorwegianSpellcheck } from "./spellcheck-extension";
 import { TableNodeView } from "./table-node-view";
 import { attrsFromSchema } from "./zod-to-attrs";
 
 export type BuildOptions = {
     placeholder?: string;
+    /** Norsk stavekontroll i appen. På som standard. */
+    spellcheck?: boolean;
 };
 
 /**
@@ -56,6 +59,7 @@ export function buildTiptapExtensions(
         TableRow,
         TableHeader,
         TableCell,
+        ...(options.spellcheck === false ? [] : [NorwegianSpellcheck]),
     ];
 
     const directiveExtensions = registry.directives.map((directive) =>

--- a/packages/ui/src/components/complex/markdown/markdown-content.tsx
+++ b/packages/ui/src/components/complex/markdown/markdown-content.tsx
@@ -28,6 +28,10 @@ export function MarkdownContent({
                 "prose prose-sm max-w-none",
                 "[&_.ProseMirror]:outline-none [&_.ProseMirror]:min-h-32",
                 "[&_.ProseMirror>:first-child]:mt-0 [&_.ProseMirror>:last-child]:mb-0",
+                // Skrivefeil fra den norske stavekontrollen. Samme rød
+                // bølgestrek som nettleseren selv bruker, så den er kjent
+                // igjen med en gang.
+                "[&_.spelling-error]:[text-decoration:underline_wavy_var(--color-destructive)] [&_.spelling-error]:[text-underline-offset:0.2em] [&_.spelling-error]:[text-decoration-skip-ink:none]",
                 className,
             )}
             {...rest}

--- a/packages/ui/src/components/complex/markdown/rich-editor.tsx
+++ b/packages/ui/src/components/complex/markdown/rich-editor.tsx
@@ -35,8 +35,12 @@ export function RichEditor({
     const lastEmitted = useRef(value);
 
     const extensions = useMemo(
-        () => buildTiptapExtensions(registry, { placeholder }),
-        [registry, placeholder],
+        () =>
+            buildTiptapExtensions(registry, {
+                placeholder,
+                spellcheck: spellCheck,
+            }),
+        [registry, placeholder, spellCheck],
     );
 
     const initialContent = useMemo(
@@ -58,6 +62,14 @@ export function RichEditor({
                 // nyheter, der skrivefeil blir stående lenge.
                 lang,
                 spellcheck: String(spellCheck),
+                // Be Grammarly holde seg unna. Utvidelsen overtar felt den
+                // kobler seg på og slår av nettleserens egen stavekontroll,
+                // men retter bare engelsk — resultatet på et norsk felt er
+                // ingen rød strek i det hele tatt. Uten Grammarly installert
+                // gjør attributtene ingenting.
+                "data-gramm": "false",
+                "data-gramm_editor": "false",
+                "data-enable-grammarly": "false",
             },
         },
         onUpdate: ({ editor: instance }) => {

--- a/packages/ui/src/components/ui/textarea.tsx
+++ b/packages/ui/src/components/ui/textarea.tsx
@@ -6,6 +6,14 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     return (
         <textarea
             data-slot="textarea"
+            // Be Grammarly holde seg unna. Utvidelsen overtar felt den kobler
+            // seg på og slår av nettleserens egen stavekontroll, men retter
+            // bare engelsk — på et norsk felt blir resultatet ingen rød strek
+            // i det hele tatt. Uten Grammarly gjør attributtene ingenting, og
+            // spreaden under lar den som trenger det overstyre.
+            data-gramm="false"
+            data-gramm_editor="false"
+            data-enable-grammarly="false"
             className={cn(
                 "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
                 className,


### PR DESCRIPTION
Oppfølger til #416. `lang="nb"` er live på new.tihlde.org, men skrivefeil får fortsatt ikke rød strek — også i privat vindu uten Grammarly.

## Hvorfor `lang="nb"` ikke var nok

Nettleserens stavekontroll krever at **hver enkelt bruker** har lagt til norsk under språkinnstillingene sine. `lang="nb"` velger bare hvilken av de aktiverte ordbøkene som skal brukes; er ikke norsk aktivert, sjekkes ingenting. I tillegg slår utvidelser som Grammarly av den innebygde stavekontrollen på feltene de kobler seg på, og Grammarly retter bare engelsk — på et norsk felt blir resultatet ingen streker i det hele tatt.

Det er ikke noe vi kan fikse per bruker, og det er nettopp derfor det er «SÅ mye skrivefeil på nettsida» (#405). Denne PR-en gjør jobben i appen i stedet.

## Hvordan

En ProseMirror-utvidelse går gjennom teksten, slår hvert ord opp i en norsk Hunspell-ordbok (`nspell` + `dictionary-nb`) og markerer det som ikke finnes med rød bølgestrek.

### Sammensatte ord — den viktigste avveiningen

Rå ordboksoppslag flagget «bedriftspresentasjon», «fadderuke» og «linjeforening» som feil. Rød strek under helt korrekte ord er **verre enn ingen stavekontroll**, for da lærer folk seg å overse strekene.

Finnes ikke ordet, prøver vi derfor å dele det i to gyldige deler, med binde-s eller -e («bedrift**s**presentasjon», «barn**e**hage»). Jeg testet flere varianter:

| innstilling | falske treff | sluppet gjennom |
| --- | --- | --- |
| min. 3 bokstaver per del, binde-s/e | ingen | «skriveefil» |
| min. 4 bokstaver per del | «fadderuke» | ingen |

Valget falt på minst 3 bokstaver. Prisen er at noen useriøse sammensetninger slipper gjennom («skriveefil» leses som skrive+e+fil) — en bevisst avveining, siden falske treff er den dyre feilen. I tillegg ligger det en liste med TIHLDE-ord (TIHLDE, bedpres, vors, fadderuke, Gløshaugen …).

### Lasting

Ordboka er 5,3 MB og lastes **først når noen åpner en editor** — aldri på de offentlige sidene. `dictionary-nb` leser filene sine med `node:fs` og sperrer for direkte import, så de kopieres ut som statiske filer før dev og build (`apps/kvark/scripts/copy-dictionary.ts`, output i `.gitignore`).

Filene får `.txt`-endelse med vilje: da serveres de som `text/plain` og komprimeres til ~1,4 MB. Vercel komprimerer ikke ukjente typer som `.dic`.

## Målt

- **523 ms** fra tastetrykk til rød strek på kald last
- ordboka lastes ikke på `/arrangementer` — verifisert at ingen forespørsel går ut
- ligger som statisk fil, ikke inlinet i JS; største JS-chunk uendret på 533 kB
- verifisert visuelt: «arangement» og «kontakperson» får strek, «bedriftspresentasjon» og «fadderuke» står rene

## To ting for review

1. **`@tanstack/react-table` er pinnet til `^8.21.3`.** Den sto på `"latest"` i `apps/kvark/package.json` og hoppet til v9 ved neste `bun add`, som brøt `kokebok.tsx` med tjue typefeil. Fella lå der fra før og ville smelt for den neste som installerte noe, men det er en endring utenfor bestillingen — si fra om den heller bør tas separat.
2. **`data-gramm="false"`** på editoren og den delte `Textarea`. Grammarly var ikke årsaken her, men uten dette ville den lagt sine engelske forslag oppå de norske strekene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
