### PR TITLE
feat(ui): del DateTimePicker i separate dato- og tidsfelt

### DIFF
--- a/apps/kvark/src/components/event-form.tsx
+++ b/apps/kvark/src/components/event-form.tsx
@@ -271,31 +271,35 @@ export function EventForm({
                                     : "Søk opp en adresse for å legge ved kartlenke, eller skriv fritt (f.eks. «Digitalt»)."}
                             </FieldDescription>
                         </Field>
-                        <Field>
-                            <FieldLabel htmlFor="event-start">
-                                Starttidspunkt
-                            </FieldLabel>
-                            <DateTimePicker
-                                id="event-start"
-                                locale={nb}
-                                placeholder="Velg starttidspunkt"
-                                value={values.start}
-                                onValueChange={(start) => onChange({ start })}
-                            />
-                        </Field>
-                        <Field>
-                            <FieldLabel htmlFor="event-end">
-                                Sluttidspunkt
-                            </FieldLabel>
-                            <DateTimePicker
-                                id="event-end"
-                                locale={nb}
-                                placeholder="Velg sluttidspunkt"
-                                minDate={values.start ?? undefined}
-                                value={values.end}
-                                onValueChange={(end) => onChange({ end })}
-                            />
-                        </Field>
+                        <div className="grid gap-4 lg:grid-cols-2">
+                            <Field>
+                                <FieldLabel htmlFor="event-start">
+                                    Starttidspunkt
+                                </FieldLabel>
+                                <DateTimePicker
+                                    id="event-start"
+                                    locale={nb}
+                                    placeholder="Velg startdato"
+                                    value={values.start}
+                                    onValueChange={(start) =>
+                                        onChange({ start })
+                                    }
+                                />
+                            </Field>
+                            <Field>
+                                <FieldLabel htmlFor="event-end">
+                                    Sluttidspunkt
+                                </FieldLabel>
+                                <DateTimePicker
+                                    id="event-end"
+                                    locale={nb}
+                                    placeholder="Velg sluttdato"
+                                    minDate={values.start ?? undefined}
+                                    value={values.end}
+                                    onValueChange={(end) => onChange({ end })}
+                                />
+                            </Field>
+                        </div>
                         <Field orientation="horizontal" className="gap-3">
                             <Checkbox
                                 id="event-requires-signup"
@@ -319,7 +323,7 @@ export function EventForm({
                                     <DateTimePicker
                                         id="event-reg-end"
                                         locale={nb}
-                                        placeholder="Velg påmeldingsfrist"
+                                        placeholder="Velg dato"
                                         maxDate={values.start ?? undefined}
                                         value={values.registrationEnd}
                                         onValueChange={(registrationEnd) =>

--- a/apps/kvark/src/routes/_dev/form-test.tsx
+++ b/apps/kvark/src/routes/_dev/form-test.tsx
@@ -815,8 +815,8 @@ function FormTestPage() {
                         <CardTitle>Datoer og tider</CardTitle>
                         <CardDescription>
                             DatePicker (enkelt + range, dag- og månedsvisning)
-                            paret med TimePicker, og DateTimePicker som
-                            kombinerer dato + tid — 24-timers norsk klokke.
+                            paret med TimePicker, og DateTimePicker som viser
+                            dato og tid som to felt — 24-timers norsk klokke.
                         </CardDescription>
                     </CardHeader>
                     <CardContent>
@@ -883,7 +883,7 @@ function FormTestPage() {
                                         </field.Label>
                                         <field.DateTimePicker
                                             locale={nb}
-                                            placeholder="Velg dato og tid"
+                                            placeholder="Velg dato"
                                         />
                                         <field.Error />
                                     </field.Field>

--- a/apps/kvark/src/routes/admin/annonser.tsx
+++ b/apps/kvark/src/routes/admin/annonser.tsx
@@ -576,7 +576,7 @@ function JobDialog({
                                 <DateTimePicker
                                     id="job-deadline"
                                     locale={nb}
-                                    placeholder="Velg søknadsfrist"
+                                    placeholder="Velg dato"
                                     value={deadline}
                                     onValueChange={setDeadline}
                                 />

--- a/apps/kvark/src/routes/admin/bannere.tsx
+++ b/apps/kvark/src/routes/admin/bannere.tsx
@@ -280,7 +280,7 @@ function BannerDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+            <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
                 <form onSubmit={handleSubmit} className="flex flex-col gap-4">
                     <DialogHeader>
                         <DialogTitle>
@@ -351,7 +351,7 @@ function BannerDialog({
                                 <DateTimePicker
                                     id="banner-visible-from"
                                     locale={nb}
-                                    placeholder="Velg dato og tid"
+                                    placeholder="Velg dato"
                                     value={visibleFrom}
                                     onValueChange={setVisibleFrom}
                                 />
@@ -363,7 +363,7 @@ function BannerDialog({
                                 <DateTimePicker
                                     id="banner-visible-until"
                                     locale={nb}
-                                    placeholder="Velg dato og tid"
+                                    placeholder="Velg dato"
                                     minDate={visibleFrom ?? undefined}
                                     value={visibleUntil}
                                     onValueChange={setVisibleUntil}

--- a/packages/ui/src/components/ui/date-picker.tsx
+++ b/packages/ui/src/components/ui/date-picker.tsx
@@ -53,24 +53,24 @@ interface DateRangePickerProps extends CommonProps {
     formatLabel?: (value: DateRange, view: DatePickerView) => string;
 }
 
-function defaultDayFormat(date: Date): string {
-    return formatDateFn(date, "PPP");
+function defaultDayFormat(date: Date, locale?: Locale): string {
+    return formatDateFn(date, "PPP", { locale });
 }
 
-function defaultMonthFormat(date: Date): string {
-    return formatDateFn(date, "LLLL yyyy");
+function defaultMonthFormat(date: Date, locale?: Locale): string {
+    return formatDateFn(date, "LLLL yyyy", { locale });
 }
 
-function defaultRangeDayFormat(range: DateRange): string {
-    if (!range.to) return defaultDayFormat(range.from);
-    return `${defaultDayFormat(range.from)} – ${defaultDayFormat(range.to)}`;
+function defaultRangeDayFormat(range: DateRange, locale?: Locale): string {
+    if (!range.to) return defaultDayFormat(range.from, locale);
+    return `${defaultDayFormat(range.from, locale)} – ${defaultDayFormat(range.to, locale)}`;
 }
 
-function defaultRangeMonthFormat(range: DateRange): string {
+function defaultRangeMonthFormat(range: DateRange, locale?: Locale): string {
     if (!range.to || isSameMonth(range.from, range.to)) {
-        return defaultMonthFormat(range.from);
+        return defaultMonthFormat(range.from, locale);
     }
-    return `${defaultMonthFormat(range.from)} – ${defaultMonthFormat(range.to)}`;
+    return `${defaultMonthFormat(range.from, locale)} – ${defaultMonthFormat(range.to, locale)}`;
 }
 
 export function DatePicker({
@@ -92,8 +92,8 @@ export function DatePicker({
         ? formatLabel
             ? formatLabel(value, view)
             : view === "month"
-              ? defaultMonthFormat(value)
-              : defaultDayFormat(value)
+              ? defaultMonthFormat(value, locale)
+              : defaultDayFormat(value, locale)
         : placeholder;
 
     return (
@@ -173,8 +173,8 @@ export function DateRangePicker({
         ? formatLabel
             ? formatLabel(value, view)
             : view === "month"
-              ? defaultRangeMonthFormat(value)
-              : defaultRangeDayFormat(value)
+              ? defaultRangeMonthFormat(value, locale)
+              : defaultRangeDayFormat(value, locale)
         : placeholder;
 
     return (

--- a/packages/ui/src/components/ui/date-time-picker.tsx
+++ b/packages/ui/src/components/ui/date-time-picker.tsx
@@ -2,30 +2,23 @@
 
 import * as React from "react";
 import {
+    endOfDay,
     format as formatDateFn,
-    isAfter,
-    isBefore,
     setHours,
     setMinutes,
     startOfDay,
 } from "date-fns";
-import { CalendarIcon, ClockIcon } from "lucide-react";
 import { type Locale } from "react-day-picker";
 
 import { cn } from "#/lib/utils";
-import { Button } from "#/components/ui/button";
-import { Calendar } from "#/components/ui/calendar";
-import { InputGroup, InputGroupAddon } from "#/components/ui/input-group";
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from "#/components/ui/popover";
+import { DatePicker } from "#/components/ui/date-picker";
+import { TimePicker, type TimeValue } from "#/components/ui/time-picker";
 
 interface DateTimePickerProps {
     value: Date | null;
     onValueChange: (value: Date | null) => void;
     placeholder?: string;
+    minuteStep?: number;
     disabled?: boolean;
     locale?: Locale;
     minDate?: Date;
@@ -37,36 +30,15 @@ interface DateTimePickerProps {
     "aria-invalid"?: boolean;
 }
 
-function pad(n: number): string {
-    return String(n).padStart(2, "0");
-}
-
-function defaultFormat(date: Date, locale?: Locale): string {
-    return formatDateFn(date, "PPP HH:mm", { locale });
-}
-
-function disabledMatcher(minDate?: Date, maxDate?: Date) {
-    if (!minDate && !maxDate) return undefined;
-    return (date: Date) => {
-        if (minDate && isBefore(date, startOfDay(minDate))) return true;
-        if (maxDate && isAfter(startOfDay(date), startOfDay(maxDate))) {
-            return true;
-        }
-        return false;
-    };
-}
-
-function clampNumber(text: string, max: number): number | null {
-    if (text === "") return null;
-    const n = parseInt(text, 10);
-    if (Number.isNaN(n) || n < 0 || n > max) return null;
-    return n;
+function combine(day: Date, time: TimeValue): Date {
+    return setMinutes(setHours(startOfDay(day), time.hour), time.minute);
 }
 
 export function DateTimePicker({
     value,
     onValueChange,
-    placeholder = "Pick a date",
+    placeholder = "Velg dato",
+    minuteStep,
     disabled,
     locale,
     minDate,
@@ -77,117 +49,64 @@ export function DateTimePicker({
     formatLabel,
     "aria-invalid": ariaInvalid,
 }: DateTimePickerProps) {
-    const [hourText, setHourText] = React.useState(() =>
-        value ? pad(value.getHours()) : "",
-    );
-    const [minuteText, setMinuteText] = React.useState(() =>
-        value ? pad(value.getMinutes()) : "",
+    // Lets the user pick a time before a date without losing the input.
+    const [pendingTime, setPendingTime] = React.useState<TimeValue | null>(
+        null,
     );
 
-    const hourRef = React.useRef<HTMLInputElement>(null);
-    const minuteRef = React.useRef<HTMLInputElement>(null);
+    const time = React.useMemo<TimeValue | null>(
+        () =>
+            value
+                ? { hour: value.getHours(), minute: value.getMinutes() }
+                : pendingTime,
+        [value, pendingTime],
+    );
 
-    React.useEffect(() => {
-        setHourText(value ? pad(value.getHours()) : "");
-        setMinuteText(value ? pad(value.getMinutes()) : "");
-    }, [value]);
-
-    const label = value
-        ? formatLabel
-            ? formatLabel(value)
-            : defaultFormat(value, locale)
-        : placeholder;
-
-    const combine = (day: Date, hour: number, minute: number): Date => {
-        return setMinutes(setHours(startOfDay(day), hour), minute);
-    };
-
-    const handleDaySelect = (day: Date | undefined) => {
+    const handleDateChange = (day: Date | null) => {
         if (!day) {
             onValueChange(null);
             return;
         }
-        const hour = value
-            ? value.getHours()
-            : (clampNumber(hourText, 23) ?? 0);
-        const minute = value
-            ? value.getMinutes()
-            : (clampNumber(minuteText, 59) ?? 0);
-        onValueChange(combine(day, hour, minute));
+        onValueChange(combine(day, time ?? { hour: 0, minute: 0 }));
     };
 
-    const commitTime = (hour: number | null, minute: number | null) => {
-        if (!value) return;
-        onValueChange(
-            combine(
-                value,
-                hour ?? value.getHours(),
-                minute ?? value.getMinutes(),
-            ),
-        );
-    };
-
-    const handleHourChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const raw = e.target.value.replace(/\D/g, "").slice(0, 2);
-        setHourText(raw);
-        const h = clampNumber(raw, 23);
-        if (h !== null) {
-            commitTime(h, clampNumber(minuteRef.current?.value ?? "", 59));
-            if (raw.length === 2) {
-                minuteRef.current?.focus();
-                minuteRef.current?.select();
-            }
-        }
-    };
-
-    const handleMinuteChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const raw = e.target.value.replace(/\D/g, "").slice(0, 2);
-        setMinuteText(raw);
-        const m = clampNumber(raw, 59);
-        if (m !== null) {
-            commitTime(clampNumber(hourRef.current?.value ?? "", 23), m);
-        }
-    };
-
-    const handleHourBlur = () => {
-        const h = clampNumber(hourText, 23);
-        if (h === null) {
-            setHourText(value ? pad(value.getHours()) : "");
-            return;
-        }
-        setHourText(pad(h));
-    };
-
-    const handleMinuteBlur = () => {
-        const m = clampNumber(minuteText, 59);
-        if (m === null) {
-            setMinuteText(value ? pad(value.getMinutes()) : "");
-            return;
-        }
-        setMinuteText(pad(m));
+    const handleTimeChange = (next: TimeValue | null) => {
+        setPendingTime(next);
+        if (!value || !next) return;
+        onValueChange(combine(value, next));
     };
 
     return (
-        <Popover>
-            <PopoverTrigger
-                render={
-                    <Button
-                        variant="outline"
-                        type="button"
-                        id={id}
-                        disabled={disabled}
-                        aria-invalid={ariaInvalid}
-                        className={cn(
-                            "w-full justify-between font-normal",
-                            !value && "text-muted-foreground",
-                            className,
-                        )}
-                    />
+        <div className={cn("flex items-start gap-2", className)}>
+            <DatePicker
+                id={id}
+                value={value}
+                onValueChange={handleDateChange}
+                placeholder={placeholder}
+                disabled={disabled}
+                locale={locale}
+                // Only the day matters here — the time part is picked
+                // separately, so widen the bounds to whole days.
+                minDate={minDate ? startOfDay(minDate) : undefined}
+                maxDate={maxDate ? endOfDay(maxDate) : undefined}
+                // Compact by default — the time field sits right next to it,
+                // so the pair has to survive half-width columns.
+                formatLabel={(date) =>
+                    formatLabel
+                        ? formatLabel(date)
+                        : formatDateFn(date, "PP", { locale })
                 }
-            >
-                <span className="truncate">{label}</span>
-                <CalendarIcon className="size-4 shrink-0 opacity-60" />
-            </PopoverTrigger>
+                aria-invalid={ariaInvalid}
+                className="min-w-0 flex-1"
+            />
+            <TimePicker
+                value={time}
+                onValueChange={handleTimeChange}
+                minuteStep={minuteStep}
+                disabled={disabled}
+                aria-invalid={ariaInvalid}
+                className="shrink-0"
+            />
             {name !== undefined && (
                 <input
                     type="hidden"
@@ -195,68 +114,6 @@ export function DateTimePicker({
                     value={value ? value.toISOString() : ""}
                 />
             )}
-            <PopoverContent
-                className="w-auto p-0"
-                align="start"
-                aria-label="Velg dato og tid"
-            >
-                <Calendar
-                    mode="single"
-                    selected={value ?? undefined}
-                    onSelect={handleDaySelect}
-                    startMonth={minDate}
-                    endMonth={maxDate}
-                    disabled={disabledMatcher(minDate, maxDate)}
-                    locale={locale}
-                    autoFocus
-                />
-                <div className="flex items-center gap-2 border-t p-3">
-                    <InputGroup className="w-full">
-                        <input
-                            ref={hourRef}
-                            type="text"
-                            inputMode="numeric"
-                            autoComplete="off"
-                            placeholder="HH"
-                            disabled={disabled}
-                            aria-label="Timer"
-                            maxLength={2}
-                            value={hourText}
-                            onChange={handleHourChange}
-                            onFocus={(e) => e.target.select()}
-                            onBlur={handleHourBlur}
-                            data-slot="input-group-control"
-                            className="field-sizing-content min-w-[2ch] bg-transparent pl-2 pr-0! text-left text-sm tabular-nums outline-none placeholder:text-muted-foreground"
-                        />
-                        <span
-                            aria-hidden="true"
-                            className="text-sm font-medium text-muted-foreground select-none"
-                        >
-                            :
-                        </span>
-                        <input
-                            ref={minuteRef}
-                            type="text"
-                            inputMode="numeric"
-                            autoComplete="off"
-                            placeholder="mm"
-                            disabled={disabled}
-                            aria-label="Minutter"
-                            maxLength={2}
-                            value={minuteText}
-                            onChange={handleMinuteChange}
-                            onFocus={(e) => e.target.select()}
-                            onBlur={handleMinuteBlur}
-                            data-slot="input-group-control"
-                            className="field-sizing-content min-w-[2ch] bg-transparent pr-0! text-left text-sm tabular-nums outline-none placeholder:text-muted-foreground"
-                        />
-                        <div aria-hidden="true" className="flex-1" />
-                        <InputGroupAddon align="inline-end">
-                            <ClockIcon className="opacity-60" />
-                        </InputGroupAddon>
-                    </InputGroup>
-                </div>
-            </PopoverContent>
-        </Popover>
+        </div>
     );
 }


### PR DESCRIPTION
## Hva

Tidsvelgeren lå inne i kalender-popoveren til `DateTimePicker`, så klokkeslettet var skjult bak et klikk på datoknappen. Nå er dato og tid to synlige felt ved siden av hverandre.

`DateTimePicker` er skrevet om fra egen implementasjon (kalender + HH:mm-inputs i popoveren) til å komponere de eksisterende primitivene `DatePicker` + `TimePicker` side ved side. **Prop-APIet er uendret** (`value: Date | null`, `onValueChange`), så alle 6 kallstedene virker som før uten endring.

## Hvorfor / hva en reviewer bør se på

- **`minDate`/`maxDate` normaliseres til hele døgn** før de sendes til `DatePicker`. `DatePicker` sammenligner rått med `isBefore`, så `minDate={values.start}` (som har klokkeslett) ville ellers låst selve startdagen for sluttdato. Grensene gjelder fortsatt bare dag, ikke klokkeslett — samme som før.
- **Tid før dato:** skriver du klokkeslett først, holdes det i `pendingTime` og brukes når datoen velges. Velger du dato uten tid, blir det 00:00.
- **Kompakt datolabel** (`15. aug. 2026` i stedet for `15. august 2026`), fordi feltparet nå må klare halvbrede kolonner. Målt: ved 240 px kolonne trunkeres labelen, ved ≥256 px ikke.
- **Bugfiks i `DatePicker`:** default-formatteringen sendte ikke `locale` til `date-fns`, så labelen ble engelsk (`August 15th, 2026`) selv med `locale={nb}`. Dette rammer også `DatePicker`/`DateRangePicker` brukt direkte, ikke bare via `DateTimePicker`.

## Horisontal plassering i adminpanelet

- `event-form.tsx`: start- og sluttidspunkt ligger nå i `grid gap-4 lg:grid-cols-2` i stedet for to felt i full bredde under hverandre.
- `bannere.tsx`: «Synlig fra/til» lå allerede i to kolonner; dialogen er utvidet fra `sm:max-w-xl` til `sm:max-w-2xl` så dato+tid får plass uten avkorting.
- Placeholderene er justert fra «Velg dato og tid» / «Velg søknadsfrist» til «Velg dato», siden knappen nå bare er datodelen.

## Verifisert

- `bun run typecheck`, `bun run lint` (ingen nye funn) og `bun run build` går grønt.
- I dev-serveren på `/form-test`: datoknappen (584 px) og tidsfeltet (112 px) ligger på samme linje (begge `top: 345`). Flyten testet ende til ende — velg 15. aug → 00:00, skriv 18:30 → skjemaverdien blir `2026-08-15T16:30:00.000Z` (18:30 lokal tid); fjern datoen → tiden beholdes; velg 20. aug → `2026-08-20T16:30:00.000Z`. Ingen nye konsollfeil.
- Skjermbilder av scrollede posisjoner kom ut svarte fordi Browser-panelet var skjult i økten, så den visuelle bekreftelsen er DOM-/layoutmålinger, ikke et bilde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)