### PR TITLE
feat(grupper): to kolonner i Om-taben på desktop

### DIFF
--- a/apps/kvark/src/components/group-om-tab.tsx
+++ b/apps/kvark/src/components/group-om-tab.tsx
@@ -14,29 +14,40 @@ export function GroupOmTab({ group }: GroupOmTabProps) {
     return (
         <div className="flex flex-col gap-6">
             <GroupPageHeader title="Om" />
-            {group.imageUrl ? (
-                <Card className="max-w-2xl overflow-hidden p-0">
-                    <img
-                        {...assetImageProps(group.imageUrl, "hero")}
-                        alt={group.name}
-                        decoding="async"
-                        className="aspect-video size-full object-cover"
-                    />
-                </Card>
-            ) : null}
 
-            <div className="flex flex-col gap-3">
-                <h3 className="text-lg font-medium">Hva gjør {group.name}?</h3>
-                {group.description ? (
-                    <MarkdownView
-                        registry={richRegistry}
-                        source={group.description}
-                    />
-                ) : (
-                    <p className="text-sm text-muted-foreground">
-                        Ingen beskrivelse tilgjengelig ennå.
-                    </p>
-                )}
+            <div
+                className={
+                    group.imageUrl
+                        ? "grid gap-6 lg:grid-cols-2 lg:items-start"
+                        : "grid gap-6"
+                }
+            >
+                {group.imageUrl ? (
+                    <Card className="order-1 max-w-2xl overflow-hidden p-0 lg:order-2 lg:sticky lg:top-24">
+                        <img
+                            {...assetImageProps(group.imageUrl, "hero")}
+                            alt={group.name}
+                            decoding="async"
+                            className="aspect-video size-full object-cover"
+                        />
+                    </Card>
+                ) : null}
+
+                <div className="order-2 flex flex-col gap-3 lg:order-1">
+                    <h3 className="text-lg font-medium">
+                        Hva gjør {group.name}?
+                    </h3>
+                    {group.description ? (
+                        <MarkdownView
+                            registry={richRegistry}
+                            source={group.description}
+                        />
+                    ) : (
+                        <p className="text-sm text-muted-foreground">
+                            Ingen beskrivelse tilgjengelig ennå.
+                        </p>
+                    )}
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Hva

Om-taben på gruppesider viser nå beskrivelse og gruppebilde side om side på desktop (`lg` og oppover): tekst til venstre, bilde til høyre.

## Hvorfor

Tidligere lå bildet over beskrivelsen i én kolonne, noe som ga mye tomt område til høyre på brede skjermer.

## Detaljer

- Bildet er `lg:sticky` slik at det følger med i lange beskrivelser.
- Under `lg` beholdes den opprinnelige rekkefølgen: bilde først, så tekst.
- Grupper uten bilde beholder én kolonne, så teksten ikke havner i en halvbred spalte.
- Kun layout-utilities (grid/order/sticky) — ingen farger eller typografi lagt til i kvark, i tråd med `apps/kvark/CLAUDE.md`.

## Verifisert

- Browser-preview på 1440px: to kolonner, tekst venstre / bilde høyre.
- Browser-preview på 375px: stablet, uendret rekkefølge.
- `bun run typecheck` og `bun run lint` passerer. `bun run format` flagger `apps/kvark/src/routes/_app/opptak.tsx`, som er eksisterende og ikke rørt i denne PR-en.

Merk: for å teste med bilde ble `image_url` midlertidig satt på `index`-gruppa i lokal dev-DB (ingen lokal gruppe har bilde). Det er reversert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)