### PR TITLE
fix(notification): gjør e-postlenker absolutte så "Se mer"-knappen virker

### DIFF
--- a/apps/api/src/lib/notification/index.ts
+++ b/apps/api/src/lib/notification/index.ts
@@ -6,6 +6,18 @@ import type {
 import type { AppContext } from "../ctx";
 import { env } from "../env";
 
+/**
+ * Notification links are stored relative so the website can route internally,
+ * but an email client has no origin to resolve them against — a relative href
+ * makes the "Se mer" button dead. Absolutise before handing the link to the
+ * email template; already-absolute links are passed through untouched.
+ */
+function toAbsoluteLink(link: string | undefined) {
+    if (!link) return link;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(link)) return link;
+    return `${env.WEBSITE_URL}${link.startsWith("/") ? "" : "/"}${link}`;
+}
+
 type EmailTemplateOverride = {
     [TName in EmailTemplateName]: {
         name: TName;
@@ -110,7 +122,7 @@ export async function sendNotification(
             props: {
                 title,
                 description,
-                link,
+                link: toAbsoluteLink(link),
                 logoUrl: `${env.WEBSITE_URL}/logo512.png`,
             },
         };

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -143,7 +143,7 @@ const envSchema = z
             WEBSITE_URL:
                 vals.WEBSITE_URL ||
                 (vals.NODE_ENV === "production"
-                    ? "https://new.tihlde.org"
+                    ? "https://tihlde.org"
                     : "http://localhost:3000"),
         };
 


### PR DESCRIPTION
## Hva

«Se mer»-knappen i varsel-e-poster (f.eks. når du får en bot) var ikke klikkbar.

Årsaken er at varsellenker lagres relative — `create.ts` sender `link: "/grupper/{slug}?tab=boter"`. Det fungerer på nettsiden, men i en e-post har `<a href="/grupper/...">` ingen origin å løses mot, så knappen blir død i Gmail/Outlook.

`sendNotification` absolutiserer nå lenken med `WEBSITE_URL` rett før den gis til e-postmalen:

- Databasevarselet beholder den relative lenken, så intern ruting på nettsiden er uendret.
- Allerede absolutte lenker (`https://…`, `mailto:` osv.) slipper uendret gjennom.
- Treffer også refusjonsvarselet i `routes/event/payment/refund.ts`, som hadde samme problem.

I tillegg er prod-fallbacken for `WEBSITE_URL` endret fra `https://new.tihlde.org` til `https://tihlde.org`.

## Verifisert

Rendret `NotificationMail` med den faktiske bot-lenken og lest ut `href`:

```
/grupper/hs?tab=boter  => https://new.tihlde.org/grupper/hs?tab=boter
https://x.no/a         => https://x.no/a   (absolutte lenker røres ikke)
grupper/hs             => https://new.tihlde.org/grupper/hs
```

(kjørt før fallback-endringen, derfor `new.tihlde.org` i outputen)

`bun run typecheck` (9/9), `bun run lint` og `bun run format` er grønne.

## For reviewer

- Fallbacken bestemmer også eneste tillatte CORS-origin i prod (`app.ts`). Endringen flytter altså standarden til `tihlde.org` dersom `WEBSITE_URL` ikke er satt eksplisitt — den bør uansett settes i prod-env.
- **Ikke fikset her:** noen e-poster bygger *frontend*-lenker fra `ROOT_URL`, som er API-domenet — `lib/event/resolve-registration.ts` (3 steder), `lib/event/payment.ts:39` og `routes/form/submission/create.ts:98`. Arrangementslenker i påmeldingsmailer peker derfor mot API-domenet allerede i dag. Bør bruke `WEBSITE_URL`; egen sak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)