### PR TITLE
feat(ui): vis forslag når stavekontrollen finner en feil

### DIFF
--- a/packages/ui/src/components/complex/markdown/internal/spell-suggestions.tsx
+++ b/packages/ui/src/components/complex/markdown/internal/spell-suggestions.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from "react";
+
+import { Button } from "#/components/ui/button";
+
+import type { SpellcheckSelection } from "./spellcheck-extension";
+
+export type SpellSuggestionsProps = {
+    selection: SpellcheckSelection;
+    /** Elementet boblen plasseres inni. Brukes til å regne om koordinatene. */
+    container: HTMLElement | null;
+    onApply: (replacement: string) => void;
+    onDismiss: () => void;
+};
+
+/**
+ * Boblen som viser hva som er galt med ordet under den røde streken, og hvilke
+ * ord ordboka foreslår i stedet. Uten den er streken bare en beskjed om at noe
+ * er feil, og skriveren må gjette hva.
+ */
+export function SpellSuggestions({
+    selection,
+    container,
+    onApply,
+    onDismiss,
+}: SpellSuggestionsProps) {
+    const popupRef = useRef<HTMLDivElement>(null);
+    const firstSuggestionRef = useRef<HTMLButtonElement>(null);
+
+    // Første forslaget tar fokus, slik at lista kan bla-es gjennom med
+    // tastaturet. `preventScroll` holder teksten i ro — hopper siden, mister
+    // skriveren stedet hen var.
+    useEffect(() => {
+        firstSuggestionRef.current?.focus({ preventScroll: true });
+    }, []);
+
+    // Klikk utenfor og Escape lukker boblen. Klikk inne i editoren håndteres av
+    // stavekontrollen selv, som melder fra at ingen feil ble truffet.
+    useEffect(() => {
+        function onPointerDown(event: PointerEvent) {
+            if (!popupRef.current) return;
+            if (popupRef.current.contains(event.target as globalThis.Node))
+                return;
+            onDismiss();
+        }
+        function onKeyDown(event: KeyboardEvent) {
+            if (event.key === "Escape") onDismiss();
+        }
+
+        document.addEventListener("pointerdown", onPointerDown);
+        document.addEventListener("keydown", onKeyDown);
+        return () => {
+            document.removeEventListener("pointerdown", onPointerDown);
+            document.removeEventListener("keydown", onKeyDown);
+        };
+    }, [onDismiss]);
+
+    const bounds = container?.getBoundingClientRect();
+    const top = selection.rect.bottom - (bounds?.top ?? 0) + 4;
+    const left = selection.rect.left - (bounds?.left ?? 0);
+
+    return (
+        <div
+            ref={popupRef}
+            role="dialog"
+            aria-label={`Forslag for ${selection.word}`}
+            style={{ top, left }}
+            className="absolute z-50 flex w-56 flex-col gap-1 rounded-lg bg-popover p-1.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10"
+        >
+            <p className="px-1.5 pt-0.5 text-muted-foreground text-xs">
+                «{selection.word}» står ikke i ordboka
+            </p>
+
+            {selection.suggestions.length === 0 ? (
+                <p className="px-1.5 pb-0.5 text-muted-foreground text-xs">
+                    Ordboka har ingen forslag.
+                </p>
+            ) : (
+                selection.suggestions.map((suggestion, index) => (
+                    <Button
+                        key={suggestion}
+                        ref={index === 0 ? firstSuggestionRef : undefined}
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 justify-start px-1.5 font-normal"
+                        onClick={() => onApply(suggestion)}
+                    >
+                        {suggestion}
+                    </Button>
+                ))
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/components/complex/markdown/internal/spellcheck-extension.ts
+++ b/packages/ui/src/components/complex/markdown/internal/spellcheck-extension.ts
@@ -3,6 +3,7 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import type { EditorState, Transaction } from "@tiptap/pm/state";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { EditorView } from "@tiptap/pm/view";
 
 import { loadSpeller, type Speller } from "./speller";
 
@@ -14,6 +15,30 @@ const spellcheckKey = new PluginKey<DecorationSet>("norsk-stavekontroll");
  */
 const WORD_PATTERN = /[\p{L}][\p{L}'’-]*/gu;
 
+/** Et ord i teksten som ordboka ikke kjenner igjen. */
+export type Misspelling = {
+    word: string;
+    /** Posisjonen ordet starter og slutter på i dokumentet. */
+    from: number;
+    to: number;
+};
+
+/** Skrivefeilen brukeren klikket på, klar til å vises i en boble. */
+export type SpellcheckSelection = Misspelling & {
+    /** Ordboka sine forslag, tom når den ikke har noen. */
+    suggestions: string[];
+    /** Hvor ordet står på skjermen, i koordinater fra `getBoundingClientRect`. */
+    rect: { top: number; bottom: number; left: number; right: number };
+};
+
+export type SpellcheckOptions = {
+    /**
+     * Kalles når brukeren klikker på et ord med rød strek, og med `null` når
+     * klikket havnet et sted uten skrivefeil. Uten denne markeres feilene bare.
+     */
+    onSelect?: (selection: SpellcheckSelection | null) => void;
+};
+
 /** Ord med tall eller versaler i seg — koder, forkortelser, TIHLDE-slang. */
 function shouldSkip(word: string): boolean {
     if (word.length < 3) return true;
@@ -22,9 +47,12 @@ function shouldSkip(word: string): boolean {
     return false;
 }
 
-function buildDecorations(doc: ProseMirrorNode, speller: Speller) {
-    const decorations: Decoration[] = [];
-
+/** Gå gjennom hver skrivefeil i dokumentet én gang. */
+function forEachMisspelling(
+    doc: ProseMirrorNode,
+    speller: Speller,
+    visit: (misspelling: Misspelling) => void,
+) {
     doc.descendants((node, position) => {
         if (!node.isText || !node.text) return;
 
@@ -34,30 +62,102 @@ function buildDecorations(doc: ProseMirrorNode, speller: Speller) {
             if (!speller.isMisspelled(word)) continue;
 
             const from = position + match.index;
-            decorations.push(
-                Decoration.inline(from, from + word.length, {
-                    class: "spelling-error",
-                }),
-            );
+            visit({ word, from, to: from + word.length });
         }
+    });
+}
+
+function buildDecorations(doc: ProseMirrorNode, speller: Speller) {
+    const decorations: Decoration[] = [];
+
+    forEachMisspelling(doc, speller, ({ word, from, to }) => {
+        decorations.push(
+            Decoration.inline(from, to, {
+                class: "spelling-error",
+                // Hjelper også de som bare holder musa over ordet, og de som
+                // ikke ser forskjell på en rød og en svart bølgestrek.
+                title: `«${word}» står ikke i ordboka. Klikk for forslag.`,
+            }),
+        );
     });
 
     return DecorationSet.create(doc, decorations);
 }
 
+/** Skrivefeilen som dekker posisjonen, om det er noen der. */
+function misspellingAt(
+    doc: ProseMirrorNode,
+    speller: Speller,
+    position: number,
+): Misspelling | null {
+    let found: Misspelling | null = null;
+    forEachMisspelling(doc, speller, (misspelling) => {
+        if (found) return;
+        if (position >= misspelling.from && position <= misspelling.to) {
+            found = misspelling;
+        }
+    });
+    return found;
+}
+
+/** Legg til forslag og skjermplassering, slik boblen trenger det. */
+function describe(
+    view: EditorView,
+    speller: Speller,
+    misspelling: Misspelling,
+): SpellcheckSelection {
+    const start = view.coordsAtPos(misspelling.from);
+    const end = view.coordsAtPos(misspelling.to);
+
+    return {
+        ...misspelling,
+        suggestions: speller.suggest(misspelling.word),
+        rect: {
+            top: Math.min(start.top, end.top),
+            bottom: Math.max(start.bottom, end.bottom),
+            left: Math.min(start.left, end.left),
+            right: Math.max(start.right, end.right),
+        },
+    };
+}
+
 /**
  * Marker skrivefeil med rød bølgestrek, på samme måte som nettleseren ville
- * gjort om brukeren hadde norsk ordbok installert.
+ * gjort om brukeren hadde norsk ordbok installert, og si fra når noen klikker
+ * på en av dem så editoren kan vise forslag til retting.
  *
  * Ordboka lastes i bakgrunnen. Fram til den er klar — og hvis den aldri blir
  * det — ligger dekorasjonene tomme, og nettleserens egen stavekontroll står
  * for det den måtte klare.
  */
-export const NorwegianSpellcheck = Extension.create({
+export const NorwegianSpellcheck = Extension.create<SpellcheckOptions>({
     name: "norwegianSpellcheck",
+
+    addOptions() {
+        return { onSelect: undefined };
+    },
 
     addProseMirrorPlugins() {
         let speller: Speller | null = null;
+        const options = this.options;
+
+        /** Svarer true når klikket traff en skrivefeil. */
+        function report(view: EditorView, position: number): boolean {
+            const { onSelect } = options;
+            if (!onSelect) return false;
+
+            const misspelling = speller
+                ? misspellingAt(view.state.doc, speller, position)
+                : null;
+
+            if (!misspelling || !speller) {
+                onSelect(null);
+                return false;
+            }
+
+            onSelect(describe(view, speller, misspelling));
+            return true;
+        }
 
         return [
             new Plugin<DecorationSet>({
@@ -114,6 +214,28 @@ export const NorwegianSpellcheck = Extension.create({
                 props: {
                     decorations(state) {
                         return spellcheckKey.getState(state);
+                    },
+
+                    handleClick(view, position) {
+                        report(view, position);
+                        // Markøren skal fortsatt flytte seg dit man klikket.
+                        return false;
+                    },
+
+                    handleDOMEvents: {
+                        // Høyreklikk er der folk er vant til å lete etter
+                        // stavekontrollens forslag. Nettlesermenyen får stå i
+                        // fred når ordet ikke har en feil å rette.
+                        contextmenu(view, event) {
+                            const position = view.posAtCoords({
+                                left: event.clientX,
+                                top: event.clientY,
+                            });
+                            if (!position) return false;
+                            if (!report(view, position.pos)) return false;
+                            event.preventDefault();
+                            return true;
+                        },
                     },
                 },
             }),

--- a/packages/ui/src/components/complex/markdown/internal/tiptap-extensions.ts
+++ b/packages/ui/src/components/complex/markdown/internal/tiptap-extensions.ts
@@ -15,7 +15,10 @@ import type {
     DirectiveRegistry,
 } from "../directive";
 
-import { NorwegianSpellcheck } from "./spellcheck-extension";
+import {
+    NorwegianSpellcheck,
+    type SpellcheckSelection,
+} from "./spellcheck-extension";
 import { TableNodeView } from "./table-node-view";
 import { attrsFromSchema } from "./zod-to-attrs";
 
@@ -23,6 +26,8 @@ export type BuildOptions = {
     placeholder?: string;
     /** Norsk stavekontroll i appen. På som standard. */
     spellcheck?: boolean;
+    /** Kalles når brukeren klikker på et ord med rød strek. */
+    onSpellcheckSelect?: (selection: SpellcheckSelection | null) => void;
 };
 
 /**
@@ -59,7 +64,13 @@ export function buildTiptapExtensions(
         TableRow,
         TableHeader,
         TableCell,
-        ...(options.spellcheck === false ? [] : [NorwegianSpellcheck]),
+        ...(options.spellcheck === false
+            ? []
+            : [
+                  NorwegianSpellcheck.configure({
+                      onSelect: options.onSpellcheckSelect,
+                  }),
+              ]),
     ];
 
     const directiveExtensions = registry.directives.map((directive) =>

--- a/packages/ui/src/components/complex/markdown/rich-editor.tsx
+++ b/packages/ui/src/components/complex/markdown/rich-editor.tsx
@@ -1,5 +1,5 @@
 import { EditorContent, useEditor } from "@tiptap/react";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { DirectiveRegistry } from "./directive";
 import { EditorToolbar } from "./editor-toolbar";
@@ -7,6 +7,8 @@ import { MarkdownContent } from "./markdown-content";
 import { mdastToTiptap } from "./internal/mdast-to-pm";
 import { parseMarkdown, stringifyMdast } from "./internal/pipeline";
 import { tiptapToMdast } from "./internal/pm-to-mdast";
+import { SpellSuggestions } from "./internal/spell-suggestions";
+import type { SpellcheckSelection } from "./internal/spellcheck-extension";
 import { buildTiptapExtensions } from "./internal/tiptap-extensions";
 
 export type RichEditorProps = {
@@ -33,14 +35,28 @@ export function RichEditor({
     spellCheck = true,
 }: RichEditorProps) {
     const lastEmitted = useRef(value);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [misspelling, setMisspelling] = useState<SpellcheckSelection | null>(
+        null,
+    );
+
+    // Stavekontrollen bygges én gang og kan ikke se React-state, så den melder
+    // fra gjennom en ref som alltid peker på gjeldende setter.
+    const selectRef = useRef(setMisspelling);
+    selectRef.current = setMisspelling;
+    const onSpellcheckSelect = useCallback(
+        (selection: SpellcheckSelection | null) => selectRef.current(selection),
+        [],
+    );
 
     const extensions = useMemo(
         () =>
             buildTiptapExtensions(registry, {
                 placeholder,
                 spellcheck: spellCheck,
+                onSpellcheckSelect,
             }),
-        [registry, placeholder, spellCheck],
+        [registry, placeholder, spellCheck, onSpellcheckSelect],
     );
 
     const initialContent = useMemo(
@@ -73,6 +89,9 @@ export function RichEditor({
             },
         },
         onUpdate: ({ editor: instance }) => {
+            // Posisjonene i boblen gjelder teksten slik den var, så den lukkes
+            // så snart noe skrives.
+            setMisspelling(null);
             const json = instance.getJSON();
             const mdast = tiptapToMdast(json, registry);
             const markdown = stringifyMdast(mdast);
@@ -89,13 +108,47 @@ export function RichEditor({
         lastEmitted.current = value;
     }, [editor, value, registry]);
 
+    const applySuggestion = useCallback(
+        (replacement: string) => {
+            if (!editor || !misspelling) return;
+            const { from, to } = misspelling;
+            setMisspelling(null);
+            editor
+                .chain()
+                .focus()
+                .command(({ tr }) => {
+                    // Ordet kan stå i en lenke eller i fet skrift, og de
+                    // markene skal følge med over på rettelsen.
+                    const marks = tr.doc.resolve(from + 1).marks();
+                    tr.replaceWith(
+                        from,
+                        to,
+                        editor.schema.text(replacement, marks),
+                    );
+                    return true;
+                })
+                .run();
+        },
+        [editor, misspelling],
+    );
+
+    const dismissSuggestions = useCallback(() => setMisspelling(null), []);
+
     return (
         <div className={className}>
-            <div className="rounded border">
+            <div ref={containerRef} className="relative rounded border">
                 <EditorToolbar editor={editor} registry={registry} />
                 <MarkdownContent className="border-t px-3 py-2">
                     <EditorContent editor={editor} />
                 </MarkdownContent>
+                {misspelling && (
+                    <SpellSuggestions
+                        selection={misspelling}
+                        container={containerRef.current}
+                        onApply={applySuggestion}
+                        onDismiss={dismissSuggestions}
+                    />
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
## Hva

Den norske stavekontrollen i rich-editoren markerte skrivefeil med rød bølgestrek, men sa aldri hva som var galt eller hva ordet skulle vært. Ordboka hadde forslag hele tiden (`speller.suggest`) — de ble bare aldri vist.

- **Tooltip** på markeringen: «‹Ordet› står ikke i ordboka. Klikk for forslag.»
- **Klikk eller høyreklikk** på ordet åpner en boble rett under det, med inntil fem forslag fra ordboka — eller beskjed om at ordboka ikke har noen, i stedet for en tom meny.
- **Valgt forslag** bytter ut ordet og beholder formateringen (fet, lenke, …).
- Boblen lukkes med Escape, klikk utenfor, eller så snart man skriver videre (posisjonene gjelder teksten slik den var). Første forslag får fokus med `preventScroll`, så lista kan velges med tastaturet uten at siden hopper.

## Filer

- `internal/spellcheck-extension.ts` — `title` på dekorasjonen, og `handleClick`/`contextmenu` melder fra om ord, forslag og skjermplassering via en ny `onSelect`-option
- `internal/spell-suggestions.tsx` — ny boble
- `internal/tiptap-extensions.ts`, `rich-editor.tsx` — kobler det sammen og utfører rettelsen

## Verifisert

I dev-preview på `/playground/markdown`:

- Klikk på «Edit» ga «Exit, Dit, Edikt, EDI», plassert rett under ordet (boble-top 191.5 mot ord-bunn 186.5, ingen scroll-hopp).
- Valg av «Exit» byttet ordet både i editoren og i markdown-kilden.
- Høyreklikk åpnet samme boble, og lot nettlesermenyen stå i fred når ordet ikke har feil.
- Rettelse av det fete ordet **rich** → **Rica** beholdt `**...**` i markdown.
- `typecheck`, `lint`, `format` og `build` er grønne.

## Verdt å vite for review

Dette gjelder bare rich-editoren (arrangementer, nyheter, wiki). Vanlige `input`/`textarea`-felt bruker fortsatt nettleserens egen stavekontroll, der vi ikke kan styre forslagsmenyen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)