### PR TITLE
fix(bøter): vis antall bøter, tillat 0, og behold scroll ved fanebytte

### DIFF
--- a/apps/api/src/routes/groups/fines/schema.ts
+++ b/apps/api/src/routes/groups/fines/schema.ts
@@ -18,8 +18,10 @@ export const createFineSchema = Schema(
         amount: z
             .number()
             .int()
-            .positive()
-            .meta({ description: "Fine amount in NOK" }),
+            // 0 er lov: en bot kan registreres som en advarsel som ikke teller
+            // i summene, selv om paragrafen foreslår én eller flere.
+            .min(0)
+            .meta({ description: "Number of fines given (0 or more)" }),
         defense: z
             .string()
             .optional()

--- a/apps/api/src/test/groups/fines.test.ts
+++ b/apps/api/src/test/groups/fines.test.ts
@@ -65,6 +65,56 @@ describe("fines", () => {
         );
 
         integrationTest(
+            "accepts a fine with an amount of 0",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "fines-zero-group",
+                    finesActivated: true,
+                });
+
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: user.id,
+                    groupSlug: group.slug,
+                    role: "leader",
+                });
+
+                const targetUser = await ctx.auth.api.createUser({
+                    body: {
+                        email: "zero-target@test.com",
+                        name: "Zero Target",
+                        password: "test123!",
+                    },
+                });
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: targetUser.user.id,
+                    groupSlug: group.slug,
+                });
+
+                // 0 bøter er en gyldig registrering — en advarsel som ikke
+                // teller i summene.
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].fines.$post({
+                    param: { groupSlug: group.slug },
+                    json: {
+                        userId: targetUser.user.id,
+                        groupSlug: group.slug,
+                        reason: "Advarsel",
+                        amount: 0,
+                    },
+                });
+
+                expect(response.status).toBe(201);
+                const json = await response.json();
+                expect(json.amount).toBe(0);
+            },
+            500_000,
+        );
+
+        integrationTest(
             "successfully creates a fine as a member with fines:create",
             async ({ ctx }) => {
                 const user = await ctx.utils.createTestUser();

--- a/apps/kvark/src/components/group-fine-dialog.tsx
+++ b/apps/kvark/src/components/group-fine-dialog.tsx
@@ -128,23 +128,32 @@ export function GroupFineDialog({
                 {fine ? (
                     <>
                         <DialogHeader>
-                            {/* Uten paragraf er `title` den samme teksten som
-                                begrunnelsen lenger ned. Da brukes en generisk
-                                overskrift i stedet for å gjenta seg selv. */}
-                            <DialogTitle>
-                                {fine.hasLaw
-                                    ? `${fine.paragraph ? `${fine.paragraph} - ` : ""}${fine.title}`
-                                    : "Bot"}
-                            </DialogTitle>
+                            {/* Den bøtelagte er det du leter etter når du blar
+                                gjennom lista, så navnet står som tittel.
+                                Paragrafen står under — uten lovverk er `title`
+                                bare begrunnelsen om igjen, og utelates. */}
+                            <DialogTitle>{fine.user}</DialogTitle>
                             <DialogDescription>
-                                Til {fine.user}
-                                {fine.createdBy
-                                    ? ` · Fra ${fine.createdBy}`
-                                    : ""}
+                                {[
+                                    fine.hasLaw
+                                        ? `${fine.paragraph ? `${fine.paragraph} - ` : ""}${fine.title}`
+                                        : null,
+                                    fine.createdBy
+                                        ? `Fra ${fine.createdBy}`
+                                        : null,
+                                ]
+                                    .filter(Boolean)
+                                    .join(" · ")}
                             </DialogDescription>
                         </DialogHeader>
                         <div className="flex flex-col gap-3">
                             <div className="flex flex-wrap gap-2">
+                                {/* Antallet er selve boten — det sto ingen
+                                    steder, verken i lista eller her. */}
+                                <Badge variant="secondary">
+                                    {fine.amount}{" "}
+                                    {fine.amount === 1 ? "bot" : "bøter"}
+                                </Badge>
                                 <Badge
                                     variant={
                                         fine.approved ? "default" : "outline"

--- a/apps/kvark/src/components/group-fine-row.tsx
+++ b/apps/kvark/src/components/group-fine-row.tsx
@@ -6,11 +6,10 @@ import type { Fine } from "#/lib/group";
 
 type GroupFineRowProps = {
     fine: Fine;
-    index: number;
     onOpen: () => void;
 };
 
-export function GroupFineRow({ fine, index, onOpen }: GroupFineRowProps) {
+export function GroupFineRow({ fine, onOpen }: GroupFineRowProps) {
     return (
         // Raden er et klikkbart kort, ikke en <button>, så den må selv si fra
         // at den kan få tastaturfokus og svare på Enter/mellomrom. Uten dette
@@ -28,7 +27,11 @@ export function GroupFineRow({ fine, index, onOpen }: GroupFineRowProps) {
                 }
             }}
         >
-            <span className="w-6 text-center font-medium">{index}</span>
+            {/* Her sto radnummeret, som så ut som et antall. Nå står det som
+                faktisk betyr noe: hvor mange bøter personen fikk. */}
+            <Badge variant="secondary" className="min-w-16 justify-center">
+                {fine.amount} {fine.amount === 1 ? "bot" : "bøter"}
+            </Badge>
             <div className="flex min-w-0 flex-1 flex-col">
                 <span className="flex items-center gap-1 truncate font-medium">
                     {fine.user}

--- a/apps/kvark/src/components/group-fines-tab.tsx
+++ b/apps/kvark/src/components/group-fines-tab.tsx
@@ -281,7 +281,6 @@ function FineList({
                     <li key={fine.id}>
                         <GroupFineRow
                             fine={fine}
-                            index={index + 1}
                             onOpen={() => onOpen(index)}
                         />
                     </li>

--- a/apps/kvark/src/components/group-give-fine-dialog.tsx
+++ b/apps/kvark/src/components/group-give-fine-dialog.tsx
@@ -53,7 +53,10 @@ export function GroupGiveFineDialog({
 }: GroupGiveFineDialogProps) {
     const [recipients, setRecipients] = useState<ComboboxMember[]>([]);
     const [law, setLaw] = useState<Law | null>(null);
-    const [amount, setAmount] = useState<number>(1);
+    // Tekst, ikke tall: med `Number(e.target.value)` ble et tomt felt straks
+    // til 0 igjen, så du fikk aldri slettet det paragrafen fylte inn for å
+    // skrive et nytt antall.
+    const [amount, setAmount] = useState("1");
     const [reason, setReason] = useState("");
     const [image, setImage] = useState<File | null>(null);
 
@@ -63,15 +66,23 @@ export function GroupGiveFineDialog({
         if (open) return;
         setRecipients([]);
         setLaw(null);
-        setAmount(1);
+        setAmount("1");
         setReason("");
         setImage(null);
     }, [open]);
 
     function handleLawChange(next: Law | null) {
         setLaw(next);
-        if (next) setAmount(next.amount);
+        if (next) setAmount(String(next.amount));
     }
+
+    // 0 er en gyldig bot (en advarsel som ikke teller i summene), så feltet
+    // valideres på «er dette et helt tall ≥ 0», ikke på at det er positivt.
+    const parsedAmount = Number(amount);
+    const amountValid =
+        amount.trim().length > 0 &&
+        Number.isInteger(parsedAmount) &&
+        parsedAmount >= 0;
 
     // En gruppe uten lovverk skal fortsatt kunne gi bøter — da er det ingen
     // paragraf å velge, og feltet er ikke påkrevd.
@@ -79,7 +90,7 @@ export function GroupGiveFineDialog({
     const canSubmit =
         recipients.length > 0 &&
         reason.trim().length > 0 &&
-        amount > 0 &&
+        amountValid &&
         (!lawRequired || law !== null) &&
         !isSubmitting;
 
@@ -89,7 +100,7 @@ export function GroupGiveFineDialog({
         onSubmit({
             userIds: recipients.map((member) => member.id),
             lawId: law?.id ?? null,
-            amount,
+            amount: parsedAmount,
             reason: reason.trim(),
             image,
         });
@@ -161,12 +172,14 @@ export function GroupGiveFineDialog({
                             <Input
                                 id="fine-amount"
                                 type="number"
-                                min={1}
+                                min={0}
+                                step={1}
                                 value={amount}
-                                onChange={(e) =>
-                                    setAmount(Number(e.target.value))
-                                }
+                                onChange={(e) => setAmount(e.target.value)}
                             />
+                            <p className="text-xs text-muted-foreground">
+                                Sett 0 hvis boten skal registreres uten å telle.
+                            </p>
                         </Field>
 
                         <Field>

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -613,12 +613,18 @@ function GroupDetail() {
                                         // medlemsoversikten.
                                         botBruker: undefined,
                                     }),
+                                    // Filtrene ligger i URL-en, men å bytte
+                                    // fane er ikke å gå til en ny side: uten
+                                    // dette kastet ruteren deg til toppen midt
+                                    // i botlista.
+                                    resetScroll: false,
                                 })
                             }
                             status={botStatus}
                             onStatusChange={(botStatus) =>
                                 navigate({
                                     search: (prev) => ({ ...prev, botStatus }),
+                                    resetScroll: false,
                                 })
                             }
                             selectedUserId={botBruker}
@@ -632,6 +638,7 @@ function GroupDetail() {
                                             ? "alle"
                                             : prev.botVisning,
                                     }),
+                                    resetScroll: false,
                                 })
                             }
                             hasMore={

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -4446,7 +4446,7 @@ export interface components {
             groupSlug: string;
             /** @description Reason for the fine */
             reason: string;
-            /** @description Fine amount in NOK */
+            /** @description Number of fines given (0 or more) */
             amount: number;
             /** @description User's defense text */
             defense?: string;


### PR DESCRIPTION
Fire fikser i botoversikten på gruppesiden, meldt inn etter bruk i praksis.

## Hva som er endret

**Antall bøter vises ingen steder → nå to steder.** Tallet helt til venstre i botkortet var radnummeret i lista (1, 2, 3 …), som så ut som et antall. Det er byttet til hvor mange bøter personen faktisk fikk (`1 bot` / `67 bøter`), og samme antall står som badge øverst i botdialogen. `amount` lå allerede på `Fine`-typen, men ble aldri rendret.

**Antall kan settes til 0.** `createFineSchema.amount` krevde `.positive()`, og feltet i Ny bot-dialogen kjørte `Number(e.target.value)` på hvert tastetrykk — et tømt felt ble umiddelbart `0` igjen, og med `min={1}` kunne du verken slette det paragrafen fylte inn eller skrive 0. Feltet holder nå verdien som tekst, og API-et godtar `>= 0`. 0 betyr en bot som registreres uten å telle i summene.

**Fanebytte hopper ikke lenger til toppen.** Botfiltrene ligger i URL-ens søkeparametre (bevisst — de overlever refresh og kan deles som lenke), men da scroller TanStack Router til topp ved hver endring. `resetScroll: false` på visning, status og personfilter.

**Botdialogens tittel.** Uten kobling til lovverket het dialogen bare «Bot». Tittelen er nå navnet på den bøtelagte, med «Fra X» under; «Til Y» er fjernet siden det nå er tittelen. Paragrafen står i samme linje som «Fra X» når boten har en — ellers ville den informasjonen forsvunnet helt fra dialogen.

## Verifisering

- `bun run typecheck` og `bun run format` grønt
- Alle 34 tester i `apps/api/src/test/groups/fines.test.ts` passerer, inkludert en ny som sjekker at `amount: 0` gir 201
- Kjørt i lokal dev mot ekte data: badge viser riktig antall, dialogtittelen er navnet, feltet lar seg tømme/sette til 0/skrive om, og scrollposisjon er målt uendret (1200 → 1200) ved bytte til «Per medlem»

## Til reviewer

- `packages/sdk/src/generated/openapi.ts` er regenerert — eneste endring er den nye beskrivelsen på `amount`.
- Ikke rørt i denne PR-en: statusnedtrekket viser rå verdi («alle») i stedet for etiketten «Alle bøter». Ser ut som en egen feil i `SelectValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)