### PR TITLE
feat(kvark): vis varsler i en bjelle i headeren

### DIFF
--- a/apps/kvark/src/api/queries/notifications.ts
+++ b/apps/kvark/src/api/queries/notifications.ts
@@ -65,7 +65,12 @@ export const getNotificationsInfiniteQuery = (
                 },
             }),
         initialPageParam: 0,
-        getNextPageParam: (lastPage) => lastPage.nextPage,
+        // `nextPage` fra API-et peker på en side som ikke finnes når siste side
+        // er full-på-grensen (page er 0-basert, pages er et antall). En kort
+        // side betyr at vi er ferdige — ellers ville "Last inn mer" hentet
+        // en tom side.
+        getNextPageParam: (lastPage) =>
+            lastPage.items.length < pageSize ? null : lastPage.nextPage,
     });
 
 export const deleteNotificationMutation = mutationOptions({

--- a/apps/kvark/src/components/AdminLayoutHeader.tsx
+++ b/apps/kvark/src/components/AdminLayoutHeader.tsx
@@ -14,6 +14,7 @@ import { PanelLeftIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import React, { useMemo } from "react";
 import { authQueryOptions } from "#/api/auth";
+import { NotificationBell } from "./notification-bell";
 import { ThemeSwitcher } from "./theme-switcher";
 
 import { avatarImageUrl } from "#/lib/assets";
@@ -77,6 +78,7 @@ export function AdminLayoutHeader() {
                     </BreadcrumbList>
                 </Breadcrumb>
                 <div className="ml-auto flex items-center gap-4">
+                    <NotificationBell />
                     <ThemeSwitcher />
                     <Link to="/profil/$id" params={{ id: "me" }}>
                         <Avatar>

--- a/apps/kvark/src/components/notification-bell.tsx
+++ b/apps/kvark/src/components/notification-bell.tsx
@@ -1,0 +1,184 @@
+import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query";
+import { Badge } from "@tihlde/ui/ui/badge";
+import { Button } from "@tihlde/ui/ui/button";
+import {
+    Popover,
+    PopoverContent,
+    PopoverHeader,
+    PopoverTitle,
+    PopoverTrigger,
+} from "@tihlde/ui/ui/popover";
+import { Separator } from "@tihlde/ui/ui/separator";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import { Bell } from "lucide-react";
+import { useState } from "react";
+
+import {
+    deleteNotificationMutation,
+    getNotificationsInfiniteQuery,
+    getUnreadNotificationCountQuery,
+    markNotificationReadMutation,
+} from "#/api/queries/notifications";
+import { LoadMoreButton } from "#/components/load-more-button";
+import { NotificationItem } from "#/components/notification-item";
+import {
+    formatNotificationTime,
+    isExternalNotificationHref,
+    notificationHref,
+} from "#/lib/notification";
+
+/** Færre enn listesiden bruker — popoveren er smal og scroller. */
+const PAGE_SIZE = 10;
+
+/**
+ * Bjella i headeren. Teller uleste varsler hele tiden, men henter selve listen
+ * først når popoveren åpnes — de fleste sidevisningene åpner den aldri.
+ */
+export function NotificationBell() {
+    const [open, setOpen] = useState(false);
+
+    const { data: unreadCount = 0 } = useQuery(
+        getUnreadNotificationCountQuery(),
+    );
+
+    const { data, isPending, hasNextPage, fetchNextPage, isFetchingNextPage } =
+        useInfiniteQuery({
+            ...getNotificationsInfiniteQuery({}, PAGE_SIZE),
+            enabled: open,
+        });
+
+    const markRead = useMutation(markNotificationReadMutation);
+    const remove = useMutation(deleteNotificationMutation);
+
+    const notifications = data?.pages.flatMap((page) => page.items) ?? [];
+
+    const badgeLabel = unreadCount > 9 ? "9+" : String(unreadCount);
+    const triggerLabel =
+        unreadCount === 0
+            ? "Varsler"
+            : unreadCount === 1
+              ? "Varsler, 1 ulest"
+              : `Varsler, ${unreadCount} uleste`;
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger
+                render={
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label={triggerLabel}
+                        className="relative"
+                    />
+                }
+            >
+                <Bell />
+                {unreadCount > 0 ? (
+                    <Badge className="absolute -top-0.5 -right-0.5 h-4 min-w-4 px-1">
+                        {badgeLabel}
+                    </Badge>
+                ) : null}
+            </PopoverTrigger>
+
+            <PopoverContent
+                align="end"
+                className="w-80 gap-0 p-0 sm:w-96"
+                aria-label="Varsler"
+            >
+                <PopoverHeader className="flex-row items-center justify-between gap-2 p-3">
+                    <PopoverTitle>Varsler</PopoverTitle>
+                    {unreadCount > 0 ? (
+                        <span className="text-xs text-muted-foreground">
+                            {unreadCount === 1
+                                ? "1 ulest"
+                                : `${unreadCount} uleste`}
+                        </span>
+                    ) : null}
+                </PopoverHeader>
+                <Separator />
+
+                {isPending ? (
+                    <div className="flex flex-col gap-2 p-3">
+                        {[0, 1, 2].map((row) => (
+                            <Skeleton key={row} className="h-14 w-full" />
+                        ))}
+                    </div>
+                ) : notifications.length === 0 ? (
+                    <p className="p-4 text-sm text-muted-foreground">
+                        Du har ingen varsler.
+                    </p>
+                ) : (
+                    /* ScrollArea fra @tihlde/ui trenger en fast høyde for å
+                       scrolle. Her vokser lista til den treffer max-h, så en
+                       vanlig overflow-container er det som faktisk virker. */
+                    <div className="max-h-96 overflow-y-auto">
+                        <ul className="flex flex-col p-1">
+                            {notifications.map((notification) => {
+                                const href = notificationHref(
+                                    notification.link,
+                                );
+                                const isBusy =
+                                    (markRead.isPending &&
+                                        markRead.variables?.notificationId ===
+                                            notification.id) ||
+                                    (remove.isPending &&
+                                        remove.variables?.notificationId ===
+                                            notification.id);
+
+                                return (
+                                    <li key={notification.id}>
+                                        <NotificationItem
+                                            title={notification.title}
+                                            description={
+                                                notification.description
+                                            }
+                                            timeLabel={formatNotificationTime(
+                                                notification.createdAt,
+                                            )}
+                                            isRead={notification.isRead}
+                                            href={href}
+                                            isExternal={isExternalNotificationHref(
+                                                href,
+                                            )}
+                                            isBusy={isBusy}
+                                            onOpen={() => {
+                                                setOpen(false);
+                                                if (!notification.isRead) {
+                                                    markRead.mutate({
+                                                        notificationId:
+                                                            notification.id,
+                                                    });
+                                                }
+                                            }}
+                                            onMarkRead={() =>
+                                                markRead.mutate({
+                                                    notificationId:
+                                                        notification.id,
+                                                })
+                                            }
+                                            onDelete={() =>
+                                                remove.mutate({
+                                                    notificationId:
+                                                        notification.id,
+                                                })
+                                            }
+                                        />
+                                    </li>
+                                );
+                            })}
+                        </ul>
+
+                        {hasNextPage ? (
+                            <div className="flex justify-center p-2">
+                                <LoadMoreButton
+                                    onClick={() => fetchNextPage()}
+                                    isLoading={isFetchingNextPage}
+                                />
+                            </div>
+                        ) : null}
+                    </div>
+                )}
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/apps/kvark/src/components/notification-item.tsx
+++ b/apps/kvark/src/components/notification-item.tsx
@@ -1,0 +1,93 @@
+import { Link } from "@tanstack/react-router";
+import { Badge } from "@tihlde/ui/ui/badge";
+import { Button } from "@tihlde/ui/ui/button";
+import { Check, Trash2 } from "lucide-react";
+
+export type NotificationItemProps = {
+    title: string;
+    description: string;
+    /** Ferdig formatert tidspunkt, f.eks. "3 timer siden". */
+    timeLabel: string;
+    isRead: boolean;
+    /** Normalisert lenke varselet peker til, om det har en. */
+    href?: string;
+    isExternal?: boolean;
+    /** Kalles når varselet åpnes — brukes til å markere det som lest. */
+    onOpen?: () => void;
+    onMarkRead?: () => void;
+    onDelete?: () => void;
+    isBusy?: boolean;
+};
+
+/**
+ * Én rad i varsellisten. Hele teksten er klikkbar når varselet har en lenke,
+ * mens knappene til høyre står utenfor lenken så de ikke navigerer bort.
+ */
+export function NotificationItem({
+    title,
+    description,
+    timeLabel,
+    isRead,
+    href,
+    isExternal = false,
+    onOpen,
+    onMarkRead,
+    onDelete,
+    isBusy = false,
+}: NotificationItemProps) {
+    const body = (
+        <div className="flex flex-col gap-1">
+            <div className="flex items-start gap-2">
+                <span className="flex-1 text-sm">{title}</span>
+                {isRead ? null : <Badge>Ny</Badge>}
+            </div>
+            <p className="text-sm text-muted-foreground">{description}</p>
+            <span className="text-xs text-muted-foreground">{timeLabel}</span>
+        </div>
+    );
+
+    return (
+        <div className="flex items-start gap-1 p-2">
+            {href && isExternal ? (
+                <a
+                    href={href}
+                    onClick={onOpen}
+                    className="flex-1"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    {body}
+                </a>
+            ) : href ? (
+                <Link to={href} onClick={onOpen} className="flex-1">
+                    {body}
+                </Link>
+            ) : (
+                <div className="flex-1">{body}</div>
+            )}
+
+            <div className="flex flex-col gap-1">
+                {isRead ? null : (
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label="Marker som lest"
+                        disabled={isBusy}
+                        onClick={onMarkRead}
+                    >
+                        <Check />
+                    </Button>
+                )}
+                <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label="Slett varsel"
+                    disabled={isBusy}
+                    onClick={onDelete}
+                >
+                    <Trash2 />
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/apps/kvark/src/components/site-header.tsx
+++ b/apps/kvark/src/components/site-header.tsx
@@ -9,6 +9,7 @@ import {
     NavigationMenuTrigger,
 } from "@tihlde/ui/ui/navigation-menu";
 import { ExternalLinkIcon, User } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { ThemeSwitcher } from "./theme-switcher";
 import { TihldeLogo } from "./icons/tihlde";
@@ -42,9 +43,15 @@ export type NavItem = NavLink | NavGroup;
 type SiteHeaderProps = {
     navItems: NavItem[];
     user?: { name: string; avatarUrl?: string } | null;
+    /**
+     * Knapper som legges til venstre for temabryteren. En slot fordi headeren
+     * ikke skal hente data selv — varselbjella gjør det, og hører hjemme i
+     * layout-ruten.
+     */
+    actions?: ReactNode;
 };
 
-export function SiteHeader({ navItems, user }: SiteHeaderProps) {
+export function SiteHeader({ navItems, user, actions }: SiteHeaderProps) {
     return (
         <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur">
             <div className="container mx-auto flex h-14 items-center justify-between gap-4 px-4">
@@ -111,6 +118,7 @@ export function SiteHeader({ navItems, user }: SiteHeaderProps) {
                 </NavigationMenu>
 
                 <div className="flex items-center gap-2">
+                    {actions}
                     <ThemeSwitcher />
                     <Link
                         {...(user

--- a/apps/kvark/src/lib/notification.ts
+++ b/apps/kvark/src/lib/notification.ts
@@ -1,0 +1,39 @@
+import { formatDistanceToNow } from "date-fns";
+import { nb } from "date-fns/locale";
+
+/**
+ * Format an ISO timestamp as a Norwegian relative distance,
+ * e.g. "3 timer siden".
+ */
+export function formatNotificationTime(iso: string): string {
+    return formatDistanceToNow(new Date(iso), { locale: nb, addSuffix: true });
+}
+
+/**
+ * Varsler lagres med to slags lenker: absolutte URL-er bygget av `ROOT_URL`
+ * (arrangementer) og rene stier (bøter). Absolutte lenker til vårt eget domene
+ * gjøres om til stier, ellers ville et klikk lastet hele appen på nytt.
+ */
+export function notificationHref(link: string | null): string | undefined {
+    if (!link) return undefined;
+    if (!/^https?:\/\//i.test(link)) return link;
+
+    try {
+        const url = new URL(link);
+        if (
+            typeof window !== "undefined" &&
+            url.origin === window.location.origin
+        ) {
+            return `${url.pathname}${url.search}${url.hash}`;
+        }
+        return link;
+    } catch {
+        // En ugyldig URL er ikke verdt å krasje varsellisten for.
+        return link;
+    }
+}
+
+/** Om lenken peker ut av appen og derfor bør åpnes i ny fane. */
+export function isExternalNotificationHref(href: string | undefined): boolean {
+    return href !== undefined && /^https?:\/\//i.test(href);
+}

--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { authQueryOptions } from "#/api/auth";
 import { EventRulesConsent } from "#/components/event-rules-consent";
+import { NotificationBell } from "#/components/notification-bell";
 import { SiteBottomBar } from "#/components/site-bottom-bar";
 import { SiteFooter } from "#/components/site-footer";
 import { SiteHeader } from "#/components/site-header";
@@ -33,7 +34,13 @@ function AppLayout() {
         // The bottom padding keeps the footer clear of the fixed bottom bar,
         // which only exists below md.
         <div className="flex min-h-screen flex-col pb-16 md:pb-0">
-            <SiteHeader navItems={navItems} user={currentUser} />
+            <SiteHeader
+                navItems={navItems}
+                user={currentUser}
+                // Bjella spør etter uleste varsler, så den vises bare for
+                // innloggede — ellers ville hver besøkende få en 401.
+                actions={isAuthenticated ? <NotificationBell /> : null}
+            />
             {eventRules.mustAccept ? (
                 <div className="container mx-auto px-4 pt-4">
                     <EventRulesConsent


### PR DESCRIPTION
## Hva

Legger til et bjelleikon til venstre for temabryteren, i både hovedheaderen og admin-headeren. Bjella viser antall uleste varsler, og popoveren lar deg lese, åpne, markere som lest og slette dem.

## Hvorfor

Varsler fantes allerede i API-et (`/api/notification`) og i `api/queries/notifications.ts`, men det eneste synlige i frontenden var et ikke-klikkbart antall-badge på egen profil. `getNotificationsInfiniteQuery`, `getNotificationsQuery` og `deleteNotificationMutation` hadde null kallsteder — man kunne ikke lese varslene sine noe sted.

## Endringer

- `components/notification-bell.tsx` — container med popover, uleste-teller, infinite-liste, marker-som-lest og sletting. Lista hentes først når popoveren åpnes (`enabled: open`); bare tellingen går kontinuerlig.
- `components/notification-item.tsx` — dum rad: tittel, tekst, «X siden», «Ny»-merke, hake og papirkurv. Klikk på teksten markerer som lest og navigerer.
- `lib/notification.ts` — norsk relativ tid + normalisering av lenker (varsler lagres både som absolutte URL-er og rene stier).
- `site-header.tsx` får en `actions`-slot i stedet for å rendre bjella selv, så headeren fortsatt er dum og datahentingen ligger i `_app.tsx`. Bjella vises kun for innloggede.
- `api/queries/notifications.ts`: `getNextPageParam` stolte på `nextPage` fra API-et, som er ett hakk for høyt (`page` er 0-basert, `pages` er et antall). Det ga en «Last inn mer» som hentet en tom side. Nå stopper den på en kort side.

## Verifisert

Innlogget lokalt mot API på :4100: badge viste «5», popoveren listet varslene, hake → 5→4 og «Ny» forsvant, papirkurv → raden forsvant, lista scroller ved maks høyde, ingen falsk «Last inn mer». Sjekket i mørkt og lyst tema og på mobilbredde. `typecheck`, `lint` og `build` er grønne.

## Verdt å vite for reviewer

- Arrangement-varsler lagrer lenka som `${ROOT_URL}/arrangementer/...`, og `ROOT_URL` er API-domenet — så de peker på API-et, ikke nettsiden, og behandles derfor som eksterne lenker. Riktig fiks er `WEBSITE_URL` i `apps/api/src/lib/event/resolve-registration.ts`, altså backend. Ikke gjort her.
- Bjella er lagt i admin-headeren også. Enkelt å ta bort hvis den bare skal være i hovedheaderen.
- `ScrollArea` fra `@tihlde/ui` scroller ikke uten fast høyde (viewport har `size-full`, og `max-height` alene løser ikke `height: 100%`), så lista bruker en vanlig `overflow-y-auto`-container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)