### PR TITLE
fix(admin): mindre bildefelt på gruppesiden

### DIFF
--- a/apps/kvark/src/components/admin-image-field.tsx
+++ b/apps/kvark/src/components/admin-image-field.tsx
@@ -18,6 +18,8 @@ type AdminImageFieldProps = {
     /** Image already saved on the resource, shown until a new one is picked. */
     existingImageUrl?: string | null;
     disabled?: boolean;
+    /** Layout-only classes for the field wrapper, e.g. a grid column span. */
+    className?: string;
 };
 
 /**
@@ -35,9 +37,10 @@ export function AdminImageField({
     onChange,
     existingImageUrl,
     disabled,
+    className,
 }: AdminImageFieldProps) {
     return (
-        <Field>
+        <Field className={className}>
             <FieldLabel>{label}</FieldLabel>
             {description ? (
                 <FieldDescription>{description}</FieldDescription>

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -434,24 +434,35 @@ function GroupCard({
                                 Krev kontraktsignering for denne gruppen
                             </FieldLabel>
                         </Field>
-                        <AdminImageField
-                            label="Logo (la stå tom for å beholde)"
-                            description="Vises som profilbilde i avatarer, kort og lister."
-                            preset="avatar"
-                            value={logo}
-                            onChange={setLogo}
-                            existingImageUrl={group.logoUrl}
-                            disabled={updateGroup.isPending || isUploading}
-                        />
-                        <AdminImageField
-                            label="Gruppebilde (la stå tom for å beholde)"
-                            description="Bilde av gruppa. Vises øverst på Om-fanen."
-                            preset="cover-video"
-                            value={image}
-                            onChange={setImage}
-                            existingImageUrl={group.imageUrl}
-                            disabled={updateGroup.isPending || isUploading}
-                        />
+                        {/* Logo takes a third of the row and the gruppebilde
+                            the rest, so the square and the 16:9 frame end up
+                            roughly the same height and sit side by side
+                            instead of stacking into two tall blocks. The
+                            subgrid keeps the two frames on the same line even
+                            when one column's label wraps and the other's
+                            does not. */}
+                        <div className="grid max-w-xl grid-cols-3 grid-rows-[auto_auto_auto] gap-x-4 gap-y-2">
+                            <AdminImageField
+                                className="col-span-1 row-span-3 grid grid-rows-subgrid gap-2"
+                                label="Logo (la stå tom for å beholde)"
+                                description="Vises som profilbilde i avatarer, kort og lister."
+                                preset="avatar"
+                                value={logo}
+                                onChange={setLogo}
+                                existingImageUrl={group.logoUrl}
+                                disabled={updateGroup.isPending || isUploading}
+                            />
+                            <AdminImageField
+                                className="col-span-2 row-span-3 grid grid-rows-subgrid gap-2"
+                                label="Gruppebilde (la stå tom for å beholde)"
+                                description="Bilde av gruppa. Vises øverst på Om-fanen."
+                                preset="cover-video"
+                                value={image}
+                                onChange={setImage}
+                                existingImageUrl={group.imageUrl}
+                                disabled={updateGroup.isPending || isUploading}
+                            />
+                        </div>
                     </FieldGroup>
                     {error && (
                         <p className="text-sm text-destructive" role="alert">


### PR DESCRIPTION
## Hva

Når man åpner en gruppe i `/admin/grupper` tok Logo og Gruppebilde hele bredden av kortet og stablet seg i to høye blokker. Nå ligger de side om side i en rad på maks 576px:

- **Logo** — 1 av 3 kolonner, kvadratisk ramme
- **Gruppebilde** — 2 av 3 kolonner, 16:9-ramme

Med de kolonnebreddene blir de to rammene omtrent like høye (0.333W mot 0.375W), så de leser som én rad i stedet for to store bilder.

## Hvorfor

Bildefeltene dominerte redigeringspanelet og dyttet kontraktsvalget og lagre-knappen langt ned.

## Verdt å vite for review

- Feltene bruker `grid-rows-subgrid` (`row-span-3`) slik at rammene havner på samme linje selv om logo-labelen brytes over to linjer og gruppebilde-labelen ikke gjør det. Uten det ville rammene forskyves i forhold til hverandre.
- `AdminImageField` tar nå imot en valgfri `className` som kun brukes til layout (kolonnespenn), i tråd med Tailwind-reglene i `apps/kvark/CLAUDE.md`.
- Ingen endringer i opplasting, komprimering eller lagring — kun layout.

## Verifisert

- Åpnet Index-gruppa i `/admin/grupper` i dev-preview: rammene ligger side om side, toppjustert, logo på ca. 1/3 av radbredden.
- `bun run typecheck`, `bun run lint`, `bun run format` og `bun run --filter kvark build` går grønt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)