### PR TITLE
feat(admin): fjern medlem fra gruppe, og slett eller arkiver bruker

### DIFF
--- a/apps/api/src/routes/user/delete.ts
+++ b/apps/api/src/routes/user/delete.ts
@@ -1,0 +1,80 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { HTTPException } from "hono/http-exception";
+import { describeRoute } from "~/lib/openapi";
+import { route } from "~/lib/route";
+import { requireAccess } from "~/middleware/access";
+import { requireAuth } from "~/middleware/auth";
+
+/**
+ * Delete a member's account for good.
+ *
+ * The blunt instrument, kept next to `PATCH /:id/status` on purpose: almost
+ * every reason to remove someone is served better by deactivating them, which
+ * keeps registrations, fines and group history intact. This route is for the
+ * cases where the record itself has to go — a duplicate account, a test user,
+ * or a deletion request under GDPR.
+ *
+ * Everything hanging off the user cascades away with the row: registrations,
+ * payments, fines, memberships, membership history, contract signatures,
+ * sessions and role grants. Authored content (news, events, gallery albums)
+ * has its author set to null and survives.
+ */
+export const deleteUserRoute = route().delete(
+    "/:id",
+    describeRoute({
+        tags: ["users"],
+        summary: "Delete a member permanently",
+        operationId: "deleteUser",
+        description:
+            "Irreversibly deletes the account along with its registrations, payments, fines, memberships and history. Prefer 'PATCH /user/{id}/status' to deactivate instead. Requires 'users:delete'.",
+    })
+        .response({
+            statusCode: 204,
+            description: "User deleted",
+        })
+        .badRequest({ description: "Cannot delete your own account" })
+        .notFound({ description: "User not found" })
+        .unauthorized()
+        .forbidden({ description: "Requires users:delete" })
+        .build(),
+    requireAuth,
+    requireAccess({ permission: "users:delete" }),
+    async (c) => {
+        const { db } = c.get("ctx");
+        const userId = c.req.param("id");
+
+        // Same guard as deactivation: there may be no one else left holding
+        // the permission needed to undo it — and here there is no undo at all.
+        if (userId === c.get("user").id) {
+            throw new HTTPException(400, {
+                message: "You cannot delete your own account",
+            });
+        }
+
+        const user = await db.query.user.findFirst({
+            where: eq(schema.user.id, userId),
+            columns: { id: true },
+        });
+
+        if (!user) {
+            throw new HTTPException(404, {
+                message: `User "${userId}" not found`,
+            });
+        }
+
+        await db.transaction(async (tx) => {
+            // `group.fines_admin_id` is the one reference to a user that does
+            // not cascade or null itself — left alone it would abort the
+            // delete with a foreign key violation.
+            await tx
+                .update(schema.group)
+                .set({ finesAdminId: null })
+                .where(eq(schema.group.finesAdminId, userId));
+
+            await tx.delete(schema.user).where(eq(schema.user.id, userId));
+        });
+
+        return c.body(null, 204);
+    },
+);

--- a/apps/api/src/routes/user/index.ts
+++ b/apps/api/src/routes/user/index.ts
@@ -2,6 +2,7 @@ import { route } from "~/lib/route";
 import { allergyRoutes } from "./allergy";
 import { getUserAllergiesRoute } from "./allergy/get-for-user";
 import { updateUserAllergiesRoute } from "./allergy/update-for-user";
+import { deleteUserRoute } from "./delete";
 import { getUserRoute } from "./get";
 import { listUsersRoute } from "./list";
 import { meRoutes } from "./me";
@@ -20,5 +21,6 @@ export const userRoutes = route()
     .route("/", getUserAllergiesRoute)
     .route("/", updateUserAllergiesRoute)
     .route("/", updateUserStatusRoute)
+    .route("/", deleteUserRoute)
     // Last: `/:id` is a catch-all and would otherwise swallow `/search`.
     .route("/", getUserRoute);

--- a/apps/api/src/test/user-delete.test.ts
+++ b/apps/api/src/test/user-delete.test.ts
@@ -1,0 +1,127 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * DELETE /api/user/:id — removing an account for good.
+ *
+ * The destructive counterpart to `PATCH /api/user/:id/status`: everything
+ * hanging off the user goes with the row, so the tests below check both that
+ * the cascade actually runs and that the one non-cascading reference
+ * (`group.fines_admin_id`) does not abort it.
+ */
+describe("DELETE /api/user/:id", () => {
+    integrationTest("requires users:delete", async ({ ctx }) => {
+        const caller = await ctx.utils.createTestUser();
+        // `users:manage` is enough to deactivate, deliberately not to delete.
+        await ctx.utils.giveUserPermissions(caller, ["users:manage"]);
+        const client = await ctx.utils.clientForUser(caller);
+
+        const target = await ctx.utils.createTestUser();
+
+        const res = await client.api.user[":id"].$delete({
+            param: { id: target.id },
+        });
+
+        expect(res.status).toBe(403);
+
+        const [row] = await ctx.db
+            .select()
+            .from(schema.user)
+            .where(eq(schema.user.id, target.id));
+        expect(row).toBeDefined();
+    });
+
+    integrationTest(
+        "deletes the account and its memberships",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["users:delete"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            const target = await ctx.utils.createTestUser();
+            const group = await ctx.utils.createTestGroup();
+            await ctx.db.insert(schema.groupMembership).values({
+                userId: target.id,
+                groupSlug: group.slug,
+                role: "member",
+            });
+
+            const res = await client.api.user[":id"].$delete({
+                param: { id: target.id },
+            });
+
+            expect(res.status).toBe(204);
+
+            const rows = await ctx.db
+                .select()
+                .from(schema.user)
+                .where(eq(schema.user.id, target.id));
+            expect(rows).toHaveLength(0);
+
+            const memberships = await ctx.db
+                .select()
+                .from(schema.groupMembership)
+                .where(eq(schema.groupMembership.userId, target.id));
+            expect(memberships).toHaveLength(0);
+        },
+    );
+
+    integrationTest(
+        "clears the group's fines admin instead of failing",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["users:delete"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            const target = await ctx.utils.createTestUser();
+            const group = await ctx.utils.createTestGroup({
+                finesActivated: true,
+                finesAdminId: target.id,
+            });
+
+            const res = await client.api.user[":id"].$delete({
+                param: { id: target.id },
+            });
+
+            expect(res.status).toBe(204);
+
+            const [row] = await ctx.db
+                .select()
+                .from(schema.group)
+                .where(eq(schema.group.slug, group.slug));
+            expect(row?.finesAdminId).toBeNull();
+        },
+    );
+
+    integrationTest("refuses to delete yourself", async ({ ctx }) => {
+        const admin = await ctx.utils.createTestUser();
+        await ctx.utils.giveUserPermissions(admin, ["users:delete"]);
+        const client = await ctx.utils.clientForUser(admin);
+
+        const res = await client.api.user[":id"].$delete({
+            param: { id: admin.id },
+        });
+
+        expect(res.status).toBe(400);
+
+        const [row] = await ctx.db
+            .select()
+            .from(schema.user)
+            .where(eq(schema.user.id, admin.id));
+        expect(row).toBeDefined();
+    });
+
+    integrationTest("404s for an unknown user", async ({ ctx }) => {
+        const admin = await ctx.utils.createTestUser();
+        await ctx.utils.giveUserPermissions(admin, ["users:delete"]);
+        const client = await ctx.utils.clientForUser(admin);
+
+        const res = await client.api.user[":id"].$delete({
+            param: { id: "does-not-exist" },
+        });
+
+        expect(res.status).toBe(404);
+    });
+});

--- a/apps/kvark/src/api/queries/user.ts
+++ b/apps/kvark/src/api/queries/user.ts
@@ -182,6 +182,28 @@ export const updateUserStatusMutation = mutationOptions({
 });
 
 /**
+ * Slett et medlem for godt.
+ *
+ * Motstykket til arkivering: kontoen forsvinner, og med den påmeldinger,
+ * betalinger, bøter, medlemskap og vervhistorikk. Bruk arkivering med mindre
+ * selve raden må bort — duplikatkontoer, testbrukere eller sletting etter GDPR.
+ */
+export const deleteUserMutation = mutationOptions({
+    mutationFn: ({ userId }: { userId: string }) =>
+        apiClient.delete("/api/user/{id}", { params: { id: userId } }),
+    onSuccess(_, __, ___, ctx) {
+        ctx.client.invalidateQueries({
+            queryKey: [...UserQueryKeys.listInfinite],
+            exact: false,
+        });
+        ctx.client.invalidateQueries({
+            queryKey: [...UserQueryKeys.profile],
+            exact: false,
+        });
+    },
+});
+
+/**
  * Rett kullet til et medlem for hånd.
  *
  * Feide gir ikke kull for alle studier, så nye medlemmer antas å være

--- a/apps/kvark/src/routes/admin/brukere.tsx
+++ b/apps/kvark/src/routes/admin/brukere.tsx
@@ -56,6 +56,7 @@ import { Stagger } from "@tihlde/ui/ui/motion";
 
 import { searchUsersQuery } from "#/api/queries/roles";
 import {
+    deleteUserMutation,
     getAllergiesQuery,
     getUserAllergiesQuery,
     getUsersInfiniteQuery,
@@ -234,14 +235,25 @@ function AllUsersTable({
         name: string;
         isActive: boolean;
     } | null>(null);
+    const [deleting, setDeleting] = useState<{
+        id: string;
+        name: string;
+        username: string | null;
+    } | null>(null);
 
     /**
      * Kullet er en avledet gruppe, så medlemslista nekter å redigere det (400).
      * `users:manage` er den eneste veien inn, og kravet er globalt — uten det
      * skjuler vi handlingen i stedet for å vise en knapp som svarer 403.
-     * Allergier og aktivering ligger bak samme rettighet.
+     * Allergier og arkivering ligger bak samme rettighet.
      */
     const canEditCohort = usePermission("users:manage");
+    /**
+     * Sletting ligger bak sin egen rettighet: den er permanent, og `users:manage`
+     * skal holde til arkivering uten å gi den muligheten på kjøpet.
+     */
+    const canDelete = usePermission("users:delete");
+    const hasActions = canEditCohort || canDelete;
 
     const debouncedSearch = useDebounced(search);
 
@@ -344,7 +356,7 @@ function AllUsersTable({
                                         <TableHead>Status</TableHead>
                                         <TableHead>Studie</TableHead>
                                         <TableHead>Kull</TableHead>
-                                        {canEditCohort && (
+                                        {hasActions && (
                                             <TableHead className="w-0" />
                                         )}
                                     </TableRow>
@@ -381,7 +393,7 @@ function AllUsersTable({
                                                     "Aktiv"
                                                 ) : (
                                                     <Badge variant="destructive">
-                                                        Deaktivert
+                                                        Arkivert
                                                     </Badge>
                                                 )}
                                             </TableCell>
@@ -394,55 +406,79 @@ function AllUsersTable({
                                             <TableCell>
                                                 {user.studyStartYear ?? "—"}
                                             </TableCell>
-                                            {canEditCohort && (
+                                            {hasActions && (
                                                 <TableCell>
                                                     <div className="flex justify-end gap-1">
-                                                        <Button
-                                                            variant="ghost"
-                                                            size="sm"
-                                                            onClick={() =>
-                                                                setEditing({
-                                                                    id: user.id,
-                                                                    name: user.name,
-                                                                    studyStartYear:
-                                                                        user.studyStartYear,
-                                                                })
-                                                            }
-                                                        >
-                                                            Rett kull
-                                                        </Button>
-                                                        <Button
-                                                            variant="ghost"
-                                                            size="sm"
-                                                            onClick={() =>
-                                                                setEditingAllergies(
-                                                                    {
-                                                                        id: user.id,
-                                                                        name: user.name,
-                                                                    },
-                                                                )
-                                                            }
-                                                        >
-                                                            Allergier
-                                                        </Button>
-                                                        <Button
-                                                            variant="ghost"
-                                                            size="sm"
-                                                            onClick={() =>
-                                                                setChangingStatus(
-                                                                    {
-                                                                        id: user.id,
-                                                                        name: user.name,
-                                                                        isActive:
-                                                                            user.isActive,
-                                                                    },
-                                                                )
-                                                            }
-                                                        >
-                                                            {user.isActive
-                                                                ? "Deaktiver"
-                                                                : "Aktiver"}
-                                                        </Button>
+                                                        {canEditCohort && (
+                                                            <>
+                                                                <Button
+                                                                    variant="ghost"
+                                                                    size="sm"
+                                                                    onClick={() =>
+                                                                        setEditing(
+                                                                            {
+                                                                                id: user.id,
+                                                                                name: user.name,
+                                                                                studyStartYear:
+                                                                                    user.studyStartYear,
+                                                                            },
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    Rett kull
+                                                                </Button>
+                                                                <Button
+                                                                    variant="ghost"
+                                                                    size="sm"
+                                                                    onClick={() =>
+                                                                        setEditingAllergies(
+                                                                            {
+                                                                                id: user.id,
+                                                                                name: user.name,
+                                                                            },
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    Allergier
+                                                                </Button>
+                                                                <Button
+                                                                    variant="ghost"
+                                                                    size="sm"
+                                                                    onClick={() =>
+                                                                        setChangingStatus(
+                                                                            {
+                                                                                id: user.id,
+                                                                                name: user.name,
+                                                                                isActive:
+                                                                                    user.isActive,
+                                                                            },
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    {user.isActive
+                                                                        ? "Arkiver"
+                                                                        : "Gjenopprett"}
+                                                                </Button>
+                                                            </>
+                                                        )}
+                                                        {canDelete && (
+                                                            <Button
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                onClick={() =>
+                                                                    setDeleting(
+                                                                        {
+                                                                            id: user.id,
+                                                                            name: user.name,
+                                                                            username:
+                                                                                user.username,
+                                                                        },
+                                                                    )
+                                                                }
+                                                            >
+                                                                Slett
+                                                            </Button>
+                                                        )}
                                                     </div>
                                                 </TableCell>
                                             )}
@@ -489,7 +525,118 @@ function AllUsersTable({
                     if (!open) setChangingStatus(null);
                 }}
             />
+
+            <DeleteUserDialog
+                user={deleting}
+                open={deleting !== null}
+                onOpenChange={(open) => {
+                    if (!open) setDeleting(null);
+                }}
+            />
         </div>
+    );
+}
+
+/**
+ * Slett et medlem for godt.
+ *
+ * Arkivering dekker nesten alle tilfeller, så denne er bevisst tung å bruke:
+ * navnet må skrives av for hånd. Alt som henger på kontoen — påmeldinger,
+ * betalinger, bøter, medlemskap og vervhistorikk — forsvinner med den.
+ */
+function DeleteUserDialog({
+    user,
+    open,
+    onOpenChange,
+}: {
+    user: { id: string; name: string; username: string | null } | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const [confirmation, setConfirmation] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const remove = useMutation(deleteUserMutation);
+
+    // Bekreftelsesfeltet følger medlemmet dialogen ble åpnet for, slik at et
+    // ferdig utfylt felt aldri blir stående igjen til neste rad.
+    const [lastUserId, setLastUserId] = useState<string | null>(null);
+    if (user && user.id !== lastUserId) {
+        setLastUserId(user.id);
+        setConfirmation("");
+        setError(null);
+    }
+
+    // Brukernavnet er kortere og entydig; navnet brukes når det mangler.
+    const expected = user?.username ?? user?.name ?? "";
+    const confirmed =
+        confirmation.trim().toLowerCase() === expected.toLowerCase();
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!user || !confirmed) return;
+
+        setError(null);
+        try {
+            await remove.mutateAsync({ userId: user.id });
+            onOpenChange(false);
+        } catch (err) {
+            setError(await extractErrorMessage(err));
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                    <DialogHeader>
+                        <DialogTitle>Slett konto</DialogTitle>
+                        <DialogDescription>{user?.name}</DialogDescription>
+                    </DialogHeader>
+                    <FieldGroup>
+                        <Field>
+                            <FieldLabel htmlFor="delete-confirmation">
+                                Skriv «{expected}» for å bekrefte
+                            </FieldLabel>
+                            <Input
+                                id="delete-confirmation"
+                                value={confirmation}
+                                onChange={(event) =>
+                                    setConfirmation(event.target.value)
+                                }
+                                autoComplete="off"
+                            />
+                            <FieldDescription>
+                                Kontoen slettes for godt, sammen med
+                                påmeldinger, betalinger, bøter, medlemskap og
+                                vervhistorikk. Dette kan ikke angres — velg
+                                Arkiver i stedet hvis historikken skal beholdes.
+                            </FieldDescription>
+                        </Field>
+                    </FieldGroup>
+                    {error && (
+                        <p className="text-sm text-destructive" role="alert">
+                            {error}
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            Avbryt
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="destructive"
+                            disabled={!confirmed || remove.isPending}
+                        >
+                            Slett for godt
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
     );
 }
 
@@ -606,10 +753,11 @@ function EditAllergiesForm({
 }
 
 /**
- * Steng et medlem ute, eller slipp dem inn igjen.
+ * Arkiver et medlem, eller hent dem tilbake.
  *
  * Kontoen slettes ikke — påmeldinger, bøter og vervhistorikk peker på den —
- * men innlogging blokkeres og sesjonene avsluttes med en gang.
+ * men innlogging blokkeres og sesjonene avsluttes med en gang. Skal selve
+ * raden bort, er det `DeleteUserDialog` som gjelder.
  */
 function ChangeStatusDialog({
     user,
@@ -656,7 +804,9 @@ function ChangeStatusDialog({
                 <form onSubmit={handleSubmit} className="flex flex-col gap-4">
                     <DialogHeader>
                         <DialogTitle>
-                            {deactivating ? "Deaktiver konto" : "Aktiver konto"}
+                            {deactivating
+                                ? "Arkiver konto"
+                                : "Gjenopprett konto"}
                         </DialogTitle>
                         <DialogDescription>{user?.name}</DialogDescription>
                     </DialogHeader>
@@ -677,8 +827,8 @@ function ChangeStatusDialog({
                                 <FieldDescription>
                                     Medlemmet mister tilgangen med en gang og
                                     kan ikke logge inn igjen. Kontoen og all
-                                    historikk beholdes, og du kan aktivere den
-                                    igjen når som helst.
+                                    historikk beholdes, og du kan gjenopprette
+                                    den når som helst.
                                 </FieldDescription>
                             </Field>
                         </FieldGroup>
@@ -705,7 +855,7 @@ function ChangeStatusDialog({
                             variant={deactivating ? "destructive" : "default"}
                             disabled={update.isPending}
                         >
-                            {deactivating ? "Deaktiver" : "Aktiver"}
+                            {deactivating ? "Arkiver" : "Gjenopprett"}
                         </Button>
                     </DialogFooter>
                 </form>

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -46,12 +46,20 @@ import {
     TableRow,
 } from "@tihlde/ui/ui/table";
 import type {
+    GroupMember,
     GroupSignatureList,
     GroupSignatureMember,
     GroupWithMemberCount,
 } from "@tihlde/sdk";
 import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
-import { CheckCircle2, PlusIcon, UsersIcon, XCircle } from "lucide-react";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import {
+    CheckCircle2,
+    PlusIcon,
+    Trash2,
+    UsersIcon,
+    XCircle,
+} from "lucide-react";
 import { useState } from "react";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
@@ -59,7 +67,9 @@ import { Stagger } from "@tihlde/ui/ui/motion";
 import { useImageUploader } from "#/api/queries/assets";
 import {
     createGroupMutation,
+    getGroupMembersQuery,
     getGroupsQuery,
+    removeGroupMemberMutation,
     updateGroupMutation,
 } from "#/api/queries/groups";
 import {
@@ -113,7 +123,7 @@ function GrupperAdminPage() {
         >
             <AdminPageHeader
                 title="Grupper"
-                description="Opprett grupper, administrer kontraktsignering og se signeringsstatus for medlemmer."
+                description="Opprett grupper, administrer medlemmer og kontraktsignering."
                 action={
                     canCreate ? (
                         <Button onClick={() => setCreateOpen(true)}>
@@ -353,6 +363,11 @@ function GroupCard({
         ["groups:update", "groups:manage"],
         `group:${group.slug}`,
     );
+    // Medlemslista speiler fjern-endepunktet: `groups:manage` for denne gruppa,
+    // eller å være lederen dens.
+    const isLeader = useIsGroupLeaderOf(group.slug);
+    const canManageMembers =
+        useScopedPermission("groups:manage", `group:${group.slug}`) || isLeader;
 
     async function handleSave() {
         setError(null);
@@ -476,6 +491,12 @@ function GroupCard({
                     >
                         {isUploading ? "Laster opp bilde …" : "Lagre"}
                     </Button>
+                    {canManageMembers && (
+                        <GroupMembersTable
+                            groupSlug={group.slug}
+                            enabled={expanded}
+                        />
+                    )}
                     {requiresSigning &&
                         (signaturesQuery.data ? (
                             <MemberSigningTable
@@ -488,6 +509,153 @@ function GroupCard({
                 </CardContent>
             </CollapsibleContent>
         </Card>
+    );
+}
+
+const ROLE_LABELS: Record<string, string> = {
+    leader: "Leder",
+    member: "Medlem",
+};
+
+/**
+ * Medlemslista til gruppa, med mulighet for å ta noen ut av den.
+ *
+ * Medlemskapet havner i «Tidligere medlemmer» når det avsluttes, så
+ * vervhistorikken består selv om personen ikke lenger står i gruppa. Rollen
+ * gruppa gir i rettighetssystemet trekkes tilbake samtidig.
+ */
+function GroupMembersTable({
+    groupSlug,
+    /** Lista hentes først når kortet er åpnet. */
+    enabled,
+}: {
+    groupSlug: string;
+    enabled: boolean;
+}) {
+    const { data: members, isPending } = useQuery({
+        ...getGroupMembersQuery(groupSlug, 0),
+        enabled,
+    });
+    const remove = useMutation(removeGroupMemberMutation);
+    const [confirming, setConfirming] = useState<GroupMember | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    async function handleRemove() {
+        if (!confirming) return;
+        setError(null);
+        try {
+            await remove.mutateAsync({
+                groupSlug,
+                userId: confirming.userId,
+            });
+            setConfirming(null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        }
+    }
+
+    if (isPending) {
+        return (
+            <div className="flex flex-col gap-2">
+                {Array.from({ length: 3 }).map((_, index) => (
+                    <Skeleton key={index} className="h-9 w-full" />
+                ))}
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-2">
+            <h4>Medlemmer</h4>
+            {!members || members.length === 0 ? (
+                <p>Ingen medlemmer i denne gruppen.</p>
+            ) : (
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Navn</TableHead>
+                            <TableHead>Rolle</TableHead>
+                            <TableHead />
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {members.map((member) => (
+                            <TableRow key={member.userId}>
+                                <TableCell>
+                                    <div className="flex flex-col gap-0.5">
+                                        <span>{member.user.name}</span>
+                                        {member.user.studyProgram && (
+                                            <span>
+                                                {member.user.studyProgram}
+                                            </span>
+                                        )}
+                                    </div>
+                                </TableCell>
+                                <TableCell>
+                                    {ROLE_LABELS[member.role] ?? member.role}
+                                </TableCell>
+                                <TableCell>
+                                    <div className="flex justify-end">
+                                        <Button
+                                            size="sm"
+                                            variant="destructive"
+                                            disabled={remove.isPending}
+                                            onClick={() => {
+                                                setError(null);
+                                                setConfirming(member);
+                                            }}
+                                        >
+                                            <Trash2 className="size-4" />
+                                            Fjern
+                                        </Button>
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            )}
+
+            <Dialog
+                open={confirming !== null}
+                onOpenChange={(open) => {
+                    if (!open) setConfirming(null);
+                }}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Fjern fra gruppen</DialogTitle>
+                    </DialogHeader>
+                    <p>
+                        {confirming?.user.name} mister plassen sin i gruppen og
+                        rettighetene som følger med den. Medlemskapet blir
+                        liggende under «Tidligere medlemmer».
+                    </p>
+                    {error && (
+                        <p className="text-sm text-destructive" role="alert">
+                            {error}
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => setConfirming(null)}
+                        >
+                            Avbryt
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            disabled={remove.isPending}
+                            onClick={handleRemove}
+                        >
+                            Fjern
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
     );
 }
 

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2538,7 +2538,11 @@ export interface paths {
         get: operations["getUserProfile"];
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete a member permanently
+         * @description Irreversibly deletes the account along with its registrations, payments, fines, memberships and history. Prefer 'PATCH /user/{id}/status' to deactivate instead. Requires 'users:delete'.
+         */
+        delete: operations["deleteUser"];
         options?: never;
         head?: never;
         patch?: never;
@@ -12658,6 +12662,56 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
+            };
+            /** @description Not Found - User not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description User deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request - Cannot delete your own account */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Forbidden - Requires users:delete */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Not Found - User not found */
             404: {


### PR DESCRIPTION
## Hva

**Admin → Grupper:** utvidede gruppekort får en `Medlemmer`-tabell (navn, studie, rolle) med `Fjern`-knapp og bekreftelsesdialog. Lista hentes først når kortet åpnes.

**Admin → Brukere:** ny `Slett`-handling ved siden av arkivering. Arkivering er uendret i oppførsel, men heter nå `Arkiver`/`Gjenopprett` i stedet for `Deaktiver`/`Aktiver`, og statusmerket sier `Arkivert`.

## Hvorfor

Gruppeadmin viste bare signeringsstatus, så det fantes ingen vei i UI-et til å ta noen ut av en undergruppe eller komité. Endepunktet (`DELETE /api/groups/:groupSlug/members/:userId`) fantes allerede — bare medlemslista for studiegrupper under Brukere brukte det. Brukeroversikten kunne på sin side bare stenge folk ute, aldri fjerne dem.

## Ny backend-rute

`DELETE /api/user/:id` ([apps/api/src/routes/user/delete.ts](apps/api/src/routes/user/delete.ts)):

- Bak `users:delete`, bevisst en annen rettighet enn `users:manage` — den skal fortsatt holde til arkivering uten å gi sletting på kjøpet.
- Nekter å slette deg selv, 404 på ukjent bruker.
- Nuller `group.fines_admin_id` i samme transaksjon. Det er den eneste referansen til en bruker som verken kaskaderer eller nulles selv, og ville ellers avbrutt slettingen med en FK-feil.

## Verdt å vite for review

Sletting er permanent og tar med seg påmeldinger, betalinger, bøter, medlemskap og vervhistorikk via cascade. Innhold brukeren har laget (nyheter, arrangementer, album) overlever med forfatter satt til `null`. Derfor er dialogen bevisst tung å bruke — brukernavnet må skrives av for hånd — og den peker på arkivering som førstevalg.

Fjern-knappen i gruppeadmin vises bare til dem som faktisk slipper gjennom server-side: `groups:manage` scoped til gruppa, eller gruppas leder.

## Testing

- 5 nye integrasjonstester i [apps/api/src/test/user-delete.test.ts](apps/api/src/test/user-delete.test.ts) (rettighetskrav, cascade på medlemskap, `fines_admin_id`-nulling, selvsletting, 404) — alle passerer.
- `bun run typecheck` 9/9, `bun run lint` og `bun run format` uten nye funn. SDK-typene regenerert med `bun run codegen`.
- Verifisert manuelt mot lokal dev: fjernet et medlem fra en midlertidig testgruppe (rad borte, `org_group_membership` tom, rad i `org_group_membership_history`); arkivert og deretter slettet en testbruker (knappen disabled til riktig brukernavn var skrevet, `auth_user`-raden borte, gruppas `fines_admin_id` satt til null i stedet for feil). Testdataene er ryddet bort igjen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)