### PR TITLE
fix(bøter): vis paragrafer med begge desimalene og filnavn på én linje

### DIFF
--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -241,11 +241,15 @@ export function mapFormerMember(member: ApiGroupFormerMember): Member {
 }
 
 /**
- * Paragrafnummeret slik det skal leses: databasen lagrer det som desimaltall
- * ("3.10"), og etterfølgende nuller strippes for visning ("3.1", "1").
+ * Paragrafnummeret slik det skal leses. Desimalene er et paragrafnummer på to
+ * siffer, ikke en brøkdel: 3.01 og 3.10 er to forskjellige paragrafer, så
+ * begge desimalene må stå ("3.10", aldri "3.1"). Heltall er overskrifter og
+ * vises uten desimaler ("1").
  */
 function formatParagraph(paragraph: string): string {
-    return String(Number(paragraph));
+    const value = Number(paragraph);
+    if (!Number.isFinite(value)) return paragraph;
+    return Number.isInteger(value) ? String(value) : value.toFixed(2);
 }
 
 /**
@@ -289,8 +293,8 @@ export function mapFineUser(user: ApiFineUser): FineUser {
 
 /**
  * Map an API law to the display shape used by the laws tab and fine dialogs.
- * The backend stores `paragraph` as a decimal string ("3.10"); trailing
- * zeros are stripped for display ("3.1", "1").
+ * The backend stores `paragraph` as a decimal string ("3.10"), som vises slik
+ * den er lagret — se {@link formatParagraph}.
  */
 export function mapLaw(law: ApiLaw): Law {
     return {

--- a/packages/ui/src/components/ui/image-dropzone.tsx
+++ b/packages/ui/src/components/ui/image-dropzone.tsx
@@ -337,11 +337,21 @@ export function ImageDropzone({
 
                 {previews.length > 0 && showSingleFrame && (
                     <div className="flex items-center justify-between gap-3">
-                        <span className="text-xs text-muted-foreground">
-                            {previews[0]?.file.name}
-                            {previews[0]
-                                ? ` · ${formatSize(previews[0].file.size)}`
-                                : ""}
+                        {/* The name is the only part allowed to grow, so a long
+                            filename is cut instead of wrapping the row onto a
+                            second line and pushing the size out of view. */}
+                        <span className="flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                            <span
+                                className="truncate"
+                                title={previews[0]?.file.name}
+                            >
+                                {previews[0]?.file.name}
+                            </span>
+                            {previews[0] ? (
+                                <span className="shrink-0">
+                                    {`· ${formatSize(previews[0].file.size)}`}
+                                </span>
+                            ) : null}
                         </span>
                         <Button
                             type="button"
@@ -349,6 +359,7 @@ export function ImageDropzone({
                             variant="ghost"
                             onClick={() => removeAt(0)}
                             disabled={disabled}
+                            className="shrink-0"
                         >
                             {labels.removeLabel}
                         </Button>


### PR DESCRIPTION
## Hva

To små feil i bøter-fanen.

**1. Paragrafer ble vist feil (`3.10` → `3.1`)**

Paragrafnummeret er `major.minor` der desimalene er et *tosifret paragrafnummer*, ikke en brøkdel — `3.01` og `3.10` er to forskjellige paragrafer. `formatParagraph` i `apps/kvark/src/lib/group.ts` gjorde `String(Number(paragraph))`, som strippet den etterfølgende nullen og viste `3.10` som `3.1` — altså samme skrivemåte som en annen paragraf.

Nå beholdes begge desimalene. Heltall vises fortsatt uten desimaler, siden de er overskrifter i lovverket (jf. hjelpeteksten i lovparagraf-dialogen: «Heltall for overskrift»).

| Lagret | Før | Etter |
| --- | --- | --- |
| `3.10` | `3.1` | `3.10` |
| `3.01` | `3.01` | `3.01` |
| `2.50` | `2.5` | `2.50` |
| `1.00` | `1` | `1` |

Backend er allerede kanonisk på to desimaler (`serializeFineLaw` og `laws/create|update` bruker `toFixed(2)`), så dette retter kun visningen i Kvark.

**2. Filnavnet i bildeopplasteren brøt over flere linjer**

I `ImageDropzone` (enkeltbilde med `preset`, som bøte-dialogen bruker) lå filnavn og filstørrelse i én span uten breddebegrensning. Et langt filnavn brøt raden over flere linjer og tok unødvendig plass:

```
9a4d26aa-ce22-4a1e-a914-6c6714647795Screenshot 2024-08-13 at 19.51.59.png
· 431.4 KB                                                    Fjern bilde
```

Navnet er nå det eneste som får vokse og kuttes med ellipsis, mens størrelsen og «Fjern bilde» står fast:

```
9a4d26aa-ce22-4a1e-a914-6c67146477…  · 431.4 KB      Fjern bilde
```

Hele navnet ligger i `title`, så det kan leses ved hover.

## Verifisert

- `bun run typecheck` og `bun run format` grønt; `bun run lint` uten nye advarsler (28 er fra før).
- `formatParagraph` kjørt direkte på `3.10 / 3.01 / 3.00 / 1.00 / 2.50 / 0.05 / 99.99 / 12.30`.
- **Ikke** sjekket i nettleser: port 3000 og 4000 var opptatt av dev-serverne til en annen økt/worktree, så en kjørende app der ville uansett ikke hatt disse endringene.

## Verdt å merke seg for review

- UUID-prefikset i filnavnet kommer fra selve fila brukeren velger — opplasteren døper ikke om noe. Denne PR-en kutter kun visningen; si fra hvis vi heller vil strippe prefikset.
- `ImageDropzone` er delt (`@tihlde/ui`), så layout-endringen treffer også søknadsskjemaene — men bare enkeltbilde-grenen med `preset`, altså der raden allerede fantes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)