### PR TITLE
fix(auth): få migrerte medlemmer forbi e-postbekreftelsen og inn i Feide-koblingen

### DIFF
--- a/apps/kvark/src/api/auth.ts
+++ b/apps/kvark/src/api/auth.ts
@@ -41,6 +41,48 @@ export const getAuthSession = createIsomorphicFn()
         return session.data;
     });
 
+/**
+ * Which providers are attached to whoever is signed in.
+ *
+ * `/koble-feide` needs this to tell a member who still has to link from one
+ * who linked long ago: the linking prompt is the point of that page for the
+ * first, and a dead end for the second.
+ */
+export const getLinkedAccounts = createIsomorphicFn()
+    .client(async () => {
+        const accounts = await clientAuthInstance.listAccounts();
+        if (accounts.error) {
+            throw new AuthError(
+                `Failed to list accounts: ${accounts.error.message}`,
+            );
+        }
+        return accounts.data ?? [];
+    })
+    .server(async () => {
+        const accounts = await clientAuthInstance.listAccounts({
+            fetchOptions: {
+                headers: getRequestHeaders(),
+            },
+        });
+
+        if (accounts.error) {
+            throw new AuthError(
+                `Failed to list accounts: ${accounts.error.message}`,
+            );
+        }
+        return accounts.data ?? [];
+    });
+
+/**
+ * Nested under `["auth"]` on purpose: linking a provider changes the session
+ * too, and every place that already invalidates auth then invalidates this
+ * without having to know it exists.
+ */
+export const linkedAccountsQueryOptions = queryOptions({
+    queryKey: ["auth", "accounts"],
+    queryFn: () => getLinkedAccounts(),
+});
+
 export const authQueryOptions = queryOptions({
     queryKey: ["auth"],
     staleTime: 1000 * 60 * 2, // 2 minutes we want to check this frequently

--- a/apps/kvark/src/routes/_auth/koble-feide.tsx
+++ b/apps/kvark/src/routes/_auth/koble-feide.tsx
@@ -7,13 +7,19 @@ import {
     Card,
     CardContent,
     CardDescription,
+    CardFooter,
     CardHeader,
     CardTitle,
 } from "@tihlde/ui/ui/card";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import { Spinner } from "@tihlde/ui/ui/spinner";
 
-import { authQueryOptions, linkFeideMutationOptions } from "#/api/auth";
+import {
+    authQueryOptions,
+    linkedAccountsQueryOptions,
+    linkFeideMutationOptions,
+    sanitizeRedirectTo,
+} from "#/api/auth";
 import { syncFeideAccountMutation } from "#/api/queries/account-link";
 
 /**
@@ -26,9 +32,15 @@ import { syncFeideAccountMutation } from "#/api/queries/account-link";
  */
 export const Route = createFileRoute("/_auth/koble-feide")({
     component: LinkFeidePage,
-    // Feide sends the member back here with ?linked, which is what tells this
-    // page to finish the job the callback could not.
-    validateSearch: z.object({ linked: z.coerce.boolean().optional() }),
+    validateSearch: z.object({
+        // Feide sends the member back here with ?linked, which is what tells
+        // this page to finish the job the callback could not.
+        linked: z.coerce.boolean().optional(),
+        // Where they were headed before login interrupted them. Carried
+        // through the Feide round trip so linking does not cost them the
+        // page they actually asked for.
+        next: z.string().optional(),
+    }),
 });
 
 function LinkFeidePage() {
@@ -95,12 +107,18 @@ function LinkFeideSkeleton() {
 
 function LinkFeideCard() {
     const { data: auth } = useSuspenseQuery(authQueryOptions);
-    const { linked } = Route.useSearch();
+    const { linked, next } = Route.useSearch();
     const navigate = useNavigate();
-    const linkMutation = useMutation(linkFeideMutationOptions);
+
+    // Hard navigation rather than the router: linking changed the session, and
+    // `next` is an arbitrary path the typed router cannot check anyway.
+    // Sanitized because it arrives from the URL.
+    const goToNext = () => {
+        window.location.href = sanitizeRedirectTo(next);
+    };
 
     if (linked && auth?.user) {
-        return <FinishLink onDone={() => navigate({ to: "/" })} />;
+        return <FinishLink onDone={goToNext} />;
     }
 
     if (!auth?.user) {
@@ -125,12 +143,71 @@ function LinkFeideCard() {
     }
 
     return (
+        <Suspense fallback={<LinkFeideSkeleton />}>
+            <LinkFeidePrompt
+                name={auth.user.name}
+                next={sanitizeRedirectTo(next)}
+                onSkip={goToNext}
+            />
+        </Suspense>
+    );
+}
+
+/**
+ * The prompt itself, behind its own boundary so the account lookup does not
+ * hold up the "your link expired" branch above — that one has no session, and
+ * listing accounts without one is a 401.
+ *
+ * A member who linked Feide long ago can land here too: any confirmation mail
+ * points at this page, including the ones sent for reasons that have nothing
+ * to do with linking. Asking them to link again is a dead end with no button
+ * out, so they are moved straight on instead.
+ */
+function LinkFeidePrompt({
+    name,
+    next,
+    onSkip,
+}: {
+    name: string;
+    next: string;
+    onSkip: () => void;
+}) {
+    const { data: accounts } = useSuspenseQuery(linkedAccountsQueryOptions);
+    const linkMutation = useMutation(linkFeideMutationOptions);
+
+    const alreadyLinked = accounts.some(
+        (account) => account.providerId === "feide",
+    );
+
+    const skipped = useRef(false);
+    useEffect(() => {
+        if (!alreadyLinked || skipped.current) return;
+        skipped.current = true;
+        onSkip();
+    }, [alreadyLinked, onSkip]);
+
+    if (alreadyLinked) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle>Feide er allerede koblet til</CardTitle>
+                    <CardDescription>Sender deg videre.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <Spinner />
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
         <Card>
             <CardHeader>
                 <CardTitle>Koble Feide til kontoen din</CardTitle>
                 <CardDescription>
-                    Du er logget inn som {auth.user.name}. Etter dette logger du
-                    inn med Feide.
+                    Du er logget inn som {name}. Kobler du til Feide, henter vi
+                    studieprogram og klasse automatisk, og du logger inn med
+                    Feide etterpå.
                 </CardDescription>
             </CardHeader>
             <CardContent className="flex flex-col gap-2">
@@ -139,10 +216,11 @@ function LinkFeideCard() {
                     disabled={linkMutation.isPending}
                     // Back here rather than to the front page: this is where
                     // the study data gets pulled, since the link itself
-                    // cannot. See FinishLink.
+                    // cannot. See FinishLink. `next` rides along so the round
+                    // trip still ends where the member was headed.
                     onClick={() =>
                         linkMutation.mutate({
-                            callbackURL: "/koble-feide?linked=1",
+                            callbackURL: `/koble-feide?linked=1&next=${encodeURIComponent(next)}`,
                         })
                     }
                 >
@@ -161,6 +239,16 @@ function LinkFeideCard() {
                     </p>
                 )}
             </CardContent>
+            {/*
+             * Not everyone can link: the members who reach this page without
+             * Feide are exactly the ones vervrebus verifies by hand. Leaving
+             * them no way past would trade one dead end for another.
+             */}
+            <CardFooter className="justify-center">
+                <Button variant="link" onClick={onSkip}>
+                    Hopp over — jeg bruker ikke Feide
+                </Button>
+            </CardFooter>
         </Card>
     );
 }

--- a/apps/kvark/src/routes/_auth/login.tsx
+++ b/apps/kvark/src/routes/_auth/login.tsx
@@ -65,6 +65,20 @@ export const Route = createFileRoute("/_auth/login")({
     validateSearch: searchSchema,
 });
 
+/**
+ * Absolute URL for the link a confirmation mail carries.
+ *
+ * Absolute because Better Auth resolves a relative callback against the API
+ * host, which would land the member on a 404 from the router. It points at
+ * /koble-feide rather than the destination itself, and carries the
+ * destination as `next` so that page can move them on afterwards.
+ */
+function feideLinkCallbackUrl(redirectTo: unknown) {
+    const url = new URL("/koble-feide", window.location.origin);
+    url.searchParams.set("next", sanitizeRedirectTo(redirectTo));
+    return url.toString();
+}
+
 const loginSchema = z.object({
     username: z.string().min(1, { error: "Brukernavn kan ikke være tomt" }),
     password: z.string().min(1, { error: "Passord kan ikke være tom" }),
@@ -153,15 +167,9 @@ function LoginPage() {
                         onSendVerification={(email) =>
                             verificationMutation.mutate({
                                 email,
-                                // Absolute: Better Auth resolves a relative
-                                // callback against the API host, which would
-                                // land the member on a 404 from the router.
                                 // Confirming signs them in, so send them
                                 // straight to the step that needs a session.
-                                callbackURL: new URL(
-                                    "/koble-feide",
-                                    window.location.origin,
-                                ).toString(),
+                                callbackURL: feideLinkCallbackUrl(redirectTo),
                             })
                         }
                         verificationSending={verificationMutation.isPending}
@@ -272,10 +280,16 @@ function LoginPage() {
                     onSend={(email) =>
                         verificationMutation.mutate({
                             email,
-                            callbackURL: new URL(
-                                sanitizeRedirectTo(redirectTo),
-                                window.location.origin,
-                            ).toString(),
+                            // Via /koble-feide, not straight to redirectTo:
+                            // whoever hits this needs a password to sign in,
+                            // which is the population that never synced with
+                            // Feide. Confirming signs them in, so this is the
+                            // one moment we hold a session and can attach
+                            // Feide to *this* account. That page sends them on
+                            // to `next` either way — it detects an existing
+                            // link, and offers a way past for members who
+                            // cannot use Feide at all.
+                            callbackURL: feideLinkCallbackUrl(redirectTo),
                         })
                     }
                 />

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -307,6 +307,22 @@ export function createAuth(options: CreateAuthOptions) {
                     url: withFrontendCallback(url, options.urls.frontend),
                 });
             },
+            /**
+             * A completed reset already proves the inbox: the token only
+             * exists in a mail sent to that address, and `/reset-password`
+             * refuses to run without it. Demanding a verification mail on top
+             * asks for the same proof twice — which is exactly what the 1685
+             * migrated members hit, since they arrive with `emailVerified`
+             * false and no password they know, so a reset is their only way
+             * in. Crediting the proof we already have is what turns that
+             * round trip from a dead end into a login.
+             */
+            async onPasswordReset({ user: u }) {
+                await options.services.db
+                    .update(user)
+                    .set({ emailVerified: true })
+                    .where(eq(user.id, u.id));
+            },
             ...(options.DANGEROUSLY_SET_INSECURE_HASHING_ALGORITHM && !isProd
                 ? {
                       password: {


### PR DESCRIPTION
Følger opp #485. Aleksanders resend-boks får folk forbi «Email not verified», men to blindveier står igjen bak den.

## 1. Bekreftelseslenken hoppet over Feide-koblingen

Den som må bruke passord for å logge inn er per definisjon en som aldri har synket med Feide. Bekreftelsen signerer dem inn, og det er det ene øyeblikket vi holder en sesjon og dermed kan feste Feide til nettopp den kontoen — beviset matching på brukernavn eller e-post ikke klarte å gi oss. Lenken sendte dem rett til forsiden, så steget skjedde aldri.

Feide-stien pekte allerede på `/koble-feide`, men hardkodet uten `next` og mistet siden de var på vei til.

- `login.tsx` — begge resend-stiene bygger callback-URL-en gjennom én `feideLinkCallbackUrl()`, som peker på `/koble-feide?next=<destinasjon>`.
- `koble-feide.tsx` — tar imot `next` og sender dem dit etterpå. To nye grener, fordi siden nå kan nås av alle:
  - allerede koblet → rett videre, uten å spørre om noe de har gjort
  - «Hopp over — jeg bruker ikke Feide» → for dem vervrebus verifiserer for hånd. Uten den byttet vi bare én blindvei mot en annen; siden hadde ingen vei ut.
- `api/auth.ts` — `linkedAccountsQueryOptions`. Nøkkelen ligger under `["auth"]`, så alt som allerede invaliderer sesjonen invaliderer denne også.

## 2. Passord-reset telte ikke som eierskapsbevis

Reset-tokenet finnes bare i en e-post sendt til adressen på kontoen, og `/reset-password` nekter å kjøre uten det. Å kreve en verifiseringsmail i tillegg ber om det samme beviset to ganger.

Det rammer de 1685 migrerte medlemmene direkte: de kommer inn med `emailVerified` false og et plassholderpassord de ikke kjenner, så en reset er eneste vei inn — og på andre siden møtte de `EMAIL_NOT_VERIFIED` likevel. Det var akkurat den runden Aleksander måtte gjennom.

`packages/auth/src/index.ts` får en `onPasswordReset`-hook som setter `emailVerified`.

## Verifisert

Kjørt mot lokal API + dev-DB, ikke bare typecheck.

Bekreftelseslenken:
- `brotherman` med `email_verified=false` → resend-boksen kom på passord-skjemaet
- e-posten API-en sendte hadde `callbackURL=http://localhost:3000/koble-feide?next=%2Fstillinger`
- fulgte lenken → innlogget, landet på `/koble-feide` med `next` intakt
- «Hopp over» → `/stillinger`
- la inn en `feide`-rad i `auth_account` → siden hoppet rett til `/stillinger` uten å spørre

Passord-reset:
- satte `email_verified=false`, kjørte `request-password-reset` → `reset-password` med tokenet fra mailen
- `email_verified` sto `t` etterpå, og `sign-in/username` ga 200 i stedet for `EMAIL_NOT_VERIFIED`

Testdata ryddet opp: `brotherman` er tilbake på `index123`, verifisert, uten Feide-rad.

`typecheck`, `lint`, `format` og `build` er grønne.

## Ikke testet

Selve Feide-runden (`Koble til Feide` → Dataporten → tilbake med `?linked=1&next=...`) krever Feide-credentials. `next` tres gjennom `callbackURL`, men den hoppet er uverifisert lokalt.

## Merk

`fix/profile-url-frontend` rører også `apps/kvark/src/api/auth.ts`. Endringene ligger i ulike deler av filen, men den som merger sist kan få en liten konflikt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)