### PR TITLE
fix(kvark): fjern horisontal overflow fra gruppekort

### DIFF
--- a/apps/kvark/src/components/group-admission-card.tsx
+++ b/apps/kvark/src/components/group-admission-card.tsx
@@ -52,7 +52,7 @@ export function GroupAdmissionCard({
     formId,
 }: GroupAdmissionCardProps) {
     return (
-        <Card size="sm" className="h-full">
+        <Card size="sm" className="h-full min-w-0">
             <Collapsible open={open} onOpenChange={onOpenChange}>
                 <CollapsibleTrigger
                     render={
@@ -173,7 +173,7 @@ function AdmissionAction({
 export function GroupAdmissionLinkCard({ group }: { group: AdmissionGroup }) {
     return (
         <Link
-            className="block cursor-pointer"
+            className="block min-w-0 cursor-pointer"
             to="/grupper/$slug"
             params={{ slug: group.slug }}
         >

--- a/apps/kvark/src/components/group-list-view.tsx
+++ b/apps/kvark/src/components/group-list-view.tsx
@@ -32,11 +32,11 @@ export function GroupListView({ tree }: { tree: GroupTreeInput }) {
             {sections.map((section) => (
                 <section key={section.id} className="flex flex-col gap-3">
                     <h2 className="text-lg font-semibold">{section.label}</h2>
-                    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
                         {section.items.map((item) => (
                             <Link
                                 key={item.slug}
-                                className="block cursor-pointer"
+                                className="block min-w-0 cursor-pointer"
                                 to="/grupper/$slug"
                                 params={{ slug: item.slug }}
                             >

--- a/apps/kvark/src/routes/_app/ny-student.tsx
+++ b/apps/kvark/src/routes/_app/ny-student.tsx
@@ -253,7 +253,7 @@ function GroupSections() {
             {sections.map((section) => (
                 <div key={section.title} className="flex flex-col gap-3">
                     <h3 className="text-lg font-semibold">{section.title}</h3>
-                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                         {section.groups.map((group) => (
                             <GroupAdmissionLinkCard
                                 key={group.slug}

--- a/apps/kvark/src/routes/_app/opptak.tsx
+++ b/apps/kvark/src/routes/_app/opptak.tsx
@@ -70,7 +70,9 @@ function AdmissionsPage() {
                     <p className="text-muted-foreground">
                         Bli med på å skape studentmiljøet
                     </p>
-                    <h1 className="text-4xl font-bold md:text-6xl">Søk verv!</h1>
+                    <h1 className="text-4xl font-bold md:text-6xl">
+                        Søk verv!
+                    </h1>
                     <p className="text-muted-foreground">
                         Her finner du en oversikt over alle vervene i TIHLDE.
                         Søk på vervene du er interessert i, og bli med på å
@@ -140,7 +142,7 @@ function AdmissionsPage() {
                             alle, og du kan være med i så mange du vil.
                         </p>
                     </div>
-                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                         {interestGroups.map((group) => (
                             <GroupAdmissionLinkCard
                                 key={group.slug}
@@ -168,7 +170,7 @@ function AdmissionSection({
     return (
         <div className="flex flex-col gap-3">
             <h3 className="text-lg font-semibold">{title}</h3>
-            <div className="grid items-start gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid grid-cols-1 items-start gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 {groups.map((group) => (
                     <AdmissionCardContainer
                         key={group.slug}


### PR DESCRIPTION
## Hva

Fjerner den horisontale overflowen på `/ny-student` (og de samme kortene på `/opptak` og `/grupper`).

## Hvorfor

Det så ut som undergruppene skapte overflowen, men den egentlige årsaken er e-postadressene deres.

`GroupIdentity` bruker `truncate`, som setter `white-space: nowrap`. Det gjør at kortets `min-content`-bredde blir hele e-postadressen. Siden grid-elementene hadde `min-width: auto` — som løses til `min-content` — kunne kortene ikke krympe under den bredden, og sporet ble tvunget bredere enn skjermen.

Undergruppene har de lengste adressene (`innovasjonsminister@tihlde.org`, `naeringslivsminister@tihlde.org`), så de var de eneste som ble for brede. Målt lokalt på 375px viewport: kortene var **361px i en 343px container**.

## Endringer

- `min-w-0` på kort-rota (`Card`) og lenke-wrapperen i `group-admission-card.tsx` og `group-list-view.tsx`, så de kan krympe og `truncate` faktisk får slå inn
- eksplisitt `grid-cols-1` på gridene i `ny-student.tsx`, `opptak.tsx` og `group-list-view.tsx` — Tailwind gir da `minmax(0,1fr)` i stedet for et implisitt `auto`-spor med min-content-gulv

Begge deler trengs: `grid-cols-1` fikser sporet, `min-w-0` fikser elementet i sporet.

## Verifisert

Browser-preview på 375px bredde:

- kortene er nå 343px (var 361px), alle like brede
- `scrollWidth === clientWidth` (375/375) på `/ny-student`, `/opptak`, `/grupper` og `/arrangementer`
- lange e-poster får ellipsis (`naeringslivsminister@tihlde....`) i stedet for å presse kortet ut
- `typecheck`, `build`, `lint` og `format` er grønne

## Verdt å vite for review

- `opptak.tsx` har én formatterings-endring på en `h1` som ikke er relatert — den kom fra oxfmt da fila ble rørt.
- Jeg sveipet fire ruter for overflow, ikke alle ~33. Andre sider kan ha egne tilfeller med andre årsaker.
- Jeg la bevisst **ikke** inn en global `overflow-x: hidden`-sikring, siden den ville skjult framtidige tilfeller i stedet for å fikse dem. Si fra hvis dere heller vil ha det nettet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)