### PR TITLE
feat(grupper): private grupper er bare for medlemmene

### DIFF
--- a/apps/api/src/lib/group/index.ts
+++ b/apps/api/src/lib/group/index.ts
@@ -8,7 +8,7 @@
  * - Checking if users can manage group resources
  */
 
-import { hasPermission } from "@photon/auth/rbac";
+import { hasPermission, hasScopedPermission } from "@photon/auth/rbac";
 import {
     assignUserRole,
     getRoleById,
@@ -17,6 +17,7 @@ import {
 import { type DbSchema, schema } from "@photon/db";
 import { type InferSelectModel, and, eq, inArray } from "drizzle-orm";
 import type { AppContext } from "~/lib/ctx";
+import { HTTPAppException } from "~/lib/errors";
 
 /**
  * Group types whose membership is a projection of Feide, not an editable list.
@@ -34,6 +35,63 @@ const DERIVED_GROUP_TYPES = new Set(["study", "studyyear"]);
 /** True when membership of this group is derived and must not be hand-edited. */
 export function isDerivedGroupType(type: string): boolean {
     return DERIVED_GROUP_TYPES.has(type.toLowerCase());
+}
+
+/**
+ * Group types whose page is for members only.
+ *
+ * A `PRIVATE` group is not a group the organisation presents outwards — the
+ * digital transformasjon-faddergruppa is the standing example. Its name still
+ * shows up wherever memberships are listed (a profile says which groups the
+ * person is in), but the page itself, the roster and the verv are the members'
+ * own. Everything that reads them therefore goes through
+ * {@link assertGroupVisible}.
+ *
+ * Compared case-insensitively: the column is a varchar rather than the
+ * `groupType` enum, and the rows migrated from Lepton are upper case.
+ */
+const PRIVATE_GROUP_TYPES = new Set(["private"]);
+
+/** True when only the group's own members may open it. */
+export function isPrivateGroupType(type: string): boolean {
+    return PRIVATE_GROUP_TYPES.has(type.toLowerCase());
+}
+
+/**
+ * Whether `userId` may read a private group's page, roster and verv.
+ *
+ * Members always may. `groups:manage` — globally or scoped to this group — is
+ * the only way in from the outside, and it exists so the admin panel keeps
+ * working; no ordinary member, and nobody signed out, gets past this.
+ */
+export async function canViewGroup(
+    ctx: AppContext,
+    group: { slug: string; type: string },
+    userId: string | null | undefined,
+): Promise<boolean> {
+    if (!isPrivateGroupType(group.type)) return true;
+    if (!userId) return false;
+    if (await isGroupMember(ctx, userId, group.slug)) return true;
+
+    return hasScopedPermission(
+        ctx,
+        userId,
+        "groups:manage",
+        `group:${group.slug}`,
+    );
+}
+
+/** {@link canViewGroup}, as a guard: throws 403 instead of returning false. */
+export async function assertGroupVisible(
+    ctx: AppContext,
+    group: { slug: string; type: string },
+    userId: string | null | undefined,
+): Promise<void> {
+    if (await canViewGroup(ctx, group, userId)) return;
+
+    throw HTTPAppException.Forbidden(
+        "Denne gruppen er privat — bare medlemmene har tilgang.",
+    );
 }
 
 /**

--- a/apps/api/src/routes/groups/form/list.ts
+++ b/apps/api/src/routes/groups/form/list.ts
@@ -2,6 +2,7 @@ import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import { userHasSubmitted } from "~/lib/form/service";
+import { assertGroupVisible } from "~/lib/group";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
@@ -21,10 +22,14 @@ export const listGroupFormsRoute = route().get(
             description: "Success",
         })
         .notFound({ description: "Group not found" })
+        .forbidden({
+            description: "The group is private and you are not a member",
+        })
         .build(),
     requireAuth,
     async (c) => {
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const user = c.get("user");
         const groupSlug = c.req.param("slug");
 
@@ -44,6 +49,8 @@ export const listGroupFormsRoute = route().get(
                 message: "Group not found",
             });
         }
+
+        await assertGroupVisible(ctx, group, user.id);
 
         // Check if user is group leader or member
         const membership = await db.query.groupMembership.findFirst({

--- a/apps/api/src/routes/groups/get.ts
+++ b/apps/api/src/routes/groups/get.ts
@@ -1,6 +1,8 @@
 import { HTTPException } from "hono/http-exception";
+import { assertGroupVisible } from "~/lib/group";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
+import { captureAuth } from "~/middleware/auth";
 import { groupSchema } from "./schema";
 
 export const getRoute = route().get(
@@ -20,9 +22,14 @@ export const getRoute = route().get(
         .notFound({
             description: "Group with the specified slug does not exist",
         })
+        .forbidden({
+            description: "The group is private and you are not a member",
+        })
         .build(),
+    captureAuth,
     async (c) => {
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const slug = c.req.param("slug");
 
         const group = await db.query.group.findFirst({
@@ -34,6 +41,8 @@ export const getRoute = route().get(
                 message: `Group with slug "${slug}" not found`,
             });
         }
+
+        await assertGroupVisible(ctx, group, c.get("user")?.id);
 
         return c.json(group);
     },

--- a/apps/api/src/routes/groups/members/history.ts
+++ b/apps/api/src/routes/groups/members/history.ts
@@ -1,8 +1,10 @@
 import { schema } from "@photon/db";
 import { desc, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
+import { assertGroupVisible } from "~/lib/group";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
+import { captureAuth } from "~/middleware/auth";
 import { formerMemberListSchema } from "../schema";
 
 export const listFormerMembersRoute = route().get(
@@ -20,9 +22,14 @@ export const listFormerMembersRoute = route().get(
             description: "List of former members retrieved successfully",
         })
         .notFound({ description: "Group not found" })
+        .forbidden({
+            description: "The group is private and you are not a member",
+        })
         .build(),
+    captureAuth,
     async (c) => {
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const groupSlug = c.req.param("groupSlug");
 
         const group = await db
@@ -37,6 +44,8 @@ export const listFormerMembersRoute = route().get(
                 message: `Group with slug "${groupSlug}" not found`,
             });
         }
+
+        await assertGroupVisible(ctx, group, c.get("user")?.id);
 
         const entries = await db.query.groupMembershipHistory.findMany({
             where: eq(schema.groupMembershipHistory.groupSlug, groupSlug),

--- a/apps/api/src/routes/groups/members/list.ts
+++ b/apps/api/src/routes/groups/members/list.ts
@@ -1,6 +1,7 @@
 import { schema } from "@photon/db";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
+import { assertGroupVisible } from "~/lib/group";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import {
@@ -8,6 +9,7 @@ import {
     type UserStudy,
     deriveStudyFromGroups,
 } from "~/lib/user/study";
+import { captureAuth } from "~/middleware/auth";
 import { memberListSchema } from "../schema";
 
 export const listMembersRoute = route().get(
@@ -24,9 +26,14 @@ export const listMembersRoute = route().get(
             description: "List of members retrieved successfully",
         })
         .notFound({ description: "Group not found" })
+        .forbidden({
+            description: "The group is private and you are not a member",
+        })
         .build(),
+    captureAuth,
     async (c) => {
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const groupSlug = c.req.param("groupSlug");
 
         // Validate group exists
@@ -42,6 +49,8 @@ export const listMembersRoute = route().get(
                 message: `Group with slug "${groupSlug}" not found`,
             });
         }
+
+        await assertGroupVisible(ctx, group, c.get("user")?.id);
 
         // Get members with their public user info (name/image for display)
         const members = await db.query.groupMembership.findMany({

--- a/apps/api/src/routes/groups/positions/list.ts
+++ b/apps/api/src/routes/groups/positions/list.ts
@@ -1,6 +1,7 @@
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
+import { assertGroupVisible } from "~/lib/group";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
@@ -21,14 +22,18 @@ export const listPositionsRoute = route().get(
             description: "List of positions",
         })
         .notFound({ description: "Group not found" })
+        .forbidden({
+            description: "The group is private and you are not a member",
+        })
         .build(),
     requireAuth,
     async (c) => {
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const groupSlug = c.req.param("groupSlug");
 
         const [group] = await db
-            .select({ slug: schema.group.slug })
+            .select({ slug: schema.group.slug, type: schema.group.type })
             .from(schema.group)
             .where(eq(schema.group.slug, groupSlug))
             .limit(1);
@@ -38,6 +43,8 @@ export const listPositionsRoute = route().get(
                 message: `Group with slug "${groupSlug}" not found`,
             });
         }
+
+        await assertGroupVisible(ctx, group, c.get("user").id);
 
         const positions = await db.query.groupPosition.findMany({
             where: eq(schema.groupPosition.groupSlug, groupSlug),

--- a/apps/api/src/test/groups/groups.test.ts
+++ b/apps/api/src/test/groups/groups.test.ts
@@ -1,3 +1,4 @@
+import { schema } from "@photon/db";
 import { describe, expect } from "vitest";
 import { integrationTest } from "~/test/config/integration";
 
@@ -280,6 +281,131 @@ describe("groups", () => {
                 const response = await client(`/api/groups/${group.slug}`);
 
                 expect(response.status).toBe(200);
+            },
+            500_000,
+        );
+    });
+
+    /**
+     * A `private` group is the members' own — the digital
+     * transformasjon-faddergruppa is the standing example. Its name still
+     * appears wherever memberships are listed, so the page and the roster are
+     * what actually have to be closed.
+     */
+    describe("private groups", () => {
+        integrationTest(
+            "a member may open a private group and see its roster",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "private-member-group",
+                    type: "PRIVATE",
+                });
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: user.id,
+                    groupSlug: group.slug,
+                    role: "member",
+                });
+
+                const detail = await client.api.groups[":slug"].$get({
+                    param: { slug: group.slug },
+                });
+                expect(detail.status).toBe(200);
+
+                const members = await client.api.groups[
+                    ":groupSlug"
+                ].members.$get({ param: { groupSlug: group.slug } });
+                expect(members.status).toBe(200);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "a signed-in non-member is refused the group and its roster",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "private-outsider-group",
+                    type: "PRIVATE",
+                });
+
+                const detail = await client.api.groups[":slug"].$get({
+                    param: { slug: group.slug },
+                });
+                expect(detail.status).toBe(403);
+
+                const members = await client.api.groups[
+                    ":groupSlug"
+                ].members.$get({ param: { groupSlug: group.slug } });
+                expect(members.status).toBe(403);
+
+                const former = await client.api.groups[
+                    ":groupSlug"
+                ].members.history.$get({ param: { groupSlug: group.slug } });
+                expect(former.status).toBe(403);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "a signed-out visitor is refused a private group",
+            async ({ ctx }) => {
+                const group = await ctx.utils.createTestGroup({
+                    slug: "private-anonymous-group",
+                    type: "PRIVATE",
+                });
+
+                const response = await ctx.app.request(
+                    `/api/groups/${group.slug}`,
+                );
+
+                expect(response.status).toBe(403);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "groups:manage still opens a private group, so the admin panel works",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+                await ctx.utils.giveUserPermissions(user, ["groups:manage"]);
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "private-admin-group",
+                    type: "PRIVATE",
+                });
+
+                const response = await client.api.groups[":slug"].$get({
+                    param: { slug: group.slug },
+                });
+
+                expect(response.status).toBe(200);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "groups:view — which every member holds — does not open one",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+                await ctx.utils.giveUserPermissions(user, ["groups:view"]);
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "private-viewer-group",
+                    type: "PRIVATE",
+                });
+
+                const response = await client.api.groups[":slug"].$get({
+                    param: { slug: group.slug },
+                });
+
+                expect(response.status).toBe(403);
             },
             500_000,
         );

--- a/apps/kvark/src/components/profile-membership-card.tsx
+++ b/apps/kvark/src/components/profile-membership-card.tsx
@@ -14,6 +14,12 @@ type ProfileMembershipCardProps = {
     role: string;
     /** «Medlem 2023–2025» for avsluttede medlemskap. Utelates for aktive. */
     period?: string;
+    /**
+     * Om gruppesiden er åpen for den som ser på. Privat gruppe man ikke er
+     * medlem av svarer 403, så da vises kortet uten lenke i stedet for å sende
+     * folk til en feilmelding.
+     */
+    canOpen?: boolean;
 };
 
 /**
@@ -27,12 +33,17 @@ export function ProfileMembershipCard({
     logoUrl,
     role,
     period,
+    canOpen = true,
 }: ProfileMembershipCardProps) {
     return (
         <Card
             size="sm"
             className="flex-row items-center gap-3 px-3"
-            render={<Link to="/grupper/$slug" params={{ slug }} />}
+            render={
+                canOpen ? (
+                    <Link to="/grupper/$slug" params={{ slug }} />
+                ) : undefined
+            }
         >
             <Avatar className="size-10 shrink-0">
                 {logoUrl ? (

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -101,6 +101,21 @@ export function groupTypeLabel(type: string): string {
 }
 
 /**
+ * Om gruppa bare er for medlemmene sine.
+ *
+ * En PRIVAT gruppe (digital transformasjon-faddergruppa er eksempelet) står
+ * fortsatt oppført der medlemskap listes, men siden, medlemslista og vervene
+ * svarer 403 for alle andre enn medlemmene. Bruk denne til å la være å lenke
+ * dit i stedet for å sende folk til en feilmelding.
+ *
+ * Case-insensitiv: typen er en fritekstkolonne, og radene fra Lepton er
+ * store bokstaver.
+ */
+export function isPrivateGroupType(type: string): boolean {
+    return type.toUpperCase() === "PRIVATE";
+}
+
+/**
  * Format an ISO timestamp as a Norwegian long date, e.g. "tor. 30. apr. 2026".
  */
 export function formatGroupDate(iso: string): string {

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -1,5 +1,14 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { Link, createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { Button } from "@tihlde/ui/ui/button";
+import {
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from "@tihlde/ui/ui/empty";
+import { LockIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { z } from "zod";
 
@@ -71,11 +80,54 @@ const searchSchema = z.object({
 export const Route = createFileRoute("/_app/grupper/$slug")({
     component: GroupDetailPage,
     validateSearch: searchSchema,
-    loader: ({ context, params }) =>
-        context.queryClient.ensureQueryData(getGroupBySlugQuery(params.slug)),
+    loader: async ({ context, params }) => {
+        try {
+            await context.queryClient.ensureQueryData(
+                getGroupBySlugQuery(params.slug),
+            );
+            return { restricted: false };
+        } catch (error) {
+            // Private grupper svarer 403 for alle andre enn medlemmene. Det
+            // avgjøres her og ikke i en errorComponent fordi statuskoden ikke
+            // overlever hydreringen — bare selve feilmeldingen gjør det.
+            if (errorStatus(error) === 403) return { restricted: true };
+            throw error;
+        }
+    },
 });
 
+/** HTTP-statusen bak en feil fra API-klienten, om den finnes. */
+function errorStatus(error: unknown): number | undefined {
+    const response = (error as { response?: { status?: number } })?.response;
+    return typeof response?.status === "number" ? response.status : undefined;
+}
+
+/** Vist i stedet for gruppesiden når gruppa er privat og du står utenfor. */
+function GroupRestricted() {
+    return (
+        <Empty>
+            <EmptyHeader>
+                <EmptyMedia variant="icon">
+                    <LockIcon />
+                </EmptyMedia>
+                <EmptyTitle>Privat gruppe</EmptyTitle>
+                <EmptyDescription>
+                    Denne gruppen er bare for medlemmene sine.
+                </EmptyDescription>
+            </EmptyHeader>
+            <Button render={<Link to="/grupper" />}>Se alle grupper</Button>
+        </Empty>
+    );
+}
+
 function GroupDetailPage() {
+    const { restricted } = Route.useLoaderData();
+    // Egen komponent: den henter gruppa med useSuspenseQuery, som ville kastet
+    // den samme 403-en på nytt hvis den ble montert her.
+    return restricted ? <GroupRestricted /> : <GroupDetail />;
+}
+
+function GroupDetail() {
     const { slug } = Route.useParams();
     const { tab: active } = Route.useSearch();
     const navigate = Route.useNavigate();

--- a/apps/kvark/src/routes/_app/profil/$id/medlemskap.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/medlemskap.tsx
@@ -1,7 +1,7 @@
-import { authQueryOptions } from "#/api/auth";
+import { authQueryOptions, sessionHasScopedPermission } from "#/api/auth";
 import { getUserProfileQuery } from "#/api/queries/user";
 import { ProfileMembershipCard } from "#/components/profile-membership-card";
-import { groupTypeLabel } from "#/lib/group";
+import { groupTypeLabel, isPrivateGroupType } from "#/lib/group";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
@@ -42,6 +42,21 @@ function RouteComponent() {
     const { data: session } = useQuery(authQueryOptions);
     const isOwnProfile = session?.user.id === id;
 
+    /**
+     * Om den som ser på kan åpne gruppesiden. Speiler `assertGroupVisible` i
+     * API-et: en privat gruppe er bare for medlemmene, og `groups:manage` er
+     * eneste vei inn utenfra. Uten dette lenker profilen til en 403.
+     */
+    const canOpenGroup = (group: { slug: string; type: string }): boolean => {
+        if (!isPrivateGroupType(group.type)) return true;
+        if (session?.groups?.some((g) => g.slug === group.slug)) return true;
+        return sessionHasScopedPermission(
+            session?.permissions,
+            "groups:manage",
+            `group:${group.slug}`,
+        );
+    };
+
     // study/studyyear er avledede grupper (projeksjon av Feide-data) og vises
     // ved profilbildet, ikke i medlemskapslisten. TIHLDE er ingen gruppe man
     // melder seg inn i – alle er med – så den skal heller ikke vises her.
@@ -81,6 +96,7 @@ function RouteComponent() {
                                 typeLabel={groupTypeLabel(group.type)}
                                 logoUrl={group.logoUrl}
                                 role={group.role}
+                                canOpen={canOpenGroup(group)}
                             />
                         </li>
                     ))}
@@ -105,6 +121,7 @@ function RouteComponent() {
                                         group.startedAt,
                                         group.endedAt,
                                     )}
+                                    canOpen={canOpenGroup(group)}
                                 />
                             </li>
                         ))}

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -8624,6 +8624,13 @@ export interface operations {
                     "application/json": components["schemas"]["Group"];
                 };
             };
+            /** @description Forbidden - The group is private and you are not a member */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Not Found - Group with the specified slug does not exist */
             404: {
                 headers: {
@@ -9188,6 +9195,13 @@ export interface operations {
                     "application/json": components["schemas"]["GroupFormerMemberList"];
                 };
             };
+            /** @description Forbidden - The group is private and you are not a member */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Not Found - Group not found */
             404: {
                 headers: {
@@ -9216,6 +9230,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["GroupMemberList"];
                 };
+            };
+            /** @description Forbidden - The group is private and you are not a member */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Not Found - Group not found */
             404: {
@@ -9383,6 +9404,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
+            };
+            /** @description Forbidden - The group is private and you are not a member */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Not Found - Group not found */
             404: {
@@ -9698,6 +9726,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
+            };
+            /** @description Forbidden - The group is private and you are not a member */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Not Found - Group not found */
             404: {


### PR DESCRIPTION
## Hvorfor

Digital transformasjon-faddergruppa (`digitaltransformasjonfaddergruppe`, 29 medlemmer) kunne åpnes av hvem som helst — også utloggede — via lenken fra profilsiden til et medlem. Gruppa skal bare være for de som går digital transformasjon.

Gruppetypen `PRIVATE` fantes allerede i skjemaet, men ingenting håndhevet den. Regelen er derfor lagt på typen i stedet for på én slug — det er det typen er til for.

> Merk: det finnes to grupper med dette navnet. `digital-samhandling` (`STUDY`) er studieretningen og lenkes ikke fra profilsider. Det er `digitaltransformasjonfaddergruppe` (`PRIVATE`) som var åpen.

## Hva som er endret

**API** — ny `assertGroupVisible` i `apps/api/src/lib/group/index.ts`. En `PRIVATE` gruppe krever medlemskap på:

- `GET /api/groups/:slug`
- `GET /api/groups/:slug/members`
- `GET /api/groups/:slug/members/history`
- `GET /api/groups/:slug/positions`
- `GET /api/groups/:slug/forms`

Bøter og lovverk var allerede medlemslåst. De tre offentlige endepunktene har fått `captureAuth` så de kjenner igjen en innlogget bruker uten å kreve innlogging for vanlige grupper.

**Kvark** — kortet på profilens medlemskapsfane rendres uten lenke når du står utenfor, og en direkte URL gir en «Privat gruppe»-side i stedet for en rå feilside.

## Til reviewer

**`groups:manage` slipper inn.** Globalt eller scopet til gruppa. Uten det knekker admin-panelet, som lister og redigerer alle grupper. `groups:view` — som hver eneste aktive student har via `member`-rollen — åpner ingenting. Si fra hvis heller ikke admin skal komme inn.

**Gruppa står fortsatt i `GET /api/groups`.** Navn og medlemstall er synlig der. Admin-panelet, arrangementsprioritering (`admin/arrangementer`) og rollestyring bygger alle på den lista, så å filtrere den ville tatt bort arbeid folk har lov til å gjøre. Selve gruppa er utilgjengelig, men navnet er ikke skjult.

**403-en leses i loaderen, ikke i en `errorComponent`.** Statuskoden overlever ikke hydreringen — bare feilmeldingen gjør det — så en `errorComponent` viste riktig tekst under SSR og feil tekst etter hydrering. Loaderen fanger 403 og returnerer `{ restricted: true }`, som serialiseres greit.

## Verifisering

- 5 nye integrasjonstester i `apps/api/src/test/groups/groups.test.ts`: medlem inn, innlogget ikke-medlem ut (detalj + medlemmer + historikk), utlogget ut, `groups:manage` inn, `groups:view` ut. Hele `src/test/groups`: 106/106 grønn.
- Manuelt i nettleseren mot lokal API og ekte data: utlogget → «Privat gruppe»-siden; innlogget uten rettigheter → kortet på et digtrans-medlems profil er der men uten lenke, mens Promo og JenteKom fortsatt er klikkbare; samme bruker lagt inn som medlem → gruppa og medlemslista åpner som før. Testbruker og testmedlemskap slettet igjen.
- `bun run typecheck`, `bun run lint` og `bun run format` grønne. `packages/sdk/src/generated/openapi.ts` er regenerert med 403-svarene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)