### PR TITLE
fix(auth): svar 409 når NTNU-brukernavnet allerede er tatt ved registrering

### DIFF
--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -109,6 +109,34 @@ export class HTTPAppException extends HTTPException {
 }
 
 /**
+ * PostgreSQL error code for a unique-constraint violation.
+ * https://www.postgresql.org/docs/current/errcodes-appendix.html
+ */
+const PG_UNIQUE_VIOLATION = "23505";
+
+/**
+ * True when `err` — or anything it wraps — is a PostgreSQL unique-constraint
+ * violation.
+ *
+ * Walks the cause chain because Drizzle wraps driver errors in a
+ * `DrizzleQueryError` that carries the `pg` error as `cause`, so the `code`
+ * is never on the error we are handed.
+ */
+function isUniqueViolation(err: unknown): boolean {
+    let current: unknown = err;
+    for (let depth = 0; current && depth < 5; depth++) {
+        if (
+            typeof current === "object" &&
+            (current as { code?: unknown }).code === PG_UNIQUE_VIOLATION
+        ) {
+            return true;
+        }
+        current = (current as { cause?: unknown }).cause;
+    }
+    return false;
+}
+
+/**
  * Global error handler for Hono apps.
  * Normalizes all errors to the standard response format.
  *
@@ -152,6 +180,26 @@ export function globalErrorHandler(err: Error, c: Context): Response {
             message: err.message || "An error occurred",
         };
         return c.json(response, err.status);
+    }
+
+    /**
+     * A unique index the code failed to check first is a conflict, not a
+     * server fault. Answering 500 here hands the caller "Internal server
+     * error" for something the user could act on — which is exactly how a
+     * student registering with an already-taken NTNU username ended up with an
+     * unreadable error instead of "log in instead" (issue #476).
+     *
+     * A safety net, not a substitute for checking: the message cannot say
+     * WHICH value collided without leaking column names, so routes should
+     * still look the conflict up and answer with something specific.
+     */
+    if (isUniqueViolation(err)) {
+        console.error("Unique constraint violation reached the handler:", err);
+        const response: HttpAppExceptionData = {
+            status: 409,
+            message: "Ressursen finnes allerede",
+        };
+        return c.json(response, 409);
     }
 
     // Unexpected errors - log and return generic message

--- a/apps/api/src/routes/user/register.ts
+++ b/apps/api/src/routes/user/register.ts
@@ -1,3 +1,4 @@
+import { usernameFromStudentEmail } from "@photon/auth";
 import {
     currentAcademicYear,
     syncBaselineRoles,
@@ -55,6 +56,11 @@ export const registerUserRoute = route().post(
         })
         .unauthorized()
         .forbidden({ description: "Requires an API key with 'users:create'" })
+        .response({
+            statusCode: 409,
+            description:
+                "Conflict - a member already holds this NTNU username or address; they should log in rather than register",
+        })
         .build(),
     requireAuthOrApiKey,
     validator("json", registerUserInputSchema),
@@ -96,6 +102,32 @@ export const registerUserRoute = route().post(
             throw new HTTPException(400, {
                 message: `No study programme with slug "${studyProgramSlug}"`,
             });
+        }
+
+        /**
+         * A member who already holds this NTNU username, told apart from the
+         * "address already in use" case Better Auth reports on its own.
+         *
+         * The two come apart constantly: an account made with Feide has
+         * `username` = NTNU username but `email` = whatever address Feide hands
+         * out, which is usually not `<username>@stud.ntnu.no`. So a student
+         * registering here with their stud address collides on the username
+         * while looking brand new by e-mail. The sign-up hook now catches this
+         * too; it is repeated here to answer with a 409 and a message the
+         * calling service can put in front of the student, rather than making
+         * them read whatever Better Auth's error happens to say.
+         */
+        const derivedUsername = usernameFromStudentEmail(email);
+        if (derivedUsername) {
+            const existing = await db.query.user.findFirst({
+                where: eq(schema.user.username, derivedUsername),
+                columns: { id: true },
+            });
+            if (existing) {
+                throw new HTTPException(409, {
+                    message: `Brukeren "${derivedUsername}" finnes allerede. Logg inn i stedet — med Feide, eller med «glemt passord» hvis passordet er borte.`,
+                });
+            }
         }
 
         let userId: string;

--- a/apps/api/src/test/user-register.test.ts
+++ b/apps/api/src/test/user-register.test.ts
@@ -91,6 +91,82 @@ describe("POST /api/user/register", () => {
         },
     );
 
+    /**
+     * A Feide-made account: `username` is the NTNU username, `email` is
+     * whatever address Feide handed out — usually NOT
+     * `<username>@stud.ntnu.no`. This is the shape that used to crash the
+     * route, since nothing looked at the username and the address looked new.
+     */
+    async function existingFeideAccount(
+        ctx: IntegrationTestContext,
+        username: string,
+    ): Promise<void> {
+        const user = await ctx.utils.createTestUser(
+            `${username}@privat.example.com`,
+        );
+        await ctx.db
+            .update(schema.user)
+            .set({ username })
+            .where(eq(schema.user.id, user.id));
+    }
+
+    integrationTest(
+        "answers 409 when the NTNU username is taken by another address",
+        async ({ ctx }) => {
+            await ctx.utils.createTestGroup({
+                slug: "dataingenir",
+                name: "Dataingeniør",
+                type: "STUDY",
+            });
+            await existingFeideAccount(ctx, "olanor");
+            const key = await apiKeyWith(ctx, ["users:create"]);
+
+            const res = await ctx.app.request("/api/user/register", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${key}`,
+                },
+                body: JSON.stringify(body),
+            });
+
+            // Not a 500: the caller has to be able to tell the student that
+            // what they want is to log in, not to register.
+            expect(res.status).toBe(409);
+            const { message } = (await res.json()) as { message: string };
+            expect(message).toContain("olanor");
+
+            // And nothing was created for the address that was still free.
+            const rows = await ctx.db
+                .select()
+                .from(schema.user)
+                .where(eq(schema.user.email, "olanor@stud.ntnu.no"));
+            expect(rows).toHaveLength(0);
+        },
+    );
+
+    integrationTest(
+        "the sign-up hook itself rejects a taken username",
+        async ({ ctx }) => {
+            // The website's own sign-up never touches the route above, so the
+            // check has to hold in the hook too — the username plugin's own
+            // uniqueness check does not run for /sign-up/email.
+            await existingFeideAccount(ctx, "olanor");
+
+            const res = await ctx.app.request("/api/auth/sign-up/email", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    name: body.name,
+                    email: body.email,
+                    password: body.password,
+                }),
+            });
+
+            expect(res.status).toBe(409);
+        },
+    );
+
     integrationTest("refuses a non-NTNU address", async ({ ctx }) => {
         const key = await apiKeyWith(ctx, ["users:create"]);
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -16,8 +16,10 @@ import {
     oauthProviderAuthServerMetadata,
     oauthProviderOpenIdConfigMetadata,
 } from "@better-auth/oauth-provider";
+import { eq } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { DbSchema } from "@photon/db";
+import { user } from "@photon/db/schema";
 import type { EmailService, CacheService } from "@photon/core/services";
 import { env } from "@photon/core/env";
 import { getUserPermissions } from "./rbac/permissions";
@@ -50,6 +52,22 @@ const isFeideConfigured = Boolean(
  */
 const STUD_NTNU_EMAIL_PATTERN =
     /^([a-z0-9]+(?:[._-][a-z0-9]+)*)@stud\.ntnu\.no$/;
+
+/**
+ * Username a self-registration would get from `email`, or undefined when the
+ * address is not one self-registration accepts.
+ *
+ * Exported so callers that create accounts through `signUpEmail` (the
+ * `users:create` route) can answer "is this student already here?" before
+ * handing the request to Better Auth, deriving the username exactly the way
+ * the sign-up hook below does rather than re-implementing the rule.
+ */
+export function usernameFromStudentEmail(
+    email: string | undefined,
+): string | undefined {
+    if (typeof email !== "string") return undefined;
+    return STUD_NTNU_EMAIL_PATTERN.exec(email.trim().toLowerCase())?.[1];
+}
 
 /**
  * Longest domain suffix shared by two URLs' hostnames, or undefined when the
@@ -314,11 +332,38 @@ export function createAuth(options: CreateAuthOptions) {
                         ? rawEmail.trim().toLowerCase()
                         : "";
 
-                const match = STUD_NTNU_EMAIL_PATTERN.exec(email);
-                if (!match) {
+                const derivedUsername = usernameFromStudentEmail(email);
+                if (!derivedUsername) {
                     throw new APIError("BAD_REQUEST", {
                         message:
                             "Registrering krever en @stud.ntnu.no-adresse.",
+                    });
+                }
+
+                /**
+                 * The username plugin's own uniqueness check never runs for
+                 * this request, so it is made here.
+                 *
+                 * `runBeforeHooks` collects what each hook returns into a
+                 * merged context but calls every hook with the ORIGINAL one, so
+                 * the plugin's `/sign-up/email` hook — which runs after this
+                 * one, plugin hooks being appended after the user hook — sees
+                 * `body.username === undefined` and skips its whole validation.
+                 * The plugin's database hook skips it too, since it treats
+                 * `/sign-up/email` as already validated over HTTP. Without this,
+                 * the only thing left is the unique index on `user.username`,
+                 * and a driver error reaching the error handler is a 500 —
+                 * which is what a student registering with an address that
+                 * differs from the one their Feide account carries used to get.
+                 */
+                const takenBy = await options.services.db.query.user.findFirst({
+                    where: eq(user.username, derivedUsername),
+                    columns: { id: true },
+                });
+                if (takenBy) {
+                    throw new APIError("CONFLICT", {
+                        message:
+                            "Det finnes allerede en bruker med dette NTNU-brukernavnet. Logg inn med Feide i stedet, eller bruk «glemt passord».",
                     });
                 }
 
@@ -326,7 +371,7 @@ export function createAuth(options: CreateAuthOptions) {
                 // must not be able to pick one that disagrees with their email.
                 return {
                     context: {
-                        body: { ...ctx.body, email, username: match[1] },
+                        body: { ...ctx.body, email, username: derivedUsername },
                     },
                 };
             }),

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -12329,6 +12329,13 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Conflict - a member already holds this NTNU username or address; they should log in rather than register */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     searchUsers: {


### PR DESCRIPTION
Fikser #476.

## Problemet

En student som allerede har en Photon-konto laget med Feide fikk en uleselig feil når de registrerte seg på nytt — via `POST /api/user/register` (Fadderuka) eller nettsidens eget skjema. Feide-kontoen har `username` = NTNU-brukernavn og `email` = adressen Feide oppgir, som sjelden er `<brukernavn>@stud.ntnu.no`. Registreringen ser derfor helt ny ut på e-post, men kolliderer på unik-indeksen `user.username`.

Better Auths egen unikhetssjekk på brukernavn kjører aldri for dette kallet. `runBeforeHooks` (better-auth 1.6.23) samler det hookene returnerer i en sammenslått kontekst, men kaller hver hook med den **opprinnelige** — så username-pluginens `/sign-up/email`-hook, som kjører etter vår, ser `body.username === undefined` og hopper over hele valideringen. Database-hooken hopper også over den, siden den regner `/sign-up/email` som validert over HTTP. Da står bare unik-indeksen igjen.

## Endringer

- **`packages/auth/src/index.ts`** — før-hooken som setter brukernavnet gjør nå unikhetssjekken selv og svarer 409 med en melding som sier «logg inn i stedet». Dekker også nettsidens sign-up. Utledningen er trukket ut i `usernameFromStudentEmail`, så begge stedene bruker samme regel.
- **`apps/api/src/routes/user/register.ts`** — slår opp brukernavnet før `signUpEmail`, på linje med slug-sjekken som alt gjøres der, og svarer 409 med brukernavnet i meldingen. 409 er dokumentert i OpenAPI.
- **`apps/api/src/lib/errors.ts`** — sikkerhetsnett: unik-brudd fra Postgres (`23505`, også når Drizzle pakker det i `DrizzleQueryError.cause`) blir 409 i stedet for «Internal server error».

## Verifisert

- Tre nye/utvidede integrasjonstester i `user-register.test.ts`: 409 fra ruta (og ingen bruker opprettet), 409 fra sign-up-hooken direkte. Begge feiler på `dev`-koden, går grønt med fiksen.
- `bunx vitest run src/test/user-register.test.ts src/test/user.test.ts src/test/auth src/test/feide` → 124 tester grønt.
- `typecheck` grønt for `@photon/api` og `@photon/auth`, `build` grønt, `lint`/`format` rent. (`@tihlde/ui#typecheck` feiler på duplikate `prosemirror-model`-versjoner — feiler også på `dev` uten disse endringene.)

**Merk:** lokalt, før fiksen, svarte kollisjonen `422 {"message":"Failed to create user"}` — better-auth pakker driverfeilen i en `UNPROCESSABLE_ENTITY`. Meldingen er like ubrukelig for studenten, men det er ikke 500. Hvis prod faktisk svarte 500 den 7. august, kan det ligge en annen årsak bak den ene responsen (f.eks. et unik-brudd i `syncDerivedStudyGroups`-transaksjonen etterpå, som var ufanget) — den er nå også dekket av sikkerhetsnettet i `globalErrorHandler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)