### PR TITLE
fix(kvark): lik font weight på hero-overskrift for opptak og ny-student

### DIFF
--- a/apps/kvark/src/routes/_app/ny-student.tsx
+++ b/apps/kvark/src/routes/_app/ny-student.tsx
@@ -73,7 +73,7 @@ function NewStudentPage() {
             <section className="relative flex min-h-[60vh] w-full items-center justify-center overflow-hidden">
                 <HeroSectionBackground />
                 <div className="relative z-10 mx-auto flex max-w-3xl flex-col items-center gap-4 px-4 py-24 text-center">
-                    <h1 className="text-4xl md:text-6xl">
+                    <h1 className="text-4xl font-bold md:text-6xl">
                         Velkommen til linjeforeningen TIHLDE!
                     </h1>
                     <p className="text-muted-foreground">

--- a/apps/kvark/src/routes/_app/opptak.tsx
+++ b/apps/kvark/src/routes/_app/opptak.tsx
@@ -70,7 +70,7 @@ function AdmissionsPage() {
                     <p className="text-muted-foreground">
                         Bli med på å skape studentmiljøet
                     </p>
-                    <h1 className="text-4xl md:text-6xl">Søk verv!</h1>
+                    <h1 className="text-4xl font-bold md:text-6xl">Søk verv!</h1>
                     <p className="text-muted-foreground">
                         Her finner du en oversikt over alle vervene i TIHLDE.
                         Søk på vervene du er interessert i, og bli med på å


### PR DESCRIPTION
## Hva

Hero-overskriften (`h1`) på `/opptak` og `/ny-student` manglet `font-bold`, og ble derfor rendret med normal vekt — i motsetning til `/bedrift`, som bruker `text-4xl font-bold md:text-6xl`.

- `apps/kvark/src/routes/_app/opptak.tsx`
- `apps/kvark/src/routes/_app/ny-student.tsx`

Øvrige overskrifter (`h2 text-3xl`, `h3 font-semibold`) hadde allerede samme vekt som tilsvarende nivåer på `/bedrift` og er urørt.

## Verifisering

- `bun run typecheck` ✅
- `bun run lint` ✅ (kun forhåndseksisterende warnings)
- Ikke verifisert visuelt i preview — port 3000 var opptatt av en annen dev-server lokalt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)