### PR TITLE
feat(annonser): bruk markdown-editor på stillingsannonser

### DIFF
--- a/apps/kvark/src/routes/admin/annonser.tsx
+++ b/apps/kvark/src/routes/admin/annonser.tsx
@@ -43,6 +43,7 @@ import {
     TableRow,
 } from "@tihlde/ui/ui/table";
 import { Textarea } from "@tihlde/ui/ui/textarea";
+import { RichEditor } from "@tihlde/ui/complex/markdown";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
@@ -56,6 +57,7 @@ import {
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { richRegistry } from "#/components/markdown/directives/presets";
 import {
     useAnyScopePermission,
     useCanActOnResource,
@@ -649,16 +651,11 @@ function JobDialog({
                             />
                         </Field>
                         <Field>
-                            <FieldLabel htmlFor="job-body">
-                                Beskrivelse
-                            </FieldLabel>
-                            <Textarea
-                                id="job-body"
-                                rows={6}
+                            <FieldLabel>Beskrivelse</FieldLabel>
+                            <RichEditor
+                                registry={richRegistry}
                                 value={body}
-                                onChange={(event) =>
-                                    setBody(event.target.value)
-                                }
+                                onChange={setBody}
                             />
                         </Field>
                         <AdminImageField

--- a/bun.lock
+++ b/bun.lock
@@ -273,6 +273,7 @@
         "react-pdf": "^10.4.1",
         "react-resizable-panels": "^4.10.0",
         "recharts": "3.8.0",
+        "remark-breaks": "^4.0.0",
         "remark-directive": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
@@ -2448,6 +2449,8 @@
 
     "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
 
+    "mdast-util-newline-to-break": ["mdast-util-newline-to-break@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-find-and-replace": "^3.0.0" } }, "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog=="],
+
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
@@ -2913,6 +2916,8 @@
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
     "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "remark-breaks": ["remark-breaks@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-newline-to-break": "^2.0.0", "unified": "^11.0.0" } }, "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ=="],
 
     "remark-directive": ["remark-directive@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-directive": "^3.0.0", "micromark-extension-directive": "^4.0.0", "unified": "^11.0.0" } }, "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,6 +54,7 @@
         "react-pdf": "^10.4.1",
         "react-resizable-panels": "^4.10.0",
         "recharts": "3.8.0",
+        "remark-breaks": "^4.0.0",
         "remark-directive": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",

--- a/packages/ui/src/components/complex/markdown/internal/pipeline.ts
+++ b/packages/ui/src/components/complex/markdown/internal/pipeline.ts
@@ -3,13 +3,18 @@ import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
 import remarkGfm from "remark-gfm";
 import remarkDirective from "remark-directive";
+import remarkBreaks from "remark-breaks";
 import type { Root } from "mdast";
 
 /** A unified processor configured to parse markdown into a directive-aware mdast. */
 export function createParser(): Processor<Root, Root, Root, Root, string> {
+    // remarkBreaks: enkelt linjeskift blir et faktisk linjeskift, ikke et
+    // mellomrom. Eldre innhold ble skrevet i et vanlig tekstfelt, der
+    // markdown-regelen om at én enter er ingenting bare ser ut som en feil.
     return unified()
         .use(remarkParse)
         .use(remarkGfm)
+        .use(remarkBreaks)
         .use(remarkDirective) as unknown as Processor<
         Root,
         Root,

--- a/packages/ui/src/components/complex/markdown/markdown-view.tsx
+++ b/packages/ui/src/components/complex/markdown/markdown-view.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import Markdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkDirective from "remark-directive";
 import remarkGfm from "remark-gfm";
 
@@ -23,6 +24,9 @@ export function MarkdownView({
         () => ({
             remarkPlugins: [
                 remarkGfm,
+                // Samme regel som i editoren: ett linjeskift vises som ett
+                // linjeskift, slik forfatteren skrev det.
+                remarkBreaks,
                 remarkDirective,
                 buildRemarkDirectivePlugin(registry),
             ],


### PR DESCRIPTION
## Hva

- Beskrivelsen i «Ny annonse»/«Rediger annonse» bruker nå `RichEditor` med `richRegistry`, samme editor som arrangementer og nyheter. Verktøylinje, overskrifter, lister, lenker, tabeller og callouts fungerer dermed også her.
- `remark-breaks` er lagt inn i den delte markdown-pipelinen (`createParser`) og i `MarkdownView`, så ett linjeskift blir ett linjeskift.

## Hvorfor

Beskrivelsesfeltet var det eneste stedet i admin som fortsatt var et rått `Textarea`, selv om den offentlige annonsesiden allerede rendret innholdet som markdown.

Linjeskift-problemet kom av markdown-regelen om at én enter er et mellomrom. For folk som skriver i et vanlig tekstfelt ser det bare ut som at teksten klemmes sammen. Med `remark-breaks` får gamle annonser som ligger lagret som ren tekst tilbake linjeskiftene sine, og de beholdes hvis noen åpner og lagrer annonsen på nytt.

## For reviewer

- Endringen i pipelinen er delt, så den treffer også arrangementer og nyheter. Innhold skrevet i editoren skiller avsnitt med blank linje, så det er upåvirket — det er bare enkeltlinjeskift inne i et avsnitt som endrer betydning, og der er det nye resultatet det forfatteren faktisk skrev. Round-trip er idempotent (verifisert: `parse → stringify → parse → stringify` gir identisk markdown).
- Ingressen er bevisst latt stå som vanlig tekstfelt — den vises som ren brødtekst i annonsekortet og øverst på annonsen, ikke som markdown.

## Verifisert

- `bun run typecheck`, `bun run lint` og `bun run build` er grønne. (Lint melder ett formatavvik i `apps/kvark/src/routes/_app/opptak.tsx` — det er fra før og urørt her.)
- Markdown-playgroundet i nettleseren: enkeltlinjeskift står nå som egne linjer i editoren.
- Render-test av visningen: `Første linje\nAndre linje` gir `<p>Første linje<br/>Andre linje</p>`, mens blank linje fortsatt gir to `<p>`.
- Ikke verifisert visuelt: selve dialogen i /admin/annonser, siden den krever innlogging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)