### PR TITLE
feat(api): godta flere frontend-origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,14 @@ NODE_ENV=development
 # Base URL of the API server
 # ROOT_URL=http://localhost:4000
 
-# URL of the Kvark frontend
+# URL of the Kvark frontend. Also the origin used to build links in emails.
 # WEBSITE_URL=http://localhost:3000
+
+# Extra frontend origins to accept (CORS + auth), comma-separated. In
+# production this defaults to the tihlde.org, www.tihlde.org and
+# new.tihlde.org set, so the domain cutover works whichever one
+# WEBSITE_URL currently points at.
+# EXTRA_WEBSITE_ORIGINS=https://tihlde.org,https://new.tihlde.org
 
 # Port for the API server (default: 4000)
 # PORT=4000

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -111,12 +111,14 @@ export const createApp = async (variables?: Variables) => {
             "*",
             cors({
                 // Credentialed requests need an explicit origin — never "*".
+                // WEBSITE_ORIGINS is WEBSITE_URL plus the other frontend
+                // origins this deployment answers on (see env.ts).
                 // Outside production, keep localhost usable even when
                 // WEBSITE_URL points somewhere else (an ngrok tunnel, say).
                 // Any localhost port is accepted in dev so worktrees/dev
                 // servers on non-default ports can talk to the API.
                 origin: (origin) => {
-                    if (origin === env.WEBSITE_URL) return origin;
+                    if (env.WEBSITE_ORIGINS.includes(origin)) return origin;
                     if (
                         env.NODE_ENV !== "production" &&
                         /^http:\/\/localhost(:\d+)?$/.test(origin)

--- a/apps/api/src/lib/ctx.ts
+++ b/apps/api/src/lib/ctx.ts
@@ -69,7 +69,7 @@ export async function createAppContext(): Promise<AppContext> {
         urls: {
             backend: env.ROOT_URL,
             frontend: env.WEBSITE_URL,
-            additionalTrusted: [env.ROOT_URL, env.WEBSITE_URL],
+            additionalTrusted: [env.ROOT_URL, ...env.WEBSITE_ORIGINS],
             basePath: "/api/auth",
         },
         DANGEROUSLY_SET_INSECURE_HASHING_ALGORITHM: false,
@@ -117,7 +117,7 @@ export async function createTestAppContext(options?: {
         urls: {
             backend: env.ROOT_URL,
             frontend: env.WEBSITE_URL,
-            additionalTrusted: [env.ROOT_URL, env.WEBSITE_URL],
+            additionalTrusted: [env.ROOT_URL, ...env.WEBSITE_ORIGINS],
             basePath: "/api/auth",
         },
         DANGEROUSLY_SET_INSECURE_HASHING_ALGORITHM: true,

--- a/apps/api/src/test/config/website-origins.test.ts
+++ b/apps/api/src/test/config/website-origins.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { parseEnv } from "@photon/core/env";
+
+/**
+ * WEBSITE_ORIGINS is the set of frontend origins the API accepts, both for
+ * CORS (see app.ts) and Better Auth's trustedOrigins (see lib/ctx.ts).
+ *
+ * It exists because the website moves from new.tihlde.org to tihlde.org while
+ * WEBSITE_URL is set in Drift's environment, not this repo: the Vercel domain
+ * move and that variable cannot change in the same instant. Production must
+ * therefore accept both ends of the cutover.
+ */
+describe("WEBSITE_ORIGINS", () => {
+    it("accepts both sides of the tihlde.org cutover in production", () => {
+        const env = parseEnv({
+            NODE_ENV: "production",
+            WEBSITE_URL: "https://new.tihlde.org",
+        });
+
+        expect(env.WEBSITE_ORIGINS).toContain("https://new.tihlde.org");
+        expect(env.WEBSITE_ORIGINS).toContain("https://tihlde.org");
+        expect(env.WEBSITE_ORIGINS).toContain("https://www.tihlde.org");
+    });
+
+    it("still accepts the cutover set once WEBSITE_URL has moved over", () => {
+        const env = parseEnv({
+            NODE_ENV: "production",
+            WEBSITE_URL: "https://tihlde.org",
+        });
+
+        expect(env.WEBSITE_ORIGINS).toContain("https://tihlde.org");
+        expect(env.WEBSITE_ORIGINS).toContain("https://new.tihlde.org");
+    });
+
+    it("lists WEBSITE_URL first, since links are built from it", () => {
+        const env = parseEnv({
+            NODE_ENV: "production",
+            WEBSITE_URL: "https://new.tihlde.org",
+        });
+
+        expect(env.WEBSITE_ORIGINS[0]).toBe("https://new.tihlde.org");
+    });
+
+    it("drops a trailing slash so it can match an Origin header", () => {
+        const env = parseEnv({
+            NODE_ENV: "production",
+            WEBSITE_URL: "https://tihlde.org/",
+        });
+
+        expect(env.WEBSITE_ORIGINS).toContain("https://tihlde.org");
+        expect(env.WEBSITE_ORIGINS).not.toContain("https://tihlde.org/");
+    });
+
+    it("does not widen dev beyond WEBSITE_URL", () => {
+        const env = parseEnv({
+            NODE_ENV: "development",
+            WEBSITE_URL: "http://localhost:3000",
+        });
+
+        expect(env.WEBSITE_ORIGINS).toEqual(["http://localhost:3000"]);
+    });
+
+    it("lets an explicit list override the production default", () => {
+        const env = parseEnv({
+            NODE_ENV: "production",
+            WEBSITE_URL: "https://tihlde.org",
+            EXTRA_WEBSITE_ORIGINS:
+                "https://beta.tihlde.org, https://tihlde.org",
+        });
+
+        expect(env.WEBSITE_ORIGINS).toEqual([
+            "https://tihlde.org",
+            "https://beta.tihlde.org",
+        ]);
+    });
+});

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -42,12 +42,46 @@ const toBoolean =
         return val.toLowerCase() === "true" || val === "1";
     };
 
+/**
+ * Frontend origins production trusts in addition to WEBSITE_URL.
+ *
+ * The website moves from new.tihlde.org to tihlde.org, but WEBSITE_URL lives
+ * in Drift's environment rather than this repo — the Vercel domain move and
+ * that variable cannot flip in the same instant. Trusting the whole set makes
+ * the cutover order-independent, and keeps links that still point at
+ * new.tihlde.org (sent emails, Vipps return URLs) working afterwards.
+ */
+const PRODUCTION_WEBSITE_ORIGINS = [
+    "https://tihlde.org",
+    "https://www.tihlde.org",
+    "https://new.tihlde.org",
+];
+
+/**
+ * Origin form of a URL ("https://tihlde.org/" -> "https://tihlde.org"), so
+ * comparisons against a browser's Origin header — which never carries a path
+ * or trailing slash — do not fail on a stray slash in configuration.
+ * Unparseable values are passed through for the caller to reject.
+ */
+function toOrigin(url: string): string {
+    try {
+        return new URL(url).origin;
+    } catch {
+        return url;
+    }
+}
+
 const envSchema = z
     .object({
         // CONFIG
         ROOT_URL: z.string().default("http://localhost:4000"),
         /** Frontend origin. Defaulted per NODE_ENV below, not here. */
         WEBSITE_URL: z.string().optional(),
+        /**
+         * Comma-separated extra frontend origins to trust alongside
+         * WEBSITE_URL. Defaulted per NODE_ENV below, not here.
+         */
+        EXTRA_WEBSITE_ORIGINS: z.string().optional(),
         PORT: z
             .string()
             .default("4000")
@@ -135,16 +169,34 @@ const envSchema = z
             .transform(toBoolean({ defaultVal: false })),
     })
     .transform((vals) => {
+        // A localhost frontend in production is never right: WEBSITE_URL
+        // anchors the allowed CORS origins there (see app.ts), so falling back
+        // to the dev default would block the real site from its own API.
+        const websiteUrl =
+            vals.WEBSITE_URL ||
+            (vals.NODE_ENV === "production"
+                ? "https://tihlde.org"
+                : "http://localhost:3000");
+
+        const extraOrigins = vals.EXTRA_WEBSITE_ORIGINS
+            ? vals.EXTRA_WEBSITE_ORIGINS.split(",")
+                  .map((origin) => origin.trim())
+                  .filter(Boolean)
+            : vals.NODE_ENV === "production"
+              ? PRODUCTION_WEBSITE_ORIGINS
+              : [];
+
         const resolved = {
             ...vals,
-            // A localhost frontend in production is never right: WEBSITE_URL is
-            // the sole allowed CORS origin there (see app.ts), so falling back
-            // to the dev default would block the real site from its own API.
-            WEBSITE_URL:
-                vals.WEBSITE_URL ||
-                (vals.NODE_ENV === "production"
-                    ? "https://tihlde.org"
-                    : "http://localhost:3000"),
+            WEBSITE_URL: websiteUrl,
+            /**
+             * Every frontend origin the API accepts, WEBSITE_URL first. Only
+             * WEBSITE_URL is used to *build* links (emails, redirects); the
+             * rest are accepted on the way in.
+             */
+            WEBSITE_ORIGINS: [
+                ...new Set([websiteUrl, ...extraOrigins].map(toOrigin)),
+            ],
         };
 
         if (!resolved.WEBHOOK_URL) {
@@ -189,9 +241,17 @@ function withLegacyAliases(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     return resolved;
 }
 
+/**
+ * Validate an environment without touching the cached singleton.
+ * Exported for testing; application code should use `env`.
+ */
+export function parseEnv(source: NodeJS.ProcessEnv): Env {
+    return envSchema.parse(withLegacyAliases(source));
+}
+
 function getEnv(): Env {
     if (!_env) {
-        _env = envSchema.parse(withLegacyAliases(process.env));
+        _env = parseEnv(process.env);
     }
     return _env;
 }


### PR DESCRIPTION
Forberedelse til at tihlde.org skal peke på Photon i stedet for den gamle frontenden.

## Problemet

CORS slapp bare inn `env.WEBSITE_URL`, og det samme gjaldt Better Auth sine `trustedOrigins`. Verifisert mot produksjon i dag:

```
Origin: https://tihlde.org      → ingen ACAO (avvist)
Origin: https://new.tihlde.org  → tillatt
```

`WEBSITE_URL` settes i Drift sitt miljø, ikke i dette repoet. Domeneflyttingen i Vercel og den variabelen kan altså ikke snu i samme øyeblikk — og i mellomrommet ville hele nettstedet blitt avvist av sitt eget API.

## Endringen

`WEBSITE_ORIGINS` er `WEBSITE_URL` pluss de andre frontend-originene deployet svarer på. I produksjon dekker den både tihlde.org, www.tihlde.org og new.tihlde.org, så:

- byttet virker uansett hvilken verdi `WEBSITE_URL` har akkurat da
- lenker som fortsatt peker på new.tihlde.org (utsendte e-poster, Vipps-returer) virker etterpå

Kan overstyres med `EXTRA_WEBSITE_ORIGINS` (kommaseparert). Utenfor produksjon er oppførselen uendret.

Lenker i e-post og redirects bygges fortsatt kun fra `WEBSITE_URL` — de ekstra originene godtas på vei inn, de brukes ikke til å lage URL-er.

## Verifisert

- `bun run typecheck`, `bun run lint`, `bun run build` — grønt
- `bun run test` — 485 tester i 67 filer, alle passerer
- 6 nye tester i `apps/api/src/test/config/website-origins.test.ts` dekker begge sider av byttet, trailing slash, dev-oppførsel og overstyring

## Må inn i `main` før domenet flyttes

Dette er den blokkerende delen av cutoveren. Redirects for gamle URL-er kommer i egen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)