### PR TITLE
fix(ui): vis plakater i 21:9, ikke 16:7

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,13 +5,14 @@
             "name": "api",
             "runtimeExecutable": "bun",
             "runtimeArgs": ["run", "--filter", "@photon/api", "dev"],
-            "port": 4000
+            "port": 4100
         },
         {
             "name": "kvark",
             "runtimeExecutable": "bun",
             "runtimeArgs": ["run", "--filter", "kvark", "dev"],
-            "port": 3000
+            "port": 3000,
+            "autoPort": true
         }
     ]
 }

--- a/apps/kvark/src/components/list-card.tsx
+++ b/apps/kvark/src/components/list-card.tsx
@@ -44,7 +44,7 @@ export function ListCard({
             children: (
                 <>
                     {/*
-                     * `self-start` keeps the media at its 16/7 ratio: as a
+                     * `self-start` keeps the media at its 21/9 ratio: as a
                      * flex child it would otherwise stretch to the row height,
                      * making covers taller on cards with more meta rows.
                      */}

--- a/packages/ui/src/components/ui/image-preset.tsx
+++ b/packages/ui/src/components/ui/image-preset.tsx
@@ -34,14 +34,19 @@ export type ImagePresetDefinition = {
 export const IMAGE_PRESETS = {
     /**
      * Nyheter, arrangementer and jobbannonser. Used by NewsCard, ListCard and
-     * DetailHero — every one of them 16/7.
+     * DetailHero — every one of them 21/9.
+     *
+     * 21/9 is not an arbitrary pick: the old Kvark upload dialog hard-cropped
+     * every event, news and jobpost image to 21:9 before storing it, so the
+     * entire migrated back catalogue is physically 1000×429, 1500×642 and so
+     * on. Rendering those in any other frame throws away pixels for nothing.
      */
     "cover-wide": {
         label: "Bredt forsidebilde",
-        hint: "Vises i 16:7 på kort og øverst på siden. Alt utenfor rammen blir beskåret.",
-        aspectClassName: "aspect-[16/7]",
+        hint: "Vises i 21:9 på kort og øverst på siden. Alt utenfor rammen blir beskåret.",
+        aspectClassName: "aspect-[21/9]",
         fit: "cover",
-        recommended: { width: 1600, height: 700 },
+        recommended: { width: 1680, height: 720 },
     },
     /** Galleriforsider and bedriftstilbud — 16/9. */
     "cover-video": {


### PR DESCRIPTION
## Hva

`cover-wide`-presetet går fra `aspect-[16/7]` til `aspect-[21/9]`. Anbefalt opplastingsstørrelse justert til 1680×720.

## Hvorfor

Den gamle Kvark-opplasteren **hard-croppet** hvert arrangement-, nyhets- og annonsebilde til 21:9 før den lastet det opp, så hele det migrerte arkivet ligger fysisk som 21:9. Stikkprøve mot prod — 91 arrangementer og 42 nyheter med bilde, alle mellom 2.331 og 2.337:

```
1000×429   1500×642   1285×549   1178×505   1353×579   1108×475
```

Vi rendret dem i 16:7 (2.286), så `object-cover` beskar ~2 % av topp og bunn på alt eksisterende innhold uten at det ga noe tilbake.

Presetsystemet var allerede internt konsekvent — `NewsCard`, `ListCard` (arrangement + annonse) og `DetailHero` leser alle fra `cover-wide`, og det gjør admin-forhåndsvisningen også. Det var bare feil tall, så dette er ett sted å endre.

## Verifisert

- `bun run typecheck` ✅
- `bun run format` ✅ (lint-warnings som gjenstår ligger i `apps/api/src/test/asset/asset.test.ts` og er urørt)
- Dev-preview: rammene på `/nyheter` og `/arrangementer` måler `21 / 9` (2.334), som matcher kildefilene

## Til reviewer

To ting i `.claude/launch.json` som ikke er del av selve bildeendringen:

- **api-porten sto på 4000**, mens `.env` setter `PORT=4100` og kvark peker på `http://localhost:4100`. Konfigurasjonen kunne altså ikke fungere. Rettet til 4100.
- **`autoPort: true` på kvark** la jeg til fordi 3000 var opptatt lokalt. Greit å droppe hvis dere heller vil at den skal feile hardt på opptatt port.

## Ikke rørt

Fant disse mens jeg gikk gjennom, men de er ikke «plakater» — si fra hvis de bør med i samme slengen:

- **Galleri-forside** var 21:9 på gamlesiden, er 16:9 nå (`cover-video`)
- **`company-offer-card.tsx:36`** og **`group-om-tab.tsx:23`** hardkoder `aspect-video` utenom presetsystemet, så de følger ikke med på framtidige endringer
- **Infobanner** hadde bilde i 21:9 på gamlesiden, har ikke bilde i det hele tatt nå

Verdt å merke seg framover: den nye opplasteren cropper ikke, den komprimerer og viser preset-rammen som forhåndsvisning. 21:9-garantien gjelder altså det gamle arkivet — nye bilder lagres i sitt eget format og beskjæres kun i CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)