### PR TITLE
feat(forms): rediger gruppe-spørreskjema og se svar

### DIFF
--- a/apps/api/src/lib/form/exceptions.ts
+++ b/apps/api/src/lib/form/exceptions.ts
@@ -8,6 +8,19 @@ export class DuplicateSubmissionException extends HTTPException {
     }
 }
 
+/**
+ * Rewriting the questions deletes the answers that belong to them, so a group
+ * form is frozen from the first submission.
+ */
+export class FormHasSubmissionsException extends HTTPException {
+    constructor() {
+        super(409, {
+            message:
+                "Spørsmålene kan ikke endres etter at noen har svart på skjemaet",
+        });
+    }
+}
+
 export class FormNotOpenForSubmissionException extends HTTPException {
     constructor() {
         super(403, {

--- a/apps/api/src/routes/form/index.ts
+++ b/apps/api/src/routes/form/index.ts
@@ -22,9 +22,10 @@ export const formRoutes = route()
     // Form statistics
     .route("/", statisticsRoute)
 
-    // Submissions
+    // Submissions. `/submissions/download` må stå før `/submissions/:id`, ellers
+    // matcher id-ruten først og «download» brukes som innsendings-id.
     .route("/", createSubmissionRoute)
     .route("/", listSubmissionsRoute)
-    .route("/", getSubmissionRoute)
     .route("/", downloadSubmissionsRoute)
+    .route("/", getSubmissionRoute)
     .route("/", deleteSubmissionWithReasonRoute);

--- a/apps/api/src/routes/form/schema.ts
+++ b/apps/api/src/routes/form/schema.ts
@@ -49,7 +49,27 @@ const updateFormBase = z.object({
     fields: z.array(updateFieldSchema).optional(),
 });
 
-export const updateFormSchema = Schema("UpdateForm", updateFormBase);
+/**
+ * The submission rules a group owns for its own forms. They live on the
+ * group_form row, not on the form, so they are only written when the form
+ * being updated is a group form.
+ */
+const groupFormSettings = {
+    // `null` tømmer mottakeren; utelatt lar den stå som den er.
+    email_receiver_on_submit: z.string().email().nullable().optional(),
+    can_submit_multiple: z.boolean().optional(),
+    is_open_for_submissions: z.boolean().optional(),
+    only_for_group_members: z.boolean().optional(),
+};
+
+/**
+ * PATCH /forms/:id is the only update endpoint a group form has, so it also
+ * carries the group settings. They are ignored for event forms and templates.
+ */
+export const updateFormSchema = Schema(
+    "UpdateForm",
+    updateFormBase.extend(groupFormSettings),
+);
 
 // ===== EVENT FORM INPUT SCHEMAS =====
 
@@ -83,12 +103,7 @@ export const createGroupFormSchema = Schema(
 
 export const updateGroupFormSchema = Schema(
     "UpdateGroupForm",
-    updateFormBase.extend({
-        email_receiver_on_submit: z.string().email().optional(),
-        can_submit_multiple: z.boolean().optional(),
-        is_open_for_submissions: z.boolean().optional(),
-        only_for_group_members: z.boolean().optional(),
-    }),
+    updateFormBase.extend(groupFormSettings),
 );
 
 // ===== SUBMISSION INPUT SCHEMAS =====
@@ -228,6 +243,11 @@ export const updateFormResponseSchema = Schema(
         created_at: z.string().optional(),
         updated_at: z.string().optional(),
         fields: z.array(formFieldResponseSchema).optional(),
+        // Null for everything that is not a group form.
+        email_receiver_on_submit: z.string().nullable().optional(),
+        can_submit_multiple: z.boolean().nullable().optional(),
+        is_open_for_submissions: z.boolean().nullable().optional(),
+        only_for_group_members: z.boolean().nullable().optional(),
     }),
 );
 

--- a/apps/api/src/routes/form/update.ts
+++ b/apps/api/src/routes/form/update.ts
@@ -3,6 +3,7 @@ import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
+import { FormHasSubmissionsException } from "~/lib/form/exceptions";
 import { canManageForm, updateFieldsAndOptions } from "~/lib/form/service";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -69,15 +70,56 @@ export const updateRoute = route().patch(
             });
         }
 
-        // Update form
-        await db
-            .update(schema.form)
-            .set({
-                title: body.title,
-                description: body.description,
-                isTemplate: body.template,
-            })
-            .where(eq(schema.form.id, formId));
+        // The submission rules live on the group_form row, so they can only be
+        // written when the form actually belongs to a group.
+        const groupForm = await db.query.formGroupForm.findFirst({
+            where: eq(schema.formGroupForm.formId, formId),
+        });
+
+        // Rewriting the questions deletes the answers hanging off them. Event
+        // forms are left alone here — organisers may edit a survey while
+        // registrations are open, and re-submitting replaces the old answer.
+        if (body.fields && groupForm) {
+            const answered = await db.query.formSubmission.findFirst({
+                where: eq(schema.formSubmission.formId, formId),
+            });
+            if (answered) {
+                throw new FormHasSubmissionsException();
+            }
+        }
+
+        // Both updates are skipped when the body carries nothing for them:
+        // Drizzle rejects a `set` where every value is undefined, so a patch
+        // that only flips «åpent for svar» must not touch the form row.
+        const formValues = {
+            title: body.title,
+            description: body.description,
+            isTemplate: body.template,
+        };
+
+        if (Object.values(formValues).some((value) => value !== undefined)) {
+            await db
+                .update(schema.form)
+                .set(formValues)
+                .where(eq(schema.form.id, formId));
+        }
+
+        const groupFormValues = {
+            emailReceiverOnSubmit: body.email_receiver_on_submit,
+            canSubmitMultiple: body.can_submit_multiple,
+            isOpenForSubmissions: body.is_open_for_submissions,
+            onlyForGroupMembers: body.only_for_group_members,
+        };
+
+        if (
+            groupForm &&
+            Object.values(groupFormValues).some((value) => value !== undefined)
+        ) {
+            await db
+                .update(schema.formGroupForm)
+                .set(groupFormValues)
+                .where(eq(schema.formGroupForm.formId, formId));
+        }
 
         // Update fields if provided
         if (body.fields) {
@@ -99,11 +141,24 @@ export const updateRoute = route().patch(
             },
         });
 
+        const updatedGroupForm = groupForm
+            ? await db.query.formGroupForm.findFirst({
+                  where: eq(schema.formGroupForm.formId, formId),
+              })
+            : undefined;
+
         return c.json({
             id: updatedForm?.id,
             title: updatedForm?.title,
             description: updatedForm?.description,
             template: updatedForm?.isTemplate,
+            email_receiver_on_submit:
+                updatedGroupForm?.emailReceiverOnSubmit ?? null,
+            can_submit_multiple: updatedGroupForm?.canSubmitMultiple ?? null,
+            is_open_for_submissions:
+                updatedGroupForm?.isOpenForSubmissions ?? null,
+            only_for_group_members:
+                updatedGroupForm?.onlyForGroupMembers ?? null,
             created_at: updatedForm?.createdAt.toISOString(),
             updated_at: updatedForm?.updatedAt.toISOString(),
             fields: updatedForm?.fields.map((field) => ({

--- a/apps/api/src/routes/groups/form/list.ts
+++ b/apps/api/src/routes/groups/form/list.ts
@@ -107,6 +107,12 @@ export const listGroupFormsRoute = route().get(
             }),
         );
 
+        // Uten en sortering kommer radene i den rekkefølgen Postgres finner
+        // dem, og et skjema hopper nedover i lista hver gang det redigeres.
+        formsWithAnswers.sort((a, b) =>
+            b.created_at.localeCompare(a.created_at),
+        );
+
         return c.json(formsWithAnswers);
     },
 );

--- a/apps/kvark/src/api/queries/forms.ts
+++ b/apps/kvark/src/api/queries/forms.ts
@@ -4,6 +4,7 @@ import {
     queryOptions,
 } from "@tanstack/react-query";
 import { apiClient } from "#/api/api-client";
+import { GroupQueryKeys } from "#/api/queries/groups";
 import type { QueryParamsHelper } from "@tihlde/sdk/types";
 import type { CreateForm, UpdateForm, CreateSubmission } from "@tihlde/sdk";
 
@@ -100,6 +101,12 @@ export const updateFormMutation = mutationOptions({
         });
         ctx.client.invalidateQueries({
             queryKey: [...FormQueryKeys.statistics, vars.formId],
+            exact: false,
+        });
+        // Tittelen og innstillingene til et gruppeskjema vises i gruppas egen
+        // skjemaliste, som ligger under en helt annen nøkkel.
+        ctx.client.invalidateQueries({
+            queryKey: [...GroupQueryKeys.forms],
             exact: false,
         });
     },

--- a/apps/kvark/src/api/queries/groups.ts
+++ b/apps/kvark/src/api/queries/groups.ts
@@ -18,7 +18,9 @@ import type {
     CreateGroupForm,
 } from "@tihlde/sdk";
 
-const GroupQueryKeys = {
+// Eksportert fordi et gruppeskjema også oppdateres gjennom /api/forms, og den
+// mutasjonen må kunne invalidere gruppas skjemaliste.
+export const GroupQueryKeys = {
     listInfinite: ["groups", "list-infinite"] as const,
     list: ["groups", "list-paged"] as const,
     mine: ["groups", "mine"] as const,

--- a/apps/kvark/src/components/form-statistics-list.tsx
+++ b/apps/kvark/src/components/form-statistics-list.tsx
@@ -1,0 +1,43 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
+import { Progress, ProgressLabel, ProgressValue } from "@tihlde/ui/ui/progress";
+
+import type { FormQuestionStatistics } from "#/lib/form";
+
+type FormStatisticsListProps = {
+    statistics: FormQuestionStatistics[];
+};
+
+export function FormStatisticsList({ statistics }: FormStatisticsListProps) {
+    if (statistics.length === 0) {
+        return (
+            <p className="text-sm text-muted-foreground">
+                Skjemaet har ingen spørsmål med alternativer, så det er ingen
+                fordeling å vise. Fritekstsvarene ligger under «Svar».
+            </p>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+            {statistics.map((question) => (
+                <Card key={question.id}>
+                    <CardHeader>
+                        <CardTitle>{question.title}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="flex flex-col gap-4">
+                        {question.options.map((option) => (
+                            <Progress key={option.id} value={option.percentage}>
+                                <ProgressLabel>{option.title}</ProgressLabel>
+                                <ProgressValue>
+                                    {() =>
+                                        `${option.count} (${option.percentage} %)`
+                                    }
+                                </ProgressValue>
+                            </Progress>
+                        ))}
+                    </CardContent>
+                </Card>
+            ))}
+        </div>
+    );
+}

--- a/apps/kvark/src/components/form-submissions-table.tsx
+++ b/apps/kvark/src/components/form-submissions-table.tsx
@@ -1,0 +1,74 @@
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@tihlde/ui/ui/table";
+
+import type { FormSubmissionRow } from "#/lib/form";
+
+type FormSubmissionsTableProps = {
+    /** Spørsmålene, i skjemaets rekkefølge. Én kolonne hver. */
+    questions: { id: string; title: string }[];
+    submissions: FormSubmissionRow[];
+};
+
+export function FormSubmissionsTable({
+    questions,
+    submissions,
+}: FormSubmissionsTableProps) {
+    if (submissions.length === 0) {
+        return (
+            <p className="text-sm text-muted-foreground">
+                Ingen har svart på skjemaet ennå.
+            </p>
+        );
+    }
+
+    // Ett spørsmål er én kolonne, så tabellen blir bredere enn siden. `Table`
+    // ruller allerede vannrett selv; svarkolonnene får en makshøyde på bredden
+    // slik at et langt fritekstsvar brytes i stedet for å strekke tabellen ut
+    // i titusenvis av piksler.
+    return (
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    <TableHead>Navn</TableHead>
+                    <TableHead>Sendt inn</TableHead>
+                    {questions.map((question) => (
+                        <TableHead key={question.id} className="max-w-xs">
+                            {question.title}
+                        </TableHead>
+                    ))}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {submissions.map((submission) => (
+                    <TableRow key={submission.id}>
+                        <TableCell>
+                            <div className="flex flex-col">
+                                <span>{submission.userName}</span>
+                                <span className="text-xs text-muted-foreground">
+                                    {submission.userEmail}
+                                </span>
+                            </div>
+                        </TableCell>
+                        <TableCell>{submission.submittedAt}</TableCell>
+                        {questions.map((question) => (
+                            <TableCell
+                                key={question.id}
+                                className="max-w-xs whitespace-normal"
+                            >
+                                {submission.answers.find(
+                                    (answer) => answer.fieldId === question.id,
+                                )?.text ?? ""}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+}

--- a/apps/kvark/src/components/group-form-edit-dialog.tsx
+++ b/apps/kvark/src/components/group-form-edit-dialog.tsx
@@ -1,0 +1,519 @@
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
+import { Button } from "@tihlde/ui/ui/button";
+import { Card, CardContent } from "@tihlde/ui/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@tihlde/ui/ui/dialog";
+import {
+    FieldContent,
+    FieldGroup,
+    FieldLegend,
+    FieldSet,
+} from "@tihlde/ui/ui/field";
+import { Separator } from "@tihlde/ui/ui/separator";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import { Spinner } from "@tihlde/ui/ui/spinner";
+import { LockIcon, PlusIcon, TrashIcon, TriangleAlert } from "lucide-react";
+import { z } from "zod";
+
+import { formHandlers, useAppForm } from "#/hooks/form";
+import type { FormQuestionType, FormQuestionValues } from "#/lib/form";
+import type { Form } from "#/lib/group";
+
+export type GroupFormEditValues = {
+    title: string;
+    description: string;
+    isOpen: boolean;
+    canSubmitMultiple: boolean;
+    onlyForMembers: boolean;
+    /** Tom streng betyr «ingen varsling». */
+    emailReceiver: string;
+    /**
+     * Utelatt når skjemaet allerede har svar. Da skal spørsmålene ikke sendes
+     * med i det hele tatt — API-et sletter svarene til spørsmål som forsvinner.
+     */
+    questions?: FormQuestionValues[];
+};
+
+const QUESTION_TYPES: { value: FormQuestionType; label: string }[] = [
+    { value: "text_answer", label: "Fritekst" },
+    { value: "single_select", label: "Ett alternativ" },
+    { value: "multiple_select", label: "Flere alternativer" },
+];
+
+const questionSchema = z
+    .object({
+        id: z.string().optional(),
+        title: z.string().min(1, { error: "Spørsmålet må ha en tekst" }),
+        type: z.enum(["text_answer", "single_select", "multiple_select"]),
+        required: z.boolean(),
+        options: z.array(
+            z.object({
+                id: z.string().optional(),
+                title: z
+                    .string()
+                    .min(1, { error: "Alternativet må ha en tekst" }),
+            }),
+        ),
+    })
+    .refine(
+        (question) =>
+            question.type === "text_answer" || question.options.length > 0,
+        { error: "Legg til minst ett alternativ", path: ["options"] },
+    );
+
+const schema = z.object({
+    title: z
+        .string()
+        .min(1, { error: "Tittel er påkrevd" })
+        .max(400, { error: "Maks 400 tegn" }),
+    description: z.string(),
+    isOpen: z.boolean(),
+    canSubmitMultiple: z.boolean(),
+    onlyForMembers: z.boolean(),
+    emailReceiver: z.union([
+        z.literal(""),
+        z.email({ error: "Ugyldig e-postadresse" }),
+    ]),
+    questions: z.array(questionSchema),
+});
+
+type GroupFormEditDialogProps = {
+    open: boolean;
+    /** Skjemaet som redigeres. Null når ingen er valgt. */
+    form: Form | null;
+    /** Spørsmålene slik de er lagret. Null mens de lastes. */
+    questions: FormQuestionValues[] | null;
+    /** Antall svar. Over 0 låser spørsmålene. */
+    answerCount: number;
+    onClose: () => void;
+    onSubmit: (values: GroupFormEditValues) => void;
+    isSubmitting: boolean;
+    error: string | null;
+};
+
+export function GroupFormEditDialog({
+    open,
+    form,
+    questions,
+    answerCount,
+    onClose,
+    onSubmit,
+    isSubmitting,
+    error,
+}: GroupFormEditDialogProps) {
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(o) => {
+                if (!o) onClose();
+            }}
+        >
+            <DialogContent className="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>Rediger spørreskjema</DialogTitle>
+                    <DialogDescription>
+                        Endringene gjelder med én gang du lagrer.
+                    </DialogDescription>
+                </DialogHeader>
+                {form && questions ? (
+                    // Nøkkelen remonterer skjemaet når et annet spørreskjema
+                    // åpnes: TanStack Form leser defaultValues bare én gang.
+                    <EditForm
+                        key={form.id}
+                        form={form}
+                        questions={questions}
+                        answerCount={answerCount}
+                        onClose={onClose}
+                        onSubmit={onSubmit}
+                        isSubmitting={isSubmitting}
+                        error={error}
+                    />
+                ) : (
+                    <div className="flex flex-col gap-3">
+                        <Skeleton className="h-9 w-full" />
+                        <Skeleton className="h-20 w-full" />
+                        <Skeleton className="h-9 w-full" />
+                    </div>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+type EditFormProps = {
+    form: Form;
+    questions: FormQuestionValues[];
+    answerCount: number;
+    onClose: () => void;
+    onSubmit: (values: GroupFormEditValues) => void;
+    isSubmitting: boolean;
+    error: string | null;
+};
+
+/**
+ * Skjemaet er skilt ut i en egen hook slik at delkomponentene under kan navngi
+ * typen sin med `ReturnType` i stedet for å gjenta generikken til TanStack Form.
+ */
+function useEditForm({
+    form,
+    questions,
+    answerCount,
+    onSubmit,
+}: Pick<EditFormProps, "form" | "questions" | "answerCount" | "onSubmit">) {
+    const questionsLocked = answerCount > 0;
+
+    return useAppForm({
+        defaultValues: {
+            title: form.title,
+            description: form.description,
+            isOpen: form.isOpen,
+            canSubmitMultiple: form.canSubmitMultiple,
+            onlyForMembers: form.onlyForMembers,
+            emailReceiver: form.emailReceiver,
+            questions,
+        },
+        validators: { onDynamic: schema },
+        onSubmit({ value }) {
+            onSubmit({
+                title: value.title.trim(),
+                description: value.description,
+                isOpen: value.isOpen,
+                canSubmitMultiple: value.canSubmitMultiple,
+                onlyForMembers: value.onlyForMembers,
+                emailReceiver: value.emailReceiver.trim(),
+                ...(questionsLocked ? {} : { questions: value.questions }),
+            });
+        },
+    });
+}
+
+type EditFormApi = ReturnType<typeof useEditForm>;
+
+function EditForm({
+    form,
+    questions,
+    answerCount,
+    onClose,
+    onSubmit,
+    isSubmitting,
+    error,
+}: EditFormProps) {
+    const editForm = useEditForm({ form, questions, answerCount, onSubmit });
+
+    return (
+        <form {...formHandlers(editForm)} className="flex flex-col gap-6">
+            {error ? (
+                <Alert variant="destructive">
+                    <TriangleAlert />
+                    <AlertTitle>Klarte ikke å lagre skjemaet</AlertTitle>
+                    <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            ) : null}
+
+            <FieldGroup>
+                <editForm.AppField name="title">
+                    {(field) => (
+                        <field.Field required>
+                            <field.Label>Tittel</field.Label>
+                            <field.Input placeholder="Skriv her..." />
+                            <field.Error />
+                        </field.Field>
+                    )}
+                </editForm.AppField>
+                <editForm.AppField name="description">
+                    {(field) => (
+                        <field.Field>
+                            <field.Label>Beskrivelse</field.Label>
+                            <field.Textarea
+                                rows={3}
+                                placeholder="Skriv her..."
+                            />
+                            <field.Description>
+                                Vises over spørsmålene
+                            </field.Description>
+                            <field.Error />
+                        </field.Field>
+                    )}
+                </editForm.AppField>
+                <editForm.AppField name="isOpen">
+                    {(field) => (
+                        <field.Field orientation="horizontal">
+                            <FieldContent>
+                                <field.Label>Åpent for svar</field.Label>
+                                <field.Description>
+                                    Skjemaet kan bare svares på og deles når det
+                                    er åpent
+                                </field.Description>
+                            </FieldContent>
+                            <field.Switch />
+                        </field.Field>
+                    )}
+                </editForm.AppField>
+                <editForm.AppField name="canSubmitMultiple">
+                    {(field) => (
+                        <field.Field orientation="horizontal">
+                            <FieldContent>
+                                <field.Label>
+                                    Tillat flere svar fra samme person
+                                </field.Label>
+                            </FieldContent>
+                            <field.Switch />
+                        </field.Field>
+                    )}
+                </editForm.AppField>
+                <editForm.AppField name="onlyForMembers">
+                    {(field) => (
+                        <field.Field orientation="horizontal">
+                            <FieldContent>
+                                <field.Label>
+                                    Bare for medlemmer av gruppen
+                                </field.Label>
+                            </FieldContent>
+                            <field.Switch />
+                        </field.Field>
+                    )}
+                </editForm.AppField>
+                <editForm.AppField name="emailReceiver">
+                    {(field) => (
+                        <field.Field>
+                            <field.Label>Varsle på e-post</field.Label>
+                            <field.Input
+                                type="email"
+                                placeholder="navn@tihlde.org"
+                            />
+                            <field.Description>
+                                Får en e-post for hvert svar. La stå tom for
+                                ingen varsling.
+                            </field.Description>
+                            <field.Error />
+                        </field.Field>
+                    )}
+                </editForm.AppField>
+            </FieldGroup>
+
+            <Separator />
+
+            {answerCount > 0 ? (
+                <Alert>
+                    <LockIcon />
+                    <AlertTitle>Spørsmålene er låst</AlertTitle>
+                    <AlertDescription>
+                        Skjemaet har {answerCount}{" "}
+                        {answerCount === 1 ? "svar" : "svar"}. Å endre
+                        spørsmålene nå ville slettet svarene som hører til dem.
+                    </AlertDescription>
+                </Alert>
+            ) : (
+                <QuestionsEditor editForm={editForm} />
+            )}
+
+            <DialogFooter>
+                <Button type="button" variant="outline" onClick={onClose}>
+                    Avbryt
+                </Button>
+                <editForm.AppForm>
+                    <editForm.SubmitButton
+                        disabled={isSubmitting}
+                        loading={
+                            <>
+                                <Spinner />
+                                <span>Lagrer...</span>
+                            </>
+                        }
+                    >
+                        Lagre
+                    </editForm.SubmitButton>
+                </editForm.AppForm>
+            </DialogFooter>
+        </form>
+    );
+}
+
+/**
+ * Spørsmålene redigeres som en liste: rekkefølgen i listen blir rekkefølgen i
+ * skjemaet, og `order` settes av den som lagrer.
+ */
+function QuestionsEditor({ editForm }: { editForm: EditFormApi }) {
+    return (
+        <editForm.Field name="questions" mode="array">
+            {(questionList) => (
+                <FieldSet>
+                    <div className="flex items-center justify-between gap-2">
+                        <FieldLegend variant="label" className="mb-0">
+                            Spørsmål
+                        </FieldLegend>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                                questionList.pushValue({
+                                    title: "",
+                                    type: "text_answer",
+                                    required: false,
+                                    options: [],
+                                })
+                            }
+                        >
+                            <PlusIcon />
+                            Nytt spørsmål
+                        </Button>
+                    </div>
+
+                    {questionList.state.value.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">
+                            Skjemaet har ingen spørsmål ennå.
+                        </p>
+                    ) : null}
+
+                    {questionList.state.value.map((_, index) => (
+                        <QuestionRow
+                            // Indeksen er nøkkelen: et nytt spørsmål har ingen
+                            // stabil id før det er lagret.
+                            key={index}
+                            editForm={editForm}
+                            index={index}
+                            onRemove={() => questionList.removeValue(index)}
+                        />
+                    ))}
+                </FieldSet>
+            )}
+        </editForm.Field>
+    );
+}
+
+function QuestionRow({
+    editForm,
+    index,
+    onRemove,
+}: {
+    editForm: EditFormApi;
+    index: number;
+    onRemove: () => void;
+}) {
+    return (
+        <Card>
+            <CardContent className="flex flex-col gap-4">
+                <div className="flex items-start gap-2">
+                    <editForm.AppField name={`questions[${index}].title`}>
+                        {(field) => (
+                            <field.Field required className="flex-1">
+                                <field.Label>Spørsmål {index + 1}</field.Label>
+                                <field.Input placeholder="Skriv her..." />
+                                <field.Error />
+                            </field.Field>
+                        )}
+                    </editForm.AppField>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Slett spørsmål ${index + 1}`}
+                        className="mt-6"
+                        onClick={onRemove}
+                    >
+                        <TrashIcon />
+                    </Button>
+                </div>
+
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                    <editForm.AppField name={`questions[${index}].type`}>
+                        {(field) => (
+                            <field.Field className="flex-1">
+                                <field.Label>Type</field.Label>
+                                <field.Select options={QUESTION_TYPES} />
+                                <field.Error />
+                            </field.Field>
+                        )}
+                    </editForm.AppField>
+                    <editForm.AppField name={`questions[${index}].required`}>
+                        {(field) => (
+                            <field.Field orientation="horizontal">
+                                <FieldContent>
+                                    <field.Label>Påkrevd</field.Label>
+                                </FieldContent>
+                                <field.Switch />
+                            </field.Field>
+                        )}
+                    </editForm.AppField>
+                </div>
+
+                <editForm.Subscribe
+                    selector={(state) => state.values.questions[index]?.type}
+                >
+                    {(type) =>
+                        type === "text_answer" || type === undefined ? null : (
+                            <OptionsEditor editForm={editForm} index={index} />
+                        )
+                    }
+                </editForm.Subscribe>
+            </CardContent>
+        </Card>
+    );
+}
+
+function OptionsEditor({
+    editForm,
+    index,
+}: {
+    editForm: EditFormApi;
+    index: number;
+}) {
+    return (
+        <editForm.Field name={`questions[${index}].options`} mode="array">
+            {(optionList) => (
+                <div className="flex flex-col gap-2">
+                    {optionList.state.value.map((_, optionIndex) => (
+                        <div key={optionIndex} className="flex items-end gap-2">
+                            <editForm.AppField
+                                name={`questions[${index}].options[${optionIndex}].title`}
+                            >
+                                {(field) => (
+                                    <field.Field className="flex-1">
+                                        <field.Label>
+                                            Alternativ {optionIndex + 1}
+                                        </field.Label>
+                                        <field.Input placeholder="Skriv her..." />
+                                        <field.Error />
+                                    </field.Field>
+                                )}
+                            </editForm.AppField>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                aria-label={`Slett alternativ ${optionIndex + 1}`}
+                                onClick={() =>
+                                    optionList.removeValue(optionIndex)
+                                }
+                            >
+                                <TrashIcon />
+                            </Button>
+                        </div>
+                    ))}
+                    {optionList.state.value.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">
+                            Spørsmålet trenger minst ett alternativ.
+                        </p>
+                    ) : null}
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="self-start"
+                        onClick={() => optionList.pushValue({ title: "" })}
+                    >
+                        <PlusIcon />
+                        Nytt alternativ
+                    </Button>
+                </div>
+            )}
+        </editForm.Field>
+    );
+}

--- a/apps/kvark/src/components/group-form-row.tsx
+++ b/apps/kvark/src/components/group-form-row.tsx
@@ -1,15 +1,19 @@
 import { Link } from "@tanstack/react-router";
 import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
+import { ListChecksIcon, PencilIcon } from "lucide-react";
 
 import { ShareButton } from "#/components/share-button";
 import type { Form } from "#/lib/group";
 
 type GroupFormRowProps = {
     form: Form;
+    /** Om den som ser på kan redigere skjemaet og se svarene. */
+    canManage: boolean;
+    onEdit: () => void;
 };
 
-export function GroupFormRow({ form }: GroupFormRowProps) {
+export function GroupFormRow({ form, canManage, onEdit }: GroupFormRowProps) {
     return (
         <Card>
             <CardHeader>
@@ -18,14 +22,12 @@ export function GroupFormRow({ form }: GroupFormRowProps) {
             <CardContent className="flex flex-col gap-3">
                 {!form.isOpen ? (
                     <p className="text-sm text-muted-foreground">
-                        Spørreskjemaet er ikke åpent for innsending av svar. Du
-                        må åpne spørreskjemaet for innsending for å kunne svare
-                        på og dele skjemaet.
+                        Spørreskjemaet er ikke åpent for innsending av svar.
+                        {canManage
+                            ? " Åpne det under «Rediger» for å kunne svare på og dele skjemaet."
+                            : ""}
                     </p>
                 ) : null}
-                {/* «Administrer» lå her, men det finnes ingen side for å se
-                    eller redigere svar ennå — knappen gjorde ingenting. Den
-                    kommer tilbake når administrasjonsgrensesnittet finnes. */}
                 <div className="flex flex-wrap items-center gap-2">
                     <Button
                         variant="outline"
@@ -40,6 +42,32 @@ export function GroupFormRow({ form }: GroupFormRowProps) {
                     >
                         Svar på/se skjema
                     </Button>
+                    {canManage ? (
+                        <>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={onEdit}
+                            >
+                                <PencilIcon />
+                                Rediger
+                            </Button>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                nativeButton={false}
+                                render={
+                                    <Link
+                                        to="/sporreskjema/$id/svar"
+                                        params={{ id: form.id }}
+                                    />
+                                }
+                            >
+                                <ListChecksIcon />
+                                Se svar
+                            </Button>
+                        </>
+                    ) : null}
                     <ShareButton
                         showLabel
                         label="Del skjema"

--- a/apps/kvark/src/components/group-forms-tab.tsx
+++ b/apps/kvark/src/components/group-forms-tab.tsx
@@ -1,26 +1,60 @@
 import { Button } from "@tihlde/ui/ui/button";
 import { Plus } from "lucide-react";
-import { useState } from "react";
 
+import {
+    GroupFormEditDialog,
+    type GroupFormEditValues,
+} from "#/components/group-form-edit-dialog";
 import { GroupFormRow } from "#/components/group-form-row";
 import { GroupNewFormDialog } from "#/components/group-new-form-dialog";
 import { GroupPageHeader } from "#/components/group-page-header";
+import type { FormQuestionValues } from "#/lib/form";
 import type { Form } from "#/lib/group";
 
 type GroupFormsTabProps = {
     forms: Form[];
     isAdmin: boolean;
+    isCreateOpen: boolean;
+    onOpenCreate: () => void;
+    onCloseCreate: () => void;
+    onCreate: (values: { title: string }) => void;
+    isCreating: boolean;
+    createError: string | null;
+    /** Skjemaet som redigeres. Null når dialogen er lukket. */
+    editingForm: Form | null;
+    /** Spørsmålene til skjemaet som redigeres. Null mens de lastes. */
+    editingQuestions: FormQuestionValues[] | null;
+    editingAnswerCount: number;
+    onEditForm: (form: Form | null) => void;
+    onSave: (values: GroupFormEditValues) => void;
+    isSaving: boolean;
+    saveError: string | null;
 };
 
-export function GroupFormsTab({ forms, isAdmin }: GroupFormsTabProps) {
-    const [creating, setCreating] = useState(false);
+export function GroupFormsTab({
+    forms,
+    isAdmin,
+    isCreateOpen,
+    onOpenCreate,
+    onCloseCreate,
+    onCreate,
+    isCreating,
+    createError,
+    editingForm,
+    editingQuestions,
+    editingAnswerCount,
+    onEditForm,
+    onSave,
+    isSaving,
+    saveError,
+}: GroupFormsTabProps) {
     return (
         <div className="flex flex-col gap-6">
             <GroupPageHeader
                 title="Spørreskjema"
                 action={
                     isAdmin ? (
-                        <Button onClick={() => setCreating(true)}>
+                        <Button onClick={onOpenCreate}>
                             <Plus />
                             Nytt spørreskjema
                         </Button>
@@ -31,7 +65,11 @@ export function GroupFormsTab({ forms, isAdmin }: GroupFormsTabProps) {
                 <ul className="flex flex-col gap-3">
                     {forms.map((form) => (
                         <li key={form.id}>
-                            <GroupFormRow form={form} />
+                            <GroupFormRow
+                                form={form}
+                                canManage={isAdmin}
+                                onEdit={() => onEditForm(form)}
+                            />
                         </li>
                     ))}
                 </ul>
@@ -41,8 +79,21 @@ export function GroupFormsTab({ forms, isAdmin }: GroupFormsTabProps) {
                 </p>
             )}
             <GroupNewFormDialog
-                open={creating}
-                onClose={() => setCreating(false)}
+                open={isCreateOpen}
+                onClose={onCloseCreate}
+                onSubmit={onCreate}
+                isSubmitting={isCreating}
+                error={createError}
+            />
+            <GroupFormEditDialog
+                open={editingForm !== null}
+                form={editingForm}
+                questions={editingQuestions}
+                answerCount={editingAnswerCount}
+                onClose={() => onEditForm(null)}
+                onSubmit={onSave}
+                isSubmitting={isSaving}
+                error={saveError}
             />
         </div>
     );

--- a/apps/kvark/src/components/group-new-form-dialog.tsx
+++ b/apps/kvark/src/components/group-new-form-dialog.tsx
@@ -1,3 +1,4 @@
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { Button } from "@tihlde/ui/ui/button";
 import {
     Dialog,
@@ -7,20 +8,51 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@tihlde/ui/ui/dialog";
-import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
-import { Input } from "@tihlde/ui/ui/input";
+import { FieldGroup } from "@tihlde/ui/ui/field";
+import { Spinner } from "@tihlde/ui/ui/spinner";
+import { TriangleAlert } from "lucide-react";
+import { z } from "zod";
+
+import { formHandlers, useAppForm } from "#/hooks/form";
+
+const schema = z.object({
+    title: z
+        .string()
+        .min(1, { error: "Tittel er påkrevd" })
+        .max(400, { error: "Maks 400 tegn" }),
+});
 
 type GroupNewFormDialogProps = {
     open: boolean;
     onClose: () => void;
+    onSubmit: (values: { title: string }) => void;
+    isSubmitting: boolean;
+    error: string | null;
 };
 
-export function GroupNewFormDialog({ open, onClose }: GroupNewFormDialogProps) {
+export function GroupNewFormDialog({
+    open,
+    onClose,
+    onSubmit,
+    isSubmitting,
+    error,
+}: GroupNewFormDialogProps) {
+    const form = useAppForm({
+        defaultValues: { title: "" },
+        validators: { onDynamic: schema },
+        onSubmit({ value }) {
+            onSubmit({ title: value.title.trim() });
+        },
+    });
+
     return (
         <Dialog
             open={open}
             onOpenChange={(o) => {
-                if (!o) onClose();
+                if (!o) {
+                    form.reset();
+                    onClose();
+                }
             }}
         >
             <DialogContent className="max-w-md">
@@ -28,31 +60,55 @@ export function GroupNewFormDialog({ open, onClose }: GroupNewFormDialogProps) {
                     <DialogTitle>Nytt spørreskjema</DialogTitle>
                     <DialogDescription>
                         Alle TIHLDE-medlemmer vil kunne svare på skjemaet, flere
-                        ganger om de ønsker. Du kan legge til spørsmål etter at
-                        du har opprettet skjemaet. Spørsmålene kan endres helt
-                        til noen har svart på skjemaet.
+                        ganger om de ønsker. Skjemaet er stengt til du åpner det
+                        under «Rediger», og der legger du også til spørsmålene.
+                        Spørsmålene kan endres helt til noen har svart.
                     </DialogDescription>
                 </DialogHeader>
-                <form className="flex flex-col gap-4">
+                <form {...formHandlers(form)} className="flex flex-col gap-4">
+                    {error ? (
+                        <Alert variant="destructive">
+                            <TriangleAlert />
+                            <AlertTitle>
+                                Klarte ikke å opprette skjemaet
+                            </AlertTitle>
+                            <AlertDescription>{error}</AlertDescription>
+                        </Alert>
+                    ) : null}
                     <FieldGroup>
-                        <Field>
-                            <FieldLabel htmlFor="form-title">
-                                Tittel *
-                            </FieldLabel>
-                            <Input
-                                id="form-title"
-                                placeholder="Skriv her..."
-                                required
-                            />
-                        </Field>
+                        <form.AppField name="title">
+                            {(field) => (
+                                <field.Field required>
+                                    <field.Label>Tittel</field.Label>
+                                    <field.Input placeholder="Skriv her..." />
+                                    <field.Error />
+                                </field.Field>
+                            )}
+                        </form.AppField>
                     </FieldGroup>
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={onClose}
+                        >
+                            Avbryt
+                        </Button>
+                        <form.AppForm>
+                            <form.SubmitButton
+                                disabled={isSubmitting}
+                                loading={
+                                    <>
+                                        <Spinner />
+                                        <span>Oppretter...</span>
+                                    </>
+                                }
+                            >
+                                Opprett spørreskjema
+                            </form.SubmitButton>
+                        </form.AppForm>
+                    </DialogFooter>
                 </form>
-                <DialogFooter>
-                    <Button variant="outline" onClick={onClose}>
-                        Avbryt
-                    </Button>
-                    <Button>Opprett spørreskjema</Button>
-                </DialogFooter>
             </DialogContent>
         </Dialog>
     );

--- a/apps/kvark/src/lib/form.ts
+++ b/apps/kvark/src/lib/form.ts
@@ -1,0 +1,130 @@
+import { format } from "date-fns";
+import { nb } from "date-fns/locale";
+
+import type {
+    FormDetail,
+    FormStatistics,
+    SubmissionList,
+    UpdateForm,
+} from "@tihlde/sdk";
+
+export type FormQuestionType =
+    | "text_answer"
+    | "single_select"
+    | "multiple_select";
+
+/** Ett spørsmål slik det redigeres i grensesnittet. */
+export type FormQuestionValues = {
+    /** Satt for spørsmål som allerede finnes; nye spørsmål har ingen id. */
+    id?: string;
+    title: string;
+    type: FormQuestionType;
+    required: boolean;
+    options: { id?: string; title: string }[];
+};
+
+/** Spørsmålene i skjemaet, i lagret rekkefølge. */
+export function mapFormQuestions(
+    fields: FormDetail["fields"],
+): FormQuestionValues[] {
+    return fields.map((field) => ({
+        id: field.id,
+        title: field.title,
+        type: field.type,
+        required: field.required,
+        options: field.options.map((option) => ({
+            id: option.id,
+            title: option.title,
+        })),
+    }));
+}
+
+/**
+ * Spørsmålene som API-payload. `order` følger rekkefølgen i listen, og
+ * fritekstspørsmål sendes uten alternativer — de ville blitt slettet uansett.
+ */
+export function toFormFieldsPayload(
+    questions: FormQuestionValues[],
+): NonNullable<UpdateForm["fields"]> {
+    return questions.map((question, index) => ({
+        ...(question.id ? { id: question.id } : {}),
+        title: question.title.trim(),
+        type: question.type,
+        required: question.required,
+        order: index,
+        options:
+            question.type === "text_answer"
+                ? []
+                : question.options.map((option, optionIndex) => ({
+                      ...(option.id ? { id: option.id } : {}),
+                      title: option.title.trim(),
+                      order: optionIndex,
+                  })),
+    }));
+}
+
+// -- Svar --
+
+/** Ett svar på ett spørsmål, klart til visning. */
+export type FormAnswer = {
+    fieldId: string | null;
+    /** Fritekstsvaret, eller de valgte alternativene skilt med komma. */
+    text: string;
+};
+
+export type FormSubmissionRow = {
+    id: string;
+    userName: string;
+    userEmail: string;
+    submittedAt: string;
+    answers: FormAnswer[];
+};
+
+export function mapSubmission(
+    submission: SubmissionList[number],
+): FormSubmissionRow {
+    return {
+        id: submission.id,
+        userName: submission.user.name,
+        userEmail: submission.user.email,
+        submittedAt: format(new Date(submission.created_at), "d. MMM yyyy", {
+            locale: nb,
+        }),
+        answers: submission.answers.map((answer) => ({
+            fieldId: answer.field_id,
+            text:
+                answer.selected_options.length > 0
+                    ? answer.selected_options
+                          .map((option) => option.title)
+                          .join(", ")
+                    : (answer.answer_text ?? ""),
+        })),
+    };
+}
+
+/** Ett spørsmål med fordelingen av svar. Bare valgspørsmål har statistikk. */
+export type FormQuestionStatistics = {
+    id: string;
+    title: string;
+    options: {
+        id: string;
+        title: string;
+        count: number;
+        percentage: number;
+    }[];
+};
+
+export function mapFormStatistics(
+    statistics: FormStatistics["statistics"],
+): FormQuestionStatistics[] {
+    return statistics.map((question) => ({
+        id: question.id,
+        title: question.title,
+        options: question.options.map((option) => ({
+            id: option.id,
+            title: option.title,
+            count: option.answer_amount,
+            percentage: option.answer_percentage,
+        })),
+    }));
+}

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -93,7 +93,13 @@ export type Law = {
 export type Form = {
     id: string;
     title: string;
+    description: string;
     isOpen: boolean;
+    /** Om samme person kan sende inn flere svar. */
+    canSubmitMultiple: boolean;
+    onlyForMembers: boolean;
+    /** E-post som varsles ved nye svar. Tom streng når ingen er satt. */
+    emailReceiver: string;
 };
 
 type ApiGroupForm = GroupFormList[number];
@@ -309,6 +315,10 @@ export function mapForm(form: ApiGroupForm): Form {
     return {
         id: form.id,
         title: form.title,
+        description: form.description ?? "",
         isOpen: form.is_open_for_submissions,
+        canSubmitMultiple: form.can_submit_multiple,
+        onlyForMembers: form.only_for_group_members,
+        emailReceiver: form.email_receiver_on_submit ?? "",
     };
 }

--- a/apps/kvark/src/lib/utils.ts
+++ b/apps/kvark/src/lib/utils.ts
@@ -108,3 +108,15 @@ export function formatStudyLabel(
           : null;
     return [study.programme, detail].filter(Boolean).join(" · ") || undefined;
 }
+
+/**
+ * HTTP-statusen bak en feil fra API-klienten, om den finnes.
+ *
+ * Ligger her og ikke i rutefilene: rutene kodesplittes, og en hjelpefunksjon
+ * som bare står i modulen rundt komponenten blir ikke med inn i komponent-
+ * chunken — den kaster «is not defined» først i nettleseren.
+ */
+export function errorStatus(error: unknown): number | undefined {
+    const response = (error as { response?: { status?: number } })?.response;
+    return typeof response?.status === "number" ? response.status : undefined;
+}

--- a/apps/kvark/src/routeTree.gen.ts
+++ b/apps/kvark/src/routeTree.gen.ts
@@ -74,6 +74,7 @@ import { Route as AppProfilIdInnstillingerRouteImport } from './routes/_app/prof
 import { Route as AppProfilIdMedlemskapRouteImport } from './routes/_app/profil/$id/medlemskap'
 import { Route as AppProfilIdPrikkerRouteImport } from './routes/_app/profil/$id/prikker'
 import { Route as AppProfilIdSporreskjemaerRouteImport } from './routes/_app/profil/$id/sporreskjemaer'
+import { Route as AppSporreskjemaIdSvarRouteImport } from './routes/_app/sporreskjema.$id_.svar'
 
 const AppRoute = AppRouteImport.update({
   id: '/_app',
@@ -401,6 +402,11 @@ const AppProfilIdSporreskjemaerRoute =
     path: '/sporreskjemaer',
     getParentRoute: () => AppProfilIdRoute,
   } as any)
+const AppSporreskjemaIdSvarRoute = AppSporreskjemaIdSvarRouteImport.update({
+  id: '/sporreskjema/$id_/svar',
+  path: '/sporreskjema/$id/svar',
+  getParentRoute: () => AppRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof AppIndexRoute
@@ -463,6 +469,7 @@ export interface FileRoutesByFullPath {
   '/profil/$id/medlemskap': typeof AppProfilIdMedlemskapRoute
   '/profil/$id/prikker': typeof AppProfilIdPrikkerRoute
   '/profil/$id/sporreskjemaer': typeof AppProfilIdSporreskjemaerRoute
+  '/sporreskjema/$id/svar': typeof AppSporreskjemaIdSvarRoute
   '/profil/$id/': typeof AppProfilIdIndexRoute
 }
 export interface FileRoutesByTo {
@@ -524,6 +531,7 @@ export interface FileRoutesByTo {
   '/profil/$id/medlemskap': typeof AppProfilIdMedlemskapRoute
   '/profil/$id/prikker': typeof AppProfilIdPrikkerRoute
   '/profil/$id/sporreskjemaer': typeof AppProfilIdSporreskjemaerRoute
+  '/sporreskjema/$id/svar': typeof AppSporreskjemaIdSvarRoute
   '/profil/$id': typeof AppProfilIdIndexRoute
 }
 export interface FileRoutesById {
@@ -592,6 +600,7 @@ export interface FileRoutesById {
   '/_app/profil/$id/medlemskap': typeof AppProfilIdMedlemskapRoute
   '/_app/profil/$id/prikker': typeof AppProfilIdPrikkerRoute
   '/_app/profil/$id/sporreskjemaer': typeof AppProfilIdSporreskjemaerRoute
+  '/_app/sporreskjema/$id_/svar': typeof AppSporreskjemaIdSvarRoute
   '/_app/profil/$id/': typeof AppProfilIdIndexRoute
 }
 export interface FileRouteTypes {
@@ -657,6 +666,7 @@ export interface FileRouteTypes {
     | '/profil/$id/medlemskap'
     | '/profil/$id/prikker'
     | '/profil/$id/sporreskjemaer'
+    | '/sporreskjema/$id/svar'
     | '/profil/$id/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -718,6 +728,7 @@ export interface FileRouteTypes {
     | '/profil/$id/medlemskap'
     | '/profil/$id/prikker'
     | '/profil/$id/sporreskjemaer'
+    | '/sporreskjema/$id/svar'
     | '/profil/$id'
   id:
     | '__root__'
@@ -785,6 +796,7 @@ export interface FileRouteTypes {
     | '/_app/profil/$id/medlemskap'
     | '/_app/profil/$id/prikker'
     | '/_app/profil/$id/sporreskjemaer'
+    | '/_app/sporreskjema/$id_/svar'
     | '/_app/profil/$id/'
   fileRoutesById: FileRoutesById
 }
@@ -1252,6 +1264,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProfilIdSporreskjemaerRouteImport
       parentRoute: typeof AppProfilIdRoute
     }
+    '/_app/sporreskjema/$id_/svar': {
+      id: '/_app/sporreskjema/$id_/svar'
+      path: '/sporreskjema/$id/svar'
+      fullPath: '/sporreskjema/$id/svar'
+      preLoaderRoute: typeof AppSporreskjemaIdSvarRouteImport
+      parentRoute: typeof AppRoute
+    }
   }
 }
 
@@ -1305,6 +1324,7 @@ interface AppRouteChildren {
   AppGrupperIndexRoute: typeof AppGrupperIndexRoute
   AppMotetidIndexRoute: typeof AppMotetidIndexRoute
   AppNyheterIndexRoute: typeof AppNyheterIndexRoute
+  AppSporreskjemaIdSvarRoute: typeof AppSporreskjemaIdSvarRoute
 }
 
 const AppRouteChildren: AppRouteChildren = {
@@ -1335,6 +1355,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppGrupperIndexRoute: AppGrupperIndexRoute,
   AppMotetidIndexRoute: AppMotetidIndexRoute,
   AppNyheterIndexRoute: AppNyheterIndexRoute,
+  AppSporreskjemaIdSvarRoute: AppSporreskjemaIdSvarRoute,
 }
 
 const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -20,6 +20,11 @@ import { z } from "zod";
 import { authQueryOptions } from "#/api/auth";
 import { useImageUploader } from "#/api/queries/assets";
 import {
+    getFormByIdQuery,
+    getFormSubmissionsQuery,
+    updateFormMutation,
+} from "#/api/queries/forms";
+import {
     useIsGroupLeaderOf,
     useIsGroupMemberOf,
     usePermission,
@@ -28,6 +33,7 @@ import {
 import {
     batchUpdateUserFinesMutation,
     createFineMutation,
+    createGroupFormMutation,
     createLawMutation,
     deleteFineMutation,
     deleteLawMutation,
@@ -54,6 +60,7 @@ import { GroupDetailHeader } from "#/components/group-detail-header";
 import type { GroupEditValues } from "#/components/group-edit-dialog";
 import { GroupEventsTab } from "#/components/group-events-tab";
 import { GroupFinesTab } from "#/components/group-fines-tab";
+import type { GroupFormEditValues } from "#/components/group-form-edit-dialog";
 import { GroupFormsTab } from "#/components/group-forms-tab";
 import {
     GroupGiveFineDialog,
@@ -63,7 +70,9 @@ import { GroupLawsTab } from "#/components/group-laws-tab";
 import { GroupMembersTab } from "#/components/group-members-tab";
 import { GROUP_NAV_ITEMS, type GroupNavKey } from "#/components/group-nav";
 import { GroupOmTab } from "#/components/group-om-tab";
+import { mapFormQuestions, toFormFieldsPayload } from "#/lib/form";
 import {
+    type Form,
     mapFine,
     mapFineUser,
     mapForm,
@@ -73,6 +82,7 @@ import {
     mapMember,
     sortMembersByName,
 } from "#/lib/group";
+import { errorStatus } from "#/lib/utils";
 
 const searchSchema = z.object({
     tab: z
@@ -115,12 +125,6 @@ export const Route = createFileRoute("/_app/grupper/$slug")({
     },
 });
 
-/** HTTP-statusen bak en feil fra API-klienten, om den finnes. */
-function errorStatus(error: unknown): number | undefined {
-    const response = (error as { response?: { status?: number } })?.response;
-    return typeof response?.status === "number" ? response.status : undefined;
-}
-
 /** Vist i stedet for gruppesiden når gruppa er privat og du står utenfor. */
 function GroupRestricted() {
     return (
@@ -153,6 +157,10 @@ function GroupDetail() {
     const [fineDialogOpen, setFineDialogOpen] = useState(false);
     const [fineError, setFineError] = useState<string | null>(null);
     const [groupError, setGroupError] = useState<string | null>(null);
+    const [newFormOpen, setNewFormOpen] = useState(false);
+    const [newFormError, setNewFormError] = useState<string | null>(null);
+    const [editingForm, setEditingForm] = useState<Form | null>(null);
+    const [editFormError, setEditFormError] = useState<string | null>(null);
 
     function setActive(tab: GroupNavKey) {
         navigate({ search: (prev) => ({ ...prev, tab }) });
@@ -176,6 +184,8 @@ function GroupDetail() {
     const createLaw = useMutation(createLawMutation);
     const updateLaw = useMutation(updateLawMutation);
     const deleteLaw = useMutation(deleteLawMutation);
+    const createGroupForm = useMutation(createGroupFormMutation);
+    const updateForm = useMutation(updateFormMutation);
 
     // The scope is known here, so these mirror the API exactly: a grant for
     // this group counts, a grant for another group does not.
@@ -266,6 +276,18 @@ function GroupDetail() {
         enabled: canViewFines,
     });
 
+    // Spørsmålene ligger bare i detaljsvaret, og svarene avgjør om de kan
+    // endres i det hele tatt. Begge hentes først når et skjema faktisk åpnes
+    // for redigering.
+    const { data: apiEditingForm } = useQuery({
+        ...getFormByIdQuery(editingForm?.id ?? ""),
+        enabled: editingForm !== null,
+    });
+    const { data: apiEditingSubmissions } = useQuery({
+        ...getFormSubmissionsQuery(editingForm?.id ?? "", 0),
+        enabled: editingForm !== null,
+    });
+
     const members = useMemo(
         () => sortMembersByName((apiMembers ?? []).map(mapMember)),
         [apiMembers],
@@ -309,6 +331,15 @@ function GroupDetail() {
         [botBruker, fineUsers, members],
     );
     const forms = useMemo(() => (apiForms ?? []).map(mapForm), [apiForms]);
+    // Redigeringsdialogen venter på begge: uten svarene vet den ikke om
+    // spørsmålene er låst, og da ville de rukket å bli redigerbare først.
+    const editingQuestions = useMemo(
+        () =>
+            apiEditingForm && apiEditingSubmissions
+                ? mapFormQuestions(apiEditingForm.fields)
+                : null,
+        [apiEditingForm, apiEditingSubmissions],
+    );
     const laws = useMemo(() => (apiLaws ?? []).map(mapLaw), [apiLaws]);
 
     // Lovverk: the fines admin (botsjef), the leader, or fines:manage for
@@ -365,6 +396,71 @@ function GroupDetail() {
                 error instanceof Error
                     ? error.message
                     : "Ukjent feil da gruppen skulle lagres",
+            );
+        }
+    }
+
+    async function handleCreateForm(values: { title: string }) {
+        setNewFormError(null);
+        try {
+            await createGroupForm.mutateAsync({
+                slug,
+                data: {
+                    title: values.title,
+                    group: slug,
+                    template: false,
+                    fields: [],
+                    // Skjemaet er stengt til spørsmålene er på plass; resten er
+                    // de samme verdiene som API-et ville satt selv.
+                    can_submit_multiple: true,
+                    is_open_for_submissions: false,
+                    only_for_group_members: false,
+                },
+            });
+            setNewFormOpen(false);
+        } catch (error) {
+            setNewFormError(
+                error instanceof Error
+                    ? error.message
+                    : "Ukjent feil da skjemaet skulle opprettes",
+            );
+        }
+    }
+
+    function handleEditForm(form: Form | null) {
+        setEditFormError(null);
+        setEditingForm(form);
+    }
+
+    /**
+     * Spørsmålene sendes bare når de faktisk er endret av noen som har lov:
+     * `updateFieldsAndOptions` sletter spørsmål som mangler i lista, og med
+     * dem svarene som hører til.
+     */
+    async function handleSaveForm(values: GroupFormEditValues) {
+        if (!editingForm) return;
+        setEditFormError(null);
+        try {
+            await updateForm.mutateAsync({
+                formId: editingForm.id,
+                data: {
+                    title: values.title,
+                    description: values.description,
+                    is_open_for_submissions: values.isOpen,
+                    can_submit_multiple: values.canSubmitMultiple,
+                    only_for_group_members: values.onlyForMembers,
+                    email_receiver_on_submit: values.emailReceiver || null,
+                    ...(values.questions
+                        ? { fields: toFormFieldsPayload(values.questions) }
+                        : {}),
+                },
+            });
+            setEditingForm(null);
+        } catch (error) {
+            setEditFormError(
+                error instanceof Error
+                    ? error.message
+                    : "Ukjent feil da skjemaet skulle lagres",
             );
         }
     }
@@ -576,7 +672,28 @@ function GroupDetail() {
                         />
                     ) : null}
                     {activeTab === "sporreskjema" ? (
-                        <GroupFormsTab forms={forms} isAdmin={canManageForms} />
+                        <GroupFormsTab
+                            forms={forms}
+                            isAdmin={canManageForms}
+                            isCreateOpen={newFormOpen}
+                            onOpenCreate={() => {
+                                setNewFormError(null);
+                                setNewFormOpen(true);
+                            }}
+                            onCloseCreate={() => setNewFormOpen(false)}
+                            onCreate={handleCreateForm}
+                            isCreating={createGroupForm.isPending}
+                            createError={newFormError}
+                            editingForm={editingForm}
+                            editingQuestions={editingQuestions}
+                            editingAnswerCount={
+                                apiEditingSubmissions?.length ?? 0
+                            }
+                            onEditForm={handleEditForm}
+                            onSave={handleSaveForm}
+                            isSaving={updateForm.isPending}
+                            saveError={editFormError}
+                        />
                     ) : null}
                 </DetailLayoutContent>
             </DetailLayout>

--- a/apps/kvark/src/routes/_app/sporreskjema.$id_.svar.tsx
+++ b/apps/kvark/src/routes/_app/sporreskjema.$id_.svar.tsx
@@ -1,0 +1,223 @@
+import {
+    useQuery,
+    useQueryClient,
+    useSuspenseQuery,
+} from "@tanstack/react-query";
+import { Link, createFileRoute } from "@tanstack/react-router";
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
+import { Button } from "@tihlde/ui/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@tihlde/ui/ui/card";
+import {
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from "@tihlde/ui/ui/empty";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
+import { ArrowLeft, DownloadIcon, LockIcon, TriangleAlert } from "lucide-react";
+import { useMemo, useState } from "react";
+import { z } from "zod";
+
+import { authClientWithRedirect } from "#/api/auth";
+import {
+    downloadFormSubmissionsQuery,
+    getFormByIdQuery,
+    getFormStatisticsQuery,
+    getFormSubmissionsQuery,
+} from "#/api/queries/forms";
+import { FormStatisticsList } from "#/components/form-statistics-list";
+import { FormSubmissionsTable } from "#/components/form-submissions-table";
+import { useGoBack } from "#/hooks/use-go-back";
+import { mapFormStatistics, mapSubmission } from "#/lib/form";
+import { errorStatus } from "#/lib/utils";
+
+const searchSchema = z.object({
+    visning: z.enum(["svar", "statistikk"]).default("svar").catch("svar"),
+});
+
+export const Route = createFileRoute("/_app/sporreskjema/$id_/svar")({
+    component: FormSubmissionsPage,
+    validateSearch: searchSchema,
+    beforeLoad: ({ location }) => authClientWithRedirect(location.href),
+    loader: ({ context, params }) =>
+        context.queryClient.ensureQueryData(getFormByIdQuery(params.id)),
+});
+
+function FormSubmissionsPage() {
+    const { id } = Route.useParams();
+    const { visning } = Route.useSearch();
+    const navigate = Route.useNavigate();
+    const goBack = useGoBack();
+    const queryClient = useQueryClient();
+    const [isDownloading, setIsDownloading] = useState(false);
+
+    const { data: form } = useSuspenseQuery(getFormByIdQuery(id));
+    // Svarene og statistikken er bare for dem som kan administrere skjemaet.
+    // Alle andre får 403, og da vises «ingen tilgang» i stedet for en tom liste.
+    const {
+        data: apiSubmissions,
+        isPending: isLoadingSubmissions,
+        error: submissionsError,
+    } = useQuery(getFormSubmissionsQuery(id, 0));
+    const denied = errorStatus(submissionsError) === 403;
+    const { data: apiStatistics } = useQuery({
+        ...getFormStatisticsQuery(id),
+        enabled: submissionsError === null,
+    });
+
+    const submissions = useMemo(
+        () => (apiSubmissions ?? []).map(mapSubmission),
+        [apiSubmissions],
+    );
+    const statistics = useMemo(
+        () => mapFormStatistics(apiStatistics?.statistics ?? []),
+        [apiStatistics],
+    );
+    const questions = useMemo(
+        () =>
+            form.fields.map((field) => ({ id: field.id, title: field.title })),
+        [form.fields],
+    );
+
+    /**
+     * CSV-en lages av API-et; her hentes den bare og lagres. Nedlastingen går
+     * ikke gjennom en vanlig lenke fordi endepunktet krever innlogging.
+     */
+    async function handleDownload() {
+        setIsDownloading(true);
+        try {
+            // Endepunktet svarer text/csv, som OpenAPI-skjemaet ikke typer.
+            const csv = await queryClient.fetchQuery(
+                downloadFormSubmissionsQuery(id),
+            );
+            const url = URL.createObjectURL(
+                new Blob([String(csv)], { type: "text/csv;charset=utf-8" }),
+            );
+            const link = document.createElement("a");
+            link.href = url;
+            link.download = `${form.title}.csv`;
+            link.click();
+            URL.revokeObjectURL(url);
+        } finally {
+            setIsDownloading(false);
+        }
+    }
+
+    return (
+        <div className="container mx-auto flex max-w-5xl flex-col gap-6 px-4 py-12">
+            <Button variant="outline" className="self-start" onClick={goBack}>
+                <ArrowLeft />
+                Tilbake
+            </Button>
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-2xl">{form.title}</CardTitle>
+                    <CardDescription>
+                        {form.group ? (
+                            <>
+                                Spørreskjema fra{" "}
+                                <Link
+                                    to="/grupper/$slug"
+                                    params={{ slug: form.group.slug }}
+                                    search={{ tab: "sporreskjema" }}
+                                >
+                                    {form.group.name}
+                                </Link>
+                            </>
+                        ) : (
+                            "Svar på spørreskjemaet"
+                        )}
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-6">
+                    {denied ? (
+                        <NoAccess />
+                    ) : submissionsError ? (
+                        <Alert variant="destructive">
+                            <TriangleAlert />
+                            <AlertTitle>Klarte ikke å hente svarene</AlertTitle>
+                            <AlertDescription>
+                                {submissionsError.message}
+                            </AlertDescription>
+                        </Alert>
+                    ) : isLoadingSubmissions ? (
+                        <div className="flex flex-col gap-3">
+                            <Skeleton className="h-9 w-full" />
+                            <Skeleton className="h-32 w-full" />
+                        </div>
+                    ) : (
+                        <>
+                            <div className="flex flex-wrap items-center gap-3">
+                                <Tabs
+                                    value={visning}
+                                    onValueChange={(v) =>
+                                        navigate({
+                                            search: {
+                                                visning: v as
+                                                    | "svar"
+                                                    | "statistikk",
+                                            },
+                                        })
+                                    }
+                                >
+                                    <TabsList>
+                                        <TabsTrigger value="svar">
+                                            {submissions.length} svar
+                                        </TabsTrigger>
+                                        <TabsTrigger value="statistikk">
+                                            Statistikk
+                                        </TabsTrigger>
+                                    </TabsList>
+                                </Tabs>
+                                <Button
+                                    variant="outline"
+                                    className="ml-auto"
+                                    disabled={
+                                        isDownloading ||
+                                        submissions.length === 0
+                                    }
+                                    onClick={handleDownload}
+                                >
+                                    <DownloadIcon />
+                                    Last ned som CSV
+                                </Button>
+                            </div>
+                            {visning === "svar" ? (
+                                <FormSubmissionsTable
+                                    questions={questions}
+                                    submissions={submissions}
+                                />
+                            ) : (
+                                <FormStatisticsList statistics={statistics} />
+                            )}
+                        </>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+function NoAccess() {
+    return (
+        <Empty>
+            <EmptyHeader>
+                <EmptyMedia variant="icon">
+                    <LockIcon />
+                </EmptyMedia>
+                <EmptyTitle>Ingen tilgang til svarene</EmptyTitle>
+                <EmptyDescription>
+                    Bare lederen av gruppen som eier skjemaet kan se svarene.
+                </EmptyDescription>
+            </EmptyHeader>
+        </Empty>
+    );
+}

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1012,26 +1012,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/forms/{formId}/submissions/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get submission
-         * @description Get a specific submission. Can view own submission or requires permission to manage the form.
-         */
-        get: operations["getFormSubmission"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/forms/{formId}/submissions/download": {
         parameters: {
             query?: never;
@@ -1044,6 +1024,26 @@ export interface paths {
          * @description Download all submissions for a form as CSV. Requires permission to manage the form.
          */
         get: operations["downloadFormSubmissions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/forms/{formId}/submissions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get submission
+         * @description Get a specific submission. Can view own submission or requires permission to manage the form.
+         */
+        get: operations["getFormSubmission"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3843,6 +3843,10 @@ export interface components {
                     order: number;
                 }[];
             }[];
+            email_receiver_on_submit?: string | null;
+            can_submit_multiple?: boolean | null;
+            is_open_for_submissions?: boolean | null;
+            only_for_group_members?: boolean | null;
         };
         UpdateForm: {
             title?: string;
@@ -3866,6 +3870,10 @@ export interface components {
                     order: number;
                 }[];
             }[];
+            email_receiver_on_submit?: string | null;
+            can_submit_multiple?: boolean;
+            is_open_for_submissions?: boolean;
+            only_for_group_members?: boolean;
         };
         DeleteFormResponse: {
             detail: string;
@@ -8031,6 +8039,51 @@ export interface operations {
             };
         };
     };
+    downloadFormSubmissions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                formId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success - Returns CSV file */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/csv": unknown;
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Form not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     getFormSubmission: {
         parameters: {
             query?: never;
@@ -8069,51 +8122,6 @@ export interface operations {
                 content?: never;
             };
             /** @description Not Found - Submission not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    downloadFormSubmissions: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                formId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Success - Returns CSV file */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/csv": unknown;
-                };
-            };
-            /** @description Authentication required */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPAppException"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Form not found */
             404: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Hva

Gruppeledere kunne opprette spørreskjema, men aldri endre dem etterpå:

- Skjema lagret med `is_open_for_submissions=false` (f.eks. «gammelt» og «Opptak» på index) viste teksten «du må åpne spørreskjemaet for innsending» uten at det fantes noen knapp som kunne gjøre det.
- Spørsmålene var låst fra opprettelsen.
- Innsendte svar fantes det ingen side for — «Administrer»-knappen ble i sin tid fjernet nettopp fordi siden ikke eksisterte.

Denne PR-en legger til redigering av eksisterende gruppeskjema og en side for svar/statistikk.

## Backend

`PATCH /api/forms/{id}` støttet **ikke** innstillingene fra før — `updateFormSchema` tok bare `title`, `description`, `template` og `fields`, så «åpent for svar» kunne ikke endres av noe endepunkt i det hele tatt. Det er utvidet:

- `UpdateForm` tar nå `is_open_for_submissions`, `can_submit_multiple`, `only_for_group_members` og `email_receiver_on_submit` (der `null` tømmer mottakeren). De skrives til `form_group_form` bare når skjemaet faktisk er et gruppeskjema.
- Begge `update`-kallene hoppes over når kroppen ikke har noe for dem. Drizzle avviser en `set` der alle verdiene er `undefined`, så en patch som bare vipper «åpent for svar» ville ellers krasjet på form-raden.
- **Ny 409** (`FormHasSubmissionsException`): spørsmålene på et gruppeskjema kan ikke endres etter at noen har svart. `updateFieldsAndOptions` sletter spørsmål som mangler i lista, og med dem svarene. Arrangementsskjema er bevisst holdt utenfor — arrangører redigerer undersøkelser mens påmeldingen er åpen, og ny innsending erstatter det gamle svaret.

To feil som lå der fra før, begge funnet under testing av det nye:

- `/submissions/download` svarte 500 fordi ruten var registrert **etter** `/submissions/:id`, så `"download"` havnet som innsendings-id i spørringen. Rekkefølgen er byttet — CSV-en fungerer nå.
- Gruppas skjemaliste hadde ingen `ORDER BY`, så et skjema hoppet nedover i lista hver gang det ble lagret. Sorteres nyeste først.

SDK-en er regenerert (`bun run codegen`).

## Frontend

- **`GroupFormEditDialog`** — dum komponent, TanStack Form via `useAppForm`. Tittel, beskrivelse, de fire innstillingene, og en spørsmåls-/alternativ-editor som byttes ut med «Spørsmålene er låst · Skjemaet har N svar» når det finnes svar.
- **Ny side `/sporreskjema/$id/svar`** — svar i tabell, statistikk med fordeling per alternativ, og CSV-nedlasting. Egen tilstand for 403 (bare den som kan administrere skjemaet ser svarene).
- Mutasjonene ligger i rutekomponenten (`grupper.$slug.tsx`); detalj- og svar-spørringene kjører først når et skjema faktisk åpnes for redigering, og dialogen venter på begge — ellers rakk spørsmålene å være redigerbare et øyeblikk før låsen slo inn.
- `GroupNewFormDialog` var en død stub uten `onSubmit` — knappen «Opprett spørreskjema» gjorde ingenting. Den er koblet til `createGroupFormMutation`; uten det finnes det ikke noe nytt skjema å redigere.

## Verdt å vite for review

`errorStatus` er flyttet fra rutefilene til `lib/utils`. Ruterne kodesplittes, og en hjelpefunksjon som bare står på modulnivå i rutefila blir ikke med inn i komponent-chunken — siden krasjet med «errorStatus is not defined» i nettleseren mens typecheck og build var grønne. Duplikatet i `grupper.$slug.tsx` (samme latente felle) er fjernet.

Ny rutefil heter `sporreskjema.$id_.svar.tsx` — understreken gjør at ruta ikke nøstes under `/sporreskjema/$id`, som ikke har noen `<Outlet />`.

## Testet

- `bun run typecheck` (kvark + api), `bun run lint`, `bun run format`, `bun run build` (4/4) — alle grønne.
- Form-testene i `apps/api`: 6/6.
- I nettleseren mot lokal API og dev-DB: låste spørsmål vist riktig på skjema med 67 svar, toggle lagret (PATCH 200, lista oppdatert), nytt skjema opprettet med to spørsmål inkl. alternativer og riktig `order`, svar- og statistikksiden med ekte data, CSV svarer 200 `text/csv`, og API-et svarer 409 når man forbigår UI-et og prøver å endre spørsmål på et skjema med svar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)