### PR TITLE
fix(kvark): send /nyheter/<lepton-id> til oversikten

### DIFF
--- a/apps/kvark/src/routes/_app/nyheter.$slug.tsx
+++ b/apps/kvark/src/routes/_app/nyheter.$slug.tsx
@@ -1,4 +1,4 @@
-import { Link, createFileRoute } from "@tanstack/react-router";
+import { Link, createFileRoute, redirect } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Button } from "@tihlde/ui/ui/button";
 import { Separator } from "@tihlde/ui/ui/separator";
@@ -14,8 +14,25 @@ import { ShareButton } from "#/components/share-button";
 import { richRegistry } from "#/components/markdown/directives/presets";
 import { formatNewsDate, wasNewsUpdated } from "#/lib/news";
 
+/**
+ * Photon nøkler nyheter på UUID. Alt annet i dette segmentet er en Lepton-lenke
+ * — den brukte løpenummer, og migreringen tok ikke vare på koblingen, så
+ * innholdet kan ikke slås opp.
+ *
+ * Tosegmentsvarianten `/nyheter/<id>/<tittel>` fanges av søskenruta; denne
+ * fanger `/nyheter/<id>` alene, som ellers gikk videre til API-et og endte i
+ * feilgrensa med en 404.
+ */
+const UUID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export const Route = createFileRoute("/_app/nyheter/$slug")({
     component: NewsDetailPage,
+    beforeLoad: ({ params }) => {
+        if (!UUID_PATTERN.test(params.slug)) {
+            throw redirect({ to: "/nyheter", replace: true, statusCode: 301 });
+        }
+    },
     loader: ({ context, params }) =>
         context.queryClient.ensureQueryData(getNewsByIdQuery(params.slug)),
 });


### PR DESCRIPTION
## Hva

`/nyheter/302` (Lepton-lenke uten tittelsegment) endte i feilgrensa med en feilmelding. Nå redirectes den til `/nyheter`, som er det tosegmentsvarianten `/nyheter/302/tittel` allerede gjorde.

## Hvorfor

Photon nøkler nyheter på UUID. Lepton brukte løpenummer, og migreringen tok ikke vare på koblingen — `news_news` har ingen kolonne for den gamle ID-en, så innholdet kan ikke slås opp. Alt i dette segmentet som ikke er en UUID er altså en død lenke, og oversikten er nærmeste treff.

Fram til #482 ga disse 500 fra API-et; etter den 404. Begge havner i feilgrensa, så brukeren får en feilmelding for det som bare er en gammel lenke.

## Hva som er endret

`beforeLoad` på `/_app/nyheter/$slug` kaster `redirect` til `/nyheter` (301, `replace`) når slug-en ikke er en UUID. Ligger i `beforeLoad` og ikke i loaderen, så det aldri blir et API-kall.

## Verifisert

`bun run typecheck` 9/9, `bun run lint` exit 0, `bun run format` rent.

I nettleseren mot dev-serveren:

| URL | Resultat |
|---|---|
| `/nyheter/302` | → `/nyheter` ✅ |
| `/nyheter/302/tihlde-lanserer-noe` | → `/nyheter` ✅ (uendret) |
| `/nyheter/5ee00de4-…-cf336ffd86a7` | blir stående på detaljstien ✅ |

Siste rad er sjekken på at guarden ikke tar ekte artikler. Selve detaljsida kunne ikke rendres ferdig lokalt fordi API-et ikke kjørte i den økta — men det endringa gjør er ruting, og den skjer før noe kall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)