### PR TITLE
fix(news): svar 404 på gamle Lepton-lenker i stedet for 500

### DIFF
--- a/apps/api/src/routes/news/delete.ts
+++ b/apps/api/src/routes/news/delete.ts
@@ -1,12 +1,13 @@
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
+import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { isNewsCreator } from "~/lib/news/middleware";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
 import { requireAuth } from "~/middleware/auth";
-import { deleteNewsResponseSchema } from "./schema";
+import { deleteNewsResponseSchema, newsIdParamSchema } from "./schema";
 
 export const deleteRoute = route().delete(
     "/:id",
@@ -26,6 +27,9 @@ export const deleteRoute = route().delete(
         .notFound({ description: "News article not found" })
         .build(),
     requireAuth,
+    // Before `requireAccess`: its ownership check looks the article up by this
+    // id, so an unparseable one would reach the database there rather than here.
+    validator("param", newsIdParamSchema),
     requireAccess({
         permission: ["news:delete", "news:manage"],
         scope: (c) => `news-${c.req.param("id")}`,
@@ -34,7 +38,7 @@ export const deleteRoute = route().delete(
     }),
     async (c) => {
         const { db } = c.get("ctx");
-        const { id } = c.req.param();
+        const { id } = c.req.valid("param");
 
         // Fetch the news article to verify it exists
         const newsArticle = await db.query.news.findFirst({

--- a/apps/api/src/routes/news/get.ts
+++ b/apps/api/src/routes/news/get.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { newsArticleSchema } from "./schema";
+import { newsArticleSchema, newsIdParamSchema } from "./schema";
 
 export const getRoute = route().get(
     "/:id",
@@ -22,7 +22,21 @@ export const getRoute = route().get(
         .build(),
     async (c) => {
         const { db } = c.get("ctx");
-        const { id } = c.req.param();
+
+        /**
+         * Parsed here rather than with `validator("param", ...)` because this
+         * route is public and reached by old Lepton links. A caller asking for
+         * an article that cannot exist is asking for one that is not here —
+         * 404, the same answer a well-formed UUID with no row gets. A 400 would
+         * make the website's error boundary treat a dead link as a bug.
+         */
+        const params = newsIdParamSchema.safeParse(c.req.param());
+        if (!params.success) {
+            throw new HTTPException(404, {
+                message: "News article not found",
+            });
+        }
+        const { id } = params.data;
 
         const newsArticle = await db.query.news.findFirst({
             where: eq(schema.news.id, id),

--- a/apps/api/src/routes/news/reactions/create.ts
+++ b/apps/api/src/routes/news/reactions/create.ts
@@ -5,7 +5,11 @@ import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
-import { createReactionSchema, newsReactionSchema } from "../schema";
+import {
+    createReactionSchema,
+    newsIdParamSchema,
+    newsReactionSchema,
+} from "../schema";
 
 export const createReactionRoute = route().post(
     "/:id/reactions",
@@ -27,12 +31,13 @@ export const createReactionRoute = route().post(
         .notFound({ description: "News article not found" })
         .build(),
     requireAuth,
+    validator("param", newsIdParamSchema),
     validator("json", createReactionSchema),
     async (c) => {
         const body = c.req.valid("json");
         const userId = c.get("user").id;
         const { db } = c.get("ctx");
-        const { id: newsId } = c.req.param();
+        const { id: newsId } = c.req.valid("param");
 
         // Check if news exists and reactions are allowed
         const newsArticle = await db.query.news.findFirst({

--- a/apps/api/src/routes/news/reactions/delete.ts
+++ b/apps/api/src/routes/news/reactions/delete.ts
@@ -1,10 +1,11 @@
 import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
+import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
-import { deleteReactionResponseSchema } from "../schema";
+import { deleteReactionResponseSchema, newsIdParamSchema } from "../schema";
 
 export const deleteReactionRoute = route().delete(
     "/:id/reactions",
@@ -22,10 +23,11 @@ export const deleteReactionRoute = route().delete(
         .notFound({ description: "News article or reaction not found" })
         .build(),
     requireAuth,
+    validator("param", newsIdParamSchema),
     async (c) => {
         const userId = c.get("user").id;
         const { db } = c.get("ctx");
-        const { id: newsId } = c.req.param();
+        const { id: newsId } = c.req.valid("param");
 
         // Check if news exists
         const newsArticle = await db.query.news.findFirst({

--- a/apps/api/src/routes/news/schema.ts
+++ b/apps/api/src/routes/news/schema.ts
@@ -4,6 +4,19 @@ import { PagniationResponseSchema } from "~/middleware/pagination";
 
 // ===== INPUT SCHEMAS =====
 
+/**
+ * The `:id` segment, checked before it reaches the database.
+ *
+ * Lepton numbered its articles, Photon uses UUIDs, and the migration kept no
+ * mapping between the two — so every `/nyheter/302` still out there arrives
+ * here as a non-UUID. Postgres answers that with `22P02 invalid input syntax
+ * for type uuid`, which reaches the error handler as a 500: an ordinary dead
+ * link reported as a server fault, ~46 times over three days in production.
+ */
+export const newsIdParamSchema = z.object({
+    id: z.uuid().meta({ description: "News article ID" }),
+});
+
 export const createNewsSchema = Schema(
     "CreateNews",
     z.object({

--- a/apps/api/src/routes/news/update.ts
+++ b/apps/api/src/routes/news/update.ts
@@ -8,7 +8,11 @@ import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
 import { requireAuth } from "~/middleware/auth";
-import { newsArticleSchema, updateNewsSchema } from "./schema";
+import {
+    newsArticleSchema,
+    newsIdParamSchema,
+    updateNewsSchema,
+} from "./schema";
 
 export const updateRoute = route().patch(
     "/:id",
@@ -28,6 +32,9 @@ export const updateRoute = route().patch(
         .notFound({ description: "News article not found" })
         .build(),
     requireAuth,
+    // Before `requireAccess`: its ownership check looks the article up by this
+    // id, so an unparseable one would reach the database there rather than here.
+    validator("param", newsIdParamSchema),
     requireAccess({
         permission: ["news:update", "news:manage"],
         scope: (c) => `news-${c.req.param("id")}`,
@@ -38,7 +45,7 @@ export const updateRoute = route().patch(
     async (c) => {
         const body = c.req.valid("json");
         const { db, bucket } = c.get("ctx");
-        const { id } = c.req.param();
+        const { id } = c.req.valid("param");
 
         // Fetch the news article to verify it exists
         const newsArticle = await db.query.news.findFirst({

--- a/apps/api/src/test/news/news.test.ts
+++ b/apps/api/src/test/news/news.test.ts
@@ -104,6 +104,20 @@ describe("News System", () => {
 
             expect(notFoundResponse.status).toBe(404);
 
+            /**
+             * 6b. A Lepton-era link is a dead link, not a server fault.
+             *
+             * `/nyheter/302` still circulates: Lepton numbered its articles and
+             * the migration kept no mapping to the UUIDs. Passed straight to
+             * Postgres this raised `22P02` and surfaced as a 500 — ~46 times
+             * over three days in production before it was caught.
+             */
+            const legacyIdResponse = await userClient.api.news[":id"].$get({
+                param: { id: "302" },
+            });
+
+            expect(legacyIdResponse.status).toBe(404);
+
             // === UPDATE NEWS ===
 
             // 7. Creator can update their own news

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -11149,6 +11149,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
+                /** @description News article ID */
                 id: string;
             };
             cookie?: never;
@@ -11194,6 +11195,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
+                /** @description News article ID */
                 id: string;
             };
             cookie?: never;
@@ -11243,6 +11245,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
+                /** @description News article ID */
                 id: string;
             };
             cookie?: never;
@@ -11292,6 +11295,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
+                /** @description News article ID */
                 id: string;
             };
             cookie?: never;


### PR DESCRIPTION
## Hva

`GET /api/news/:id` sendte `:id` uvalidert inn i Drizzle-spørringen. Alt som ikke er en UUID fikk Postgres til å svare `22P02 invalid input syntax for type uuid`, som traff feilhåndtereren som en **500**.

Funnet ved gjennomgang av Grafana-loggene (`{container="Photon"}`) etter Feide-varslene: 138 loggelinjer / ~46 requests på tre døgn, alle på formen `invalid input syntax for type uuid: "302"`.

## Hvorfor

Lepton nummererte nyhetene, Photon bruker UUID, og migreringen tok ikke vare på koblingen — `news_news` har ingen kolonne for den gamle ID-en, så `/nyheter/302` kan ikke slås opp. Det er altså en helt vanlig død lenke, rapportert som en serverfeil.

Tosegmentsvarianten `/nyheter/302/tittel` redirectes allerede til oversikten i `nyheter.$slug.$title.tsx`. Den bare-numeriske gjør det ikke, og traff denne ruta.

## Hva som er endret

- Nytt `newsIdParamSchema` i `apps/api/src/routes/news/schema.ts`.
- **Offentlig `GET /news/:id`** parser id-en selv og svarer **404**, ikke 400. En artikkel som ikke kan finnes, finnes ikke — og en 400 ville fått nettsidens feilgrense til å behandle en død lenke som en bug.
- **De fire innloggede rutene** (update, delete, reaksjoner ×2) bruker `validator("param", ...)` og svarer 400, som er riktig når det er adminpanelet vårt som kaller. Alle fire hadde samme krasj.
- Regresjonstest på `/api/news/302` i `news.test.ts`.

## Verdt å vite for review

På `update` og `delete` ligger `validator("param", ...)` **før** `requireAccess`, ikke etter. Eierskapssjekken der (`isNewsCreator`) slår artikkelen opp på samme id, så en uparsbar id ville nådd databasen der i stedet — rekkefølgen er en del av fiksen, ikke tilfeldig.

`packages/sdk/src/generated/openapi.ts` fikk 4 linjer automatisk fra SDK-byggen (400-svarene på de innloggede rutene).

## Verifisert

- `bun run typecheck` — 9/9 grønn
- `bun run lint` — exit 0, ingen nye warnings; `bun run format` rent
- `bun run test src/test/news/news.test.ts` — passerer. Loggen bekrefter at `GET /api/news/302` faktisk kjøres og nå kortsluttes på 0 ms uten å røre databasen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)