### PR TITLE
feat(kvark): flytt PostHog-sporing til photon-prosjektet

### DIFF
--- a/apps/kvark/.env.example
+++ b/apps/kvark/.env.example
@@ -2,6 +2,7 @@
 VITE_AUTH_BASE_URL=http://localhost:4000
 VITE_API_URL=http://localhost:4000/
 
-# Optional analytics
+# Optional analytics (PostHog EU-instans). Capturing er uansett skrudd av i dev.
 VITE_POSTHOG_KEY=phc_xxx
+VITE_POSTHOG_HOST=https://eu.i.posthog.com
 

--- a/apps/kvark/src/integrations/posthog/provider.tsx
+++ b/apps/kvark/src/integrations/posthog/provider.tsx
@@ -5,10 +5,19 @@ import type { ReactNode } from "react";
 if (typeof window !== "undefined" && import.meta.env.VITE_POSTHOG_KEY) {
     posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
         api_host:
-            import.meta.env.VITE_POSTHOG_HOST || "https://us.i.posthog.com",
+            import.meta.env.VITE_POSTHOG_HOST || "https://eu.i.posthog.com",
         person_profiles: "identified_only",
-        capture_pageview: false,
+        // TanStack Router navigerer via history API, så pageviews må fanges
+        // på history-endringer og ikke bare ved full sidelast.
+        capture_pageview: "history_change",
         defaults: "2025-11-30",
+        debug: import.meta.env.DEV,
+        loaded: (ph) => {
+            // Ikke send data fra lokal utvikling inn i prod-prosjektet.
+            if (import.meta.env.DEV) {
+                ph.opt_out_capturing();
+            }
+        },
     });
 }
 

--- a/apps/kvark/src/routes/_app/opptak.tsx
+++ b/apps/kvark/src/routes/_app/opptak.tsx
@@ -70,7 +70,9 @@ function AdmissionsPage() {
                     <p className="text-muted-foreground">
                         Bli med på å skape studentmiljøet
                     </p>
-                    <h1 className="text-4xl font-bold md:text-6xl">Søk verv!</h1>
+                    <h1 className="text-4xl font-bold md:text-6xl">
+                        Søk verv!
+                    </h1>
                     <p className="text-muted-foreground">
                         Her finner du en oversikt over alle vervene i TIHLDE.
                         Søk på vervene du er interessert i, og bli med på å


### PR DESCRIPTION
Flytter PostHog-sporingen fra Vercel-prosjektet `tihlde/kvark` til `tihlde/photon`. Samme PostHog-prosjekt/token som før, så historikken er sammenhengende.

## Vercel
Lagt til på `tihlde/photon` (Production + Preview):
- `VITE_POSTHOG_KEY` — samme verdi som kvarks `VITE_POSTHOG_API_KEY` (merk navnebyttet, koden her leser `VITE_POSTHOG_KEY`)
- `VITE_POSTHOG_HOST` = `https://eu.i.posthog.com`

De gamle PostHog-variablene er fjernet fra `tihlde/kvark`. Variablene trer i kraft ved neste deploy.

## Kode
- `capture_pageview: false` → `"history_change"`. Dette var en reell bug: TanStack Router navigerer via history API, så med `false` ble ingen sidevisninger sporet i det hele tatt.
- Fallback-host endret fra US til EU (instansen vi faktisk bruker).
- Capturing slås av lokalt (`import.meta.env.DEV`), som i gamle Kvark. `debug` kun i dev.
- `.env.example` dokumenterer `VITE_POSTHOG_HOST`.
- Tar med en oxfmt-retting i `opptak.tsx` som lå igjen på branchen og gjorde `bun run format` rød.

## Verifisert
- `typecheck` og `lint` grønt, produksjonsbygg av `apps/kvark` går gjennom, og bundlen inneholder `capture_pageview:"history_change"`, EU-hosten og nøkkelen.
- Kjørte prod-bygget i nettleser: PostHog initialiserte, traff API-et (401 fra testnøkkelen — altså ekte nettverkskall), og fanget ny hendelse ved `pushState`-navigering.

## Ikke med i denne PR-en
- `POSTHOG_CLI_*` (sourcemap-opplasting) — Photon har ingen posthog-cli i byggesteget.
- De ~20 egendefinerte `analyticsEvent(...)`-kallene fra gamle Kvark. Vi får nå pageviews + autocapture, ikke egendefinerte hendelser.
- `posthog.identify()` finnes ingen steder, og `person_profiles` er `identified_only`, så det opprettes ingen personprofiler. Samme som før, men verdt å koble på Better Auth-brukeren senere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)