### PR TITLE
fix(kvark): fjern horisontal overflow på alle skjermbredder

### DIFF
--- a/apps/kvark/src/components/detail-date-range.tsx
+++ b/apps/kvark/src/components/detail-date-range.tsx
@@ -61,7 +61,7 @@ function MultiDay({
     end: DetailDatePoint;
 }) {
     return (
-        <div className="grid min-w-0 grid-cols-[auto_1fr] gap-x-3">
+        <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-x-3">
             <Marker />
             <span className="self-center leading-6">{start.date}</span>
 

--- a/apps/kvark/src/components/detail-layout.tsx
+++ b/apps/kvark/src/components/detail-layout.tsx
@@ -37,9 +37,11 @@ export function DetailHeader({
     actions,
 }: DetailHeaderProps) {
     return (
-        <div className="grid grid-cols-[auto_1fr] items-start gap-x-4 gap-y-3 md:grid-cols-[auto_1fr_auto] md:items-stretch">
+        <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-4 gap-y-3 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-stretch">
             {avatar}
-            <div className="min-w-0">{title}</div>
+            {/* Lange, ubrytelige gruppenavn (Forvaltningsgruppen) må kunne
+                brytes, ellers presser de headeren ut av skjermen på mobil. */}
+            <div className="min-w-0 break-words">{title}</div>
             {subtitle ? (
                 <div className="col-span-2 min-w-0 md:col-span-1 md:col-start-2">
                     {subtitle}

--- a/apps/kvark/src/components/detail-page.tsx
+++ b/apps/kvark/src/components/detail-page.tsx
@@ -20,7 +20,7 @@ export function DetailPage({
             {back}
             {hero}
             {sidebar ? (
-                <div className="grid gap-6 lg:grid-cols-[1fr_22rem] lg:gap-8">
+                <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem] lg:gap-8">
                     <header className="flex flex-col gap-4 lg:col-start-1 lg:row-start-1">
                         {header}
                     </header>

--- a/apps/kvark/src/components/site-bottom-bar.tsx
+++ b/apps/kvark/src/components/site-bottom-bar.tsx
@@ -32,7 +32,7 @@ export function SiteBottomBar({
     const closeMenu = () => setMenuOpen(false);
 
     return (
-        <BottomBar className="md:hidden">
+        <BottomBar className="lg:hidden">
             <div className="flex items-stretch justify-between gap-1 px-2 py-1">
                 <BottomBarItem
                     render={<Link to="/" activeOptions={{ exact: true }} />}

--- a/apps/kvark/src/components/site-header.tsx
+++ b/apps/kvark/src/components/site-header.tsx
@@ -63,7 +63,7 @@ export function SiteHeader({ navItems, user, actions }: SiteHeaderProps) {
                     <TihldeLogo variant="full" className="h-5 w-auto" />
                 </Link>
 
-                <NavigationMenu className="hidden md:flex">
+                <NavigationMenu className="hidden lg:flex">
                     <NavigationMenuList>
                         {navItems.map((item) =>
                             item.kind === "group" ? (

--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -32,8 +32,8 @@ function AppLayout() {
 
     return (
         // The bottom padding keeps the footer clear of the fixed bottom bar,
-        // which only exists below md.
-        <div className="flex min-h-screen flex-col pb-16 md:pb-0">
+        // which only exists below lg.
+        <div className="flex min-h-screen flex-col pb-16 lg:pb-0">
             <SiteHeader
                 navItems={navItems}
                 user={currentUser}

--- a/apps/kvark/src/routes/_app/annonser.index.tsx
+++ b/apps/kvark/src/routes/_app/annonser.index.tsx
@@ -50,7 +50,7 @@ function JobsPage() {
                 </p>
             </Reveal>
 
-            <div className="grid gap-6 md:grid-cols-[20rem_1fr]">
+            <div className="grid gap-6 md:grid-cols-[20rem_minmax(0,1fr)]">
                 <aside>
                     <JobFilters
                         value={filters}

--- a/apps/kvark/src/routes/_app/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.index.tsx
@@ -170,7 +170,7 @@ function EventsPage() {
                 </p>
             </Reveal>
 
-            <div className="grid gap-6 md:grid-cols-[20rem_1fr]">
+            <div className="grid gap-6 md:grid-cols-[20rem_minmax(0,1fr)]">
                 <aside>
                     <EventFilters
                         value={filters}

--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -285,9 +285,11 @@ function SectionHeader({
 }) {
     return (
         <Reveal
-            render={<div className="flex items-center justify-between gap-4" />}
+            render={
+                <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2" />
+            }
         >
-            <h2 className="text-2xl">{title}</h2>
+            <h2 className="min-w-0 text-2xl">{title}</h2>
             {actionLabel && actionTo ? (
                 <Button
                     variant="ghost"

--- a/apps/kvark/src/routes/_app/playground.markdown.tsx
+++ b/apps/kvark/src/routes/_app/playground.markdown.tsx
@@ -77,8 +77,8 @@ function MarkdownPlaygroundPage() {
                 </p>
             </div>
 
-            <div className="grid gap-4 lg:grid-cols-2">
-                <div className="flex flex-col gap-2">
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <div className="flex min-w-0 flex-col gap-2">
                     <h2 className="text-lg">Editor — rich registry</h2>
                     <RichEditor
                         registry={richRegistry}
@@ -87,7 +87,7 @@ function MarkdownPlaygroundPage() {
                     />
                 </div>
 
-                <div className="flex flex-col gap-2">
+                <div className="flex min-w-0 flex-col gap-2">
                     <h2 className="text-lg">Editor — callout-only registry</h2>
                     <RichEditor
                         registry={calloutOnlyRegistry}

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -245,7 +245,7 @@ function RouteComponent() {
                     }}
                 />
             ) : null}
-            <div className="grid gap-6 md:grid-cols-[16rem_1fr]">
+            <div className="grid gap-6 md:grid-cols-[16rem_minmax(0,1fr)]">
                 <ProfileNav
                     navGroups={navGroups}
                     onLogout={isOwnProfile ? handleLogout : undefined}

--- a/apps/kvark/src/routes/_dev/form-test.tsx
+++ b/apps/kvark/src/routes/_dev/form-test.tsx
@@ -821,7 +821,7 @@ function FormTestPage() {
                     </CardHeader>
                     <CardContent>
                         <FieldGroup>
-                            <div className="grid grid-cols-[1fr_auto] items-end gap-3">
+                            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3">
                                 <form.AppField name="meetingDate">
                                     {(field) => (
                                         <field.Field required>
@@ -847,7 +847,7 @@ function FormTestPage() {
                                 </form.AppField>
                             </div>
 
-                            <div className="grid grid-cols-[1fr_auto] items-end gap-3">
+                            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3">
                                 <form.AppField name="birthMonth">
                                     {(field) => (
                                         <field.Field required>
@@ -935,7 +935,7 @@ function FormTestPage() {
                         </CardDescription>
                     </CardHeader>
                     <CardContent>
-                        <div className="grid gap-4 md:grid-cols-[18rem_1fr]">
+                        <div className="grid gap-4 md:grid-cols-[18rem_minmax(0,1fr)]">
                             <JobFiltersDemo />
                             <div className="flex items-center justify-center rounded-lg border border-dashed p-8 text-sm text-muted-foreground">
                                 Resultatområde (mock)

--- a/packages/ui/src/components/complex/markdown/markdown-content.tsx
+++ b/packages/ui/src/components/complex/markdown/markdown-content.tsx
@@ -26,6 +26,10 @@ export function MarkdownContent({
             data-slot="markdown-content"
             className={cn(
                 "prose prose-sm max-w-none",
+                // Markdown kan inneholde innhold som er bredere enn skjermen
+                // (tabeller, kodeblokker, lange URL-er). Det skal skrolle i sin
+                // egen boks — ellers presser det hele sida ut på mobil.
+                "break-words [&_pre]:overflow-x-auto [&_table]:block [&_table]:w-full [&_table]:overflow-x-auto",
                 "[&_.ProseMirror]:outline-none [&_.ProseMirror]:min-h-32",
                 "[&_.ProseMirror>:first-child]:mt-0 [&_.ProseMirror>:last-child]:mb-0",
                 // Skrivefeil fra den norske stavekontrollen. Samme rød


### PR DESCRIPTION
Oppfølger til #460. Der fikset vi gruppekortene; her er resten av appen sveipet systematisk.

## Metode

Sveipet **alle** ruter — 23 offentlige, 14 admin, pluss detaljsider — på **320, 375, 768, 820, 1024 og 1440px**, og målte `documentElement.scrollWidth` mot `clientWidth` på hver. For hvert treff ble den faktiske skyldige funnet ved å skjule subtrær til overflowen forsvant, ikke gjettet.

Verdt å merke seg: appen har **ingen** global `overflow-x: hidden`, så målingene er ærlige. Jeg la heller ikke inn en slik sikring — den ville skjult framtidige tilfeller i stedet for å fikse dem.

## Fire uavhengige årsaker

**1. Headeren — traff alle sider i båndet 768–812px (bl.a. iPad portrait)**
Desktop-menyen slås på ved `md` (768px) og krever 534px, men har bare 490px ledig ved siden av logo og profilklynge. Det finnes ikke nok å spare på gap/padding, så menyen og bunnlinja er flyttet fra `md` til `lg` som par. Nettbrett i portrett beholder mobilnavigasjonen til desktop-menyen faktisk får plass.

**2. `1fr`-spor uten min-content-gulv**
`1fr` er `minmax(auto,1fr)`, så sporet kunne ikke krympe under innholdets min-content. Byttet til `minmax(0,1fr)` i `arrangementer`, `annonser`, `profil/$id`, `detail-page`, `detail-layout`, `detail-date-range` og `form-test`. Dette var samme grunnårsak som i #460.

**3. Lange, ubrytelige ord i `DetailHeader`**
«Forvaltningsgruppen» sprengte headeren på 320px. Lagt til `break-words`.

**4. Markdown med brede tabeller/kodeblokker**
Presset hele sida ut. Tabeller og `pre` skroller nå i sin egen boks — fikset i `@tihlde/ui` siden den eier typografien, så det gjelder også nyheter og arrangementsbeskrivelser, ikke bare playground-sida.

## Verifisert

`scrollWidth === clientWidth` på alle ruter på alle seks bredder. Tabeller skroller i sin egen boks med sida i ro (verifisert visuelt). `typecheck` (kvark + ui), `build`, `lint` og `format` er grønne.

## Verdt å vite for review

- **Punkt 1 er en UX-endring, ikke bare en bugfix.** Nettbrett i portrett (768–1023px) får nå mobilmenyen i stedet for desktop-menyen. Det var den eneste måten å fjerne overflowen på uten å klippe vekk navigasjonspunkter. Si fra om dere heller vil ha en annen løsning her — f.eks. kortere menyetiketter så den passer ved `md`.
- `form-test.tsx` og `playground.markdown.tsx` er dev-sider, men de er routbare, så de er tatt med.
- Sveipet kjørte mot lokal database. Innhold i prod kan være lengre enn lokalt og utløse tilfeller jeg ikke traff — men de tre grunnårsakene over er strukturelle og gjelder uansett innhold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)