### PR TITLE
feat(galleri): rediger og slett enkeltbilder

### DIFF
--- a/apps/kvark/src/components/gallery-lightbox.tsx
+++ b/apps/kvark/src/components/gallery-lightbox.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@tihlde/ui/ui/button";
 import { Dialog, DialogContent } from "@tihlde/ui/ui/dialog";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Pencil } from "lucide-react";
 import { useCallback, useEffect, useRef } from "react";
 
 import { assetImageUrl } from "#/lib/assets";
@@ -18,6 +18,9 @@ type GalleryLightboxProps = {
     /** Index into `pictures`, or null when the lightbox is closed. */
     openIndex: number | null;
     onOpenChange: (index: number | null) => void;
+    /** Viser «Rediger»-knappen. Uten `onEdit` skjules den uansett. */
+    canEdit?: boolean;
+    onEdit?: (picture: LightboxPicture) => void;
 };
 
 /**
@@ -28,6 +31,8 @@ export function GalleryLightbox({
     pictures,
     openIndex,
     onOpenChange,
+    canEdit = false,
+    onEdit,
 }: GalleryLightboxProps) {
     const index = openIndex ?? -1;
     const picture = pictures[index] ?? null;
@@ -139,16 +144,29 @@ export function GalleryLightbox({
                     ) : null}
                 </div>
 
-                <div className="flex flex-col gap-1 px-2 pb-2">
-                    {picture.title ? <p>{picture.title}</p> : null}
-                    {picture.description ? (
-                        <p className="text-muted-foreground">
-                            {picture.description}
+                <div className="flex items-end justify-between gap-4 px-2 pb-2">
+                    <div className="flex min-w-0 flex-col gap-1">
+                        {picture.title ? <p>{picture.title}</p> : null}
+                        {picture.description ? (
+                            <p className="text-muted-foreground">
+                                {picture.description}
+                            </p>
+                        ) : null}
+                        <p className="text-sm text-muted-foreground">
+                            {index + 1} / {pictures.length}
                         </p>
+                    </div>
+                    {canEdit && onEdit ? (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="shrink-0"
+                            onClick={() => onEdit(picture)}
+                        >
+                            <Pencil />
+                            Rediger
+                        </Button>
                     ) : null}
-                    <p className="text-sm text-muted-foreground">
-                        {index + 1} / {pictures.length}
-                    </p>
                 </div>
             </DialogContent>
         </Dialog>

--- a/apps/kvark/src/components/gallery-picture-editor-dialog.tsx
+++ b/apps/kvark/src/components/gallery-picture-editor-dialog.tsx
@@ -1,0 +1,219 @@
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
+import { Button } from "@tihlde/ui/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@tihlde/ui/ui/dialog";
+import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
+import { Input } from "@tihlde/ui/ui/input";
+import { Textarea } from "@tihlde/ui/ui/textarea";
+import { XCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { assetImageUrl } from "#/lib/assets";
+
+export type PictureEditorValues = {
+    title: string;
+    description: string;
+    imageAlt: string;
+};
+
+export type EditablePicture = {
+    id: string;
+    imageUrl: string;
+    title?: string | null;
+    description?: string | null;
+    imageAlt?: string | null;
+};
+
+type GalleryPictureEditorDialogProps = {
+    open: boolean;
+    picture: EditablePicture | null;
+    canDelete: boolean;
+    isSaving: boolean;
+    isDeleting: boolean;
+    error: string | null;
+    onClose: () => void;
+    onSubmit: (values: PictureEditorValues) => void;
+    onDelete: () => void;
+};
+
+/**
+ * Rediger tittel, beskrivelse og bildetekst på ett bilde, eller slett det.
+ *
+ * Sletting bekreftes i selve dialogen i stedet for i en `AlertDialog`: denne
+ * dialogen åpnes fra lightboxen, og et tredje dialoglag oppå det ville stablet
+ * to fokusfeller på hverandre.
+ */
+export function GalleryPictureEditorDialog({
+    open,
+    picture,
+    canDelete,
+    isSaving,
+    isDeleting,
+    error,
+    onClose,
+    onSubmit,
+    onDelete,
+}: GalleryPictureEditorDialogProps) {
+    const [title, setTitle] = useState("");
+    const [description, setDescription] = useState("");
+    const [imageAlt, setImageAlt] = useState("");
+    const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+    // Fyll feltene på nytt hver gang dialogen åpnes for et (nytt) bilde.
+    useEffect(() => {
+        if (!open) return;
+        setTitle(picture?.title ?? "");
+        setDescription(picture?.description ?? "");
+        setImageAlt(picture?.imageAlt ?? "");
+        setConfirmingDelete(false);
+    }, [open, picture]);
+
+    const busy = isSaving || isDeleting;
+
+    function handleSubmit() {
+        if (busy) return;
+        onSubmit({
+            title: title.trim(),
+            description: description.trim(),
+            imageAlt: imageAlt.trim(),
+        });
+    }
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(o) => {
+                if (!o) onClose();
+            }}
+        >
+            <DialogContent className="max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Rediger bilde</DialogTitle>
+                    <DialogDescription>
+                        Endre tittel, beskrivelse og bildetekst.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {picture ? (
+                    <img
+                        src={assetImageUrl(picture.imageUrl, 480)}
+                        alt={picture.imageAlt ?? picture.title ?? ""}
+                        decoding="async"
+                        className="max-h-48 w-full object-contain"
+                    />
+                ) : null}
+
+                <form
+                    className="flex flex-col gap-4"
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        handleSubmit();
+                    }}
+                >
+                    <FieldGroup>
+                        <Field>
+                            <FieldLabel htmlFor="picture-title">
+                                Tittel
+                            </FieldLabel>
+                            <Input
+                                id="picture-title"
+                                value={title}
+                                maxLength={100}
+                                placeholder="Skriv her..."
+                                onChange={(e) => setTitle(e.target.value)}
+                            />
+                        </Field>
+                        <Field>
+                            <FieldLabel htmlFor="picture-description">
+                                Beskrivelse
+                            </FieldLabel>
+                            <Textarea
+                                id="picture-description"
+                                rows={3}
+                                value={description}
+                                maxLength={5000}
+                                placeholder="Skriv her..."
+                                onChange={(e) => setDescription(e.target.value)}
+                            />
+                        </Field>
+                        <Field>
+                            <FieldLabel htmlFor="picture-alt">
+                                Bildetekst
+                            </FieldLabel>
+                            <Input
+                                id="picture-alt"
+                                value={imageAlt}
+                                maxLength={200}
+                                placeholder="Skriv her..."
+                                onChange={(e) => setImageAlt(e.target.value)}
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                Beskriver bildet for skjermlesere og vises hvis
+                                bildet ikke lastes.
+                            </p>
+                        </Field>
+                    </FieldGroup>
+                </form>
+
+                {error ? (
+                    <Alert variant="destructive">
+                        <XCircle className="size-4" />
+                        <AlertTitle>Kunne ikke lagre</AlertTitle>
+                        <AlertDescription>{error}</AlertDescription>
+                    </Alert>
+                ) : null}
+
+                {confirmingDelete ? (
+                    <DialogFooter>
+                        <p className="mr-auto text-sm text-muted-foreground">
+                            Slette bildet permanent?
+                        </p>
+                        <Button
+                            variant="outline"
+                            disabled={busy}
+                            onClick={() => setConfirmingDelete(false)}
+                        >
+                            Avbryt
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            disabled={busy}
+                            onClick={onDelete}
+                        >
+                            {isDeleting ? "Sletter..." : "Slett bildet"}
+                        </Button>
+                    </DialogFooter>
+                ) : (
+                    <DialogFooter>
+                        {canDelete ? (
+                            <Button
+                                variant="destructive"
+                                className="mr-auto"
+                                disabled={busy}
+                                onClick={() => setConfirmingDelete(true)}
+                            >
+                                Slett bilde
+                            </Button>
+                        ) : null}
+                        <Button
+                            variant="outline"
+                            disabled={busy}
+                            onClick={onClose}
+                        >
+                            Avbryt
+                        </Button>
+                        <Button disabled={busy} onClick={handleSubmit}>
+                            {isSaving ? "Lagrer..." : "Lagre"}
+                        </Button>
+                    </DialogFooter>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/kvark/src/routes/_app/galleri.$slug.tsx
+++ b/apps/kvark/src/routes/_app/galleri.$slug.tsx
@@ -1,4 +1,5 @@
 import {
+    useMutation,
     useSuspenseInfiniteQuery,
     useSuspenseQuery,
 } from "@tanstack/react-query";
@@ -9,13 +10,18 @@ import { CalendarIcon } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
 
 import {
+    deleteGalleryPictureMutation,
     getGalleryPicturesInfiniteQuery,
     getGalleryQuery,
+    updateGalleryPictureMutation,
 } from "#/api/queries/galleries";
 import { GalleryLightbox } from "#/components/gallery-lightbox";
+import type { LightboxPicture } from "#/components/gallery-lightbox";
 import { GalleryPicture } from "#/components/gallery-picture";
+import { GalleryPictureEditorDialog } from "#/components/gallery-picture-editor-dialog";
 import { LoadMoreButton } from "#/components/load-more-button";
 import { useMediaQuery } from "#/hooks/use-media-query";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 
 export const Route = createFileRoute("/_app/galleri/$slug")({
     component: GalleryDetailPage,
@@ -62,6 +68,25 @@ function PictureGrid({ slug }: { slug: string }) {
     const pictures = data.pages.flatMap((page) => page.items);
     const columnCount = useColumnCount();
     const [openIndex, setOpenIndex] = useState<number | null>(null);
+    const [editing, setEditing] = useState<LightboxPicture | null>(null);
+
+    const canEdit = useAnyScopePermission([
+        "galleries:pictures:update",
+        "galleries:manage",
+    ]);
+    const canDelete = useAnyScopePermission([
+        "galleries:pictures:delete",
+        "galleries:manage",
+    ]);
+
+    const updatePicture = useMutation(updateGalleryPictureMutation);
+    const deletePicture = useMutation(deleteGalleryPictureMutation);
+
+    function closeEditor() {
+        setEditing(null);
+        updatePicture.reset();
+        deletePicture.reset();
+    }
 
     const columns = useMemo(() => {
         const result: (typeof pictures)[] = Array.from(
@@ -135,6 +160,52 @@ function PictureGrid({ slug }: { slug: string }) {
                 pictures={pictures}
                 openIndex={openIndex}
                 onOpenChange={setOpenIndex}
+                canEdit={canEdit}
+                onEdit={(picture) => {
+                    // Lightboxen lukkes: redigeringsdialogen har sitt eget
+                    // forhåndsvisningsbilde, og to dialoger oppå hverandre
+                    // stabler to fokusfeller.
+                    setOpenIndex(null);
+                    setEditing(picture);
+                }}
+            />
+
+            <GalleryPictureEditorDialog
+                open={editing !== null}
+                picture={editing}
+                canDelete={canDelete}
+                isSaving={updatePicture.isPending}
+                isDeleting={deletePicture.isPending}
+                error={
+                    updatePicture.error?.message ??
+                    deletePicture.error?.message ??
+                    null
+                }
+                onClose={closeEditor}
+                onSubmit={(values) => {
+                    if (!editing) return;
+                    updatePicture.mutate(
+                        {
+                            slug,
+                            pictureId: editing.id,
+                            data: {
+                                // Tomt felt betyr «ingen verdi», ikke tom
+                                // streng — API-et lagrer null.
+                                title: values.title || null,
+                                description: values.description || null,
+                                imageAlt: values.imageAlt || null,
+                            },
+                        },
+                        { onSuccess: closeEditor },
+                    );
+                }}
+                onDelete={() => {
+                    if (!editing) return;
+                    deletePicture.mutate(
+                        { slug, pictureId: editing.id },
+                        { onSuccess: closeEditor },
+                    );
+                }}
             />
         </div>
     );


### PR DESCRIPTION
## Problem

Enkeltbilder i et galleri kunne verken redigeres eller slettes. `PATCH` og `DELETE` på `/api/galleries/{slug}/pictures/{pictureId}` har eksistert hele tiden, og `updateGalleryPictureMutation` / `deleteGalleryPictureMutation` lå ferdig i `api/queries/galleries.ts` — de ble bare aldri kalt fra noe sted i frontenden. Et bilde med feil bildetekst kunne i praksis bare fjernes ved å slette hele albumet.

Dette er en regresjon fra gamle Kvark, som hadde `GalleryDetails/components/PictureEditor.tsx`: en «Rediger bilde»-dialog med tittel, beskrivelse, bildetekst og «Slett bilde».

## Hva som er endret

- **`gallery-picture-editor-dialog.tsx`** (ny): tittel, beskrivelse og bildetekst, med forhåndsvisning av bildet. Tomt felt lagres som `null`, ikke tom streng.
- **`gallery-lightbox.tsx`**: valgfri «Rediger»-knapp i bunnlinjen, styrt av `canEdit` + `onEdit`. Komponenten er fortsatt dum — den henter og muterer ingenting.
- **`galleri.$slug.tsx`** eier dialogtilstanden og mutasjonene, som ellers i appen.

Rettigheter følger API-et: redigering bak `galleries:pictures:update` eller `galleries:manage`, sletting bak `galleries:pictures:delete` eller `galleries:manage`.

## Verdt å vite for reviewer

- **Lightboxen lukkes når dialogen åpnes.** Å legge redigeringsdialogen oppå lightboxen ville stablet to Base UI-fokusfeller; dialogen har derfor sitt eget forhåndsvisningsbilde i stedet.
- **Sletting bekreftes i samme dialog**, ikke i en `AlertDialog`, av samme grunn — det ville vært et tredje dialoglag.

## Verifisering

Kjørt lokalt mot dev-API-et, logget inn som `brotherman` (admin), på albumet «Vårgalla 2026»:

- Lagret tittel, beskrivelse og bildetekst på et bilde. `GET /api/galleries/vaargalla-2026/pictures` bekreftet at alle tre feltene ble persistert.
- Slettet et bilde via to-stegs-bekreftelsen: `pictureCount` gikk fra 40 til 39. Bildet er lagt tilbake igjen etterpå.
- `bun run typecheck`, `bun run lint` og `bun run format` er grønne.

Merk: i dette verifiseringsmiljøet ligger forhåndsvisningsfanen i bakgrunnen (`document.visibilityState === "hidden"`), så CSS-animasjoner står stille og Base UI rekker aldri å avmontere en popup etter lukking. Det gjelder like mye eksisterende dialoger (sjekket mot banner-dialogen i `/admin/bannere`) og er ikke noe denne PR-en innfører.

🤖 Generated with [Claude Code](https://claude.com/claude-code)