### PR TITLE
La en betrodd tjeneste navngi brukernavnet ved registrering

### DIFF
--- a/apps/api/src/routes/user/register.ts
+++ b/apps/api/src/routes/user/register.ts
@@ -1,4 +1,4 @@
-import { usernameFromStudentEmail } from "@photon/auth";
+import { runTrustedSignUp, usernameFromStudentEmail } from "@photon/auth";
 import {
     currentAcademicYear,
     syncBaselineRoles,
@@ -32,9 +32,17 @@ const ALLOWED_PERMISSIONS = ["users:create", "root"];
  * table with its own rules is how the two systems drifted apart in the first
  * place.
  *
- * The caller therefore does NOT choose the username. It is the e-mail's local
- * part, which is the student's NTNU username — the same value Lepton used as
- * `user_id`, so it stays the join key services already hold members by.
+ * The username is normally the e-mail's local part, which is the student's NTNU
+ * username — the same value Lepton used as `user_id`, so it stays the join key
+ * services already hold members by.
+ *
+ * A caller may name it instead, and that is the one rule this route relaxes.
+ * Fadderuka registers students on stand during fadderuka, and many have not
+ * been given their @stud.ntnu.no address yet; refusing them is refusing exactly
+ * the group the sign-up exists for. They are asked for their Feide username, so
+ * the account still carries the NTNU identity and a later Feide login lands on
+ * it rather than on a second account. The trust that the caller collected it
+ * honestly is the same trust the API key already carries.
  */
 export const registerUserRoute = route().post(
     "/register",
@@ -43,7 +51,7 @@ export const registerUserRoute = route().post(
         summary: "Register a member from another TIHLDE service",
         operationId: "registerUser",
         description:
-            "Creates an account the same way the website's sign-up does — @stud.ntnu.no only, username derived from the address, verification mail sent — and enrols the member in a study programme. Requires an API key with 'users:create'.",
+            "Creates an account the same way the website's sign-up does — verification mail sent — and enrols the member in a study programme. The username is derived from the @stud.ntnu.no address, unless the caller names one, which also lifts the requirement that the address be a stud one. Requires an API key with 'users:create'.",
     })
         .schemaResponse({
             statusCode: 201,
@@ -52,7 +60,7 @@ export const registerUserRoute = route().post(
         })
         .badRequest({
             description:
-                "Address is not @stud.ntnu.no, password too short, or the study programme does not exist",
+                "Address is not @stud.ntnu.no and no username was given, password too short, or the study programme does not exist",
         })
         .unauthorized()
         .forbidden({ description: "Requires an API key with 'users:create'" })
@@ -86,7 +94,13 @@ export const registerUserRoute = route().post(
             });
         }
 
-        const { name, email, password, studyProgramSlug } = c.req.valid("json");
+        const {
+            name,
+            email,
+            password,
+            studyProgramSlug,
+            username: chosenUsername,
+        } = c.req.valid("json");
 
         /**
          * Checked before the account is created, not after. `signUpEmail`
@@ -117,7 +131,8 @@ export const registerUserRoute = route().post(
          * calling service can put in front of the student, rather than making
          * them read whatever Better Auth's error happens to say.
          */
-        const derivedUsername = usernameFromStudentEmail(email);
+        const derivedUsername =
+            chosenUsername ?? usernameFromStudentEmail(email);
         if (derivedUsername) {
             const existing = await db.query.user.findFirst({
                 where: eq(schema.user.username, derivedUsername),
@@ -132,9 +147,14 @@ export const registerUserRoute = route().post(
 
         let userId: string;
         try {
-            const result = await auth.api.signUpEmail({
-                body: { name, email, password },
-            });
+            const signUp = () =>
+                auth.api.signUpEmail({ body: { name, email, password } });
+            // A named username is passed out-of-band rather than in the body:
+            // `/sign-up/email` is public, so a body-supplied one would let
+            // anyone claim a student's NTNU username. See `runTrustedSignUp`.
+            const result = chosenUsername
+                ? await runTrustedSignUp(chosenUsername, signUp)
+                : await signUp();
             userId = result.user.id;
         } catch (err) {
             // Better Auth reports the @stud.ntnu.no rule, a weak password and

--- a/apps/api/src/routes/user/schema.ts
+++ b/apps/api/src/routes/user/schema.ts
@@ -183,7 +183,7 @@ export const registerUserInputSchema = Schema(
         }),
         email: z.string().trim().toLowerCase().email().meta({
             description:
-                "Must be a @stud.ntnu.no address; the username is derived from it, exactly as in the website's own sign-up",
+                "The member's address. Must be @stud.ntnu.no unless 'username' is given, since the username is otherwise derived from it",
         }),
         password: z.string().min(8).max(128).meta({
             description: "The password the member chose",
@@ -192,6 +192,16 @@ export const registerUserInputSchema = Schema(
             description:
                 "Slug of the STUDY group to enrol the member in, e.g. 'dataingenir'",
         }),
+        username: z
+            .string()
+            .trim()
+            .toLowerCase()
+            .regex(/^[a-z0-9]{1,15}$/)
+            .optional()
+            .meta({
+                description:
+                    "The NTNU username to give the member, for callers registering students who have not been given their @stud.ntnu.no address yet. Should be the member's Feide username, so a later Feide login lands on this same account. Omit to derive it from the address.",
+            }),
     }),
 );
 

--- a/apps/api/src/test/user-register.test.ts
+++ b/apps/api/src/test/user-register.test.ts
@@ -167,20 +167,146 @@ describe("POST /api/user/register", () => {
         },
     );
 
-    integrationTest("refuses a non-NTNU address", async ({ ctx }) => {
-        const key = await apiKeyWith(ctx, ["users:create"]);
+    integrationTest(
+        "refuses a non-NTNU address when no username is given",
+        async ({ ctx }) => {
+            const key = await apiKeyWith(ctx, ["users:create"]);
 
-        const res = await ctx.app.request("/api/user/register", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${key}`,
-            },
-            body: JSON.stringify({ ...body, email: "ola@gmail.com" }),
-        });
+            const res = await ctx.app.request("/api/user/register", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${key}`,
+                },
+                body: JSON.stringify({ ...body, email: "ola@gmail.com" }),
+            });
 
-        expect(res.status).toBe(400);
-    });
+            expect(res.status).toBe(400);
+        },
+    );
+
+    /**
+     * The reason the rule is relaxed at all: students on stand during fadderuka
+     * often have not been given their @stud.ntnu.no address yet, and the
+     * sign-up form exists precisely for them.
+     */
+    integrationTest(
+        "accepts a private address when the caller names the username",
+        async ({ ctx }) => {
+            await ctx.utils.createTestGroup({
+                slug: "dataingenir",
+                name: "Dataingeniør",
+                type: "STUDY",
+            });
+            const key = await apiKeyWith(ctx, ["users:create"]);
+
+            const res = await ctx.app.request("/api/user/register", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${key}`,
+                },
+                body: JSON.stringify({
+                    ...body,
+                    email: "ola@gmail.com",
+                    username: "olanor",
+                }),
+            });
+
+            expect(res.status).toBe(201);
+            expect((await res.json()) as { username: string }).toMatchObject({
+                username: "olanor",
+            });
+
+            const [created] = await ctx.db
+                .select({
+                    username: schema.user.username,
+                    email: schema.user.email,
+                })
+                .from(schema.user)
+                .where(eq(schema.user.username, "olanor"));
+            expect(created).toMatchObject({
+                username: "olanor",
+                email: "ola@gmail.com",
+            });
+        },
+    );
+
+    integrationTest(
+        "refuses a named username that is already taken",
+        async ({ ctx }) => {
+            await ctx.utils.createTestGroup({
+                slug: "dataingenir",
+                name: "Dataingeniør",
+                type: "STUDY",
+            });
+            const key = await apiKeyWith(ctx, ["users:create"]);
+            // `createTestUser` takes only an address, so the username — which
+            // is what this test is about — is set directly.
+            const taken = await ctx.utils.createTestUser();
+            await ctx.db
+                .update(schema.user)
+                .set({ username: "olanor" })
+                .where(eq(schema.user.id, taken.id));
+
+            const res = await ctx.app.request("/api/user/register", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${key}`,
+                },
+                body: JSON.stringify({
+                    ...body,
+                    email: "ola@gmail.com",
+                    username: "olanor",
+                }),
+            });
+
+            expect(res.status).toBe(409);
+        },
+    );
+
+    /**
+     * The security property the whole design turns on.
+     *
+     * `/sign-up/email` is a public endpoint. If a username in the request body
+     * were honoured there, anyone could claim a student's NTNU username before
+     * that student ever registers — and every service keying members on the
+     * username, this one included, would hand the impostor their identity.
+     * A named username therefore travels out-of-band (`runTrustedSignUp`) and
+     * is reachable only from the API-key route.
+     */
+    integrationTest(
+        "ignores a username sent in the body of the public sign-up",
+        async ({ ctx }) => {
+            const res = await ctx.app.request("/api/auth/sign-up/email", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    name: "Angriper",
+                    email: "angriper@stud.ntnu.no",
+                    password: "hemmeligpassord",
+                    username: "offeret",
+                }),
+            });
+
+            // Either the sign-up is refused outright, or it succeeds with the
+            // username derived from the address — never with the one asked for.
+            const [stolen] = await ctx.db
+                .select({ id: schema.user.id })
+                .from(schema.user)
+                .where(eq(schema.user.username, "offeret"));
+            expect(stolen).toBeUndefined();
+
+            if (res.status < 400) {
+                const [derived] = await ctx.db
+                    .select({ username: schema.user.username })
+                    .from(schema.user)
+                    .where(eq(schema.user.email, "angriper@stud.ntnu.no"));
+                expect(derived?.username).toBe("angriper");
+            }
+        },
+    );
 
     integrationTest(
         "refuses an API key without users:create",

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
     betterAuth,
     type BetterAuthOptions,
@@ -67,6 +68,44 @@ export function usernameFromStudentEmail(
 ): string | undefined {
     if (typeof email !== "string") return undefined;
     return STUD_NTNU_EMAIL_PATTERN.exec(email.trim().toLowerCase())?.[1];
+}
+
+/** Shape a caller-supplied username has to have: the same one Feide hands out. */
+const USERNAME_PATTERN = /^[a-z0-9]{1,15}$/;
+
+/**
+ * A username chosen by a trusted server-side caller, for the duration of one
+ * `signUpEmail` call.
+ *
+ * Fadderuka registers brand-new students during fadderuka, and many of them
+ * have not been given their @stud.ntnu.no address yet — so the address cannot
+ * be what the username is derived from. They type their Feide username instead,
+ * which is what makes a later Feide login land on the same account.
+ *
+ * Deliberately NOT read from the request body. `/sign-up/email` is a public
+ * HTTP endpoint, so a body-supplied username would let anyone claim a student's
+ * NTNU username before that student ever registers. Async-local storage cannot
+ * be reached over HTTP: only code inside `runTrustedSignUp` sees it, and the
+ * one caller is the API-key route that has already checked `users:create`.
+ */
+const trustedSignUpStore = new AsyncLocalStorage<{ username: string }>();
+
+/**
+ * Run `fn` with `username` marked as trusted, so the sign-up hook uses it
+ * instead of deriving one from the e-mail address.
+ */
+export function runTrustedSignUp<T>(
+    username: string,
+    fn: () => Promise<T>,
+): Promise<T> {
+    const normalised = username.trim().toLowerCase();
+    if (!USERNAME_PATTERN.test(normalised)) {
+        throw new APIError("BAD_REQUEST", {
+            message:
+                "Brukernavnet kan bare inneholde små bokstaver og tall, og maks 15 tegn.",
+        });
+    }
+    return trustedSignUpStore.run({ username: normalised }, fn);
 }
 
 /**
@@ -345,7 +384,14 @@ export function createAuth(options: CreateAuthOptions) {
                         ? rawEmail.trim().toLowerCase()
                         : "";
 
-                const derivedUsername = usernameFromStudentEmail(email);
+                /**
+                 * A trusted server-side caller may name the username outright;
+                 * everyone else still has to prove it with a stud address.
+                 * See `runTrustedSignUp` for why this cannot come from the body.
+                 */
+                const trusted = trustedSignUpStore.getStore();
+                const derivedUsername =
+                    trusted?.username ?? usernameFromStudentEmail(email);
                 if (!derivedUsername) {
                     throw new APIError("BAD_REQUEST", {
                         message:
@@ -380,8 +426,8 @@ export function createAuth(options: CreateAuthOptions) {
                     });
                 }
 
-                // Username is derived, never taken from the request: a caller
-                // must not be able to pick one that disagrees with their email.
+                // Never taken from the request body: it is either derived from
+                // the address, or named by a trusted server-side caller.
                 return {
                     context: {
                         body: { ...ctx.body, email, username: derivedUsername },

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2411,7 +2411,7 @@ export interface paths {
         put?: never;
         /**
          * Register a member from another TIHLDE service
-         * @description Creates an account the same way the website's sign-up does — @stud.ntnu.no only, username derived from the address, verification mail sent — and enrols the member in a study programme. Requires an API key with 'users:create'.
+         * @description Creates an account the same way the website's sign-up does — verification mail sent — and enrols the member in a study programme. The username is derived from the @stud.ntnu.no address, unless the caller names one, which also lifts the requirement that the address be a stud one. Requires an API key with 'users:create'.
          */
         post: operations["registerUser"];
         delete?: never;
@@ -5637,13 +5637,15 @@ export interface components {
             name: string;
             /**
              * Format: email
-             * @description Must be a @stud.ntnu.no address; the username is derived from it, exactly as in the website's own sign-up
+             * @description The member's address. Must be @stud.ntnu.no unless 'username' is given, since the username is otherwise derived from it
              */
             email: string;
             /** @description The password the member chose */
             password: string;
             /** @description Slug of the STUDY group to enrol the member in, e.g. 'dataingenir' */
             studyProgramSlug: string;
+            /** @description The NTNU username to give the member, for callers registering students who have not been given their @stud.ntnu.no address yet. Should be the member's Feide username, so a later Feide login lands on this same account. Omit to derive it from the address. */
+            username?: string;
         };
         UserSearchResult: {
             id: string;
@@ -12306,7 +12308,7 @@ export interface operations {
                     "application/json": components["schemas"]["RegisterUser"];
                 };
             };
-            /** @description Bad Request - Address is not @stud.ntnu.no, password too short, or the study programme does not exist */
+            /** @description Bad Request - Address is not @stud.ntnu.no and no username was given, password too short, or the study programme does not exist */
             400: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Fadderuka registrerer ferske studenter på stand under fadderuka, og mange har ikke fått `@stud.ntnu.no`-adressen sin ennå. Siden brukernavnet utledes av adressen, avviser `POST /api/user/register` dem i dag — altså nøyaktig den gruppa registreringen finnes for.

## Hva som endres

Kalleren kan nå sende et valgfritt `username`. Gjør den det, faller kravet om stud-adresse bort, mens uniknessjekken, passordreglene og verifiserings-e-posten står uendret. Utelates det, er oppførselen som før.

Fadderuka spør studenten om Feide-brukernavnet, så kontoen bærer NTNU-identiteten og en senere Feide-innlogging lander på den i stedet for på en ny konto. Det er den samme kontrakten Lepton hadde.

## Hvorfor det ikke ligger i request-bodyen

`/sign-up/email` er et **offentlig** endepunkt. Leste sign-up-hooken brukernavnet fra bodyen, kunne hvem som helst kapre en students NTNU-brukernavn før studenten selv rakk å registrere seg — og alle tjenester som nøkler medlemmer på brukernavnet, denne inkludert, ville gitt bedrageren identiteten deres. Kommentaren i hooken advarte allerede mot nettopp dette.

Brukernavnet går derfor utenom bodyen, via `AsyncLocalStorage` (`runTrustedSignUp`). Det kan ikke nås over HTTP — bare kode inne i den wrapperen ser det, og den ene kalleren er API-nøkkelruten som allerede har sjekket `users:create`. Egenskapen er dekket av en test som sender `username` i bodyen til det offentlige sign-up-endepunktet og verifiserer at det aldri blir tatt i bruk.

Dette er bevisst en oppmykning av valget dokumentert i `register.ts` («The caller therefore does NOT choose the username»), så det bør vurderes av noen som kjenner den avveiningen.

## Verifisering

- `bun run typecheck` — 9 tasks, rent
- `bun run test` — 69 filer, 496 tester, alle grønne
- `bun run lint` — ingen nye advarsler
- Nye tester: privat adresse godtas når brukernavnet navngis, stud-kravet står når det ikke gjør det, 409 på tatt brukernavn, og at et body-oppgitt brukernavn på offentlig sign-up ignoreres

`packages/sdk/src/generated/openapi.ts` er regenerert, som i #477.

## Kontekst

Motparten er TIHLDE/Fadderuka#119. Den har ingen effekt før denne er deployet — uten den avvises private adresser fortsatt med 400. Fadderuka starter 10. august.

🤖 Generated with [Claude Code](https://claude.com/claude-code)