### PR TITLE
fix(oauth): videresend sesjonscookien når samtykkesiden lastes server-side

### DIFF
--- a/apps/kvark/src/api/queries/oauth.ts
+++ b/apps/kvark/src/api/queries/oauth.ts
@@ -1,4 +1,6 @@
 import { mutationOptions, queryOptions } from "@tanstack/react-query";
+import { createIsomorphicFn } from "@tanstack/react-start";
+import { getRequestHeaders } from "@tanstack/react-start/server";
 import { clientAuthInstance } from "#/api/auth";
 
 const OAuthQueryKeys = {
@@ -42,17 +44,44 @@ async function unwrap<T>(
     return result.data as T;
 }
 
+/**
+ * Henter klienten både på server og klient.
+ *
+ * `/oauth2/get-client` krever sesjon, og samtykkesiden laster den i en loader
+ * — som kjører server-side under SSR. Der følger ikke nettleserens
+ * sesjonscookie med av seg selv, så forespørselen kom fram uautentisert og
+ * Photon svarte 401. Samme mønster som `getAuthSession` i #/api/auth.
+ */
+const fetchOAuthClient = createIsomorphicFn()
+    .client(async (clientId: string) =>
+        clientAuthInstance.oauth2.getClient({
+            query: { client_id: clientId },
+        }),
+    )
+    .server(async (clientId: string) =>
+        clientAuthInstance.oauth2.getClient({
+            query: { client_id: clientId },
+            fetchOptions: { headers: getRequestHeaders() },
+        }),
+    );
+
 export const oauthClientQuery = (clientId: string) =>
     queryOptions({
         queryKey: [...OAuthQueryKeys.client, clientId],
         queryFn: async () =>
             unwrap<OAuthClientPublic>(
-                await clientAuthInstance.oauth2.getClient({
-                    query: { client_id: clientId },
-                }),
+                await fetchOAuthClient(clientId),
                 "Kunne ikke hente OAuth-klient",
             ),
     });
+
+const fetchOAuthClients = createIsomorphicFn()
+    .client(async () => clientAuthInstance.oauth2.getClients())
+    .server(async () =>
+        clientAuthInstance.oauth2.getClients({
+            fetchOptions: { headers: getRequestHeaders() },
+        }),
+    );
 
 export const oauthClientsQuery = queryOptions({
     queryKey: [...OAuthQueryKeys.clientList],
@@ -61,7 +90,7 @@ export const oauthClientsQuery = queryOptions({
     staleTime: 0,
     queryFn: async () =>
         unwrap<OAuthClientFull[]>(
-            await clientAuthInstance.oauth2.getClients(),
+            await fetchOAuthClients(),
             "Kunne ikke hente OAuth-klienter",
         ),
 });


### PR DESCRIPTION
Innlogging via OAuth stopper på samtykkesiden med:

```
Kunne ikke hente OAuth-klient: Unauthorized
```

## Årsak

Samtykkesiden henter klientdetaljene fra `/api/auth/oauth2/get-client`, som krever sesjon. Den lastes i en `loader` — og loadere kjører **server-side under SSR**. Der følger ikke nettleserens sesjonscookie med av seg selv, så Photon ser en uautentisert forespørsel og svarer 401.

Resten av appen løser dette allerede: `getAuthSession` i `#/api/auth` bruker `createIsomorphicFn()` med en `.server()`-variant som videresender `getRequestHeaders()`. OAuth-spørringene manglet det.

## Hvorfor det ikke ble oppdaget før

`skip_consent` avgjør om en klient i det hele tatt går innom siden:

| Klient | `skip_consent` |
|---|---|
| Fadderuka | **true** |
| Mordvember, Projects / Index, Pythons, Sporty / Proton | ikke satt |

Fadderuka hopper over samtykkesiden og fungerte derfor ende til ende. De fire andre traff veggen med én gang. Feilen var dessuten usynlig før den første OAuth-klienten fantes — ingen hadde noen gang blitt sendt til den siden.

## Endringen

`fetchOAuthClient` og `fetchOAuthClients` er nå isomorfe, med server-varianter som sender `getRequestHeaders()`. Ingen endring i oppførsel på klientsiden.

## Verifisert

Kvarks egen kode typesjekker rent (`tsc --noEmit`, ingen feil under `src/`) og `bun run build` er grønt.

Feilene som gjenstår i `@tihlde/ui` — manglende `remark-breaks` og to prosemirror-versjoner — er urelaterte og lå der fra før.

Selve samtykkerunden er ikke kjørt ende til ende; den krever en innlogging i nettleseren mot en deployet utgave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)