### PR TITLE
feat(spørreskjema): koble opp opprettelse av gruppe-spørreskjema

### DIFF
--- a/apps/kvark/src/components/group-forms-tab.tsx
+++ b/apps/kvark/src/components/group-forms-tab.tsx
@@ -1,26 +1,28 @@
 import { Button } from "@tihlde/ui/ui/button";
 import { Plus } from "lucide-react";
-import { useState } from "react";
 
 import { GroupFormRow } from "#/components/group-form-row";
-import { GroupNewFormDialog } from "#/components/group-new-form-dialog";
 import { GroupPageHeader } from "#/components/group-page-header";
 import type { Form } from "#/lib/group";
 
 type GroupFormsTabProps = {
     forms: Form[];
     isAdmin: boolean;
+    onNewForm: () => void;
 };
 
-export function GroupFormsTab({ forms, isAdmin }: GroupFormsTabProps) {
-    const [creating, setCreating] = useState(false);
+export function GroupFormsTab({
+    forms,
+    isAdmin,
+    onNewForm,
+}: GroupFormsTabProps) {
     return (
         <div className="flex flex-col gap-6">
             <GroupPageHeader
                 title="Spørreskjema"
                 action={
                     isAdmin ? (
-                        <Button onClick={() => setCreating(true)}>
+                        <Button onClick={onNewForm}>
                             <Plus />
                             Nytt spørreskjema
                         </Button>
@@ -40,10 +42,6 @@ export function GroupFormsTab({ forms, isAdmin }: GroupFormsTabProps) {
                     Ingen spørreskjema tilgjengelig ennå.
                 </p>
             )}
-            <GroupNewFormDialog
-                open={creating}
-                onClose={() => setCreating(false)}
-            />
         </div>
     );
 }

--- a/apps/kvark/src/components/group-new-form-dialog.tsx
+++ b/apps/kvark/src/components/group-new-form-dialog.tsx
@@ -7,51 +7,428 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@tihlde/ui/ui/dialog";
-import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
-import { Input } from "@tihlde/ui/ui/input";
+import { FieldError, FieldGroup, FieldSeparator } from "@tihlde/ui/ui/field";
+import { Spinner } from "@tihlde/ui/ui/spinner";
+import { Plus, Trash2 } from "lucide-react";
+import { useEffect } from "react";
+import { z } from "zod";
+
+import { formHandlers, useAppForm } from "#/hooks/form";
+
+const QUESTION_TYPES = [
+    { value: "text_answer", label: "Fritekst" },
+    { value: "single_select", label: "Ett alternativ" },
+    { value: "multiple_select", label: "Flere alternativer" },
+] as const;
+
+const optionSchema = z.object({
+    // Lokal nøkkel for React-lista. Sendes ikke til API-et.
+    key: z.string(),
+    title: z
+        .string()
+        .min(1, { error: "Alternativet må ha en tekst" })
+        .max(400, { error: "Maks 400 tegn" }),
+});
+
+const questionSchema = z
+    .object({
+        key: z.string(),
+        title: z
+            .string()
+            .min(1, { error: "Spørsmålet må ha en tekst" })
+            .max(400, { error: "Maks 400 tegn" }),
+        type: z.enum(["text_answer", "single_select", "multiple_select"]),
+        required: z.boolean(),
+        options: z.array(optionSchema),
+    })
+    .refine((q) => q.type === "text_answer" || q.options.length > 0, {
+        error: "Legg til minst ett alternativ",
+        path: ["options"],
+    });
+
+const newFormSchema = z.object({
+    title: z
+        .string()
+        .min(1, { error: "Tittel er påkrevd" })
+        .max(400, { error: "Maks 400 tegn" }),
+    description: z.string().max(2000, { error: "Maks 2000 tegn" }),
+    emailReceiverOnSubmit: z.union([
+        z.email({ error: "Må være en gyldig e-postadresse" }),
+        z.literal(""),
+    ]),
+    canSubmitMultiple: z.boolean(),
+    isOpenForSubmissions: z.boolean(),
+    onlyForGroupMembers: z.boolean(),
+    questions: z.array(questionSchema),
+});
+
+export type NewFormValues = z.infer<typeof newFormSchema>;
+type NewFormQuestion = NewFormValues["questions"][number];
+
+const EMPTY_VALUES: NewFormValues = {
+    title: "",
+    description: "",
+    emailReceiverOnSubmit: "",
+    canSubmitMultiple: true,
+    // Et nyopprettet skjema er åpent med en gang: det finnes ingen egen side
+    // for å åpne det i etterkant, så et lukket skjema ville vært et skjema
+    // ingen kan svare på.
+    isOpenForSubmissions: true,
+    onlyForGroupMembers: false,
+    questions: [],
+};
+
+/** Stabil nøkkel per spørsmål/alternativ så lista overlever sletting midt i. */
+function newKey(): string {
+    return globalThis.crypto.randomUUID();
+}
+
+function emptyQuestion(): NewFormQuestion {
+    return {
+        key: newKey(),
+        title: "",
+        type: "text_answer",
+        required: false,
+        options: [],
+    };
+}
 
 type GroupNewFormDialogProps = {
     open: boolean;
-    onClose: () => void;
+    onOpenChange: (open: boolean) => void;
+    onSubmit: (values: NewFormValues) => void | Promise<void>;
+    isSubmitting?: boolean;
+    /** Feil fra opprettelsen, vist i dialogen så skjemaet beholdes. */
+    error?: string | null;
 };
 
-export function GroupNewFormDialog({ open, onClose }: GroupNewFormDialogProps) {
+export function GroupNewFormDialog({
+    open,
+    onOpenChange,
+    onSubmit,
+    isSubmitting,
+    error,
+}: GroupNewFormDialogProps) {
+    const form = useAppForm({
+        defaultValues: EMPTY_VALUES,
+        validators: { onDynamic: newFormSchema },
+        async onSubmit({ value }) {
+            await onSubmit(value);
+        },
+    });
+
+    // Dialogen blir stående montert mellom hver gang den åpnes, så uten dette
+    // møter neste skjema forrige skjemas tittel og spørsmål.
+    useEffect(() => {
+        if (!open) form.reset();
+    }, [open, form]);
+
     return (
-        <Dialog
-            open={open}
-            onOpenChange={(o) => {
-                if (!o) onClose();
-            }}
-        >
-            <DialogContent className="max-w-md">
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
                 <DialogHeader>
                     <DialogTitle>Nytt spørreskjema</DialogTitle>
                     <DialogDescription>
-                        Alle TIHLDE-medlemmer vil kunne svare på skjemaet, flere
-                        ganger om de ønsker. Du kan legge til spørsmål etter at
-                        du har opprettet skjemaet. Spørsmålene kan endres helt
-                        til noen har svart på skjemaet.
+                        Legg til spørsmålene du vil ha svar på. Spørsmålene kan
+                        endres helt til noen har svart på skjemaet.
                     </DialogDescription>
                 </DialogHeader>
-                <form className="flex flex-col gap-4">
+                <form
+                    id="new-group-form"
+                    {...formHandlers(form)}
+                    className="flex flex-col gap-4"
+                >
                     <FieldGroup>
-                        <Field>
-                            <FieldLabel htmlFor="form-title">
-                                Tittel *
-                            </FieldLabel>
-                            <Input
-                                id="form-title"
-                                placeholder="Skriv her..."
-                                required
-                            />
-                        </Field>
+                        <form.AppField name="title">
+                            {(field) => (
+                                <field.Field required>
+                                    <field.Label>Tittel</field.Label>
+                                    <field.Input placeholder="Skriv her..." />
+                                    <field.Error />
+                                </field.Field>
+                            )}
+                        </form.AppField>
+
+                        <form.AppField name="description">
+                            {(field) => (
+                                <field.Field>
+                                    <field.Label>Beskrivelse</field.Label>
+                                    <field.Textarea
+                                        rows={3}
+                                        placeholder="Hva handler skjemaet om?"
+                                    />
+                                    <field.Error />
+                                </field.Field>
+                            )}
+                        </form.AppField>
+
+                        <FieldSeparator />
+
+                        <form.Field name="questions" mode="array">
+                            {(questions) => (
+                                <div className="flex flex-col gap-4">
+                                    {questions.state.value.map(
+                                        (question, index) => (
+                                            <div
+                                                key={question.key}
+                                                className="flex flex-col gap-3"
+                                            >
+                                                <div className="flex items-center justify-between gap-2">
+                                                    <span className="text-sm font-medium">
+                                                        Spørsmål {index + 1}
+                                                    </span>
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        aria-label={`Fjern spørsmål ${index + 1}`}
+                                                        onClick={() =>
+                                                            questions.removeValue(
+                                                                index,
+                                                            )
+                                                        }
+                                                    >
+                                                        <Trash2 />
+                                                    </Button>
+                                                </div>
+
+                                                <form.AppField
+                                                    name={`questions[${index}].title`}
+                                                >
+                                                    {(field) => (
+                                                        <field.Field required>
+                                                            <field.Label>
+                                                                Spørsmål
+                                                            </field.Label>
+                                                            <field.Input placeholder="Skriv her..." />
+                                                            <field.Error />
+                                                        </field.Field>
+                                                    )}
+                                                </form.AppField>
+
+                                                <form.AppField
+                                                    name={`questions[${index}].type`}
+                                                >
+                                                    {(field) => (
+                                                        <field.Field>
+                                                            <field.Label>
+                                                                Svartype
+                                                            </field.Label>
+                                                            <field.Select
+                                                                options={[
+                                                                    ...QUESTION_TYPES,
+                                                                ]}
+                                                            />
+                                                            <field.Error />
+                                                        </field.Field>
+                                                    )}
+                                                </form.AppField>
+
+                                                <form.AppField
+                                                    name={`questions[${index}].required`}
+                                                >
+                                                    {(field) => (
+                                                        <field.Field orientation="horizontal">
+                                                            <field.Label>
+                                                                Må besvares
+                                                            </field.Label>
+                                                            <field.Switch />
+                                                        </field.Field>
+                                                    )}
+                                                </form.AppField>
+
+                                                {/* Svartypen leses via Subscribe,
+                                                    ikke fra spørsmålsobjektet:
+                                                    array-feltet rendrer ikke på
+                                                    nytt når et underfelt endres,
+                                                    så alternativene ville aldri
+                                                    dukket opp. */}
+                                                <form.Subscribe
+                                                    selector={(state) =>
+                                                        state.values.questions[
+                                                            index
+                                                        ]?.type
+                                                    }
+                                                >
+                                                    {(type) =>
+                                                        type ===
+                                                        "text_answer" ? null : (
+                                                            <form.Field
+                                                                name={`questions[${index}].options`}
+                                                                mode="array"
+                                                            >
+                                                                {(options) => (
+                                                                    <div className="flex flex-col gap-2">
+                                                                        {options.state.value.map(
+                                                                            (
+                                                                                option,
+                                                                                optionIndex,
+                                                                            ) => (
+                                                                                <div
+                                                                                    key={
+                                                                                        option.key
+                                                                                    }
+                                                                                    className="flex items-end gap-2"
+                                                                                >
+                                                                                    <form.AppField
+                                                                                        name={`questions[${index}].options[${optionIndex}].title`}
+                                                                                    >
+                                                                                        {(
+                                                                                            field,
+                                                                                        ) => (
+                                                                                            <field.Field
+                                                                                                required
+                                                                                                className="flex-1"
+                                                                                            >
+                                                                                                <field.Label>
+                                                                                                    Alternativ{" "}
+                                                                                                    {optionIndex +
+                                                                                                        1}
+                                                                                                </field.Label>
+                                                                                                <field.Input placeholder="Skriv her..." />
+                                                                                                <field.Error />
+                                                                                            </field.Field>
+                                                                                        )}
+                                                                                    </form.AppField>
+                                                                                    <Button
+                                                                                        type="button"
+                                                                                        variant="ghost"
+                                                                                        size="icon"
+                                                                                        aria-label={`Fjern alternativ ${optionIndex + 1}`}
+                                                                                        onClick={() =>
+                                                                                            options.removeValue(
+                                                                                                optionIndex,
+                                                                                            )
+                                                                                        }
+                                                                                    >
+                                                                                        <Trash2 />
+                                                                                    </Button>
+                                                                                </div>
+                                                                            ),
+                                                                        )}
+                                                                        <Button
+                                                                            type="button"
+                                                                            variant="outline"
+                                                                            size="sm"
+                                                                            onClick={() =>
+                                                                                options.pushValue(
+                                                                                    {
+                                                                                        key: newKey(),
+                                                                                        title: "",
+                                                                                    },
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <Plus />
+                                                                            Legg
+                                                                            til
+                                                                            alternativ
+                                                                        </Button>
+                                                                        <FieldError
+                                                                            errors={
+                                                                                options
+                                                                                    .state
+                                                                                    .meta
+                                                                                    .errors
+                                                                            }
+                                                                        />
+                                                                    </div>
+                                                                )}
+                                                            </form.Field>
+                                                        )
+                                                    }
+                                                </form.Subscribe>
+
+                                                <FieldSeparator />
+                                            </div>
+                                        ),
+                                    )}
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() =>
+                                            questions.pushValue(emptyQuestion())
+                                        }
+                                    >
+                                        <Plus />
+                                        Legg til spørsmål
+                                    </Button>
+                                </div>
+                            )}
+                        </form.Field>
+
+                        <FieldSeparator />
+
+                        <form.AppField name="isOpenForSubmissions">
+                            {(field) => (
+                                <field.Field orientation="horizontal">
+                                    <field.Label>Åpent for svar</field.Label>
+                                    <field.Switch />
+                                </field.Field>
+                            )}
+                        </form.AppField>
+
+                        <form.AppField name="canSubmitMultiple">
+                            {(field) => (
+                                <field.Field orientation="horizontal">
+                                    <field.Label>
+                                        Kan svare flere ganger
+                                    </field.Label>
+                                    <field.Switch />
+                                </field.Field>
+                            )}
+                        </form.AppField>
+
+                        <form.AppField name="onlyForGroupMembers">
+                            {(field) => (
+                                <field.Field orientation="horizontal">
+                                    <field.Label>
+                                        Kun for gruppens medlemmer
+                                    </field.Label>
+                                    <field.Switch />
+                                </field.Field>
+                            )}
+                        </form.AppField>
+
+                        <form.AppField name="emailReceiverOnSubmit">
+                            {(field) => (
+                                <field.Field>
+                                    <field.Label>
+                                        Varsle denne e-postadressen ved nye svar
+                                    </field.Label>
+                                    <field.Input
+                                        type="email"
+                                        placeholder="valgfritt@tihlde.org"
+                                    />
+                                    <field.Error />
+                                </field.Field>
+                            )}
+                        </form.AppField>
                     </FieldGroup>
+                    {error ? <p role="alert">{error}</p> : null}
                 </form>
                 <DialogFooter>
-                    <Button variant="outline" onClick={onClose}>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                    >
                         Avbryt
                     </Button>
-                    <Button>Opprett spørreskjema</Button>
+                    <Button
+                        type="submit"
+                        form="new-group-form"
+                        disabled={isSubmitting}
+                    >
+                        {isSubmitting ? (
+                            <>
+                                <Spinner />
+                                <span>Oppretter...</span>
+                            </>
+                        ) : (
+                            "Opprett spørreskjema"
+                        )}
+                    </Button>
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -28,6 +28,7 @@ import {
 import {
     batchUpdateUserFinesMutation,
     createFineMutation,
+    createGroupFormMutation,
     createLawMutation,
     deleteFineMutation,
     deleteLawMutation,
@@ -60,6 +61,10 @@ import {
     type GiveFineValues,
 } from "#/components/group-give-fine-dialog";
 import { GroupLawsTab } from "#/components/group-laws-tab";
+import {
+    GroupNewFormDialog,
+    type NewFormValues,
+} from "#/components/group-new-form-dialog";
 import { GroupMembersTab } from "#/components/group-members-tab";
 import { GROUP_NAV_ITEMS, type GroupNavKey } from "#/components/group-nav";
 import { GroupOmTab } from "#/components/group-om-tab";
@@ -153,6 +158,8 @@ function GroupDetail() {
     const [fineDialogOpen, setFineDialogOpen] = useState(false);
     const [fineError, setFineError] = useState<string | null>(null);
     const [groupError, setGroupError] = useState<string | null>(null);
+    const [formDialogOpen, setFormDialogOpen] = useState(false);
+    const [formError, setFormError] = useState<string | null>(null);
 
     function setActive(tab: GroupNavKey) {
         navigate({ search: (prev) => ({ ...prev, tab }) });
@@ -173,6 +180,7 @@ function GroupDetail() {
     const updateFine = useMutation(updateFineMutation);
     const batchUpdateUserFines = useMutation(batchUpdateUserFinesMutation);
     const deleteFine = useMutation(deleteFineMutation);
+    const createGroupForm = useMutation(createGroupFormMutation);
     const createLaw = useMutation(createLawMutation);
     const updateLaw = useMutation(updateLawMutation);
     const deleteLaw = useMutation(deleteLawMutation);
@@ -365,6 +373,65 @@ function GroupDetail() {
                 error instanceof Error
                     ? error.message
                     : "Ukjent feil da gruppen skulle lagres",
+            );
+        }
+    }
+
+    function openNewForm() {
+        setFormError(null);
+        setFormDialogOpen(true);
+    }
+
+    /**
+     * Rekkefølgen på spørsmål og alternativer er posisjonen i lista: API-et
+     * sorterer på `order`, så uten den ville skjemaet vist spørsmålene i
+     * vilkårlig rekkefølge.
+     */
+    async function handleCreateForm(values: NewFormValues) {
+        setFormError(null);
+        try {
+            await createGroupForm.mutateAsync({
+                slug,
+                data: {
+                    group: slug,
+                    title: values.title,
+                    template: false,
+                    can_submit_multiple: values.canSubmitMultiple,
+                    is_open_for_submissions: values.isOpenForSubmissions,
+                    only_for_group_members: values.onlyForGroupMembers,
+                    ...(values.description
+                        ? { description: values.description }
+                        : {}),
+                    ...(values.emailReceiverOnSubmit
+                        ? {
+                              email_receiver_on_submit:
+                                  values.emailReceiverOnSubmit,
+                          }
+                        : {}),
+                    fields: values.questions.map((question, order) => ({
+                        title: question.title,
+                        type: question.type,
+                        required: question.required,
+                        order,
+                        options:
+                            question.type === "text_answer"
+                                ? []
+                                : question.options.map(
+                                      (option, optionOrder) => ({
+                                          title: option.title,
+                                          order: optionOrder,
+                                      }),
+                                  ),
+                    })),
+                },
+            });
+
+            setFormDialogOpen(false);
+        } catch (error) {
+            setFormError(
+                error instanceof Error
+                    ? error.message
+                    : "Ukjent feil da spørreskjemaet skulle opprettes",
             );
         }
     }
@@ -576,7 +643,11 @@ function GroupDetail() {
                         />
                     ) : null}
                     {activeTab === "sporreskjema" ? (
-                        <GroupFormsTab forms={forms} isAdmin={canManageForms} />
+                        <GroupFormsTab
+                            forms={forms}
+                            isAdmin={canManageForms}
+                            onNewForm={openNewForm}
+                        />
                     ) : null}
                 </DetailLayoutContent>
             </DetailLayout>
@@ -589,6 +660,14 @@ function GroupDetail() {
                 onSubmit={handleGiveFine}
                 isSubmitting={createFine.isPending || isUploading}
                 error={fineError}
+            />
+
+            <GroupNewFormDialog
+                open={formDialogOpen}
+                onOpenChange={setFormDialogOpen}
+                onSubmit={handleCreateForm}
+                isSubmitting={createGroupForm.isPending}
+                error={formError}
             />
         </>
     );


### PR DESCRIPTION
## Problem

Det gikk ikke an å opprette et nytt spørreskjema. `GroupNewFormDialog` var en tom skallkomponent: ett tittelfelt uten state, ingen `onSubmit`, ingen mutasjon — knappen «Opprett spørreskjema» lå til og med utenfor `<form>`-taggen. Klikk på den gjorde bokstavelig talt ingenting.

Backend-endepunktet `POST /api/groups/{slug}/forms` og `createGroupFormMutation` fantes hele tiden; de ble bare aldri kalt fra noe sted i frontenden.

## Hva som er endret

- **`group-new-form-dialog.tsx`** er nå et ekte skjema med `useAppForm` + Zod-validering:
  - tittel (påkrevd) og beskrivelse
  - spørsmålsbygger: fritekst / ett alternativ / flere alternativer, med alternativer og «må besvares»
  - innstillinger: «åpent for svar», «kan svare flere ganger», «kun for gruppens medlemmer», varslings-e-post
- **`grupper.$slug.tsx`** eier dialogtilstanden og kaller mutasjonen — samme mønster som bot-dialogen. Feil vises i dialogen så utfyllingen beholdes.
- **`group-forms-tab.tsx`** er igjen en dum komponent som bare varsler via `onNewForm`.

## Verdt å vite for reviewer

- **Hvorfor spørsmålsbygger i opprettelsesdialogen:** det finnes ikke noe grensesnitt for å redigere et skjema etterpå. Uten spørsmålene ved opprettelse ville skjemaet vært tomt og ubrukelig.
- **«Åpent for svar» står på som standard** (API-ets default er `false`). Det finnes ingen side for å åpne et skjema i etterkant, så et lukket skjema ville vært umulig å svare på.
- **`form.Subscribe` for svartypen:** array-feltet i TanStack Form rendrer ikke på nytt når et underfelt endres, så alternativ-feltene dukket aldri opp når svartypen ble endret. Dette ble fanget under verifisering i nettleseren.

## Verifisering

Kjørt lokalt mot dev-API-et, logget inn som testbruker:

- Opprettet et skjema med ett flervalgsspørsmål på gruppa Index. API-et returnerte feltet som `single_select` med alternativene «Blå»/«Grønn» i riktig rekkefølge og `is_open_for_submissions: true`.
- Skjemaet dukket opp i lista umiddelbart (query-invalidering) og kunne besvares på `/sporreskjema/<id>`.
- Validering blokkerer innsending og viser «Tittel er påkrevd», «Spørsmålet må ha en tekst» og «Legg til minst ett alternativ».
- Testskjemaet er slettet igjen.
- `bun run typecheck`, `bun run lint` og `bun run format` er grønne.

## Utenfor scope

Det finnes fortsatt ingen måte å redigere et eksisterende skjema på — skjemaer som allerede er lagret som lukket (f.eks. «gammelt» og «Opptak») kan ikke åpnes, spørsmål kan ikke endres, og det finnes ingen side for å se innsendte svar. API-et støtter alt dette allerede (`PATCH /api/forms/{id}`, submissions, statistics); det trengs en egen PR for grensesnittet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)