### PR TITLE
feat(admin): animer gruppe-accordion og gi hele adminpanelet inngangsmotion

### DIFF
--- a/apps/kvark/src/routes/admin/_super-admin/api-keys.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/api-keys.tsx
@@ -41,6 +41,8 @@ import {
     regenerateApiKeyMutation,
     updateApiKeyMutation,
 } from "#/api/queries/api-keys";
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 
@@ -58,7 +60,11 @@ function ApiKeysPage() {
     const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="API Nøkler"
                 description="Nøkler gir tjenester programmatisk tilgang til API-et. Hemmeligheten vises kun én gang."
@@ -94,7 +100,7 @@ function ApiKeysPage() {
                 secret={revealedSecret}
                 onClose={() => setRevealedSecret(null)}
             />
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/_super-admin/database.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/database.tsx
@@ -4,6 +4,8 @@ import { DatabaseIcon } from "lucide-react";
 import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent } from "@tihlde/ui/ui/card";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 
@@ -14,7 +16,11 @@ export const Route = createFileRoute("/admin/_super-admin/database")({
 
 function DatabaseViewerPage() {
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Database Viewer"
                 description="Inspiser databasen direkte for feilsøking."
@@ -42,6 +48,6 @@ function DatabaseViewerPage() {
                     </AdminEmptyState>
                 </CardContent>
             </Card>
-        </div>
+        </Stagger>
     );
 }

--- a/apps/kvark/src/routes/admin/_super-admin/logs.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/logs.tsx
@@ -3,6 +3,8 @@ import { LogsIcon } from "lucide-react";
 
 import { Card, CardContent } from "@tihlde/ui/ui/card";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 
@@ -13,7 +15,11 @@ export const Route = createFileRoute("/admin/_super-admin/logs")({
 
 function LogsPage() {
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Logs"
                 description="Applikasjons- og revisjonslogger."
@@ -28,6 +34,6 @@ function LogsPage() {
                     />
                 </CardContent>
             </Card>
-        </div>
+        </Stagger>
     );
 }

--- a/apps/kvark/src/routes/admin/_super-admin/oauth-clients.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/oauth-clients.tsx
@@ -31,6 +31,7 @@ import {
     TableRow,
 } from "@tihlde/ui/ui/table";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import { Stagger } from "@tihlde/ui/ui/motion";
 
 import {
     createOAuthClientMutation,
@@ -80,7 +81,11 @@ function OAuthClientsPage() {
     }
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <div className="flex items-end justify-between gap-4">
                 <div className="flex flex-col gap-1">
                     <h1 className="text-3xl">OAuth-klienter</h1>
@@ -118,7 +123,7 @@ function OAuthClientsPage() {
                 secret={revealedSecret}
                 onClose={() => setRevealedSecret(null)}
             />
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/annonser.tsx
+++ b/apps/kvark/src/routes/admin/annonser.tsx
@@ -44,6 +44,8 @@ import {
 } from "@tihlde/ui/ui/table";
 import { Textarea } from "@tihlde/ui/ui/textarea";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { useImageUploader } from "#/api/queries/assets";
 import {
     createJobMutation,
@@ -109,7 +111,11 @@ function JobsAdminPage() {
     >(null);
 
     return (
-        <div className="container mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Annonser"
                 description="Opprett og administrer stillingsannonser fra bedrifter."
@@ -193,7 +199,7 @@ function JobsAdminPage() {
                     if (!open) setDialog(null);
                 }}
             />
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -33,6 +33,8 @@ import {
 } from "@tihlde/ui/ui/table";
 import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { searchAddressQuery } from "#/api/queries/address";
 import { useImageUploader } from "#/api/queries/assets";
 import {
@@ -112,7 +114,11 @@ function EventAdminDetailPage() {
         : "detaljer";
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title={event.title}
                 description={`${formatDateTime(event.startTime)} · ${event.organizer?.name ?? "Ingen arrangør"}`}
@@ -143,7 +149,7 @@ function EventAdminDetailPage() {
                     <PaymentsTab eventId={eventId} />
                 </Suspense>
             )}
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.index.tsx
@@ -28,6 +28,8 @@ import {
     TableRow,
 } from "@tihlde/ui/ui/table";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { getEventsQuery } from "#/api/queries/events";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
@@ -82,7 +84,11 @@ function EventsAdminPage() {
     const resetPage = () => setPage(0);
 
     return (
-        <div className="container mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Arrangementer"
                 description="Alle arrangementer. Velg et for å redigere det, se påmeldte, registrere oppmøte og håndtere betalinger."
@@ -161,7 +167,7 @@ function EventsAdminPage() {
                     onPageChange={setPage}
                 />
             </Suspense>
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/arrangementer.ny.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.ny.tsx
@@ -6,6 +6,8 @@ import { useEffect, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { XCircle } from "lucide-react";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { searchAddressQuery } from "#/api/queries/address";
 import { useImageUploader } from "#/api/queries/assets";
 import { createEventMutation } from "#/api/queries/events";
@@ -197,15 +199,23 @@ function NewEventPage() {
 
     if (!canCreate) {
         return (
-            <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+            <Stagger
+                render={
+                    <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+                }
+            >
                 <AdminPageHeader title="Nytt arrangement" />
                 <AdminNoAccess action="opprette arrangementer" />
-            </div>
+            </Stagger>
         );
     }
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Nytt arrangement"
                 description="Beskrivelsen lagres som markdown og formateringen vises direkte mens du skriver."
@@ -240,6 +250,6 @@ function NewEventPage() {
                     </Alert>
                 )}
             </EventForm>
-        </div>
+        </Stagger>
     );
 }

--- a/apps/kvark/src/routes/admin/bannere.tsx
+++ b/apps/kvark/src/routes/admin/bannere.tsx
@@ -36,6 +36,8 @@ import {
     getBannersQuery,
     updateBannerMutation,
 } from "#/api/queries/banners";
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { useAnyScopePermission } from "#/hooks/use-permission";
@@ -58,7 +60,11 @@ function BannersAdminPage() {
     >(null);
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Bannere"
                 description="Tidsstyrte toppbannere for viktige beskjeder på forsiden."
@@ -86,7 +92,7 @@ function BannersAdminPage() {
                     if (!open) setDialog(null);
                 }}
             />
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/brukere.tsx
+++ b/apps/kvark/src/routes/admin/brukere.tsx
@@ -51,6 +51,8 @@ import {
     removeGroupMemberMutation,
     updateGroupMemberRoleMutation,
 } from "#/api/queries/groups";
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { searchUsersQuery } from "#/api/queries/roles";
 import {
     getUsersInfiniteQuery,
@@ -172,7 +174,11 @@ function UsersAdminPage() {
         : !canManageMembers;
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Brukere"
                 description="Søk i alle brukere, eller velg et studie for å administrere medlemskap og roller."
@@ -212,7 +218,7 @@ function UsersAdminPage() {
                     onOpenChange={setAddOpen}
                 />
             )}
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/galleri.tsx
+++ b/apps/kvark/src/routes/admin/galleri.tsx
@@ -50,6 +50,8 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { uploadAssetMutation } from "#/api/queries/assets";
 import { getEventsQuery } from "#/api/queries/events";
 import {
@@ -96,7 +98,11 @@ function GalleryAdminPage() {
     >(null);
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Galleri"
                 description="Opprett gallerier og last opp bilder fra arrangementer."
@@ -122,7 +128,7 @@ function GalleryAdminPage() {
                     if (!open) setDialog(null);
                 }}
             />
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -11,6 +11,11 @@ import {
 } from "@tihlde/ui/ui/card";
 import { Checkbox } from "@tihlde/ui/ui/checkbox";
 import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from "@tihlde/ui/ui/collapsible";
+import {
     Dialog,
     DialogContent,
     DialogFooter,
@@ -48,6 +53,8 @@ import type {
 import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import { CheckCircle2, PlusIcon, UsersIcon, XCircle } from "lucide-react";
 import { useState } from "react";
+
+import { Stagger } from "@tihlde/ui/ui/motion";
 
 import { useImageUploader } from "#/api/queries/assets";
 import {
@@ -99,7 +106,11 @@ function GrupperAdminPage() {
     const groups = allGroups.filter((group) => group.type === tab);
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Grupper"
                 description="Opprett grupper, administrer kontraktsignering og se signeringsstatus for medlemmer."
@@ -150,7 +161,7 @@ function GrupperAdminPage() {
                     ))}
                 </div>
             )}
-        </div>
+        </Stagger>
     );
 }
 
@@ -373,7 +384,15 @@ function GroupCard({
     });
 
     return (
-        <Card>
+        <Card
+            // The card *is* the collapsible root, so the panel below can roll
+            // its height open instead of the content popping into place.
+            // `gap-0` because the card's own gap would otherwise sit between the
+            // header and a zero-height panel; the panel brings its own top
+            // padding once it is open.
+            className="gap-0"
+            render={<Collapsible open={expanded} onOpenChange={onToggle} />}
+        >
             <CardHeader>
                 <div className="flex items-center justify-between gap-4">
                     <div className="flex flex-col gap-1">
@@ -391,19 +410,17 @@ function GroupCard({
                             <Badge variant="outline">Bøter aktivert</Badge>
                         )}
                         {canEdit ? (
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={onToggle}
+                            <CollapsibleTrigger
+                                render={<Button variant="outline" size="sm" />}
                             >
                                 {expanded ? "Lukk" : "Rediger"}
-                            </Button>
+                            </CollapsibleTrigger>
                         ) : null}
                     </div>
                 </div>
             </CardHeader>
-            {expanded && (
-                <CardContent className="flex flex-col gap-6">
+            <CollapsibleContent>
+                <CardContent className="flex flex-col gap-6 pt-4">
                     <FieldGroup>
                         <Field orientation="horizontal" className="gap-3">
                             <Checkbox
@@ -458,7 +475,7 @@ function GroupCard({
                             <p>Laster signeringsstatus…</p>
                         ))}
                 </CardContent>
-            )}
+            </CollapsibleContent>
         </Card>
     );
 }

--- a/apps/kvark/src/routes/admin/index.tsx
+++ b/apps/kvark/src/routes/admin/index.tsx
@@ -16,6 +16,8 @@ import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { AdminStatCard } from "#/components/admin-stat-card";
@@ -58,7 +60,11 @@ function DashboardPage() {
     ]);
 
     return (
-        <div className="container mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Dashboard"
                 description="Oversikt over innhold og administrasjon i Kvark."
@@ -86,7 +92,7 @@ function DashboardPage() {
                     <RecentNews />
                 </Suspense>
             </div>
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/kontaktskjema.tsx
+++ b/apps/kvark/src/routes/admin/kontaktskjema.tsx
@@ -10,6 +10,7 @@ import {
     TableHeader,
     TableRow,
 } from "@tihlde/ui/ui/table";
+import { Stagger } from "@tihlde/ui/ui/motion";
 import { Building2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { z } from "zod";
@@ -131,19 +132,19 @@ function AdminCompanyContactPage() {
 
     if (!canView) {
         return (
-            <div className="flex flex-col gap-6">
+            <Stagger render={<div className="flex flex-col gap-6" />}>
                 {header}
                 <AdminEmptyState
                     icon={Building2}
                     title="Ingen tilgang"
                     description="Du har ikke tilgang til å behandle henvendelser fra bedrifter."
                 />
-            </div>
+            </Stagger>
         );
     }
 
     return (
-        <div className="flex flex-col gap-6">
+        <Stagger render={<div className="flex flex-col gap-6" />}>
             {header}
 
             {!isLoading && (applications ?? []).length === 0 ? (
@@ -238,6 +239,6 @@ function AdminCompanyContactPage() {
                     });
                 }}
             />
-        </div>
+        </Stagger>
     );
 }

--- a/apps/kvark/src/routes/admin/nyheter.tsx
+++ b/apps/kvark/src/routes/admin/nyheter.tsx
@@ -30,6 +30,8 @@ import {
 import { Textarea } from "@tihlde/ui/ui/textarea";
 import z from "zod";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { useImageUploader } from "#/api/queries/assets";
 import {
     createNewsMutation,
@@ -75,7 +77,11 @@ function NewsAdminPage() {
     }
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Nyheter"
                 description="Alle publiserte nyheter. Brødteksten lagres som markdown."
@@ -104,7 +110,7 @@ function NewsAdminPage() {
                     if (!open) closeDialog();
                 }}
             />
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/opptak.tsx
+++ b/apps/kvark/src/routes/admin/opptak.tsx
@@ -26,6 +26,8 @@ import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import { CheckCircle2, Upload, XCircle, Zap } from "lucide-react";
 import { Suspense, lazy, useEffect, useState } from "react";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { uploadAssetMutation } from "#/api/queries/assets";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { useAnyScopePermission } from "#/hooks/use-permission";
@@ -60,7 +62,11 @@ function OpptakAdminPage() {
     ]);
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Kontraktstyring"
                 description="Last opp og administrer frivillighetskontrakter."
@@ -74,7 +80,7 @@ function OpptakAdminPage() {
                         : undefined
                 }
             />
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/prikker.tsx
+++ b/apps/kvark/src/routes/admin/prikker.tsx
@@ -40,6 +40,8 @@ import {
     getEventsQuery,
     getStrikesQuery,
 } from "#/api/queries/events";
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { searchUsersQuery } from "#/api/queries/roles";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
@@ -65,7 +67,11 @@ function StrikesAdminPage() {
     const [createOpen, setCreateOpen] = useState(false);
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                 <AdminPageHeader
                     title="Prikker"
@@ -85,7 +91,7 @@ function StrikesAdminPage() {
                 open={createOpen}
                 onOpenChange={setCreateOpen}
             />
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/roller.tsx
+++ b/apps/kvark/src/routes/admin/roller.tsx
@@ -34,6 +34,8 @@ import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import { MoreHorizontalIcon, PlusIcon, ShieldIcon, XIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { getGroupMembersQuery, getGroupsQuery } from "#/api/queries/groups";
 import {
     assignPositionMutation,
@@ -112,7 +114,11 @@ function RolesAdminPage() {
     ]);
 
     return (
-        <div className="container mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="Roller og verv"
                 description="Administrer verv i grupper og globale roller."
@@ -132,7 +138,7 @@ function RolesAdminPage() {
             ) : (
                 <RolesSection />
             )}
-        </div>
+        </Stagger>
     );
 }
 

--- a/apps/kvark/src/routes/admin/soknader.tsx
+++ b/apps/kvark/src/routes/admin/soknader.tsx
@@ -15,6 +15,8 @@ import { FileText } from "lucide-react";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { authQueryOptions, sessionHasPermission } from "#/api/auth";
 import {
     type ApplicationType,
@@ -169,7 +171,7 @@ function AdminApplicationsPage() {
 
     if (visibleTabs.length === 0) {
         return (
-            <div className="flex flex-col gap-6">
+            <Stagger render={<div className="flex flex-col gap-6" />}>
                 <AdminPageHeader
                     title="Søknader"
                     description="Utlegg, søknader om støtte og saker meldt inn til Hovedstyret."
@@ -179,12 +181,12 @@ function AdminApplicationsPage() {
                     title="Ingen tilgang"
                     description="Du har ikke tilgang til å behandle noen søknadstyper."
                 />
-            </div>
+            </Stagger>
         );
     }
 
     return (
-        <div className="flex flex-col gap-6">
+        <Stagger render={<div className="flex flex-col gap-6" />}>
             <AdminPageHeader
                 title="Søknader"
                 description="Utlegg, søknader om støtte og saker meldt inn til Hovedstyret."
@@ -302,6 +304,6 @@ function AdminApplicationsPage() {
                     });
                 }}
             />
-        </div>
+        </Stagger>
     );
 }

--- a/apps/kvark/src/routes/admin/toddel.tsx
+++ b/apps/kvark/src/routes/admin/toddel.tsx
@@ -25,6 +25,8 @@ import {
     TableRow,
 } from "@tihlde/ui/ui/table";
 
+import { Stagger } from "@tihlde/ui/ui/motion";
+
 import { uploadAssetMutation } from "#/api/queries/assets";
 import {
     createToddelMutation,
@@ -59,7 +61,11 @@ function ToddelAdminPage() {
     >(null);
 
     return (
-        <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+        <Stagger
+            render={
+                <div className="container mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8" />
+            }
+        >
             <AdminPageHeader
                 title="TÖDDEL"
                 description="Legg ut nye utgaver av studentbladet, og rediger de som allerede ligger ute."
@@ -88,7 +94,7 @@ function ToddelAdminPage() {
                     onClose={() => setDialog(null)}
                 />
             )}
-        </div>
+        </Stagger>
     );
 }
 


### PR DESCRIPTION
## Hva

To ting, begge motion i adminpanelet:

**1. Gruppe-accordion i `/admin/grupper` animerer nå.**
Panelet var `{expanded && <CardContent/>}` — ren mount/unmount, så det fantes ingen høyde å interpolere og innholdet poppet inn og ut. Nå er selve `Card`-et collapsible-rota (`render={<Collapsible/>}`), og innholdet ligger i `CollapsibleContent`, som allerede har riktig motion i `@tihlde/ui`: `transition-[height]`, 200 ms, `ease-out`, mellom 0 og målt panelhøyde. Knappen er blitt `CollapsibleTrigger` som rendrer `Button`, så den får `aria-expanded`/`aria-controls` på kjøpet.

**2. Inngangsanimasjon på hele adminpanelet.**
Ingen adminside brukte `Reveal`/`Stagger`, mens resten av Kvark (nyheter, arrangementer, galleri, annonser) gjør det. Alle 20 adminrutene er nå pakket i `<Stagger>`: header → tabs → tabell/kortliste toner opp 40 ms fra hverandre, 260 ms hver, samme `--ease-out`-token som ellers.

## Hvorfor

Adminpanelet var det eneste stedet i Kvark uten motion, og gruppekortet var det tydeligste utslaget — et helt kortinnhold som dukket opp uten overgang.

## Verdt å vite for review

- **Ingen animasjonsklasser er lagt i `apps/kvark`.** All motion kommer fra `@tihlde/ui` (`Collapsible`, `Stagger`), slik `apps/kvark/CLAUDE.md` krever. Endringene i appen er kun layout-klasser og komposisjon.
- **`gap-0` på gruppekortet er bevisst:** kortets egen `gap-4` ville ellers stått igjen som en tom glippe over et null-høyt panel når kortet er lukket. Panelet tar med sin egen `pt-4` når det er åpent.
- Base UI setter panelhøyden tilbake til `auto` når åpne-transisjonen er ferdig, så signeringstabellen som lastes etter at kortet er åpnet blir ikke klippet.
- `Stagger`-innpakkingen er mekanisk og rører ikke innholdet i noen rute — kun ytterste `<div>` byttet til `<Stagger render={<div … />}>`.

## Testet

- `bun run typecheck`, `lint`, `format`, `build` — alle grønne.
- I dev-server, innlogget: satte panelets `transition-duration` til 6 s og tok skjermbilde — kortet står halvåpent med innholdet klippet mens knappen alt har slått om. `transitionstart` for `height` fyrer, panelet får `data-ending-style` og `--collapsible-panel-height`. Lukket kort har ingen glippe under headeren.
- Stagger-barna rapporterer `reveal-in 0.26s`, delay `0 / 0.04 / 0.08s`, `backwards`.
- SSR-render av alle 18 adminruter: 200 med `data-slot="stagger"` i markupen. Unntak: `/admin/oauth-clients` feiler lokalt med «Kunne ikke hente OAuth-klienter: Unauthorized` fra loaderen — en API/tilgangs-greie som ligger foran render og er uavhengig av denne endringen, men det betyr at akkurat den sida ikke er visuelt bekreftet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)