### PR TITLE
fix(assets): promoter opplastede bilder så de ikke blir slettet etter 2 døgn

### DIFF
--- a/apps/api/src/lib/asset/index.ts
+++ b/apps/api/src/lib/asset/index.ts
@@ -48,6 +48,44 @@ export async function getStagedAssetsForCleanup(
 }
 
 /**
+ * The asset key a stored URL refers to, or null when the URL points somewhere
+ * else (an external image, or the Azure blobs the old site used).
+ */
+export function assetKeyFromUrl(url: string): string | null {
+    try {
+        const { pathname } = new URL(url);
+        const marker = "/api/assets/";
+        const index = pathname.indexOf(marker);
+        if (index === -1) return null;
+
+        const key = decodeURIComponent(
+            pathname.slice(index + marker.length),
+        ).trim();
+        return key.length > 0 ? key : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Claim the uploaded assets a row now points at.
+ *
+ * Uploads land as "staged" and the cleanup cron deletes them two days later,
+ * so every URL a row stores has to be promoted or the picture vanishes from
+ * the page a couple of days after someone set it. URLs that are not our own
+ * assets are left alone.
+ */
+export async function promoteAssetUrls(
+    bucket: StorageService,
+    urls: (string | null | undefined)[],
+): Promise<void> {
+    for (const url of urls) {
+        const key = url ? assetKeyFromUrl(url) : null;
+        if (key) await bucket.promoteAsset(key);
+    }
+}
+
+/**
  * Delete an asset from both storage and database
  */
 export async function deleteAsset(

--- a/apps/api/src/lib/asset/references.ts
+++ b/apps/api/src/lib/asset/references.ts
@@ -1,0 +1,105 @@
+import { type DbSchema, schema } from "@photon/db";
+import { type SQL, getTableName, inArray, like, or, sql } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type { AnyPgColumn, PgTable } from "drizzle-orm/pg-core";
+import { assetKeyFromUrl } from "./index";
+
+/**
+ * Every column in the database that can point at an uploaded asset.
+ *
+ * Two shapes occur: some columns store the public URL
+ * (`https://…/api/assets/<key>`), others the raw S3 key. Both are matched.
+ *
+ * This list is the safety net behind {@link promoteAssetUrls}: the cleanup job
+ * consults it before deleting a staged asset, so a route that forgets to
+ * promote loses nothing. Keep it complete — `asset-references.test.ts` fails
+ * if a new column looks like it belongs here and is listed in neither this
+ * table nor {@link NON_ASSET_COLUMNS}.
+ */
+export const ASSET_REFERENCE_COLUMNS: AssetReference[] = [
+    ref(schema.event, schema.event.imageUrl),
+    ref(schema.news, schema.news.imageUrl),
+    ref(schema.jobPost, schema.jobPost.imageUrl),
+    ref(schema.galleryAlbum, schema.galleryAlbum.imageUrl),
+    ref(schema.galleryPicture, schema.galleryPicture.imageUrl),
+    ref(schema.toddel, schema.toddel.imageUrl),
+    ref(schema.toddel, schema.toddel.pdfUrl),
+    ref(schema.group, schema.group.imageUrl),
+    ref(schema.group, schema.group.logoUrl),
+    ref(schema.fine, schema.fine.image),
+    ref(schema.userSettings, schema.userSettings.imageUrl),
+    ref(schema.user, schema.user.image),
+    ref(schema.banner, schema.banner.url),
+    ref(schema.contract, schema.contract.fileKey),
+    ref(schema.contractSignature, schema.contractSignature.signedPdfKey),
+    ref(schema.contractSignature, schema.contractSignature.signatureFileKey),
+    ref(schema.application, schema.application.pdfAssetKey),
+    ref(schema.applicationAttachment, schema.applicationAttachment.assetKey),
+];
+
+/**
+ * Columns whose name looks asset-ish but that hold something else. Listed so
+ * the coverage test forces a decision on every new column rather than letting
+ * one slip through unnoticed.
+ */
+export const NON_ASSET_COLUMNS: Record<string, string> = {
+    "asset_file.key": "the asset itself, not a reference to one",
+    "asset_file.original_filename": "a display name, not a key",
+    "gallery_picture.source_url": "link to where the picture came from",
+    "user_settings.github_url": "external profile",
+    "user_settings.linkedin_url": "external profile",
+    "event_registration.allow_photo": "a consent flag, not a picture",
+    "auth_jwks.public_key": "signing key",
+    "auth_jwks.private_key": "signing key",
+    "auth_oauth_client.uri": "OAuth client metadata",
+    "auth_oauth_client.redirect_uris": "OAuth redirects",
+    "auth_oauth_client.post_logout_redirect_uris": "OAuth redirects",
+    "org_contract_signature.signed_pdf_hash": "checksum of the PDF",
+};
+
+export type AssetReference = {
+    table: PgTable;
+    column: AnyPgColumn;
+    /** "org_group.image_url", used in logs and in the coverage test. */
+    label: string;
+};
+
+function ref(table: PgTable, column: AnyPgColumn): AssetReference {
+    return { table, column, label: `${getTableName(table)}.${column.name}` };
+}
+
+/**
+ * Which of `keys` are still referenced by a row somewhere, and by what.
+ *
+ * Matching is on the raw key and on any URL ending in `/api/assets/<key>`, so
+ * it survives a change of hostname. A key containing `_` matches slightly more
+ * loosely than it should — LIKE reads it as a wildcard — which can only ever
+ * keep an asset alive that was about to be deleted, never the reverse.
+ */
+export async function findAssetReferences(
+    db: NodePgDatabase<DbSchema>,
+    keys: string[],
+): Promise<Map<string, string>> {
+    const found = new Map<string, string>();
+    if (keys.length === 0) return found;
+
+    for (const { table, column, label } of ASSET_REFERENCE_COLUMNS) {
+        const matches: SQL[] = [
+            inArray(column, keys),
+            ...keys.map((key) => like(column, `%/api/assets/${key}`)),
+        ];
+
+        const rows = await db
+            .select({ value: sql<string>`${column}` })
+            .from(table)
+            .where(or(...matches));
+
+        for (const { value } of rows) {
+            if (!value) continue;
+            const key = assetKeyFromUrl(value) ?? value;
+            if (!found.has(key)) found.set(key, label);
+        }
+    }
+
+    return found;
+}

--- a/apps/api/src/lib/asset/worker.ts
+++ b/apps/api/src/lib/asset/worker.ts
@@ -1,6 +1,7 @@
 import cron from "node-cron";
 import type { AppContext } from "~/lib/ctx";
 import { deleteAsset, getStagedAssetsForCleanup } from "./index";
+import { findAssetReferences } from "./references";
 
 /**
  * Number of days after which staged assets are eligible for cleanup
@@ -12,6 +13,71 @@ const STAGING_EXPIRY_DAYS = 2;
  */
 const CLEANUP_BATCH_SIZE = 100;
 
+export type CleanupResult = {
+    deleted: number;
+    rescued: number;
+    failed: number;
+};
+
+/**
+ * Delete staged assets nothing claimed, and rescue the ones something did.
+ *
+ * A staged asset that a row already points at is a route that forgot to
+ * promote — deleting it would break a live page, so it is promoted instead and
+ * logged loudly. That check is what makes a forgotten `promoteAssetUrls` a
+ * warning in the log rather than a picture that disappears two days later.
+ */
+export async function runAssetCleanup(ctx: AppContext): Promise<CleanupResult> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - STAGING_EXPIRY_DAYS);
+
+    const assets = await getStagedAssetsForCleanup(
+        ctx.db,
+        cutoff,
+        CLEANUP_BATCH_SIZE,
+    );
+
+    if (assets.length === 0) {
+        return { deleted: 0, rescued: 0, failed: 0 };
+    }
+
+    const referenced = await findAssetReferences(
+        ctx.db,
+        assets.map((asset) => asset.key),
+    );
+
+    let deleted = 0;
+    let rescued = 0;
+    let failed = 0;
+
+    for (const asset of assets) {
+        const referencedBy = referenced.get(asset.key);
+
+        if (referencedBy) {
+            await ctx.bucket.promoteAsset(asset.key);
+            rescued++;
+            console.warn(
+                `⚠️  Rescued staged asset ${asset.key}: still referenced by ${referencedBy}. Whatever wrote that row should promote the asset.`,
+            );
+            continue;
+        }
+
+        try {
+            await deleteAsset(ctx.bucket, asset.key);
+            deleted++;
+        } catch (error) {
+            failed++;
+            console.error(`Failed to delete asset ${asset.key}:`, error);
+        }
+    }
+
+    console.log(
+        `✅ Asset cleanup complete: ${deleted} deleted, ${rescued} rescued, ${failed} failed`,
+    );
+
+    return { deleted, rescued, failed };
+}
+
 /**
  * Start the asset cleanup cron job
  * Runs every hour at minute 15 to clean up staged assets older than 2 days
@@ -20,42 +86,7 @@ export function startAssetCleanupCron(ctx: AppContext): void {
     // Run at minute 15 of every hour
     cron.schedule("15 * * * *", async () => {
         try {
-            const cutoff = new Date();
-            cutoff.setDate(cutoff.getDate() - STAGING_EXPIRY_DAYS);
-
-            const assets = await getStagedAssetsForCleanup(
-                ctx.db,
-                cutoff,
-                CLEANUP_BATCH_SIZE,
-            );
-
-            if (assets.length === 0) {
-                return;
-            }
-
-            console.log(
-                `🧹 Cleaning up ${assets.length} staged asset(s) older than ${STAGING_EXPIRY_DAYS} days`,
-            );
-
-            let deleted = 0;
-            let failed = 0;
-
-            for (const asset of assets) {
-                try {
-                    await deleteAsset(ctx.bucket, asset.key);
-                    deleted++;
-                } catch (error) {
-                    failed++;
-                    console.error(
-                        `Failed to delete asset ${asset.key}:`,
-                        error,
-                    );
-                }
-            }
-
-            console.log(
-                `✅ Asset cleanup complete: ${deleted} deleted, ${failed} failed`,
-            );
+            await runAssetCleanup(ctx);
         } catch (error) {
             console.error("Error in asset cleanup cron:", error);
         }

--- a/apps/api/src/lib/gallery/index.ts
+++ b/apps/api/src/lib/gallery/index.ts
@@ -124,26 +124,6 @@ export async function findAlbumEvent(
     return found ?? null;
 }
 
-/**
- * The asset key a picture URL refers to, or null when the picture lives
- * somewhere else (e.g. the Azure blobs the old site used).
- */
-export function assetKeyFromUrl(imageUrl: string): string | null {
-    try {
-        const { pathname } = new URL(imageUrl);
-        const marker = "/api/assets/";
-        const index = pathname.indexOf(marker);
-        if (index === -1) return null;
-
-        const key = decodeURIComponent(
-            pathname.slice(index + marker.length),
-        ).trim();
-        return key.length > 0 ? key : null;
-    } catch {
-        return null;
-    }
-}
-
 /** Whether the given user created the album (used for ownership checks). */
 export async function isAlbumCreator(
     ctx: AppContext,

--- a/apps/api/src/lib/user/settings.ts
+++ b/apps/api/src/lib/user/settings.ts
@@ -2,6 +2,7 @@ import { genderVariants, userAllergy, userSettings } from "@photon/db/schema";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
+import { promoteAssetUrls } from "../asset";
 import type { AppContext } from "../ctx";
 
 export const UserAllergySchema = z.object({
@@ -89,6 +90,10 @@ export async function createUserSettings(
 ): Promise<UserSettings> {
     const { db } = ctx;
 
+    // The profile picture is staged until a row claims it; without this the
+    // cleanup cron deletes the file after two days.
+    await promoteAssetUrls(ctx.bucket, [settings.imageUrl]);
+
     // Use transaction for atomicity
     return await db.transaction(async (tx) => {
         // Create settings
@@ -128,6 +133,8 @@ export async function updateUserSettings(
     ctx: AppContext,
 ): Promise<UserSettings> {
     const { db } = ctx;
+
+    await promoteAssetUrls(ctx.bucket, [updates.imageUrl]);
 
     return await db.transaction(async (tx) => {
         // Separate allergies from other updates

--- a/apps/api/src/routes/event/create.ts
+++ b/apps/api/src/routes/event/create.ts
@@ -2,6 +2,7 @@ import { type DbSchema, schema } from "@photon/db";
 import { type InferInsertModel, eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
+import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { requireAccess } from "~/middleware/access";
 import { generateUniqueEventSlug } from "../../lib/event/slug";
@@ -30,7 +31,11 @@ export const createRoute = route().post(
     async (c) => {
         const body = c.req.valid("json");
         const userId = c.get("user").id;
-        const { db } = c.get("ctx");
+        const { db, bucket } = c.get("ctx");
+
+        // Uploaded pictures are staged until a row claims them; without this
+        // the cleanup cron deletes the file after two days.
+        await promoteAssetUrls(bucket, [body.imageUrl]);
 
         let createdEventId: string | undefined;
 

--- a/apps/api/src/routes/event/update.ts
+++ b/apps/api/src/routes/event/update.ts
@@ -2,6 +2,7 @@ import { type DbSchema, schema } from "@photon/db";
 import { type InferInsertModel, eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
+import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { requireAccess } from "~/middleware/access";
 import { isEventOwner } from "../../lib/event/middleware";
@@ -40,7 +41,11 @@ export const updateRoute = route().put(
         const body = c.req.valid("json");
         const eventId = c.req.param("id");
         const userId = c.get("user").id;
-        const { db } = c.get("ctx");
+        const { db, bucket } = c.get("ctx");
+
+        // Uploaded pictures are staged until a row claims them; without this
+        // the cleanup cron deletes the file after two days.
+        await promoteAssetUrls(bucket, [body.imageUrl]);
 
         const updatedSlug = await db.transaction(async (tx) => {
             // Fetch existing event

--- a/apps/api/src/routes/gallery/create.ts
+++ b/apps/api/src/routes/gallery/create.ts
@@ -6,6 +6,7 @@ import {
     generateUniqueAlbumSlug,
     serializeAlbum,
 } from "~/lib/gallery";
+import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -37,6 +38,10 @@ export const createRoute = route().post(
         const userId = c.get("user").id;
 
         const slug = await generateUniqueAlbumSlug(ctx, body.title);
+
+        // The cover is staged until a row claims it; without this the cleanup
+        // cron deletes the file after two days.
+        await promoteAssetUrls(ctx.bucket, [body.imageUrl]);
 
         const [album] = await ctx.db
             .insert(schema.galleryAlbum)

--- a/apps/api/src/routes/gallery/pictures/create.ts
+++ b/apps/api/src/routes/gallery/pictures/create.ts
@@ -2,7 +2,8 @@ import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
-import { assetKeyFromUrl, findAlbumBySlugOrId } from "~/lib/gallery";
+import { promoteAssetUrls } from "~/lib/asset";
+import { findAlbumBySlugOrId } from "~/lib/gallery";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -44,15 +45,12 @@ export const createPicturesRoute = route().post(
             throw new HTTPException(404, { message: "Fant ikke galleriet" });
         }
 
-        /**
-         * Uploads land in the asset store as "staged" and are deleted after
-         * two days unless something claims them. Promote the ones that point
-         * back at our own asset route, or every picture would disappear from
-         * the album two days after it was added.
-         */
-        for (const key of pictures.map((p) => assetKeyFromUrl(p.imageUrl))) {
-            if (key) await ctx.bucket.promoteAsset(key);
-        }
+        // Without this every picture disappears from the album two days after
+        // it was added.
+        await promoteAssetUrls(
+            ctx.bucket,
+            pictures.map((p) => p.imageUrl),
+        );
 
         const inserted = await ctx.db
             .insert(schema.galleryPicture)

--- a/apps/api/src/routes/gallery/update.ts
+++ b/apps/api/src/routes/gallery/update.ts
@@ -8,6 +8,7 @@ import {
     isAlbumCreator,
     serializeAlbum,
 } from "~/lib/gallery";
+import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -46,6 +47,10 @@ export const updateRoute = route().patch(
         if (!existing) {
             throw new HTTPException(404, { message: "Fant ikke galleriet" });
         }
+
+        // The cover is staged until a row claims it; without this the cleanup
+        // cron deletes the file after two days.
+        await promoteAssetUrls(ctx.bucket, [body.imageUrl]);
 
         const [album] = await ctx.db
             .update(schema.galleryAlbum)

--- a/apps/api/src/routes/groups/create.ts
+++ b/apps/api/src/routes/groups/create.ts
@@ -2,6 +2,7 @@ import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
+import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -28,7 +29,7 @@ export const createRoute = route().post(
     validator("json", createGroupSchema),
     async (c) => {
         const body = c.req.valid("json");
-        const { db } = c.get("ctx");
+        const { db, bucket } = c.get("ctx");
 
         // Check if slug already exists
         const existingGroup = await db
@@ -57,6 +58,9 @@ export const createRoute = route().post(
                 });
             }
         }
+
+        // Both pictures are staged uploads until something claims them.
+        await promoteAssetUrls(bucket, [body.imageUrl, body.logoUrl]);
 
         const [newGroup] = await db
             .insert(schema.group)

--- a/apps/api/src/routes/groups/fines/create.ts
+++ b/apps/api/src/routes/groups/fines/create.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { isGroupLeader } from "~/lib/group/middleware";
+import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -41,7 +42,7 @@ export const createFineRoute = route().post(
     validator("json", createFineSchema),
     async (c) => {
         const body = c.req.valid("json");
-        const { db } = c.get("ctx");
+        const { db, bucket } = c.get("ctx");
         const user = c.get("user");
 
         // Validate group exists and has fines activated
@@ -96,6 +97,10 @@ export const createFineRoute = route().post(
                 });
             }
         }
+
+        // Uploaded pictures are staged until a row claims them; without
+        // this the cleanup cron deletes the file after two days.
+        await promoteAssetUrls(bucket, [body.image]);
 
         // Create the fine
         const [created] = await db

--- a/apps/api/src/routes/groups/update.ts
+++ b/apps/api/src/routes/groups/update.ts
@@ -2,6 +2,7 @@ import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
+import { promoteAssetUrls } from "~/lib/asset";
 import { isGroupLeader } from "~/lib/group/middleware";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -42,7 +43,7 @@ export const updateRoute = route().patch(
     async (c) => {
         const body = c.req.valid("json");
         const slug = c.req.param("slug");
-        const { db } = c.get("ctx");
+        const { db, bucket } = c.get("ctx");
 
         // Check if group exists
         const existingGroup = await db
@@ -71,6 +72,11 @@ export const updateRoute = route().patch(
                 });
             }
         }
+
+        // Gruppebilde and logo are uploaded before this call and are still
+        // staged, so the cleanup cron would delete them two days later and
+        // leave the group's «Om»-side pointing at a 404.
+        await promoteAssetUrls(bucket, [body.imageUrl, body.logoUrl]);
 
         await db
             .update(schema.group)

--- a/apps/api/src/routes/job/create.ts
+++ b/apps/api/src/routes/job/create.ts
@@ -1,5 +1,6 @@
 import { schema } from "@photon/db";
 import { validator } from "hono-openapi";
+import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -28,7 +29,11 @@ export const createRoute = route().post(
     async (c) => {
         const body = c.req.valid("json");
         const userId = c.get("user").id;
-        const { db } = c.get("ctx");
+        const { db, bucket } = c.get("ctx");
+
+        // Uploaded pictures are staged until a row claims them; without
+        // this the cleanup cron deletes the file after two days.
+        await promoteAssetUrls(bucket, [body.imageUrl]);
 
         const [newJob] = await db
             .insert(schema.jobPost)

--- a/apps/api/src/routes/job/update.ts
+++ b/apps/api/src/routes/job/update.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { isJobCreator } from "~/lib/job/middleware";
+import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -35,7 +36,7 @@ export const updateRoute = route().patch(
     validator("json", updateJobSchema),
     async (c) => {
         const body = c.req.valid("json");
-        const { db } = c.get("ctx");
+        const { db, bucket } = c.get("ctx");
         const { id } = c.req.param();
 
         // Fetch the job posting for validation
@@ -108,6 +109,10 @@ export const updateRoute = route().patch(
         if (classEnd) {
             updateData.classEnd = classEnd as schema.UserClass;
         }
+
+        // Uploaded pictures are staged until a row claims them; without
+        // this the cleanup cron deletes the file after two days.
+        await promoteAssetUrls(bucket, [body.imageUrl]);
 
         const [updatedJob] = await db
             .update(schema.jobPost)

--- a/apps/api/src/routes/news/create.ts
+++ b/apps/api/src/routes/news/create.ts
@@ -1,5 +1,6 @@
 import { schema } from "@photon/db";
 import { validator } from "hono-openapi";
+import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -27,7 +28,11 @@ export const createRoute = route().post(
     async (c) => {
         const body = c.req.valid("json");
         const userId = c.get("user").id;
-        const { db } = c.get("ctx");
+        const { db, bucket } = c.get("ctx");
+
+        // Uploaded pictures are staged until a row claims them; without
+        // this the cleanup cron deletes the file after two days.
+        await promoteAssetUrls(bucket, [body.imageUrl]);
 
         const [newNews] = await db
             .insert(schema.news)

--- a/apps/api/src/routes/news/update.ts
+++ b/apps/api/src/routes/news/update.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { isNewsCreator } from "~/lib/news/middleware";
+import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -35,7 +36,7 @@ export const updateRoute = route().patch(
     validator("json", updateNewsSchema),
     async (c) => {
         const body = c.req.valid("json");
-        const { db } = c.get("ctx");
+        const { db, bucket } = c.get("ctx");
         const { id } = c.req.param();
 
         // Fetch the news article to verify it exists
@@ -48,6 +49,10 @@ export const updateRoute = route().patch(
                 message: "News article not found",
             });
         }
+
+        // Uploaded pictures are staged until a row claims them; without
+        // this the cleanup cron deletes the file after two days.
+        await promoteAssetUrls(bucket, [body.imageUrl]);
 
         // Update the news article
         const [updatedNews] = await db

--- a/apps/api/src/test/asset/asset-references.test.ts
+++ b/apps/api/src/test/asset/asset-references.test.ts
@@ -1,0 +1,130 @@
+import { schema } from "@photon/db";
+import { eq, getTableName, is } from "drizzle-orm";
+import { PgTable, getTableConfig } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+import {
+    ASSET_REFERENCE_COLUMNS,
+    NON_ASSET_COLUMNS,
+} from "~/lib/asset/references";
+import { runAssetCleanup } from "~/lib/asset/worker";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * Column names that might hold an uploaded file. Anything matching has to be
+ * classified — either it references an asset and the cleanup job must know
+ * about it, or it is something else and says so in NON_ASSET_COLUMNS.
+ */
+const SUSPICIOUS = /(^|_)(url|uri|uris|image|logo|photo|avatar|file|pdf|key)$/;
+
+describe("asset reference registry", () => {
+    it("classifies every column that could hold an uploaded file", () => {
+        const registered = new Set(ASSET_REFERENCE_COLUMNS.map((r) => r.label));
+        const unclassified: string[] = [];
+
+        for (const value of Object.values(schema)) {
+            if (!is(value, PgTable)) continue;
+
+            for (const column of getTableConfig(value).columns) {
+                const label = `${getTableName(value)}.${column.name}`;
+                if (!SUSPICIOUS.test(column.name)) continue;
+                if (registered.has(label)) continue;
+                if (label in NON_ASSET_COLUMNS) continue;
+                unclassified.push(label);
+            }
+        }
+
+        // A new column here means: add it to ASSET_REFERENCE_COLUMNS if it can
+        // hold an uploaded file, or to NON_ASSET_COLUMNS with a reason if not.
+        expect(unclassified).toEqual([]);
+    });
+
+    it("lists no column that has since been renamed or dropped", () => {
+        const existing = new Set<string>();
+
+        for (const value of Object.values(schema)) {
+            if (!is(value, PgTable)) continue;
+            for (const column of getTableConfig(value).columns) {
+                existing.add(`${getTableName(value)}.${column.name}`);
+            }
+        }
+
+        const stale = [
+            ...ASSET_REFERENCE_COLUMNS.map((r) => r.label),
+            ...Object.keys(NON_ASSET_COLUMNS),
+        ].filter((label) => !existing.has(label));
+
+        expect(stale).toEqual([]);
+    });
+});
+
+describe("staged asset cleanup", () => {
+    integrationTest(
+        "rescues a staged asset a row still points at instead of deleting it",
+        async ({ ctx }) => {
+            const { db, bucket } = ctx;
+
+            const author = await ctx.utils.createTestUser();
+
+            const key = "uploads/2026/01/orphaned-news-image.png";
+            await bucket.upload(key, Buffer.from("news picture"), {
+                originalFilename: "news.png",
+                contentType: "image/png",
+                uploadedById: author.id,
+            });
+
+            // A route that forgot to promote: the row points at the asset, but
+            // the asset is still staged and now older than the two-day window.
+            await db.insert(schema.news).values({
+                title: "Forgot to promote",
+                header: "…",
+                body: "…",
+                imageUrl: `https://photon.tihlde.org/api/assets/${key}`,
+                createdById: author.id,
+            });
+
+            const threeDaysAgo = new Date();
+            threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+            await db
+                .update(schema.asset)
+                .set({ createdAt: threeDaysAgo })
+                .where(eq(schema.asset.key, key));
+
+            const result = await runAssetCleanup(ctx);
+
+            expect(result.rescued).toBe(1);
+            expect(result.deleted).toBe(0);
+
+            // The file survives, and is now permanent.
+            expect(await bucket.exists(key)).toBe(true);
+            expect((await bucket.getAsset(key))?.status).toBe("ready");
+        },
+        600_000,
+    );
+
+    integrationTest(
+        "still deletes a staged asset nothing points at",
+        async ({ ctx }) => {
+            const { db, bucket } = ctx;
+
+            const key = "uploads/2026/01/nobody-wants-me.png";
+            await bucket.upload(key, Buffer.from("unclaimed"), {
+                originalFilename: "unclaimed.png",
+                contentType: "image/png",
+            });
+
+            const threeDaysAgo = new Date();
+            threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+            await db
+                .update(schema.asset)
+                .set({ createdAt: threeDaysAgo })
+                .where(eq(schema.asset.key, key));
+
+            const result = await runAssetCleanup(ctx);
+
+            expect(result.deleted).toBeGreaterThanOrEqual(1);
+            expect(await bucket.exists(key)).toBe(false);
+            expect(await bucket.getAsset(key)).toBeNull();
+        },
+        600_000,
+    );
+});

--- a/apps/api/src/test/groups/groups.test.ts
+++ b/apps/api/src/test/groups/groups.test.ts
@@ -1,3 +1,5 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
 import { describe, expect } from "vitest";
 import { integrationTest } from "~/test/config/integration";
 
@@ -364,6 +366,56 @@ describe("groups", () => {
 
                 const json = await response.json();
                 expect(json.message).toBe("Group updated successfully");
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "promotes gruppebilde and logo so the staging cleanup spares them",
+            async ({ ctx }) => {
+                const { db, bucket } = ctx;
+
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+                await ctx.utils.giveUserPermissions(user, ["groups:update"]);
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "picture-test",
+                });
+
+                const imageKey = await bucket.upload(
+                    "uploads/2026/08/gruppebilde.png",
+                    Buffer.from("wide photo"),
+                    {
+                        originalFilename: "gruppebilde.png",
+                        contentType: "image/png",
+                    },
+                );
+                const logoKey = await bucket.upload(
+                    "uploads/2026/08/logo.png",
+                    Buffer.from("square mark"),
+                    {
+                        originalFilename: "logo.png",
+                        contentType: "image/png",
+                    },
+                );
+
+                const response = await client.api.groups[":slug"].$patch({
+                    param: { slug: group.slug },
+                    json: {
+                        imageUrl: `http://localhost/api/assets/${imageKey}`,
+                        logoUrl: `http://localhost/api/assets/${logoKey}`,
+                    },
+                });
+
+                expect(response.status).toBe(200);
+
+                const promoted = await db.query.asset.findMany({
+                    where: eq(schema.asset.status, "ready"),
+                });
+                expect(promoted.map((a) => a.key)).toEqual(
+                    expect.arrayContaining([imageKey, logoKey]),
+                );
             },
             500_000,
         );


### PR DESCRIPTION
## Problemet

Gruppebildene under «Om»-taben forsvant — for **index** og **nok** var filene borte fra bucketen mens `org_group.image_url` fortsatt pekte på dem (bekreftet: begge URL-ene ga 404 i prod, mens logoene fra Lepton-importen ga 200).

Opplastinger havner i `asset_file` som `staged`, og cron-jobben i `lib/asset/worker.ts` sletter alt som fortsatt er staged etter 2 døgn — både S3-objektet og raden. En ressurs som lenker til en fil må derfor kalle `promoteAsset`. Töddel, galleribilder, kontrakter og søknader gjorde det; `PATCH /api/groups/:slug` skrev bare URL-en rett i tabellen.

Ved gjennomgang av hele schemaet viste det seg å gjelde flere skrivestier enn grupper.

## Hva som er rettet

Ny hjelper `promoteAssetUrls()` i `lib/asset`, kalt fra hver skrivesti som lagrer en opplastet URL:

| Rute | Kolonne |
|---|---|
| `groups/create.ts`, `groups/update.ts` | `org_group.image_url`, `logo_url` |
| `event/create.ts`, `event/update.ts` | `event.image_url` |
| `news/create.ts`, `news/update.ts` | `news_news.image_url` |
| `job/create.ts`, `job/update.ts` | `job_post.image_url` |
| `gallery/create.ts`, `gallery/update.ts` | albumcover `gallery_album.image_url` |
| `groups/fines/create.ts` | bevisbilde `org_fine.image` |
| `lib/user/settings.ts` (create + update) | profilbilde `user_settings.image_url` |

Allerede riktige og verifisert uendret: Töddel, galleribilder, kontrakter (`create` + `sign`), søknader. `gallery/pictures/update.ts` og `fines/update.ts` tar ikke imot bilde-URL, så der er det ingenting å promotere.

`assetKeyFromUrl` er flyttet fra `lib/gallery` til `lib/asset` — galleriet var eneste bruker, og nå deles den.

## Sikring mot at det gjentar seg

Ett kall per rute fikser dagens feil, men ikke neste rute noen skriver. Derfor to lag til:

**1. Backstop i opprydningsjobben.** `lib/asset/references.ts` lister alle 18 kolonnene i databasen som kan peke på et asset. `runAssetCleanup()` slår opp hver staged nøkkel mot dem før sletting — er den fortsatt referert, blir assetet **promotert i stedet for slettet**, med `⚠️ Rescued staged asset …: still referenced by <kolonne>` i loggen. Matching skjer på både rå nøkkel og enhver URL som slutter på `/api/assets/<key>`, så den tåler at hostnavnet endres. En glemt promotering blir dermed en loggmelding, ikke et bilde som forsvinner.

**2. Dekningstest mot schemaet.** Går gjennom alle tabeller og feiler hvis en kolonne som ser ut som den kan holde en fil (`*_url`, `*_image`, `*_key`, `*_pdf`, `*_file`, …) verken står i registeret eller i `NON_ASSET_COLUMNS` med en begrunnelse. En ny bildekolonne kan da ikke legges til uten at noen tar stilling.

Cleanup-løkka er flyttet ut av cron-callbacken til `runAssetCleanup()` så testene kan kjøre den direkte.

## Verifisering

Begge sikringene er falsifisert, ikke bare kjørt grønt:

- fjernet `news.imageUrl` fra registeret → dekningstesten feiler med `news_news.image_url`
- slo av rescue-grenen → rescue-testen feiler med `expected +0 to be 1`
- kommenterte ut promoteringen i `groups/update.ts` → den nye gruppetesten feiler med `expected [] to deeply equal ArrayContaining`

**436/436 tester** grønne (59 filer), typecheck, build og format rene, ingen nye lint-feil.

## For deployen

Første cron-kjøring etter deploy (hver time, :15) rescuer alt som ligger staged og fortsatt er referert — altså alt som er lastet opp de siste to døgnene og ellers ville forsvunnet. Verdt å se etter `⚠️ Rescued staged asset` i Grafana; hver slik linje er en skrivesti som fortsatt mangler promotering.

Gruppebildene til index og nok er permanent tapt — filene er slettet fra bucketen og må lastes opp på nytt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)