### PR TITLE
perf(kvark): gjør hero-animasjonen compositor-only

### DIFF
--- a/apps/kvark/src/components/hero-section.tsx
+++ b/apps/kvark/src/components/hero-section.tsx
@@ -5,40 +5,41 @@ import React from "react";
 const lineCount = 32;
 const svgWidth = 1440;
 const svgHeight = 720;
-const svgCenterX = svgWidth / 2;
 const svgCenterY = svgHeight / 2;
 const waveLoopDistance = (svgWidth * 2) / 3;
 const waveDrawEnd = svgWidth + waveLoopDistance;
 const waveSegmentWidth = svgWidth / 12;
-const contentFadeXRadius = svgWidth * 0.42;
-const contentFadeYRadius = svgHeight * 0.42;
-const scrollDurationSeconds = 24;
 const formatCoordinate = (value: number) => value.toFixed(1);
 
-// Heartbeat pulse: a light-blue highlight sweeps across the waves in ~2s,
-// then rests until the next beat — an 8s cycle (2s / 8s = 0.25 keyTime).
+// The drawn strip is wider than the hero so it can loop: the scroll layer is
+// `waveDrawEnd` units wide and slides left by exactly `waveLoopDistance`, which
+// is one wavelength of the pattern, so the frame it lands on is identical to
+// the one it started from. Both are expressed as percentages because the
+// animation lives in CSS — see `hero-waves-drift` in @tihlde/ui's styles.css.
+const scrollLayerWidthPercent = (waveDrawEnd / svgWidth) * 100;
+const scrollLoopPercent = (waveLoopDistance / waveDrawEnd) * 100;
+
 // Electric blue: a saturated theme-primary (navy-500) halo around a bright,
 // near-white blue core line — reads as a neon/electric glow within the theme.
 const pulseGlowColor = "#1B61E4";
 const pulseCoreColor = "#9AC2FF";
-const pulseCycleSeconds = 14;
 const pulseBandWidth = 900;
-// Slow, smooth right-to-left glide (Stripe-like): one soft glow drifts across
-// over ~8s with gentle ease-in-out, then rests off-screen until the next pass.
-const pulseKeyTimes = "0;0.57;1";
-const pulseValues = [
-    `${svgWidth} 0`,
-    `-${pulseBandWidth} 0`,
-    `-${pulseBandWidth} 0`,
-].join(";");
-const pulseKeySplines = "0.42 0 0.58 1;0 0 1 1";
+const pulseBandWidthPercent = (pulseBandWidth / svgWidth) * 100;
+// The scroll layer nested inside the band, as a percentage of the *band* —
+// it still has to come out to `scrollLayerWidthPercent` of the hero itself.
+const bandScrollLayerWidthPercent =
+    (scrollLayerWidthPercent / pulseBandWidthPercent) * 100;
+
 // Smooth Gaussian falloff for the glow band. Many closely-spaced stops avoid
 // the visible slope-change "bands" (Mach banding) that a few stops produce.
-const pulseStops = Array.from({ length: 25 }, (_, i) => {
-    const offset = i / 24;
-    const opacity = Math.exp(-Math.pow((offset - 0.5) / 0.22, 2));
-    return { offset, opacity };
-});
+const pulseBandMask = `linear-gradient(90deg, ${Array.from(
+    { length: 25 },
+    (_, i) => {
+        const offset = i / 24;
+        const opacity = Math.exp(-Math.pow((offset - 0.5) / 0.22, 2));
+        return `rgb(0 0 0 / ${opacity.toFixed(3)}) ${(offset * 100).toFixed(1)}%`;
+    },
+).join(", ")})`;
 
 type WaveConfig = {
     yBase: number;
@@ -86,15 +87,58 @@ function buildWavePath(config: WaveConfig) {
     return path;
 }
 
-export function HeroSectionBackground({ className }: { className?: string }) {
-    const fadeId = React.useId().replace(/:/g, "");
-    const vignetteGradientId = `${fadeId}-vignette-gradient`;
-    const contentFadeGradientId = `${fadeId}-content-fade-gradient`;
-    const vignetteMaskId = `${fadeId}-vignette-mask`;
-    const pulseGradientId = `${fadeId}-pulse-gradient`;
-    const pulseMaskId = `${fadeId}-pulse-mask`;
-    const pulseGlowId = `${fadeId}-pulse-glow`;
+const wavePaths = Array.from({ length: lineCount }).map((_, i) => {
+    const yBase = (i / (lineCount - 1)) * svgHeight;
+    const depth = Math.abs(yBase - svgCenterY) / svgCenterY;
 
+    return buildWavePath({
+        yBase,
+        amp: 22 + (1 - depth) * 38,
+        phase: i * 0.22,
+        width: svgWidth,
+        startX: 0,
+        endX: waveDrawEnd,
+    });
+});
+
+/**
+ * One copy of the wave strip. `preserveAspectRatio="none"` stretches it to fill
+ * whatever box it is given, so every copy lines up pixel for pixel with the
+ * others regardless of the hero's aspect ratio.
+ */
+function WaveStrip({
+    stroke,
+    strokeWidth,
+    strokeOpacity,
+    keyPrefix,
+}: {
+    stroke: string;
+    strokeWidth: number;
+    strokeOpacity?: number;
+    keyPrefix: string;
+}) {
+    return (
+        <svg
+            viewBox={`0 0 ${waveDrawEnd} ${svgHeight}`}
+            preserveAspectRatio="none"
+            className="absolute inset-0 h-full w-full"
+            aria-hidden
+        >
+            {wavePaths.map((path, i) => (
+                <path
+                    key={`${keyPrefix}-${i}`}
+                    d={path}
+                    fill="none"
+                    stroke={stroke}
+                    strokeWidth={strokeWidth}
+                    strokeOpacity={strokeOpacity}
+                />
+            ))}
+        </svg>
+    );
+}
+
+export function HeroSectionBackground({ className }: { className?: string }) {
     // Ingen bevegelse for de som har bedt om det. Pulslaget droppes helt i
     // stedet for bare å stoppes: uten animasjonen ville glødebåndet blitt
     // stående som en statisk stripe midt i bildet.
@@ -102,199 +146,81 @@ export function HeroSectionBackground({ className }: { className?: string }) {
         "(prefers-reduced-motion: reduce)",
     );
 
-    const paths = React.useMemo(
-        () =>
-            Array.from({ length: lineCount }).map((_, i) => {
-                const yBase = (i / (lineCount - 1)) * svgHeight;
-                const depth = Math.abs(yBase - svgCenterY) / svgCenterY;
-                const amp = 22 + (1 - depth) * 38;
-
-                return buildWavePath({
-                    yBase,
-                    amp,
-                    phase: i * 0.22,
-                    width: svgWidth,
-                    startX: 0,
-                    endX: waveDrawEnd,
-                });
-            }),
-        [],
-    );
-
     return (
-        <svg
-            viewBox={`0 0 ${svgWidth} ${svgHeight}`}
-            preserveAspectRatio="none"
+        <div
+            data-slot="hero-waves"
             className={cn(
-                "absolute inset-0 w-full h-[90vh] text-black",
+                "absolute inset-0 h-[90vh] w-full overflow-hidden text-black",
                 className,
             )}
+            style={
+                {
+                    "--hero-waves-loop": `${scrollLoopPercent}%`,
+                } as React.CSSProperties
+            }
+            aria-hidden
         >
-            <defs>
-                <radialGradient
-                    id={vignetteGradientId}
-                    cx="0"
-                    cy="0"
-                    r="1"
-                    gradientTransform={`translate(${svgCenterX} ${svgCenterY}) scale(${svgWidth * 1.2} ${svgHeight * 0.5})`}
-                    gradientUnits="userSpaceOnUse"
+            <div className="absolute inset-0 opacity-40 dark:opacity-[0.28]">
+                <div
+                    data-slot="hero-waves-drift"
+                    className="absolute inset-y-0 left-0"
+                    style={{ width: `${scrollLayerWidthPercent}%` }}
                 >
-                    <stop offset="0%" stopColor="white" stopOpacity="1" />
-                    <stop offset="50%" stopColor="white" stopOpacity="1" />
-                    <stop offset="100%" stopColor="white" stopOpacity="0" />
-                </radialGradient>
-                <radialGradient
-                    id={contentFadeGradientId}
-                    cx="0"
-                    cy="0"
-                    r="1"
-                    gradientTransform={`translate(${svgCenterX} ${svgCenterY}) scale(${contentFadeXRadius} ${contentFadeYRadius})`}
-                    gradientUnits="userSpaceOnUse"
-                >
-                    <stop offset="0%" stopColor="black" stopOpacity="0.92" />
-                    <stop offset="58%" stopColor="black" stopOpacity="0.92" />
-                    <stop offset="100%" stopColor="black" stopOpacity="0" />
-                </radialGradient>
-                <mask
-                    id={vignetteMaskId}
-                    maskUnits="userSpaceOnUse"
-                    x="0"
-                    y="0"
-                    width={svgWidth}
-                    height={svgHeight}
-                >
-                    <rect
-                        width={svgWidth}
-                        height={svgHeight}
-                        fill={`url(#${vignetteGradientId})`}
+                    <WaveStrip
+                        keyPrefix="line"
+                        stroke="currentColor"
+                        strokeWidth={0.8}
                     />
-                    <rect
-                        width={svgWidth}
-                        height={svgHeight}
-                        fill={`url(#${contentFadeGradientId})`}
-                    />
-                </mask>
-                <linearGradient
-                    id={pulseGradientId}
-                    gradientUnits="userSpaceOnUse"
-                    x1="0"
-                    y1="0"
-                    x2={pulseBandWidth}
-                    y2="0"
-                >
-                    {pulseStops.map((stop) => (
-                        <stop
-                            key={stop.offset}
-                            offset={stop.offset}
-                            stopColor="white"
-                            stopOpacity={stop.opacity}
-                        />
-                    ))}
-                    <animateTransform
-                        attributeName="gradientTransform"
-                        type="translate"
-                        dur={`${pulseCycleSeconds}s`}
-                        keyTimes={pulseKeyTimes}
-                        keySplines={pulseKeySplines}
-                        calcMode="spline"
-                        values={pulseValues}
-                        repeatCount="indefinite"
-                    />
-                </linearGradient>
-                <mask
-                    id={pulseMaskId}
-                    maskUnits="userSpaceOnUse"
-                    x="0"
-                    y="0"
-                    width={svgWidth}
-                    height={svgHeight}
-                >
-                    <rect
-                        width={svgWidth}
-                        height={svgHeight}
-                        fill={`url(#${pulseGradientId})`}
-                    />
-                </mask>
-                <filter
-                    id={pulseGlowId}
-                    x="-20%"
-                    y="-20%"
-                    width="140%"
-                    height="140%"
-                >
-                    <feGaussianBlur stdDeviation="3" />
-                </filter>
-            </defs>
-            <g
-                className="opacity-40 dark:opacity-[0.28]"
-                mask={`url(#${vignetteMaskId})`}
-            >
-                <g>
-                    {prefersReducedMotion ? null : (
-                        <animateTransform
-                            attributeName="transform"
-                            dur={`${scrollDurationSeconds}s`}
-                            from="0 0"
-                            repeatCount="indefinite"
-                            to={`-${waveLoopDistance} 0`}
-                            type="translate"
-                        />
-                    )}
-                    {paths.map((path, i) => (
-                        <path
-                            key={i}
-                            d={path}
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth={0.8}
-                        />
-                    ))}
-                </g>
-            </g>
+                </div>
+            </div>
+
             {prefersReducedMotion ? null : (
-                <g mask={`url(#${pulseMaskId})`}>
-                    <g mask={`url(#${vignetteMaskId})`}>
-                        <g>
-                            <animateTransform
-                                attributeName="transform"
-                                dur={`${scrollDurationSeconds}s`}
-                                from="0 0"
-                                repeatCount="indefinite"
-                                to={`-${waveLoopDistance} 0`}
-                                type="translate"
-                            />
+                <div
+                    data-slot="hero-waves-sweep"
+                    className="absolute inset-y-0 left-0"
+                    style={{
+                        width: `${pulseBandWidthPercent}%`,
+                        maskImage: pulseBandMask,
+                    }}
+                >
+                    <div
+                        data-slot="hero-waves-sweep-counter"
+                        className="absolute inset-0"
+                    >
+                        <div
+                            data-slot="hero-waves-drift"
+                            className="absolute inset-y-0 left-0"
+                            style={{
+                                width: `${bandScrollLayerWidthPercent}%`,
+                            }}
+                        >
                             {/*
-                             * Filteret ligger på gruppen, ikke på hver path.
-                             * Per path ble det ett Gaussian-blur-pass per linje
-                             * per frame (32 stk) og forsiden falt til ~29 FPS på
-                             * mobil. Linjene overlapper knapt, så ett felles
-                             * pass ser tilnærmet likt ut.
+                             * Softness comes from a CSS blur on this wrapper,
+                             * not an SVG filter. A filter inside the SVG is
+                             * re-run every frame the SVG moves; this one is
+                             * baked into the layer's raster once and then just
+                             * translated with it.
                              */}
-                            <g filter={`url(#${pulseGlowId})`}>
-                                {paths.map((path, i) => (
-                                    <path
-                                        key={`glow-${i}`}
-                                        d={path}
-                                        fill="none"
-                                        stroke={pulseGlowColor}
-                                        strokeWidth={7}
-                                        strokeOpacity={0.7}
-                                    />
-                                ))}
-                            </g>
-                            {paths.map((path, i) => (
-                                <path
-                                    key={`beat-${i}`}
-                                    d={path}
-                                    fill="none"
-                                    stroke={pulseCoreColor}
-                                    strokeWidth={1.6}
+                            <div
+                                className="absolute inset-0"
+                                style={{ filter: "blur(2px)" }}
+                            >
+                                <WaveStrip
+                                    keyPrefix="glow"
+                                    stroke={pulseGlowColor}
+                                    strokeWidth={7}
+                                    strokeOpacity={0.7}
                                 />
-                            ))}
-                        </g>
-                    </g>
-                </g>
+                            </div>
+                            <WaveStrip
+                                keyPrefix="beat"
+                                stroke={pulseCoreColor}
+                                strokeWidth={1.6}
+                            />
+                        </div>
+                    </div>
+                </div>
             )}
-        </svg>
+        </div>
     );
 }

--- a/apps/kvark/src/routes/_app/opptak.tsx
+++ b/apps/kvark/src/routes/_app/opptak.tsx
@@ -70,7 +70,9 @@ function AdmissionsPage() {
                     <p className="text-muted-foreground">
                         Bli med på å skape studentmiljøet
                     </p>
-                    <h1 className="text-4xl font-bold md:text-6xl">Søk verv!</h1>
+                    <h1 className="text-4xl font-bold md:text-6xl">
+                        Søk verv!
+                    </h1>
                     <p className="text-muted-foreground">
                         Her finner du en oversikt over alle vervene i TIHLDE.
                         Søk på vervene du er interessert i, og bli med på å

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -374,6 +374,117 @@
     --tw-prose-kbd: var(--foreground);
 }
 
+/* ── Hero waves ───────────────────────────────────────────────────────────
+   Backing animation for <HeroSectionBackground>. Every moving part here is a
+   `transform` on its own layer, and nothing that moves is ever re-painted:
+   the whole thing is handed to the compositor once and then only translated.
+
+   That constraint is the entire point. The first version drove this with SMIL
+   inside the SVG — an `animateTransform` on the line groups plus one on a
+   gradient that fed a `<mask>`, with an `feGaussianBlur` on top. None of those
+   can be composited: an animated mask has to be regenerated and re-applied
+   every frame, over a full-viewport element, on the main thread. On a phone
+   that is a continuous full-screen repaint behind a `backdrop-blur` header,
+   which is why the sweep stuttered and why opening the menu on the front page
+   felt stuck — the animation was starving everything else.
+
+   The sweep is the interesting bit. A highlight window has to travel while the
+   lines it lights up stay put, so the band carries a *static* mask and moves,
+   and its child moves back by exactly the same amount. Net motion of the lines
+   is zero, both transforms are compositor-only, and the mask never changes.
+   The two keyframes below are inverses of each other and share a duration —
+   they must be edited as a pair or the highlighted lines will drift out of
+   register with the ones underneath. */
+@keyframes hero-waves-drift {
+    from {
+        transform: translate3d(0, 0, 0);
+    }
+    to {
+        /* One full wavelength of the pattern, so the loop is seamless. The
+           distance is geometry, so it comes from the component that draws the
+           waves rather than being restated here. */
+        transform: translate3d(calc(-1 * var(--hero-waves-loop, 40%)), 0, 0);
+    }
+}
+
+@keyframes hero-waves-sweep {
+    0% {
+        transform: translate3d(160%, 0, 0);
+        animation-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
+    }
+    /* Crosses in the first 57% of the cycle, then waits off-screen — the rest
+       is what makes it read as an occasional pass rather than a conveyor. */
+    57%,
+    100% {
+        transform: translate3d(-100%, 0, 0);
+    }
+}
+
+@keyframes hero-waves-sweep-counter {
+    0% {
+        transform: translate3d(-160%, 0, 0);
+        animation-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
+    }
+    57%,
+    100% {
+        transform: translate3d(100%, 0, 0);
+    }
+}
+
+[data-slot="hero-waves-drift"] {
+    animation: hero-waves-drift var(--hero-waves-drift-duration, 18s) linear
+        infinite;
+    will-change: transform;
+}
+
+[data-slot="hero-waves-sweep"] {
+    animation: hero-waves-sweep var(--hero-waves-sweep-duration, 9s) infinite;
+    will-change: transform;
+}
+
+[data-slot="hero-waves-sweep-counter"] {
+    animation: hero-waves-sweep-counter var(--hero-waves-sweep-duration, 9s)
+        infinite;
+    will-change: transform;
+}
+
+/* Freeze the whole thing while the mobile menu is open. That drawer lays a
+   full-viewport `backdrop-filter` scrim over the page, and a backdrop filter
+   has to be re-sampled on every frame its backdrop moves — so the waves were
+   buying a full-screen blur recomputation per frame to animate something the
+   user cannot see through the blur anyway.
+
+   Keyed off the drawer's own `data-state` rather than <body>'s
+   `data-scroll-locked`: closing the menu by tapping a link navigates away
+   mid-close and vaul never removes that attribute, which would leave the hero
+   frozen for the rest of the session. This selector is correct on both close
+   paths, and if it ever stops matching the animation simply keeps running. */
+body:has([data-slot="drawer-content"][data-state="open"])
+    [data-slot^="hero-waves"] {
+    animation-play-state: paused;
+}
+
+/* Fades the lines out towards the edges and holds them well back behind the
+   hero copy. Painted once as a static mask; the layers underneath animate
+   inside it. `intersect` multiplies the two, so the centre keeps the 8% the
+   second gradient leaves and the outer falloff still applies on top. */
+[data-slot="hero-waves"] {
+    mask-image:
+        radial-gradient(
+            120% 50% at 50% 50%,
+            #000 0%,
+            #000 50%,
+            transparent 100%
+        ),
+        radial-gradient(
+            42% 42% at 50% 50%,
+            rgb(0 0 0 / 0.08) 0%,
+            rgb(0 0 0 / 0.08) 58%,
+            #000 100%
+        );
+    mask-composite: intersect;
+}
+
 /* Møtetid: subtle nudge on the primary action when the user tries to paint
    the grid before entering edit mode. */
 @keyframes motetid-primary-nudge {


### PR DESCRIPTION
Mobilmenyen lagget, ting føltes tregt, og den lyse stripen i heroen hakket seg sakte bortover mot venstre. Alle tre har samme årsak.

## Årsaken

Hero-bakgrunnen ble drevet av SMIL inne i SVG-en: `animateTransform` på linjegruppene, én på en gradient som matet en `<mask>`, og en `feGaussianBlur` på toppen.

**Ingen av de tre kan komposittes.** En animert maske må regenereres og påføres på nytt hver eneste frame, over et element som dekker hele viewporten, på hovedtråden. Det er en kontinuerlig fullskjerm-repaint — som er nøyaktig hvorfor stripen hakket, og hvorfor menyen og sidelastingen føltes trege: animasjonen sultet alt annet. Koden hadde allerede en kommentar om at forsiden falt til ~29 FPS på mobil av samme grunn (glow-filteret ble den gangen flyttet fra hver path til gruppen).

Menyen har i tillegg en `backdrop-filter`-skjerm over hele viewporten, og et backdrop-filter må re-samples hver frame bakgrunnen beveger seg — så mens menyen var åpen betalte vi en fullskjerms blur-reberegning per frame for noe man ikke kan se gjennom bluren uansett.

## Endringen

**`apps/kvark/src/components/hero-section.tsx`** — alt som beveger seg er nå en `transform` på sitt eget lag, og ingenting som beveger seg males om.

Lysstripen er den interessante biten: et lysvindu skal bevege seg mens linjene det lyser opp står stille. Løsningen er at båndet bærer en *statisk* maske og flytter seg, mens barnet flytter seg nøyaktig like langt tilbake. Netto bevegelse på linjene er null, begge transformene er compositor-only, og masken endrer seg aldri. De to keyframene er inverser av hverandre og deler varighet — de må redigeres som et par.

Vignetten er nå en statisk CSS-maske (`mask-composite: intersect`), og gløden bruker `filter: blur()` på en wrapper, som bakes inn i lagets raster én gang i stedet for en SVG-filter som kjøres på nytt hver frame.

**`packages/ui/src/styles.css`** — keyframes ligger her, som resten av animasjonene (kvark får ikke ha animasjonsklasser, jf. `apps/kvark/CLAUDE.md`). Pluss regelen som fryser bølgene mens mobilmenyen er åpen.

Tempoet er også satt opp: sveipet krysser på ~5,1 s (mot ~8 s), driften går på 18 s (mot 24 s).

## Verdt å vite for review

**Pause-regelen henger på drawerens egen `data-state`, ikke på `body[data-scroll-locked]`.** Førstevalget var `data-scroll-locked`, men når du lukker menyen ved å trykke på en lenke navigerer ruten bort midt i lukkingen og vaul fjerner aldri det attributtet. Det ville frosset heroen resten av økta. Testet på begge lukkeveiene — Escape og lenkeklikk. Feilmodusen for `:has()`-selektoren er godartet: treffer den ikke, kjører animasjonen bare videre som i dag.

Sidefunn, ikke rørt her: at `data-scroll-locked` blir liggende igjen på `<body>` etter navigering fra menyen er en reell (om enn tilsynelatende harmløs) lekkasje i drawer-oppsettet.

`opptak.tsx` er kun formatering — filen brøt prosjektets eget oxfmt-oppsett på `dev`.

## Verifisering

- Sveip og motbevegelse er eksakte inverser (`-221.444px` / `+221.444px`) og deler tidslinje — linjene i båndet står i register med de under.
- Rest-fasen ser identisk ut med før endringen, så vignett-geometrien stemmer. Sjekket på mobil (375×812) og desktop, og på `/ny-student`.
- Ingen nye console-feil.
- `typecheck`, `lint` og `format` passerer; `build` går grønt, og keyframes, `mask-composite: intersect` (lightningcss la selv på `-webkit-mask-composite: source-in`) og pause-regelen ligger i byggets CSS.

**Ikke verifisert:** FPS. Browser-panelet rapporterer `visibilityState: hidden`, så `requestAnimationFrame` er strupet og et tall derfra ville vært meningsløst. Beviset over er strukturelt — hva som faktisk kjører per frame — ikke en måling. Bør bekreftes på en ekte telefon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)