### PR TITLE
feat(arrangementer): krev godkjente arrangementsregler før påmelding

### DIFF
--- a/apps/api/src/lib/user/settings.ts
+++ b/apps/api/src/lib/user/settings.ts
@@ -36,11 +36,55 @@ function emptyToNull<T extends string>(value: T | undefined) {
     return value === undefined ? undefined : value === "" ? null : value;
 }
 
-export const UpdateUserSettingsSchema = UserSettingsSchema.partial();
+/**
+ * `allergies` overstyres eksplisitt: `.default([])` gjør feltet påkrevd i den
+ * genererte OpenAPI-typen selv etter `.partial()`, og da måtte enhver klient
+ * som endrer én innstilling sende hele allergilista på nytt — eller slette den
+ * ved et uhell.
+ */
+export const UpdateUserSettingsSchema = UserSettingsSchema.partial().extend({
+    allergies: z.array(z.string()).optional(),
+});
 
 export type UserAllergy = z.infer<typeof UserAllergySchema>;
 export type UserSettings = z.infer<typeof UserSettingsSchema>;
 export type UpdateUserSettings = z.infer<typeof UpdateUserSettingsSchema>;
+
+/**
+ * Fallbacks for the columns that are `NOT NULL` but that a partial update need
+ * not carry, used when a user updates a single setting before they have a
+ * settings row at all — which is the normal state, since nothing creates the
+ * row at sign-up. Without them a new member could never accept the event rules,
+ * as the only paths to a row were full onboarding or the Lepton migration.
+ *
+ * `isOnboarded` stays false, so these placeholders are recognisable as "never
+ * answered" rather than "answered like this".
+ */
+const IMPLICIT_SETTINGS_DEFAULTS = {
+    gender: "other",
+    allowsPhotosByDefault: false,
+    acceptsEventRules: false,
+    receiveMailCommunication: true,
+    isOnboarded: false,
+} as const;
+
+/**
+ * Whether the user has accepted the event rules.
+ *
+ * No settings row means they never answered, which counts as "not accepted" —
+ * the rules are an active choice, so the absence of one can't grant it.
+ */
+export async function hasAcceptedEventRules(
+    userId: string,
+    ctx: AppContext,
+): Promise<boolean> {
+    const settings = await ctx.db.query.userSettings.findFirst({
+        where: (s, { eq }) => eq(s.userId, userId),
+        columns: { acceptsEventRules: true },
+    });
+
+    return settings?.acceptsEventRules ?? false;
+}
 
 export async function getUserSettings(
     userId: string,
@@ -86,9 +130,7 @@ export async function createUserSettings(
 
     // Use transaction for atomicity
     return await db.transaction(async (tx) => {
-        // Create settings
-        await tx.insert(userSettings).values({
-            userId,
+        const values = {
             gender: settings.gender,
             allowsPhotosByDefault: settings.allowsPhotosByDefault,
             acceptsEventRules: settings.acceptsEventRules,
@@ -98,7 +140,15 @@ export async function createUserSettings(
             linkedinUrl: emptyToNull(settings.linkedinUrl) ?? null,
             receiveMailCommunication: settings.receiveMailCommunication,
             isOnboarded: true, // Mark as onboarded when creating
-        });
+        };
+
+        // Onboarding overwrites any placeholder row left behind by an earlier
+        // single-setting update (accepting the event rules creates one), so
+        // answering the real questions is never blocked by it.
+        await tx
+            .insert(userSettings)
+            .values({ ...values, userId })
+            .onConflictDoUpdate({ target: userSettings.userId, set: values });
 
         // Set allergies
         if (settings.allergies.length > 0) {
@@ -130,16 +180,28 @@ export async function updateUserSettings(
 
         // Update settings if there are any field updates
         if (Object.keys(settingsUpdates).length > 0) {
+            const values = {
+                ...settingsUpdates,
+                imageUrl: settingsUpdates.imageUrl ?? undefined,
+                bioDescription: emptyToNull(settingsUpdates.bioDescription),
+                githubUrl: emptyToNull(settingsUpdates.githubUrl),
+                linkedinUrl: emptyToNull(settingsUpdates.linkedinUrl),
+            };
+
+            // Upsert rather than update: members who never onboarded have no
+            // row, and a plain UPDATE silently matched nothing — so accepting
+            // the event rules appeared to work and changed nothing.
             await tx
-                .update(userSettings)
-                .set({
-                    ...settingsUpdates,
-                    imageUrl: settingsUpdates.imageUrl ?? undefined,
-                    bioDescription: emptyToNull(settingsUpdates.bioDescription),
-                    githubUrl: emptyToNull(settingsUpdates.githubUrl),
-                    linkedinUrl: emptyToNull(settingsUpdates.linkedinUrl),
+                .insert(userSettings)
+                .values({
+                    ...IMPLICIT_SETTINGS_DEFAULTS,
+                    ...values,
+                    userId,
                 })
-                .where(eq(userSettings.userId, userId));
+                .onConflictDoUpdate({
+                    target: userSettings.userId,
+                    set: values,
+                });
         }
 
         // Update allergies if provided

--- a/apps/api/src/routes/event/registration/create.ts
+++ b/apps/api/src/routes/event/registration/create.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../lib/event/priority";
 import { getUserStrikeCount } from "../../../lib/event/strikes";
 import { route } from "../../../lib/route";
+import { hasAcceptedEventRules } from "../../../lib/user/settings";
 import { requireAccess } from "../../../middleware/access";
 import { requireAuth } from "../../../middleware/auth";
 import {
@@ -36,7 +37,7 @@ export const registerToEventRoute = route().post(
         .notFound({ description: "Event not found" })
         .forbidden({
             description:
-                "Event only allows members covered by a priority pool, or members of a specific institute, to register",
+                "User has not accepted the event rules, or the event only allows members covered by a priority pool or members of a specific institute to register",
         })
         .response({
             statusCode: 409,
@@ -73,6 +74,16 @@ export const registerToEventRoute = route().post(
         if (event.isRegistrationClosed || !event.requiresSigningUp) {
             throw new HTTPException(409, {
                 message: "Event is not open for registration",
+            });
+        }
+
+        // Checked before every event-specific rule so the message a member
+        // gets is the one thing they can act on. The frontend shows the same
+        // block ahead of time — hitting it here means they went around it.
+        if (!(await hasAcceptedEventRules(userId, c.get("ctx")))) {
+            throw new HTTPException(403, {
+                message:
+                    "You must accept the event rules before registering for events",
             });
         }
 

--- a/apps/api/src/routes/user/me/settings/onboard.ts
+++ b/apps/api/src/routes/user/me/settings/onboard.ts
@@ -2,7 +2,7 @@ import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { createUserSettings, getUserSettings } from "~/lib/user/settings";
+import { createUserSettings } from "~/lib/user/settings";
 import { requireAuth } from "~/middleware/auth";
 import { onboardUserInputSchema, userSettingsSchema } from "../../schema";
 
@@ -29,10 +29,16 @@ export const onboardRoute = route().post(
         const body = c.req.valid("json");
         const ctx = c.get("ctx");
 
-        // Check if user already has settings
-        const existingSettings = await getUserSettings(userId, ctx);
+        // Only a completed onboarding blocks a new one. A settings row on its
+        // own does not: accepting the event rules creates a placeholder row
+        // with `isOnboarded` false, and that must not lock the user out of
+        // ever answering the real questions.
+        const existing = await ctx.db.query.userSettings.findFirst({
+            where: (settings, { eq }) => eq(settings.userId, userId),
+            columns: { isOnboarded: true },
+        });
 
-        if (existingSettings) {
+        if (existing?.isOnboarded) {
             throw new HTTPException(400, {
                 message: "User has already completed onboarding",
             });

--- a/apps/api/src/routes/user/me/settings/update.ts
+++ b/apps/api/src/routes/user/me/settings/update.ts
@@ -1,8 +1,7 @@
 import { validator } from "hono-openapi";
-import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { getUserSettings, updateUserSettings } from "~/lib/user/settings";
+import { updateUserSettings } from "~/lib/user/settings";
 import { requireAuth } from "~/middleware/auth";
 import {
     updateUserSettingsInputSchema,
@@ -16,7 +15,7 @@ export const updateSettingsRoute = route().patch(
         summary: "Update user settings",
         operationId: "updateUserSettings",
         description:
-            "Partially update the authenticated user's settings. Only provided fields will be updated. User must have completed onboarding first.",
+            "Partially update the authenticated user's settings. Only provided fields will be updated. Settings are created on first update for users who have not onboarded, so a member can accept the event rules without filling in a full profile.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -24,10 +23,6 @@ export const updateSettingsRoute = route().patch(
             description: "Settings updated successfully",
         })
         .badRequest({ description: "Invalid input" })
-        .notFound({
-            description:
-                "User settings do not exist (user needs to complete onboarding first)",
-        })
         .build(),
     requireAuth,
     validator("json", updateUserSettingsInputSchema),
@@ -36,17 +31,8 @@ export const updateSettingsRoute = route().patch(
         const body = c.req.valid("json");
         const ctx = c.get("ctx");
 
-        // Check if user has settings
-        const existingSettings = await getUserSettings(userId, ctx);
-
-        if (!existingSettings) {
-            throw new HTTPException(404, {
-                message:
-                    "User settings not found. Please complete onboarding first.",
-            });
-        }
-
-        // Update settings
+        // Creates the row when it is missing: a member who never onboarded
+        // must still be able to accept the event rules.
         const updatedSettings = await updateUserSettings(userId, body, ctx);
 
         return c.json(updatedSettings, 200);

--- a/apps/api/src/test/config/integration/util/accept-event-rules.ts
+++ b/apps/api/src/test/config/integration/util/accept-event-rules.ts
@@ -1,0 +1,27 @@
+import { schema } from "@photon/db";
+import type { TestUtilContext } from ".";
+
+/**
+ * Mark a test user as having accepted the event rules.
+ *
+ * Registering for an event requires it, so any test that signs a user up must
+ * call this first — the same step a real member takes from the notice in the
+ * frontend.
+ */
+export const createAcceptEventRules =
+    (ctx: TestUtilContext) => async (userId: string) => {
+        await ctx.db
+            .insert(schema.userSettings)
+            .values({
+                userId,
+                gender: "other",
+                allowsPhotosByDefault: false,
+                acceptsEventRules: true,
+                receiveMailCommunication: true,
+                isOnboarded: false,
+            })
+            .onConflictDoUpdate({
+                target: schema.userSettings.userId,
+                set: { acceptsEventRules: true },
+            });
+    };

--- a/apps/api/src/test/config/integration/util/index.ts
+++ b/apps/api/src/test/config/integration/util/index.ts
@@ -1,5 +1,6 @@
 import type { TestAppContext } from "..";
 import type { createApp } from "../../../..";
+import { createAcceptEventRules } from "./accept-event-rules";
 import { createCreatePendingRegistration } from "./create-pending-registration";
 import { createSetupEventCategories } from "./create-setup-event-categories";
 import { createCreateTestEvent } from "./create-test-event";
@@ -25,5 +26,6 @@ export const createTestUtils = (ctx: TestUtilContext) => {
         createTestGroup: createCreateTestGroup(ctx),
         createPendingRegistration: createCreatePendingRegistration(ctx),
         giveUserPermissions: createGiveUserPermissions(ctx),
+        acceptEventRules: createAcceptEventRules(ctx),
     };
 };

--- a/apps/api/src/test/event/event-fields.test.ts
+++ b/apps/api/src/test/event/event-fields.test.ts
@@ -147,6 +147,7 @@ describe("registration allowPhoto", () => {
             await ctx.utils.giveUserPermissions(decliningUser, [
                 "events:registrations:create",
             ]);
+            await ctx.utils.acceptEventRules(decliningUser.id);
             const decliningClient =
                 await ctx.utils.clientForUser(decliningUser);
 
@@ -164,6 +165,7 @@ describe("registration allowPhoto", () => {
             await ctx.utils.giveUserPermissions(defaultUser, [
                 "events:registrations:create",
             ]);
+            await ctx.utils.acceptEventRules(defaultUser.id);
             const defaultClient = await ctx.utils.clientForUser(defaultUser);
 
             const defaultResponse = await defaultClient.api.event[
@@ -269,6 +271,8 @@ describe("onlyAllowPrioritized sign-up enforcement", () => {
             await ctx.utils.giveUserPermissions(outsider, [
                 "events:registrations:create",
             ]);
+            // Accepted, so the 403 below can only come from the priority pool.
+            await ctx.utils.acceptEventRules(outsider.id);
             const outsiderClient = await ctx.utils.clientForUser(outsider);
 
             const outsiderResponse = await outsiderClient.api.event[
@@ -283,6 +287,7 @@ describe("onlyAllowPrioritized sign-up enforcement", () => {
             await ctx.utils.giveUserPermissions(member, [
                 "events:registrations:create",
             ]);
+            await ctx.utils.acceptEventRules(member.id);
             await ctx.db.insert(schema.groupMembership).values({
                 userId: member.id,
                 groupSlug: "index",

--- a/apps/api/src/test/event/event-rules-consent.test.ts
+++ b/apps/api/src/test/event/event-rules-consent.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+describe("event rules consent", () => {
+    integrationTest(
+        "rejects registration from a user who has not accepted the event rules",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent();
+
+            // A brand new member: signed up, permitted to register, but has
+            // never answered the event rules question.
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(user, [
+                "events:registrations:create",
+            ]);
+            const client = await ctx.utils.clientForUser(user);
+
+            const response = await client.api.event[
+                ":eventId"
+            ].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            expect(response.status).toBe(403);
+            const json = (await response.json()) as unknown as {
+                message: string;
+            };
+            expect(json.message).toBe(
+                "You must accept the event rules before registering for events",
+            );
+
+            const rows = await ctx.db.query.eventRegistration.findMany({
+                where: (reg, { eq }) => eq(reg.eventId, event.id),
+            });
+            expect(rows).toHaveLength(0);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "lets the same user register right after accepting from the notice",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent();
+
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(user, [
+                "events:registrations:create",
+            ]);
+            const client = await ctx.utils.clientForUser(user);
+
+            // Exactly what the checkbox in the frontend notice sends — no
+            // settings row exists yet, so this also covers the upsert.
+            const acceptResponse = await client.api.user.me.settings.$patch({
+                json: { acceptsEventRules: true },
+            });
+            expect(acceptResponse.status).toBe(200);
+
+            const response = await client.api.event[
+                ":eventId"
+            ].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            expect(response.status).toBe(200);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "rejects a user who explicitly declined the event rules",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent();
+
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(user, [
+                "events:registrations:create",
+            ]);
+            const client = await ctx.utils.clientForUser(user);
+
+            await client.api.user.me.settings.$post({
+                json: {
+                    gender: "other",
+                    allowsPhotosByDefault: false,
+                    acceptsEventRules: false,
+                    receiveMailCommunication: true,
+                    allergies: [],
+                },
+            });
+
+            const response = await client.api.event[
+                ":eventId"
+            ].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            expect(response.status).toBe(403);
+        },
+        500_000,
+    );
+});

--- a/apps/api/src/test/event/institute-restriction.test.ts
+++ b/apps/api/src/test/event/institute-restriction.test.ts
@@ -57,6 +57,7 @@ describe("event institute restriction", () => {
             await ctx.utils.giveUserPermissions(user, [
                 "events:registrations:create",
             ]);
+            await ctx.utils.acceptEventRules(user.id);
             await ctx.db.insert(schema.groupMembership).values({
                 userId: user.id,
                 groupSlug: digsec.slug,
@@ -101,6 +102,7 @@ describe("event institute restriction", () => {
             await ctx.utils.giveUserPermissions(user, [
                 "events:registrations:create",
             ]);
+            await ctx.utils.acceptEventRules(user.id);
             await ctx.db.insert(schema.groupMembership).values({
                 userId: user.id,
                 groupSlug: dataing.slug,
@@ -140,6 +142,7 @@ describe("event institute restriction", () => {
             await ctx.utils.giveUserPermissions(user, [
                 "events:registrations:create",
             ]);
+            await ctx.utils.acceptEventRules(user.id);
 
             const client = await ctx.utils.clientForUser(user);
             const response = await client.api.event[
@@ -169,6 +172,7 @@ describe("event institute restriction", () => {
             await ctx.utils.giveUserPermissions(user, [
                 "events:registrations:create",
             ]);
+            await ctx.utils.acceptEventRules(user.id);
 
             const client = await ctx.utils.clientForUser(user);
             const response = await client.api.event[

--- a/apps/api/src/test/user.test.ts
+++ b/apps/api/src/test/user.test.ts
@@ -469,25 +469,57 @@ describe("user endpoints", () => {
     );
 
     integrationTest(
-        "returns 404 when user hasn't onboarded",
+        "creates settings when user hasn't onboarded",
         async ({ ctx }) => {
             const user = await ctx.utils.createTestUser();
             const client = await ctx.utils.clientForUser(user);
 
+            // A member who never onboarded must still be able to accept the
+            // event rules — otherwise they cannot register for anything.
             const response = await client.api.user.me.settings.$patch({
                 json: {
-                    gender: "female",
+                    acceptsEventRules: true,
                 },
             });
 
-            expect(response.status).toBe(404);
+            expect(response.status).toBe(200);
 
-            const json = (await response.json()) as unknown as {
-                message: string;
-            };
-            expect(json.message).toBe(
-                "User settings not found. Please complete onboarding first.",
-            );
+            const json = await response.json();
+            expect(json.acceptsEventRules).toBe(true);
+
+            const settings = await ctx.db.query.userSettings.findFirst({
+                where: (s, { eq }) => eq(s.userId, user.id),
+            });
+            // The placeholder row is not a completed onboarding.
+            expect(settings?.isOnboarded).toBe(false);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "lets a user onboard after accepting the event rules",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+
+            await client.api.user.me.settings.$patch({
+                json: { acceptsEventRules: true },
+            });
+
+            const response = await client.api.user.me.settings.$post({
+                json: {
+                    gender: "female",
+                    allowsPhotosByDefault: true,
+                    acceptsEventRules: true,
+                    receiveMailCommunication: true,
+                    allergies: [],
+                },
+            });
+
+            expect(response.status).toBe(201);
+
+            const json = await response.json();
+            expect(json.gender).toBe("female");
         },
         500_000,
     );

--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -47,6 +47,13 @@ type EventRegistrationCardProps = {
     onPay?: () => void;
     qrSlot?: ReactNode;
     headerSlot?: ReactNode;
+    /**
+     * Satt når medlemmet ikke har godkjent arrangementsreglene. Da vises
+     * `eventRulesSlot` i stedet for påmeldingsknappen — også før påmeldingen
+     * åpner, som er hele poenget: de skal oppdage det i god tid.
+     */
+    requiresEventRulesConsent?: boolean;
+    eventRulesSlot?: ReactNode;
     notEligibleReason?: string;
     waitlistPosition?: number;
     /** Satt mens en på-/avmelding er underveis, så knappen ikke kan dobbeltklikkes. */
@@ -61,7 +68,18 @@ type EventRegistrationCardProps = {
 export function EventRegistrationCard(props: EventRegistrationCardProps) {
     const [allowPhoto, setAllowPhoto] = useState(true);
     const timeline = buildTimeline(props);
-    const state = getStateRendering(props, { allowPhoto, setAllowPhoto });
+    // Bare tilstandene der medlemmet ellers kunne ha meldt seg på — å be noen
+    // godkjenne reglene på et arrangement som er stengt hjelper ingen.
+    const blockedByEventRules =
+        props.requiresEventRulesConsent === true &&
+        (props.registrationState === "open" ||
+            props.registrationState === "not-open" ||
+            props.registrationState === "full");
+    const state = getStateRendering(
+        props,
+        { allowPhoto, setAllowPhoto },
+        blockedByEventRules,
+    );
     // Uten påmelding er både tidslinjen og «0/∞ påmeldte» bare støy.
     const showRegistrationDetails = props.registrationState !== "no-signup";
 
@@ -96,6 +114,7 @@ export function EventRegistrationCard(props: EventRegistrationCardProps) {
                         ) : null}
                     </InfoRow>
                 ) : null}
+                {blockedByEventRules ? props.eventRulesSlot : null}
                 {state.actions}
                 {props.actionError ? (
                     <Alert variant="destructive">
@@ -124,6 +143,7 @@ type PhotoConsentState = {
 function getStateRendering(
     props: EventRegistrationCardProps,
     photoConsent: PhotoConsentState,
+    blockedByEventRules: boolean,
 ): StateRendering {
     const state = props.registrationState;
 
@@ -232,7 +252,9 @@ function getStateRendering(
             return {
                 icon: AlertCircle,
                 message: "Arrangementet er fullt",
-                actions: (
+                // Ventelista går gjennom samme påmelding, så den er stengt av
+                // samme grunn — knappen ville bare gitt en avvisning.
+                actions: blockedByEventRules ? null : (
                     <Button
                         variant="outline"
                         className="w-full"
@@ -253,6 +275,10 @@ function getStateRendering(
             };
 
         case "open":
+            // Varselet forklarer hvorfor, og har handlingen som låser opp
+            // påmeldingen. En knapp ved siden av ville bare blitt avvist.
+            if (blockedByEventRules) return {};
+
             return {
                 actions: (
                     <>

--- a/apps/kvark/src/components/event-rules-consent.tsx
+++ b/apps/kvark/src/components/event-rules-consent.tsx
@@ -1,0 +1,104 @@
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
+import { Button } from "@tihlde/ui/ui/button";
+import { Checkbox } from "@tihlde/ui/ui/checkbox";
+import { Label } from "@tihlde/ui/ui/label";
+import { ScrollText } from "lucide-react";
+
+export const EVENT_RULES_URL = "https://wiki.tihlde.org/arrangementer";
+
+type EventRulesConsentProps = {
+    /** Kalles når medlemmet huker av. Én handling — det finnes ingen angre. */
+    onAccept: () => void;
+    isSubmitting?: boolean;
+    error?: string | null;
+    /**
+     * `banner` brukes over hele appen, `inline` inne i påmeldingskortet der
+     * overskriften allerede er «Påmelding».
+     */
+    variant?: "banner" | "inline";
+    /** Overstyrer linja under tittelen — den avhenger av påmeldingsstatus. */
+    message?: string;
+};
+
+/**
+ * Blokkeringen medlemmer møtte for sent i Lepton: reglene måtte godkjennes på
+ * profilen, og de oppdaget det først idet påmeldingen åpnet — da var plassen
+ * ofte tatt. Her kan de godkjenne der de står, uten å forlate siden.
+ */
+export function EventRulesConsent({
+    onAccept,
+    isSubmitting,
+    error,
+    variant = "banner",
+    message,
+}: EventRulesConsentProps) {
+    const checkbox = (
+        <div className="flex flex-col gap-2">
+            <Label className="flex items-start gap-3">
+                <Checkbox
+                    className="shrink-0"
+                    checked={false}
+                    disabled={isSubmitting}
+                    onCheckedChange={(checked) => {
+                        if (checked === true) onAccept();
+                    }}
+                />
+                <span>Jeg har lest og godtar arrangementsreglene</span>
+            </Label>
+            {error ? <AlertDescription>{error}</AlertDescription> : null}
+        </div>
+    );
+
+    if (variant === "inline") {
+        return (
+            <Alert>
+                <ScrollText className="size-4" />
+                <AlertTitle>Du må godkjenne arrangementsreglene</AlertTitle>
+                <AlertDescription className="flex flex-col gap-3">
+                    <span>
+                        {message ??
+                            "Gjør det nå, så er du klar når påmeldingen åpner."}
+                    </span>
+                    {checkbox}
+                    <RulesLink />
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    return (
+        <Alert>
+            <ScrollText className="size-4" />
+            <AlertTitle>Du må godkjenne arrangementsreglene</AlertTitle>
+            <AlertDescription className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <span>
+                    Uten dette kan du ikke melde deg på arrangementer. Godkjenn
+                    nå, så slipper du å miste en plass senere.
+                </span>
+                <div className="flex items-center gap-4">
+                    {checkbox}
+                    <RulesLink />
+                </div>
+            </AlertDescription>
+        </Alert>
+    );
+}
+
+function RulesLink() {
+    return (
+        <Button
+            size="sm"
+            variant="outline"
+            nativeButton={false}
+            render={
+                <a
+                    href={EVENT_RULES_URL}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                />
+            }
+        >
+            Les reglene
+        </Button>
+    );
+}

--- a/apps/kvark/src/hooks/use-event-rules-consent.ts
+++ b/apps/kvark/src/hooks/use-event-rules-consent.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { authQueryOptions, invalidateAuth } from "#/api/auth";
+import { updateUserSettingsMutation } from "#/api/queries/user";
+import { usePermission } from "#/hooks/use-permission";
+
+/**
+ * Om medlemmet mangler godkjenning av arrangementsreglene, og handlingen som
+ * fikser det.
+ *
+ * API-et avviser påmelding uten godkjenning, så dette må vises før
+ * påmeldingen åpner — ikke i det sekundet plassene slippes.
+ */
+export function useEventRulesConsent() {
+    const { data: session } = useQuery(authQueryOptions);
+    // Alumni og andre uten påmeldingsrett har ingen nytte av varselet — de
+    // stoppes uansett et annet sted.
+    const canRegister = usePermission("events:registrations:create");
+    const accept = useMutation(updateUserSettingsMutation);
+
+    const mustAccept =
+        Boolean(session) &&
+        canRegister &&
+        session?.user.settings?.acceptsEventRules !== true;
+
+    return {
+        mustAccept,
+        isSubmitting: accept.isPending,
+        error: accept.error
+            ? "Kunne ikke lagre godkjenningen. Prøv igjen."
+            : null,
+        async acceptEventRules() {
+            await accept.mutateAsync({ data: { acceptsEventRules: true } });
+            // Godkjenningen ligger i sesjonen, så den må hentes på nytt for at
+            // påmeldingsknappen skal dukke opp uten en refresh.
+            await invalidateAuth();
+        },
+    };
+}

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -123,6 +123,9 @@ export function registrationErrorMessage(error: unknown): string {
     if (message.includes("already registered")) {
         return "Du er allerede påmeldt. Last siden på nytt for å se påmeldingen din.";
     }
+    if (message.includes("accept the event rules")) {
+        return "Du må godkjenne arrangementsreglene før du kan melde deg på. Huk av i varselet over.";
+    }
     if (message.includes("priority pool")) {
         return "Dette arrangementet er forbeholdt medlemmer i en prioritert gruppe.";
     }

--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -2,15 +2,20 @@ import { Outlet, createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 
 import { authQueryOptions } from "#/api/auth";
+import { EventRulesConsent } from "#/components/event-rules-consent";
 import { SiteBottomBar } from "#/components/site-bottom-bar";
 import { SiteFooter } from "#/components/site-footer";
 import { SiteHeader } from "#/components/site-header";
 import { useSiteNavItems } from "#/components/site-nav-items";
+import { useEventRulesConsent } from "#/hooks/use-event-rules-consent";
 
 export const Route = createFileRoute("/_app")({ component: AppLayout });
 
 function AppLayout() {
     const { data: session } = useQuery(authQueryOptions);
+    // Vises over hele appen til reglene er godkjent, så ingen møter sperren
+    // først i det påmeldingen åpner.
+    const eventRules = useEventRulesConsent();
 
     const currentUser = session?.user
         ? {
@@ -29,6 +34,15 @@ function AppLayout() {
         // which only exists below md.
         <div className="flex min-h-screen flex-col pb-16 md:pb-0">
             <SiteHeader navItems={navItems} user={currentUser} />
+            {eventRules.mustAccept ? (
+                <div className="container mx-auto px-4 pt-4">
+                    <EventRulesConsent
+                        onAccept={eventRules.acceptEventRules}
+                        isSubmitting={eventRules.isSubmitting}
+                        error={eventRules.error}
+                    />
+                </div>
+            ) : null}
             <main className="flex flex-1 flex-col">
                 <Outlet />
             </main>

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -33,9 +33,11 @@ import { DetailsCard } from "#/components/details-card";
 import { EventQrDialog } from "#/components/event-qr-dialog";
 import { EventRegistrantsDialog } from "#/components/event-registrants-dialog";
 import { EventRegistrationCard } from "#/components/event-registration-card";
+import { EventRulesConsent } from "#/components/event-rules-consent";
 import { IconActionButton } from "#/components/icon-action-button";
 import { MapLink } from "#/components/map-link";
 import { ShareButton } from "#/components/share-button";
+import { useEventRulesConsent } from "#/hooks/use-event-rules-consent";
 import { useCanActOnResource } from "#/hooks/use-permission";
 import { buildGoogleCalendarUrl } from "#/lib/calendar-url";
 import { buildMapsUrls } from "#/lib/maps";
@@ -76,6 +78,7 @@ function EventDetailPage() {
         getEventRegistrationsQuery(event.id, 0),
     );
 
+    const eventRules = useEventRulesConsent();
     const registerMutation = useMutation(registerForEventMutation);
     const unregisterMutation = useMutation(unregisterFromEventMutation);
     const favoriteMutation = useMutation(updateFavoriteEventMutation);
@@ -335,6 +338,20 @@ function EventDetailPage() {
                             unregisterMutation.isPending
                         }
                         actionError={registrationError}
+                        requiresEventRulesConsent={eventRules.mustAccept}
+                        eventRulesSlot={
+                            <EventRulesConsent
+                                variant="inline"
+                                message={
+                                    registrationState === "not-open"
+                                        ? "Gjør det nå, så er du klar når påmeldingen åpner."
+                                        : "Huk av, så kan du melde deg på med én gang."
+                                }
+                                onAccept={eventRules.acceptEventRules}
+                                isSubmitting={eventRules.isSubmitting}
+                                error={eventRules.error}
+                            />
+                        }
                         waitlistPosition={
                             event.registration?.waitlistPosition ?? undefined
                         }

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2255,7 +2255,7 @@ export interface paths {
         head?: never;
         /**
          * Update user settings
-         * @description Partially update the authenticated user's settings. Only provided fields will be updated. User must have completed onboarding first.
+         * @description Partially update the authenticated user's settings. Only provided fields will be updated. Settings are created on first update for users who have not onboarded, so a member can accept the event rules without filling in a full profile.
          */
         patch: operations["updateUserSettings"];
         trace?: never;
@@ -5326,8 +5326,7 @@ export interface components {
             githubUrl?: string | "";
             linkedinUrl?: string | "";
             receiveMailCommunication?: boolean;
-            /** @default [] */
-            allergies: string[];
+            allergies?: string[];
         };
         UpdateUserSettingsInput: {
             /** @enum {string} */
@@ -5340,8 +5339,7 @@ export interface components {
             githubUrl?: string | "";
             linkedinUrl?: string | "";
             receiveMailCommunication?: boolean;
-            /** @default [] */
-            allergies: string[];
+            allergies?: string[];
         };
         Allergy: {
             /** @description Unique identifier for the allergy */
@@ -7112,7 +7110,7 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Event only allows members covered by a priority pool, or members of a specific institute, to register */
+            /** @description Forbidden - User has not accepted the event rules, or the event only allows members covered by a priority pool or members of a specific institute to register */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11624,13 +11622,6 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
-            };
-            /** @description Not Found - User settings do not exist (user needs to complete onboarding first) */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };


### PR DESCRIPTION
## Hva

Håndhever godkjenning av arrangementsreglene før påmelding — og, viktigere, varsler medlemmet i god tid før påmeldingen åpner, i stedet for i det sekundet plassene slippes.

## Hvorfor

`accepts_event_rules` ble migrert fra Lepton, men ingenting leste feltet: påmeldingsruta slapp alle gjennom uansett. Samtidig får nye medlemmer aldri en innstillingsrad i det hele tatt — ingenting oppretter den ved Feide- eller e-postinnlogging, og Kvark har ingen onboarding-flyt.

I Lepton måtte man innom profilen for å godkjenne, og mange oppdaget kravet først da de forsøkte å melde seg på sitt første arrangement. Da var plassen ofte tatt. Denne PR-en flytter både varselet og selve godkjenningen dit medlemmet allerede er.

## Endringer

**Backend**
- `POST /event/:id/registration` svarer 403 hvis reglene ikke er godkjent. Sjekken ligger før institutt- og prioriteringsreglene, så meldingen medlemmet får er den de kan gjøre noe med. Manglende innstillingsrad teller som «ikke godkjent» — reglene er et aktivt valg, og fraværet av ett kan ikke gi det.
- `PATCH /api/user/me/settings` er nå en upsert. Uten det kunne et medlem uten innstillingsrad aldri godkjenne: endepunktet svarte 404 med «complete onboarding first». Raden opprettes med `isOnboarded: false`, og onboarding sjekker nå det flagget i stedet for om raden finnes — så en regelgodkjenning ikke låser deg ute fra å svare på de faktiske spørsmålene senere.
- `allergies` er gjort valgfri i oppdateringsskjemaet. `.default([])` gjorde feltet påkrevd i den genererte SDK-typen, så enhver klient som endret én innstilling måtte sende hele allergilista på nytt — eller slette den ved et uhell.

**Frontend**
- Banner over hele appen for innloggede med påmeldingsrett som ikke har godkjent.
- Varsel i påmeldingskortet på arrangementssiden, også i tilstanden «påmelding åpner om …». Teksten tilpasser seg: «Gjør det nå, så er du klar når påmeldingen åpner» før åpning, «Huk av, så kan du melde deg på med én gang» etterpå.
- Avkryssingsboksen lagrer direkte, med lenke til [arrangementsreglene](https://wiki.tihlde.org/arrangementer). Ingen navigering til profilen.
- «Meld deg på» og «Sett meg på venteliste» skjules mens godkjenningen mangler — ventelista går gjennom samme påmelding og ville blitt avvist på samme grunnlag. Alumni og andre uten `events:registrations:create` ser ingenting.

## Verifisering

- Hele API-testsuiten grønn: 434 tester i 59 filer. Tre nye tester dekker 403 uten godkjenning, godkjenning → påmelding i samme flyt (dekker også upserten), og eksplisitt avslag.
- Eksisterende påmeldingstester godkjenner nå reglene først via en ny testhjelper. I prioriteringspool-testen er det gjort eksplisitt, slik at 403-en der fortsatt kommer fra pool-regelen.
- Manuelt i nettleseren som testbruker uten godkjenning: banner rett etter innlogging, varsel i påmeldingskortet på et arrangement som åpner om en måned, avkryssing fjernet begge umiddelbart og lot «Meld deg på» dukke opp. Bekreftet lagret i databasen. Også sjekket på mobil.
- `typecheck`, `lint` og `format` er rene.

## Verdt å vite for review

- Migrerte Lepton-brukere med `accepts_event_rules = false` blir nå faktisk stoppet — som i Lepton, men de ser det i god tid. Det kan være verdt å telle hvor mange det gjelder i prod før utrulling.
- Upsert-stien fyller `gender` med `"other"` og `receiveMailCommunication` med `true` som plassholdere, siden kolonnene er `NOT NULL`. `isOnboarded: false` gjør dem gjenkjennelige som «aldri besvart» framfor «besvart slik».

🤖 Generated with [Claude Code](https://claude.com/claude-code)