### PR TITLE
feat(event): organizer-filter i event-lista + gruppens arrangementsfane

### DIFF
--- a/apps/api/src/routes/event/list.ts
+++ b/apps/api/src/routes/event/list.ts
@@ -82,6 +82,7 @@ export const listRoute = route().get(
             expired,
             openSignUp,
             category,
+            organizerGroupSlug,
             ordering,
         } = c.req.valid("query");
 
@@ -95,6 +96,9 @@ export const listRoute = route().get(
                 search ? ilike(schema.event.title, `%${search}%`) : undefined,
                 category
                     ? inArray(schema.event.categorySlug, category)
+                    : undefined,
+                organizerGroupSlug
+                    ? eq(schema.event.organizerGroupSlug, organizerGroupSlug)
                     : undefined,
                 expired != null
                     ? expired

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -462,6 +462,10 @@ export const eventListFilterSchema = PaginationSchema.extend({
         type: "boolean",
         description: "Whether to include only events with open sign-ups",
     }),
+    organizerGroupSlug: z.string().optional().meta({
+        description:
+            "Only return events organised by this group. Omit to return events from every organizer.",
+    }),
     ordering: z.enum(["upcoming", "newest", "oldest"]).optional().meta({
         description:
             "How to order the result. 'upcoming' puts ongoing and future events first, soonest first, with past events after them most-recent-first. 'newest' and 'oldest' sort every event by start time, descending and ascending respectively. Omit to keep the legacy default: ascending when expired=false, descending otherwise.",

--- a/apps/api/src/test/event/list-organizer.test.ts
+++ b/apps/api/src/test/event/list-organizer.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+describe("event list organizer filter", () => {
+    integrationTest(
+        "organizerGroupSlug returns only the events that group organises",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+
+            const organizer = await ctx.utils.createTestGroup({
+                slug: `organizer-${Date.now()}`,
+            });
+            const otherGroup = await ctx.utils.createTestGroup({
+                slug: `other-${Date.now()}`,
+            });
+
+            const ownEvent = await ctx.utils.createTestEvent({
+                title: "Own Event",
+                slug: `own-${Date.now()}`,
+                organizerGroupSlug: organizer.slug,
+            });
+            const otherEvent = await ctx.utils.createTestEvent({
+                title: "Other Event",
+                slug: `other-event-${Date.now()}`,
+                organizerGroupSlug: otherGroup.slug,
+            });
+            const unorganizedEvent = await ctx.utils.createTestEvent({
+                title: "Unorganized Event",
+                slug: `unorganized-${Date.now()}`,
+            });
+
+            const client = ctx.utils.client();
+            const response = await client.api.event.$get({
+                query: { organizerGroupSlug: organizer.slug },
+            });
+            expect(response.status).toBe(200);
+            const body = await response.json();
+
+            const ids = body.items.map((e) => e.id);
+            expect(ids).toContain(ownEvent.id);
+            expect(ids).not.toContain(otherEvent.id);
+            expect(ids).not.toContain(unorganizedEvent.id);
+            // totalCount drives the pagination, so it has to be filtered too.
+            expect(body.totalCount).toBe(1);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "omitting organizerGroupSlug keeps events from every organizer",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+
+            const organizer = await ctx.utils.createTestGroup({
+                slug: `organizer-all-${Date.now()}`,
+            });
+
+            const organizedEvent = await ctx.utils.createTestEvent({
+                title: "Organized Event",
+                slug: `organized-${Date.now()}`,
+                organizerGroupSlug: organizer.slug,
+            });
+            const unorganizedEvent = await ctx.utils.createTestEvent({
+                title: "Unorganized Event",
+                slug: `no-organizer-${Date.now()}`,
+            });
+
+            const client = ctx.utils.client();
+            const response = await client.api.event.$get({ query: {} });
+            expect(response.status).toBe(200);
+            const body = await response.json();
+
+            const ids = body.items.map((e) => e.id);
+            expect(ids).toContain(organizedEvent.id);
+            expect(ids).toContain(unorganizedEvent.id);
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/components/group-events-tab.tsx
+++ b/apps/kvark/src/components/group-events-tab.tsx
@@ -1,14 +1,98 @@
-import { GroupPageHeader } from "#/components/group-page-header";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
+import { useState } from "react";
 
-export function GroupEventsTab() {
-    // The backend event list endpoint (GET /api/event) has no organizer/group
-    // filter, so events cannot yet be scoped to a single group.
+import { getEventsInfiniteQuery } from "#/api/queries/events";
+import { EventCard } from "#/components/event-card";
+import { GroupPageHeader } from "#/components/group-page-header";
+import { LoadMoreButton } from "#/components/load-more-button";
+import { formatEventDateTime } from "#/lib/event";
+
+type EventPeriod = "kommende" | "tidligere";
+
+const PERIODS: { value: EventPeriod; label: string }[] = [
+    { value: "kommende", label: "Kommende" },
+    { value: "tidligere", label: "Tidligere" },
+];
+
+type GroupEventsTabProps = {
+    /** Slug of the group whose events to list. */
+    slug: string;
+};
+
+export function GroupEventsTab({ slug }: GroupEventsTabProps) {
+    const [period, setPeriod] = useState<EventPeriod>("kommende");
+
+    const { data, isPending, hasNextPage, fetchNextPage, isFetchingNextPage } =
+        useInfiniteQuery(
+            getEventsInfiniteQuery({
+                organizerGroupSlug: slug,
+                expired: period === "tidligere",
+            }),
+        );
+
+    const events = data?.pages.flatMap((page) => page.items) ?? [];
+
     return (
         <div className="flex flex-col gap-6">
-            <GroupPageHeader title="Arrangementer" />
-            <p className="text-sm text-muted-foreground">
-                Ingen arrangementer å vise for denne gruppen ennå.
-            </p>
+            <GroupPageHeader
+                title="Arrangementer"
+                action={
+                    <Tabs
+                        value={period}
+                        onValueChange={(next) => setPeriod(next as EventPeriod)}
+                    >
+                        <TabsList>
+                            {PERIODS.map((p) => (
+                                <TabsTrigger key={p.value} value={p.value}>
+                                    {p.label}
+                                </TabsTrigger>
+                            ))}
+                        </TabsList>
+                    </Tabs>
+                }
+            />
+
+            {isPending ? (
+                <div className="flex flex-col gap-4 sm:gap-1">
+                    {[0, 1, 2].map((row) => (
+                        <Skeleton key={row} className="h-24 w-full" />
+                    ))}
+                </div>
+            ) : events.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                    {period === "kommende"
+                        ? "Gruppen har ingen kommende arrangementer."
+                        : "Gruppen har ingen tidligere arrangementer."}
+                </p>
+            ) : (
+                <ul className="flex flex-col gap-4 sm:gap-1">
+                    {events.map((event) => (
+                        <li key={event.id}>
+                            <EventCard
+                                slug={event.slug}
+                                title={event.title}
+                                startsAt={formatEventDateTime(event.startTime)}
+                                location={event.location ?? ""}
+                                organizer={event.organizer?.name ?? ""}
+                                category={event.category?.label}
+                                imageUrl={event.image || undefined}
+                                imageAlt={event.imageAlt || undefined}
+                            />
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {hasNextPage && (
+                <div className="flex justify-center">
+                    <LoadMoreButton
+                        onClick={() => fetchNextPage()}
+                        isLoading={isFetchingNextPage}
+                    />
+                </div>
+            )}
         </div>
     );
 }

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -592,7 +592,9 @@ function GroupDetail() {
                             }
                         />
                     ) : null}
-                    {activeTab === "arrangementer" ? <GroupEventsTab /> : null}
+                    {activeTab === "arrangementer" ? (
+                        <GroupEventsTab slug={slug} />
+                    ) : null}
                     {activeTab === "boter" ? (
                         <GroupFinesTab
                             fines={fines}

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -7090,6 +7090,8 @@ export interface operations {
                 expired?: boolean;
                 /** @description Whether to include only events with open sign-ups */
                 openSignUp?: boolean;
+                /** @description Only return events organised by this group. Omit to return events from every organizer. */
+                organizerGroupSlug?: string;
                 /** @description How to order the result. 'upcoming' puts ongoing and future events first, soonest first, with past events after them most-recent-first. 'newest' and 'oldest' sort every event by start time, descending and ascending respectively. Omit to keep the legacy default: ascending when expired=false, descending otherwise. */
                 ordering?: "upcoming" | "newest" | "oldest";
             };


### PR DESCRIPTION
Fikser #399.

Fanen «Arrangementer» på gruppesiden var aldri bygget — den viste «Ingen arrangementer å vise for denne gruppen ennå» fordi `GET /api/event` manglet et organizer-filter. Det leste som en bug for brukerne.

## Endringer

**API**
- `organizerGroupSlug` lagt til i `eventListFilterSchema` og `list.ts`. Filteret går inn i `filters`-uttrykket, så det treffer også `totalCount` og dermed pagineringen.
- Kolonnen fantes allerede (`event.organizer_group_slug`), så ingen migrasjon.

**SDK**
- `@tihlde/sdk` regenerert med det nye query-parameteret.

**Kvark**
- `GroupEventsTab` tar nå `slug` og henter arrangementene via `getEventsInfiniteQuery({ organizerGroupSlug })`.
- Skeleton mens den laster, `EventCard`-liste, Kommende/Tidligere-veksler og «Last inn mer».

## Verifisert
- Nye integrasjonstester: filteret returnerer bare gruppens arrangementer (og `totalCount` er filtrert), og utelatt filter endrer ingenting. `vitest` grønn sammen med `visibility.test.ts`.
- Mot lokal dev-API: `?organizerGroupSlug=sosialen` gir 139 av 1229 arrangementer, alle med organizer `sosialen`; ukjent slug gir 0.
- I nettleseren på `/grupper/sosialen`: skeleton → 10 kommende, «Tidligere» gir 139 med «Last inn mer» (25 → 50). `/grupper/2017` viser tom-tilstanden.
- `bun run typecheck` og `bun run build` grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)