### PR TITLE
feat(kvark): redirects fra gamle tihlde.org-adresser

### DIFF
--- a/apps/kvark/public/robots.txt
+++ b/apps/kvark/public/robots.txt
@@ -1,3 +1,19 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+
+# Sider bak innlogging eller med personopplysninger skal ikke indekseres.
+# Listen er arvet fra den gamle tihlde.org-frontenden.
+Disallow: /toddel
+Disallow: /profil/*
+Disallow: /grupper/*
+Disallow: /admin/*
+Disallow: /galleri/*
+Disallow: /kokebok/*
+Disallow: /qr-koder
+Disallow: /soknader
+Disallow: /kontrakt
+Disallow: /sporreskjema/*
+Disallow: /motetid/*
+
+# Gruppeoversikten er offentlig, den enkelte gruppesiden er det ikke.
+Allow: /grupper$

--- a/apps/kvark/src/legacy-routes.ts
+++ b/apps/kvark/src/legacy-routes.ts
@@ -1,0 +1,54 @@
+/**
+ * Redirects fra URL-ene den gamle tihlde.org-frontenden brukte.
+ *
+ * Når tihlde.org peker på denne appen, arver vi alle lenkene som ligger ute
+ * fra før: Google-treff, Discord-meldinger, e-poster, Facebook-innlegg. Uten
+ * disse reglene blir de 404.
+ *
+ * Tre grupper:
+ *
+ * 1. Ruter som bare har byttet navn (`/logg-inn` → `/login`). Her lander
+ *    brukeren nøyaktig der hen skulle.
+ * 2. Funksjoner som ikke er portet (badges, korte lenker, tilbakemelding).
+ *    De går til forsiden.
+ *
+ * Innholdslenker med gammel Lepton-ID (`/arrangementer/1234/julebord`) hører
+ * også hjemme her, men ligger som splat-ruter under `src/routes/` i stedet.
+ * Mønstrene her er ikke segmentpresise: `/arrangementer/*` treffer også
+ * `/arrangementer` selv og ekte detaljsider, altså en redirect-løkke over hele
+ * arrangementssiden. Routeren skiller `$slug` fra `$slug/$` eksakt.
+ *
+ * 301 og ikke 302: adressene kommer aldri tilbake, og søkemotorer skal flytte
+ * rankingen over på den nye URL-en.
+ */
+
+type RedirectRule = { redirect: { to: string; status: 301 } };
+
+function to(target: string): RedirectRule {
+    return { redirect: { to: target, status: 301 } };
+}
+
+export const legacyRouteRules: Record<string, RedirectRule> = {
+    // --- Ruter som har byttet navn ---------------------------------------
+    "/logg-inn": to("/login"),
+    "/glemt-passord": to("/forgot-password"),
+    "/ny-bruker": to("/register"),
+    "/ny-bruker/**": to("/register"),
+    "/stillingsannonser": to("/annonser"),
+    "/bedrifter": to("/bedrift"),
+    "/bedrifter/**": to("/bedrift"),
+    // Interessegrupper er ikke borte, de er en gruppetype som vises under
+    // /grupper. Bare den eneadresserte siden er det.
+    "/interessegrupper": to("/grupper"),
+    // Gammel URL uten ID betydde «min profil». /profil/me er aliaset som
+    // grupper.$slug-siden og menyene bruker for det samme.
+    "/profil": to("/profil/me"),
+    "/stillingsannonser/**": to("/annonser"),
+
+    // --- Funksjoner som ikke er portet ------------------------------------
+    "/badges": to("/"),
+    "/badges/**": to("/"),
+    "/tilbakemelding": to("/"),
+    "/linker": to("/"),
+    "/endringslogg": to("/"),
+};

--- a/apps/kvark/src/routeTree.gen.ts
+++ b/apps/kvark/src/routeTree.gen.ts
@@ -53,6 +53,7 @@ import { Route as AppGalleriIndexRouteImport } from './routes/_app/galleri.index
 import { Route as AppGalleriSlugRouteImport } from './routes/_app/galleri.$slug'
 import { Route as AppGrupperIndexRouteImport } from './routes/_app/grupper.index'
 import { Route as AppGrupperSlugRouteImport } from './routes/_app/grupper.$slug'
+import { Route as AppKokebokStudyIdRouteImport } from './routes/_app/kokebok.$studyId'
 import { Route as AppMotetidIndexRouteImport } from './routes/_app/motetid.index'
 import { Route as AppMotetidSlugRouteImport } from './routes/_app/motetid.$slug'
 import { Route as AppMotetidNyRouteImport } from './routes/_app/motetid.ny'
@@ -69,6 +70,11 @@ import { Route as AdminSuperAdminOauthClientsRouteImport } from './routes/admin/
 import { Route as AdminArrangementerIndexRouteImport } from './routes/admin/arrangementer.index'
 import { Route as AdminArrangementerEventIdRouteImport } from './routes/admin/arrangementer.$eventId'
 import { Route as AdminArrangementerNyRouteImport } from './routes/admin/arrangementer.ny'
+import { Route as AppArrangementerSlugTitleRouteImport } from './routes/_app/arrangementer.$slug.$title'
+import { Route as AppGalleriSlugTitleRouteImport } from './routes/_app/galleri.$slug.$title'
+import { Route as AppGrupperSlugSectionRouteImport } from './routes/_app/grupper.$slug.$section'
+import { Route as AppKokebokStudyIdSplatRouteImport } from './routes/_app/kokebok.$studyId.$'
+import { Route as AppNyheterSlugTitleRouteImport } from './routes/_app/nyheter.$slug.$title'
 import { Route as AppProfilIdIndexRouteImport } from './routes/_app/profil/$id/index'
 import { Route as AppProfilIdArrangementerRouteImport } from './routes/_app/profil/$id/arrangementer'
 import { Route as AppProfilIdInnstillingerRouteImport } from './routes/_app/profil/$id/innstillinger'
@@ -293,6 +299,11 @@ const AppGrupperSlugRoute = AppGrupperSlugRouteImport.update({
   path: '/grupper/$slug',
   getParentRoute: () => AppRoute,
 } as any)
+const AppKokebokStudyIdRoute = AppKokebokStudyIdRouteImport.update({
+  id: '/$studyId',
+  path: '/$studyId',
+  getParentRoute: () => AppKokebokRoute,
+} as any)
 const AppMotetidIndexRoute = AppMotetidIndexRouteImport.update({
   id: '/motetid/',
   path: '/motetid/',
@@ -375,6 +386,32 @@ const AdminArrangementerNyRoute = AdminArrangementerNyRouteImport.update({
   path: '/arrangementer/ny',
   getParentRoute: () => AdminRoute,
 } as any)
+const AppArrangementerSlugTitleRoute =
+  AppArrangementerSlugTitleRouteImport.update({
+    id: '/$title',
+    path: '/$title',
+    getParentRoute: () => AppArrangementerSlugRoute,
+  } as any)
+const AppGalleriSlugTitleRoute = AppGalleriSlugTitleRouteImport.update({
+  id: '/$title',
+  path: '/$title',
+  getParentRoute: () => AppGalleriSlugRoute,
+} as any)
+const AppGrupperSlugSectionRoute = AppGrupperSlugSectionRouteImport.update({
+  id: '/$section',
+  path: '/$section',
+  getParentRoute: () => AppGrupperSlugRoute,
+} as any)
+const AppKokebokStudyIdSplatRoute = AppKokebokStudyIdSplatRouteImport.update({
+  id: '/$',
+  path: '/$',
+  getParentRoute: () => AppKokebokStudyIdRoute,
+} as any)
+const AppNyheterSlugTitleRoute = AppNyheterSlugTitleRouteImport.update({
+  id: '/$title',
+  path: '/$title',
+  getParentRoute: () => AppNyheterSlugRoute,
+} as any)
 const AppProfilIdIndexRoute = AppProfilIdIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -417,7 +454,7 @@ const AppSporreskjemaIdSvarRoute = AppSporreskjemaIdSvarRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof AppIndexRoute
   '/admin': typeof AdminRouteWithChildren
-  '/kokebok': typeof AppKokebokRoute
+  '/kokebok': typeof AppKokebokRouteWithChildren
   '/kontrakt': typeof AppKontraktRoute
   '/ny-student': typeof AppNyStudentRoute
   '/opptak': typeof AppOpptakRoute
@@ -446,13 +483,14 @@ export interface FileRoutesByFullPath {
   '/admin/toddel': typeof AdminToddelRoute
   '/admin/': typeof AdminIndexRoute
   '/annonser/$slug': typeof AppAnnonserSlugRoute
-  '/arrangementer/$slug': typeof AppArrangementerSlugRoute
+  '/arrangementer/$slug': typeof AppArrangementerSlugRouteWithChildren
   '/bedrift/studiene': typeof AppBedriftStudieneRoute
-  '/galleri/$slug': typeof AppGalleriSlugRoute
-  '/grupper/$slug': typeof AppGrupperSlugRoute
+  '/galleri/$slug': typeof AppGalleriSlugRouteWithChildren
+  '/grupper/$slug': typeof AppGrupperSlugRouteWithChildren
+  '/kokebok/$studyId': typeof AppKokebokStudyIdRouteWithChildren
   '/motetid/$slug': typeof AppMotetidSlugRoute
   '/motetid/ny': typeof AppMotetidNyRoute
-  '/nyheter/$slug': typeof AppNyheterSlugRoute
+  '/nyheter/$slug': typeof AppNyheterSlugRouteWithChildren
   '/playground/markdown': typeof AppPlaygroundMarkdownRoute
   '/profil/$id': typeof AppProfilIdRouteWithChildren
   '/sporreskjema/$id': typeof AppSporreskjemaIdRoute
@@ -471,6 +509,11 @@ export interface FileRoutesByFullPath {
   '/motetid/': typeof AppMotetidIndexRoute
   '/nyheter/': typeof AppNyheterIndexRoute
   '/admin/arrangementer/': typeof AdminArrangementerIndexRoute
+  '/arrangementer/$slug/$title': typeof AppArrangementerSlugTitleRoute
+  '/galleri/$slug/$title': typeof AppGalleriSlugTitleRoute
+  '/grupper/$slug/$section': typeof AppGrupperSlugSectionRoute
+  '/kokebok/$studyId/$': typeof AppKokebokStudyIdSplatRoute
+  '/nyheter/$slug/$title': typeof AppNyheterSlugTitleRoute
   '/profil/$id/arrangementer': typeof AppProfilIdArrangementerRoute
   '/profil/$id/innstillinger': typeof AppProfilIdInnstillingerRoute
   '/profil/$id/medlemskap': typeof AppProfilIdMedlemskapRoute
@@ -481,7 +524,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof AppIndexRoute
-  '/kokebok': typeof AppKokebokRoute
+  '/kokebok': typeof AppKokebokRouteWithChildren
   '/kontrakt': typeof AppKontraktRoute
   '/ny-student': typeof AppNyStudentRoute
   '/opptak': typeof AppOpptakRoute
@@ -510,13 +553,14 @@ export interface FileRoutesByTo {
   '/admin/soknader': typeof AdminSoknaderRoute
   '/admin/toddel': typeof AdminToddelRoute
   '/annonser/$slug': typeof AppAnnonserSlugRoute
-  '/arrangementer/$slug': typeof AppArrangementerSlugRoute
+  '/arrangementer/$slug': typeof AppArrangementerSlugRouteWithChildren
   '/bedrift/studiene': typeof AppBedriftStudieneRoute
-  '/galleri/$slug': typeof AppGalleriSlugRoute
-  '/grupper/$slug': typeof AppGrupperSlugRoute
+  '/galleri/$slug': typeof AppGalleriSlugRouteWithChildren
+  '/grupper/$slug': typeof AppGrupperSlugRouteWithChildren
+  '/kokebok/$studyId': typeof AppKokebokStudyIdRouteWithChildren
   '/motetid/$slug': typeof AppMotetidSlugRoute
   '/motetid/ny': typeof AppMotetidNyRoute
-  '/nyheter/$slug': typeof AppNyheterSlugRoute
+  '/nyheter/$slug': typeof AppNyheterSlugRouteWithChildren
   '/playground/markdown': typeof AppPlaygroundMarkdownRoute
   '/sporreskjema/$id': typeof AppSporreskjemaIdRoute
   '/oauth/consent': typeof AuthOauthConsentRoute
@@ -534,6 +578,11 @@ export interface FileRoutesByTo {
   '/motetid': typeof AppMotetidIndexRoute
   '/nyheter': typeof AppNyheterIndexRoute
   '/admin/arrangementer': typeof AdminArrangementerIndexRoute
+  '/arrangementer/$slug/$title': typeof AppArrangementerSlugTitleRoute
+  '/galleri/$slug/$title': typeof AppGalleriSlugTitleRoute
+  '/grupper/$slug/$section': typeof AppGrupperSlugSectionRoute
+  '/kokebok/$studyId/$': typeof AppKokebokStudyIdSplatRoute
+  '/nyheter/$slug/$title': typeof AppNyheterSlugTitleRoute
   '/profil/$id/arrangementer': typeof AppProfilIdArrangementerRoute
   '/profil/$id/innstillinger': typeof AppProfilIdInnstillingerRoute
   '/profil/$id/medlemskap': typeof AppProfilIdMedlemskapRoute
@@ -548,7 +597,7 @@ export interface FileRoutesById {
   '/_auth': typeof AuthRouteWithChildren
   '/_dev': typeof DevRouteWithChildren
   '/admin': typeof AdminRouteWithChildren
-  '/_app/kokebok': typeof AppKokebokRoute
+  '/_app/kokebok': typeof AppKokebokRouteWithChildren
   '/_app/kontrakt': typeof AppKontraktRoute
   '/_app/ny-student': typeof AppNyStudentRoute
   '/_app/opptak': typeof AppOpptakRoute
@@ -579,13 +628,14 @@ export interface FileRoutesById {
   '/_app/': typeof AppIndexRoute
   '/admin/': typeof AdminIndexRoute
   '/_app/annonser/$slug': typeof AppAnnonserSlugRoute
-  '/_app/arrangementer/$slug': typeof AppArrangementerSlugRoute
+  '/_app/arrangementer/$slug': typeof AppArrangementerSlugRouteWithChildren
   '/_app/bedrift/studiene': typeof AppBedriftStudieneRoute
-  '/_app/galleri/$slug': typeof AppGalleriSlugRoute
-  '/_app/grupper/$slug': typeof AppGrupperSlugRoute
+  '/_app/galleri/$slug': typeof AppGalleriSlugRouteWithChildren
+  '/_app/grupper/$slug': typeof AppGrupperSlugRouteWithChildren
+  '/_app/kokebok/$studyId': typeof AppKokebokStudyIdRouteWithChildren
   '/_app/motetid/$slug': typeof AppMotetidSlugRoute
   '/_app/motetid/ny': typeof AppMotetidNyRoute
-  '/_app/nyheter/$slug': typeof AppNyheterSlugRoute
+  '/_app/nyheter/$slug': typeof AppNyheterSlugRouteWithChildren
   '/_app/playground/markdown': typeof AppPlaygroundMarkdownRoute
   '/_app/profil/$id': typeof AppProfilIdRouteWithChildren
   '/_app/sporreskjema/$id': typeof AppSporreskjemaIdRoute
@@ -604,6 +654,11 @@ export interface FileRoutesById {
   '/_app/motetid/': typeof AppMotetidIndexRoute
   '/_app/nyheter/': typeof AppNyheterIndexRoute
   '/admin/arrangementer/': typeof AdminArrangementerIndexRoute
+  '/_app/arrangementer/$slug/$title': typeof AppArrangementerSlugTitleRoute
+  '/_app/galleri/$slug/$title': typeof AppGalleriSlugTitleRoute
+  '/_app/grupper/$slug/$section': typeof AppGrupperSlugSectionRoute
+  '/_app/kokebok/$studyId/$': typeof AppKokebokStudyIdSplatRoute
+  '/_app/nyheter/$slug/$title': typeof AppNyheterSlugTitleRoute
   '/_app/profil/$id/arrangementer': typeof AppProfilIdArrangementerRoute
   '/_app/profil/$id/innstillinger': typeof AppProfilIdInnstillingerRoute
   '/_app/profil/$id/medlemskap': typeof AppProfilIdMedlemskapRoute
@@ -650,6 +705,7 @@ export interface FileRouteTypes {
     | '/bedrift/studiene'
     | '/galleri/$slug'
     | '/grupper/$slug'
+    | '/kokebok/$studyId'
     | '/motetid/$slug'
     | '/motetid/ny'
     | '/nyheter/$slug'
@@ -671,6 +727,11 @@ export interface FileRouteTypes {
     | '/motetid/'
     | '/nyheter/'
     | '/admin/arrangementer/'
+    | '/arrangementer/$slug/$title'
+    | '/galleri/$slug/$title'
+    | '/grupper/$slug/$section'
+    | '/kokebok/$studyId/$'
+    | '/nyheter/$slug/$title'
     | '/profil/$id/arrangementer'
     | '/profil/$id/innstillinger'
     | '/profil/$id/medlemskap'
@@ -714,6 +775,7 @@ export interface FileRouteTypes {
     | '/bedrift/studiene'
     | '/galleri/$slug'
     | '/grupper/$slug'
+    | '/kokebok/$studyId'
     | '/motetid/$slug'
     | '/motetid/ny'
     | '/nyheter/$slug'
@@ -734,6 +796,11 @@ export interface FileRouteTypes {
     | '/motetid'
     | '/nyheter'
     | '/admin/arrangementer'
+    | '/arrangementer/$slug/$title'
+    | '/galleri/$slug/$title'
+    | '/grupper/$slug/$section'
+    | '/kokebok/$studyId/$'
+    | '/nyheter/$slug/$title'
     | '/profil/$id/arrangementer'
     | '/profil/$id/innstillinger'
     | '/profil/$id/medlemskap'
@@ -782,6 +849,7 @@ export interface FileRouteTypes {
     | '/_app/bedrift/studiene'
     | '/_app/galleri/$slug'
     | '/_app/grupper/$slug'
+    | '/_app/kokebok/$studyId'
     | '/_app/motetid/$slug'
     | '/_app/motetid/ny'
     | '/_app/nyheter/$slug'
@@ -803,6 +871,11 @@ export interface FileRouteTypes {
     | '/_app/motetid/'
     | '/_app/nyheter/'
     | '/admin/arrangementer/'
+    | '/_app/arrangementer/$slug/$title'
+    | '/_app/galleri/$slug/$title'
+    | '/_app/grupper/$slug/$section'
+    | '/_app/kokebok/$studyId/$'
+    | '/_app/nyheter/$slug/$title'
     | '/_app/profil/$id/arrangementer'
     | '/_app/profil/$id/innstillinger'
     | '/_app/profil/$id/medlemskap'
@@ -1129,6 +1202,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppGrupperSlugRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/kokebok/$studyId': {
+      id: '/_app/kokebok/$studyId'
+      path: '/$studyId'
+      fullPath: '/kokebok/$studyId'
+      preLoaderRoute: typeof AppKokebokStudyIdRouteImport
+      parentRoute: typeof AppKokebokRoute
+    }
     '/_app/motetid/': {
       id: '/_app/motetid/'
       path: '/motetid'
@@ -1241,6 +1321,41 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminArrangementerNyRouteImport
       parentRoute: typeof AdminRoute
     }
+    '/_app/arrangementer/$slug/$title': {
+      id: '/_app/arrangementer/$slug/$title'
+      path: '/$title'
+      fullPath: '/arrangementer/$slug/$title'
+      preLoaderRoute: typeof AppArrangementerSlugTitleRouteImport
+      parentRoute: typeof AppArrangementerSlugRoute
+    }
+    '/_app/galleri/$slug/$title': {
+      id: '/_app/galleri/$slug/$title'
+      path: '/$title'
+      fullPath: '/galleri/$slug/$title'
+      preLoaderRoute: typeof AppGalleriSlugTitleRouteImport
+      parentRoute: typeof AppGalleriSlugRoute
+    }
+    '/_app/grupper/$slug/$section': {
+      id: '/_app/grupper/$slug/$section'
+      path: '/$section'
+      fullPath: '/grupper/$slug/$section'
+      preLoaderRoute: typeof AppGrupperSlugSectionRouteImport
+      parentRoute: typeof AppGrupperSlugRoute
+    }
+    '/_app/kokebok/$studyId/$': {
+      id: '/_app/kokebok/$studyId/$'
+      path: '/$'
+      fullPath: '/kokebok/$studyId/$'
+      preLoaderRoute: typeof AppKokebokStudyIdSplatRouteImport
+      parentRoute: typeof AppKokebokStudyIdRoute
+    }
+    '/_app/nyheter/$slug/$title': {
+      id: '/_app/nyheter/$slug/$title'
+      path: '/$title'
+      fullPath: '/nyheter/$slug/$title'
+      preLoaderRoute: typeof AppNyheterSlugTitleRouteImport
+      parentRoute: typeof AppNyheterSlugRoute
+    }
     '/_app/profil/$id/': {
       id: '/_app/profil/$id/'
       path: '/'
@@ -1293,6 +1408,76 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface AppKokebokStudyIdRouteChildren {
+  AppKokebokStudyIdSplatRoute: typeof AppKokebokStudyIdSplatRoute
+}
+
+const AppKokebokStudyIdRouteChildren: AppKokebokStudyIdRouteChildren = {
+  AppKokebokStudyIdSplatRoute: AppKokebokStudyIdSplatRoute,
+}
+
+const AppKokebokStudyIdRouteWithChildren =
+  AppKokebokStudyIdRoute._addFileChildren(AppKokebokStudyIdRouteChildren)
+
+interface AppKokebokRouteChildren {
+  AppKokebokStudyIdRoute: typeof AppKokebokStudyIdRouteWithChildren
+}
+
+const AppKokebokRouteChildren: AppKokebokRouteChildren = {
+  AppKokebokStudyIdRoute: AppKokebokStudyIdRouteWithChildren,
+}
+
+const AppKokebokRouteWithChildren = AppKokebokRoute._addFileChildren(
+  AppKokebokRouteChildren,
+)
+
+interface AppArrangementerSlugRouteChildren {
+  AppArrangementerSlugTitleRoute: typeof AppArrangementerSlugTitleRoute
+}
+
+const AppArrangementerSlugRouteChildren: AppArrangementerSlugRouteChildren = {
+  AppArrangementerSlugTitleRoute: AppArrangementerSlugTitleRoute,
+}
+
+const AppArrangementerSlugRouteWithChildren =
+  AppArrangementerSlugRoute._addFileChildren(AppArrangementerSlugRouteChildren)
+
+interface AppGalleriSlugRouteChildren {
+  AppGalleriSlugTitleRoute: typeof AppGalleriSlugTitleRoute
+}
+
+const AppGalleriSlugRouteChildren: AppGalleriSlugRouteChildren = {
+  AppGalleriSlugTitleRoute: AppGalleriSlugTitleRoute,
+}
+
+const AppGalleriSlugRouteWithChildren = AppGalleriSlugRoute._addFileChildren(
+  AppGalleriSlugRouteChildren,
+)
+
+interface AppGrupperSlugRouteChildren {
+  AppGrupperSlugSectionRoute: typeof AppGrupperSlugSectionRoute
+}
+
+const AppGrupperSlugRouteChildren: AppGrupperSlugRouteChildren = {
+  AppGrupperSlugSectionRoute: AppGrupperSlugSectionRoute,
+}
+
+const AppGrupperSlugRouteWithChildren = AppGrupperSlugRoute._addFileChildren(
+  AppGrupperSlugRouteChildren,
+)
+
+interface AppNyheterSlugRouteChildren {
+  AppNyheterSlugTitleRoute: typeof AppNyheterSlugTitleRoute
+}
+
+const AppNyheterSlugRouteChildren: AppNyheterSlugRouteChildren = {
+  AppNyheterSlugTitleRoute: AppNyheterSlugTitleRoute,
+}
+
+const AppNyheterSlugRouteWithChildren = AppNyheterSlugRoute._addFileChildren(
+  AppNyheterSlugRouteChildren,
+)
+
 interface AppProfilIdRouteChildren {
   AppProfilIdArrangementerRoute: typeof AppProfilIdArrangementerRoute
   AppProfilIdInnstillingerRoute: typeof AppProfilIdInnstillingerRoute
@@ -1316,7 +1501,7 @@ const AppProfilIdRouteWithChildren = AppProfilIdRoute._addFileChildren(
 )
 
 interface AppRouteChildren {
-  AppKokebokRoute: typeof AppKokebokRoute
+  AppKokebokRoute: typeof AppKokebokRouteWithChildren
   AppKontraktRoute: typeof AppKontraktRoute
   AppNyStudentRoute: typeof AppNyStudentRoute
   AppOpptakRoute: typeof AppOpptakRoute
@@ -1326,13 +1511,13 @@ interface AppRouteChildren {
   AppToddelRoute: typeof AppToddelRoute
   AppIndexRoute: typeof AppIndexRoute
   AppAnnonserSlugRoute: typeof AppAnnonserSlugRoute
-  AppArrangementerSlugRoute: typeof AppArrangementerSlugRoute
+  AppArrangementerSlugRoute: typeof AppArrangementerSlugRouteWithChildren
   AppBedriftStudieneRoute: typeof AppBedriftStudieneRoute
-  AppGalleriSlugRoute: typeof AppGalleriSlugRoute
-  AppGrupperSlugRoute: typeof AppGrupperSlugRoute
+  AppGalleriSlugRoute: typeof AppGalleriSlugRouteWithChildren
+  AppGrupperSlugRoute: typeof AppGrupperSlugRouteWithChildren
   AppMotetidSlugRoute: typeof AppMotetidSlugRoute
   AppMotetidNyRoute: typeof AppMotetidNyRoute
-  AppNyheterSlugRoute: typeof AppNyheterSlugRoute
+  AppNyheterSlugRoute: typeof AppNyheterSlugRouteWithChildren
   AppPlaygroundMarkdownRoute: typeof AppPlaygroundMarkdownRoute
   AppProfilIdRoute: typeof AppProfilIdRouteWithChildren
   AppSporreskjemaIdRoute: typeof AppSporreskjemaIdRoute
@@ -1347,7 +1532,7 @@ interface AppRouteChildren {
 }
 
 const AppRouteChildren: AppRouteChildren = {
-  AppKokebokRoute: AppKokebokRoute,
+  AppKokebokRoute: AppKokebokRouteWithChildren,
   AppKontraktRoute: AppKontraktRoute,
   AppNyStudentRoute: AppNyStudentRoute,
   AppOpptakRoute: AppOpptakRoute,
@@ -1357,13 +1542,13 @@ const AppRouteChildren: AppRouteChildren = {
   AppToddelRoute: AppToddelRoute,
   AppIndexRoute: AppIndexRoute,
   AppAnnonserSlugRoute: AppAnnonserSlugRoute,
-  AppArrangementerSlugRoute: AppArrangementerSlugRoute,
+  AppArrangementerSlugRoute: AppArrangementerSlugRouteWithChildren,
   AppBedriftStudieneRoute: AppBedriftStudieneRoute,
-  AppGalleriSlugRoute: AppGalleriSlugRoute,
-  AppGrupperSlugRoute: AppGrupperSlugRoute,
+  AppGalleriSlugRoute: AppGalleriSlugRouteWithChildren,
+  AppGrupperSlugRoute: AppGrupperSlugRouteWithChildren,
   AppMotetidSlugRoute: AppMotetidSlugRoute,
   AppMotetidNyRoute: AppMotetidNyRoute,
-  AppNyheterSlugRoute: AppNyheterSlugRoute,
+  AppNyheterSlugRoute: AppNyheterSlugRouteWithChildren,
   AppPlaygroundMarkdownRoute: AppPlaygroundMarkdownRoute,
   AppProfilIdRoute: AppProfilIdRouteWithChildren,
   AppSporreskjemaIdRoute: AppSporreskjemaIdRoute,

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.$title.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.$title.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/**
+ * Gammelt lenkeformat: /arrangementer/<lepton-id>/<tittel>.
+ *
+ * Lepton brukte løpenummer, Photon bruker UUID, og migreringen tok ikke vare
+ * på den gamle ID-en — det konkrete innholdet kan ikke slås opp. Oversikten er
+ * nærmeste treff.
+ *
+ * To eksplisitte segmenter og ikke en splat: `$slug/$` matcher også
+ * `/arrangementer/<slug>` alene, siden splat-en kan være tom, og da ble hver ekte
+ * detaljside sendt til oversikten.
+ */
+export const Route = createFileRoute("/_app/arrangementer/$slug/$title")({
+    beforeLoad: () => {
+        throw redirect({
+            to: "/arrangementer",
+            replace: true,
+            statusCode: 301,
+        });
+    },
+});

--- a/apps/kvark/src/routes/_app/galleri.$slug.$title.tsx
+++ b/apps/kvark/src/routes/_app/galleri.$slug.$title.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/**
+ * Gammelt lenkeformat: /galleri/<lepton-id>/<tittel>.
+ *
+ * Lepton brukte løpenummer, Photon bruker UUID, og migreringen tok ikke vare
+ * på den gamle ID-en — det konkrete innholdet kan ikke slås opp. Oversikten er
+ * nærmeste treff.
+ *
+ * To eksplisitte segmenter og ikke en splat: `$slug/$` matcher også
+ * `/galleri/<slug>` alene, siden splat-en kan være tom, og da ble hver ekte
+ * detaljside sendt til oversikten.
+ */
+export const Route = createFileRoute("/_app/galleri/$slug/$title")({
+    beforeLoad: () => {
+        throw redirect({ to: "/galleri", replace: true, statusCode: 301 });
+    },
+});

--- a/apps/kvark/src/routes/_app/grupper.$slug.$section.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.$section.tsx
@@ -1,0 +1,35 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/**
+ * Gamle gruppeundersider var egne adresser (/grupper/<slug>/boter). Nå er de
+ * faner på gruppesiden, styrt av ?tab=. Navnene er de samme, så den gamle
+ * lenken lander på riktig fane — ukjente undersider går til Om.
+ *
+ * Eksplisitt $section og ikke en splat: `/grupper/$slug/$` matcher også
+ * `/grupper/<slug>` selv, siden splat-en kan være tom, og gruppesiden endte i
+ * en redirect-løkke.
+ */
+const TAB_BY_LEGACY_SECTION = {
+    arrangementer: "arrangementer",
+    boter: "boter",
+    lovverk: "lovverk",
+    sporreskjema: "sporreskjema",
+    medlemmer: "medlemmer",
+} as const;
+
+export const Route = createFileRoute("/_app/grupper/$slug/$section")({
+    beforeLoad: ({ params }) => {
+        const tab =
+            TAB_BY_LEGACY_SECTION[
+                params.section as keyof typeof TAB_BY_LEGACY_SECTION
+            ] ?? "om";
+
+        throw redirect({
+            to: "/grupper/$slug",
+            params: { slug: params.slug },
+            search: { tab },
+            replace: true,
+            statusCode: 301,
+        });
+    },
+});

--- a/apps/kvark/src/routes/_app/kokebok.$studyId.$.tsx
+++ b/apps/kvark/src/routes/_app/kokebok.$studyId.$.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/** /kokebok/<studie>/<klasse> og dypere. Se kokebok.$studyId. */
+export const Route = createFileRoute("/_app/kokebok/$studyId/$")({
+    beforeLoad: () => {
+        throw redirect({ to: "/kokebok", replace: true, statusCode: 301 });
+    },
+});

--- a/apps/kvark/src/routes/_app/kokebok.$studyId.tsx
+++ b/apps/kvark/src/routes/_app/kokebok.$studyId.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/**
+ * Kokeboken tok studie og klasse i URL-en (/kokebok/<studie>/<klasse>); nå
+ * velges de på siden selv.
+ *
+ * Eksplisitte parametersegmenter og ikke en splat: `/kokebok/$` matcher også
+ * `/kokebok` selv, siden splat-en kan være tom — det ble en redirect-løkke på
+ * selve kokeboksiden.
+ */
+export const Route = createFileRoute("/_app/kokebok/$studyId")({
+    beforeLoad: () => {
+        throw redirect({ to: "/kokebok", replace: true, statusCode: 301 });
+    },
+});

--- a/apps/kvark/src/routes/_app/nyheter.$slug.$title.tsx
+++ b/apps/kvark/src/routes/_app/nyheter.$slug.$title.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/**
+ * Gammelt lenkeformat: /nyheter/<lepton-id>/<tittel>.
+ *
+ * Lepton brukte løpenummer, Photon bruker UUID, og migreringen tok ikke vare
+ * på den gamle ID-en — det konkrete innholdet kan ikke slås opp. Oversikten er
+ * nærmeste treff.
+ *
+ * To eksplisitte segmenter og ikke en splat: `$slug/$` matcher også
+ * `/nyheter/<slug>` alene, siden splat-en kan være tom, og da ble hver ekte
+ * detaljside sendt til oversikten.
+ */
+export const Route = createFileRoute("/_app/nyheter/$slug/$title")({
+    beforeLoad: () => {
+        throw redirect({ to: "/nyheter", replace: true, statusCode: 301 });
+    },
+});

--- a/apps/kvark/vite.config.ts
+++ b/apps/kvark/vite.config.ts
@@ -7,6 +7,8 @@ import viteReact from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { nitro } from "nitro/vite";
 
+import { legacyRouteRules } from "./src/legacy-routes";
+
 const config = defineConfig({
     resolve: {
         tsconfigPaths: true,
@@ -22,7 +24,12 @@ const config = defineConfig({
         // On Vercel, Nitro externalizes React but its static tracer misses the
         // SSR runtime's raw `require("react")`, so React is absent from the
         // serverless bundle ("Cannot find module 'react'"). Force it to be traced.
-        nitro({ traceDeps: ["react", "react-dom"] }),
+        nitro({
+            traceDeps: ["react", "react-dom"],
+            // Serverside 301-er for de gamle tihlde.org-adressene, se
+            // src/legacy-routes.ts.
+            routeRules: legacyRouteRules,
+        }),
         tailwindcss(),
         tanstackStart(),
         viteReact(),


### PR DESCRIPTION
Forberedelse til at tihlde.org skal peke på Photon i stedet for den gamle frontenden.

Når domenet flyttes arver vi alle lenkene som allerede ligger ute — Google-treff, Discord-meldinger, utsendte e-poster, Facebook-innlegg. Uten redirects blir de 404.

## Hva som mappes

**Ruter som har byttet navn** (lander nøyaktig der brukeren skulle):

| Gammel | Ny |
|---|---|
| `/logg-inn` | `/login` |
| `/glemt-passord` | `/forgot-password` |
| `/ny-bruker`, `/ny-bruker/**` | `/register` |
| `/stillingsannonser` | `/annonser` |
| `/bedrifter` | `/bedrift` |
| `/interessegrupper` | `/grupper` |
| `/profil` | `/profil/me` |
| `/grupper/<slug>/boter` m.fl. | `/grupper/<slug>?tab=boter` |
| `/kokebok/<studie>/<klasse>` | `/kokebok` |

**Lenker med gammel Lepton-ID** → oversikten. Lepton brukte løpenummer, Photon bruker UUID, og migreringen tok ikke vare på den gamle ID-en, så `/arrangementer/1234/julebord` kan ikke slås opp. Gjelder `/arrangementer`, `/nyheter` og `/galleri`.

**Funksjoner som ikke er portet** → forsiden: `/badges`, `/linker`, `/tilbakemelding`, `/endringslogg`.

## To fallgruver som ble avdekket under testing

Begge ville tatt ned ekte sider, og begge ble funnet ved å faktisk kjøre requestene — ikke ved lesing.

1. **Nitros routeRules-mønstre er ikke segmentpresise.** `/arrangementer/*/**` matcher også `/arrangementer` selv og hver ekte detaljside. Første versjon ga redirect-løkke på hele arrangementssiden. ID-lenkene ligger derfor som ruter, ikke routeRules.
2. **Splat matcher tomt segment.** `/kokebok/$` matcher `/kokebok`, og `/arrangementer/$slug/$` matcher `/arrangementer/<slug>` — altså ble hver ekte arrangementsside sendt til oversikten. Rutefilene bruker eksplisitte parametre (`$slug/$title`, `$slug/$section`, `$studyId`) i stedet.

## robots.txt

Ny fil tillot alt; den gamle sperret profiler, admin, galleri m.m. Sperrelisten er portert og utvidet med `/soknader`, `/kontrakt`, `/sporreskjema/*` og `/motetid/*`.

## Verifisert

Alle URL-ene kjørt mot lokal dev-server med redirects fulgt til endestasjon:

- alle gamle adresser i tabellen over lander 200 på riktig side
- ekte detaljsider er urørt: `/arrangementer/julebord-1369`, `/arrangementer/<uuid>` og `/nyheter/<uuid>` løser til seg selv
- ingen redirect-løkker
- `/grupper/<slug>/boter` lander på riktig fane
- 301 (ikke 302) — adressene kommer ikke tilbake, og rankingen skal flyttes

`bun run typecheck`, `bun run lint`, `bun run build` grønt. `bun run test` — 485 tester passerer.

Galleriets detaljside er ikke verifisert mot ekte data (lokal DB har ingen album), men ruten er identisk i form med nyheter og arrangementer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)