### PR TITLE
feat: krev innlogging for kontrakt, galleri, opptak og deltakerlister

### DIFF
--- a/apps/api/src/routes/event/get.ts
+++ b/apps/api/src/routes/event/get.ts
@@ -1,3 +1,5 @@
+import { schema } from "@photon/db";
+import { and, eq, inArray } from "drizzle-orm";
 import type z from "zod";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "../../lib/route";
@@ -77,6 +79,21 @@ export const getRoute = route().get(
         if (event.visibility === "members" && !user) {
             return c.json("The event was not found", 404);
         }
+
+        // How many are going is public; who they are is not. The roster
+        // endpoint is members-only, so the count lives here instead — it is
+        // the same set of statuses that endpoint counts by default.
+        const registeredCount = await db.$count(
+            schema.eventRegistration,
+            and(
+                eq(schema.eventRegistration.eventId, event.id),
+                inArray(schema.eventRegistration.status, [
+                    "registered",
+                    "attended",
+                    "no_show",
+                ]),
+            ),
+        );
 
         let registration: z.infer<typeof eventDetailSchema>["registration"] =
             null;
@@ -174,6 +191,7 @@ export const getRoute = route().get(
             allowWaitlist: event.allowWaitlist,
             capacity: event.capacity,
             canCauseStrikes: event.canCauseStrikes,
+            registeredCount,
             image: event.imageUrl,
             imageAlt: event.imageAlt,
             createdById: event.createdByUserId,

--- a/apps/api/src/routes/event/registration/list.ts
+++ b/apps/api/src/routes/event/registration/list.ts
@@ -7,7 +7,7 @@ import z from "zod";
 import { canActOnEvent } from "~/lib/event/access";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { captureAuth } from "~/middleware/auth";
+import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
     getPageOffset,
@@ -16,9 +16,9 @@ import {
 import { eventRegistrationListResponseSchema } from "../schema";
 
 /**
- * The statuses that count as "successfully registered". This is the public
- * default and must not change: the event page renders `totalCount` from this
- * endpoint as the visible registration count.
+ * The statuses that count as "successfully registered". This is the default
+ * and must not change: it is what `registeredCount` on the event itself counts,
+ * and the two numbers have to agree.
  */
 const DEFAULT_STATUSES = ["registered", "attended", "no_show"] as const;
 
@@ -38,7 +38,7 @@ export const getAllRegistrationsForEventsRoute = route().get(
         summary: "Get event registrations",
         operationId: "listEventRegistrations",
         description:
-            "Retrieve a paginated list of users registered for a specific event. Event admins additionally receive email, registration time, waitlist position and payment status, and may filter by registration status.",
+            "Retrieve a paginated list of users registered for a specific event. Members only — who attends is not something the open internet gets to enumerate; the event itself carries a public `registeredCount` for the visible number. Event admins additionally receive email, registration time, waitlist position and payment status, and may filter by registration status.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -46,11 +46,12 @@ export const getAllRegistrationsForEventsRoute = route().get(
             description: "OK",
         })
         .badRequest({ description: "Unknown registration status" })
+        .unauthorized({ description: "Authentication required" })
         .forbidden({
             description: "Filtering by status requires event admin permissions",
         })
         .build(),
-    captureAuth,
+    requireAuth,
     validator("query", querySchema),
     async (c) => {
         const ctx = c.get("ctx");
@@ -61,13 +62,11 @@ export const getAllRegistrationsForEventsRoute = route().get(
         // Email, payment status, waitlist position and photo consent are all
         // admin-facing: only include them for callers who can manage events.
         const user = c.get("user");
-        const isEventAdmin = user
-            ? await canActOnEvent(ctx, user.id, eventId, [
-                  "events:update",
-                  "events:manage",
-                  "events:registrations:view",
-              ])
-            : false;
+        const isEventAdmin = await canActOnEvent(ctx, user.id, eventId, [
+            "events:update",
+            "events:manage",
+            "events:registrations:view",
+        ]);
 
         let statuses: readonly string[] = DEFAULT_STATUSES;
         if (status) {

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -557,6 +557,10 @@ export const eventDetailSchema = Schema(
             description:
                 "Can this event give strikes for late cancellation or no-show?",
         }),
+        registeredCount: z.number().int().meta({
+            description:
+                "Number of people signed up (registered, attended or no-show). Public, unlike the roster itself, so the open event page can show how many are going without naming them.",
+        }),
         image: z
             .url()
             .nullable()

--- a/apps/api/src/routes/gallery/get.ts
+++ b/apps/api/src/routes/gallery/get.ts
@@ -8,6 +8,7 @@ import {
 } from "~/lib/gallery";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
+import { requireAuth } from "~/middleware/auth";
 import { gallerySchema } from "./schema";
 
 export const getRoute = route().get(
@@ -17,7 +18,7 @@ export const getRoute = route().get(
         summary: "Get gallery",
         operationId: "getGallery",
         description:
-            "Get a single album by slug (or ID). Pictures are fetched separately via /api/galleries/{slug}/pictures. Public endpoint.",
+            "Get a single album by slug (or ID). Pictures are fetched separately via /api/galleries/{slug}/pictures. Members only.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -25,7 +26,9 @@ export const getRoute = route().get(
             description: "Album details",
         })
         .notFound({ description: "Gallery not found" })
+        .unauthorized({ description: "Authentication required" })
         .build(),
+    requireAuth,
     async (c) => {
         const ctx = c.get("ctx");
         const { slug } = c.req.param();

--- a/apps/api/src/routes/gallery/list.ts
+++ b/apps/api/src/routes/gallery/list.ts
@@ -5,6 +5,7 @@ import type z from "zod";
 import { serializeAlbum } from "~/lib/gallery";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
+import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
     getPageOffset,
@@ -19,14 +20,16 @@ export const listRoute = route().get(
         summary: "List galleries",
         operationId: "listGalleries",
         description:
-            "Get a paginated list of photo albums, newest first. Public endpoint.",
+            "Get a paginated list of photo albums, newest first. Members only.",
     })
         .schemaResponse({
             statusCode: 200,
             schema: galleryListResponseSchema,
             description: "OK",
         })
+        .unauthorized({ description: "Authentication required" })
         .build(),
+    requireAuth,
     validator("query", PaginationSchema.extend(galleryListQuerySchema.shape)),
     async (c) => {
         const { db } = c.get("ctx");

--- a/apps/api/src/routes/gallery/pictures/list.ts
+++ b/apps/api/src/routes/gallery/pictures/list.ts
@@ -6,6 +6,7 @@ import type z from "zod";
 import { findAlbumBySlugOrId } from "~/lib/gallery";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
+import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
     getPageOffset,
@@ -20,7 +21,7 @@ export const listPicturesRoute = route().get(
         summary: "List pictures in a gallery",
         operationId: "listGalleryPictures",
         description:
-            "Get a paginated list of the pictures in an album. This is what backs the 'Last inn mer' button. Public endpoint.",
+            "Get a paginated list of the pictures in an album. This is what backs the 'Last inn mer' button. Members only.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -28,7 +29,9 @@ export const listPicturesRoute = route().get(
             description: "OK",
         })
         .notFound({ description: "Gallery not found" })
+        .unauthorized({ description: "Authentication required" })
         .build(),
+    requireAuth,
     validator("query", PaginationSchema),
     async (c) => {
         const ctx = c.get("ctx");

--- a/apps/api/src/test/event/registration-list.test.ts
+++ b/apps/api/src/test/event/registration-list.test.ts
@@ -33,13 +33,41 @@ async function seedRegistrations(ctx: IntegrationTestContext) {
 
 describe("Event registration listing", () => {
     integrationTest(
-        // Regression guard: the public event page renders totalCount as the
-        // visible registration count.
-        "hides admin fields and non-registered statuses from anonymous callers",
+        // Regression guard: who attends must not be enumerable from the open
+        // internet. The count itself stays public, on the event.
+        "refuses anonymous callers, but the event still carries the count",
         async ({ ctx }) => {
             const { event } = await seedRegistrations(ctx);
 
             const client = ctx.utils.client();
+            const res = await client.api.event[":eventId"].registration.$get({
+                param: { eventId: event.id },
+                query: {},
+            });
+
+            expect(res.status).toBe(401);
+
+            const eventRes = await client.api.event[":eventId"].$get({
+                param: { eventId: event.id },
+            });
+            expect(eventRes.status).toBe(200);
+            // The 404 branch returns a bare string, so narrow before reading.
+            const body = await eventRes.json();
+            expect(typeof body).not.toBe("string");
+            expect(
+                typeof body === "string" ? undefined : body.registeredCount,
+            ).toBe(1);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "hides admin fields and non-registered statuses from ordinary members",
+        async ({ ctx }) => {
+            const { event } = await seedRegistrations(ctx);
+
+            const member = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(member);
             const res = await client.api.event[":eventId"].registration.$get({
                 param: { eventId: event.id },
                 query: {},

--- a/apps/api/src/test/gallery/gallery.test.ts
+++ b/apps/api/src/test/gallery/gallery.test.ts
@@ -162,7 +162,7 @@ describe("Gallery System", () => {
             });
             expect((await unlinkResponse.json()).event).toBeNull();
 
-            // === GET (public, by slug) ===
+            // === GET (members only, by slug) ===
 
             const getResponse = await userClient.api.galleries[":slug"].$get({
                 param: { slug: album.slug },
@@ -204,6 +204,40 @@ describe("Gallery System", () => {
                 param: { slug: album.slug },
             });
             expect(goneResponse.status).toBe(404);
+        },
+    );
+
+    integrationTest(
+        "the archive is for members: anonymous callers get 401",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["galleries:manage"]);
+            const adminClient = await ctx.utils.clientForUser(admin);
+
+            const created = await adminClient.api.galleries.$post({
+                json: { title: "Internt galleri" },
+            });
+            const album = await created.json();
+
+            const anonymous = ctx.utils.client();
+
+            const listResponse = await anonymous.api.galleries.$get({
+                query: {},
+            });
+            expect(listResponse.status).toBe(401);
+
+            const getResponse = await anonymous.api.galleries[":slug"].$get({
+                param: { slug: album.slug },
+            });
+            expect(getResponse.status).toBe(401);
+
+            const picturesResponse = await anonymous.api.galleries[
+                ":slug"
+            ].pictures.$get({
+                param: { slug: album.slug },
+                query: {},
+            });
+            expect(picturesResponse.status).toBe(401);
         },
     );
 });

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -74,9 +74,12 @@ function EventDetailPage() {
         refetchIntervalInBackground: true,
     });
     const { data: session } = useQuery(authQueryOptions);
-    const { data: registrations } = useQuery(
-        getEventRegistrationsQuery(event.id, 0),
-    );
+    // Deltakerlisten er for medlemmer — utloggede får antallet fra
+    // arrangementet selv, og ville bare fått 401 her.
+    const { data: registrations } = useQuery({
+        ...getEventRegistrationsQuery(event.id, 0),
+        enabled: Boolean(session),
+    });
 
     const eventRules = useEventRulesConsent();
     const registerMutation = useMutation(registerForEventMutation);
@@ -119,7 +122,7 @@ function EventDetailPage() {
         : null;
 
     const price = formatEventPrice(event.isPaidEvent, event.payInfo?.price);
-    const registeredCount = registrations?.totalCount ?? 0;
+    const registeredCount = event.registeredCount;
     const registrants = (registrations?.registeredUsers ?? []).map((u) => ({
         id: u.id,
         name: u.name,

--- a/apps/kvark/src/routes/_app/galleri.$slug.tsx
+++ b/apps/kvark/src/routes/_app/galleri.$slug.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import { CalendarIcon } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
 
+import { authClientWithRedirect } from "#/api/auth";
 import {
     deleteGalleryPictureMutation,
     getGalleryPicturesInfiniteQuery,
@@ -25,6 +26,7 @@ import { useAnyScopePermission } from "#/hooks/use-permission";
 
 export const Route = createFileRoute("/_app/galleri/$slug")({
     component: GalleryDetailPage,
+    beforeLoad: ({ location }) => authClientWithRedirect(location.href),
     loader: ({ context, params }) =>
         context.queryClient.ensureQueryData(getGalleryQuery(params.slug)),
 });

--- a/apps/kvark/src/routes/_app/galleri.index.tsx
+++ b/apps/kvark/src/routes/_app/galleri.index.tsx
@@ -3,12 +3,14 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Empty, EmptyDescription, EmptyTitle } from "@tihlde/ui/ui/empty";
 import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
 
+import { authClientWithRedirect } from "#/api/auth";
 import { getGalleriesInfiniteQuery } from "#/api/queries/galleries";
 import { GalleryCard } from "#/components/gallery-card";
 import { LoadMoreButton } from "#/components/load-more-button";
 
 export const Route = createFileRoute("/_app/galleri/")({
     component: GalleriesPage,
+    beforeLoad: ({ location }) => authClientWithRedirect(location.href),
     loader: ({ context }) =>
         context.queryClient.ensureInfiniteQueryData(
             getGalleriesInfiniteQuery(),

--- a/apps/kvark/src/routes/_app/kontrakt.tsx
+++ b/apps/kvark/src/routes/_app/kontrakt.tsx
@@ -15,7 +15,7 @@ import { SignatureInput } from "@tihlde/ui/ui/signature-input";
 import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
-import { authQueryOptions } from "#/api/auth";
+import { authClientWithRedirect, authQueryOptions } from "#/api/auth";
 import {
     getActiveContractQuery,
     getMySignatureQuery,
@@ -32,6 +32,7 @@ const SIGNED_PDF_URL = new URL(
 
 export const Route = createFileRoute("/_app/kontrakt")({
     component: KontraktPage,
+    beforeLoad: ({ location }) => authClientWithRedirect(location.href),
     loader: ({ context }) =>
         context.queryClient.ensureQueryData(getActiveContractQuery()),
 });

--- a/apps/kvark/src/routes/_app/opptak.tsx
+++ b/apps/kvark/src/routes/_app/opptak.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 
-import { authQueryOptions } from "#/api/auth";
+import { authClientWithRedirect, authQueryOptions } from "#/api/auth";
 import { getGroupFormsQuery, getGroupsQuery } from "#/api/queries/groups";
 import {
     type AdmissionGroup,
@@ -15,6 +15,7 @@ import { ADMISSION_INFOS } from "#/data/admissions";
 
 export const Route = createFileRoute("/_app/opptak")({
     component: AdmissionsPage,
+    beforeLoad: ({ location }) => authClientWithRedirect(location.href),
     loader: ({ context }) =>
         context.queryClient.ensureQueryData(getGroupsQuery(0)),
 });

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -753,7 +753,7 @@ export interface paths {
         };
         /**
          * Get event registrations
-         * @description Retrieve a paginated list of users registered for a specific event. Event admins additionally receive email, registration time, waitlist position and payment status, and may filter by registration status.
+         * @description Retrieve a paginated list of users registered for a specific event. Members only — who attends is not something the open internet gets to enumerate; the event itself carries a public `registeredCount` for the visible number. Event admins additionally receive email, registration time, waitlist position and payment status, and may filter by registration status.
          */
         get: operations["listEventRegistrations"];
         put?: never;
@@ -1081,7 +1081,7 @@ export interface paths {
         };
         /**
          * List galleries
-         * @description Get a paginated list of photo albums, newest first. Public endpoint.
+         * @description Get a paginated list of photo albums, newest first. Members only.
          */
         get: operations["listGalleries"];
         put?: never;
@@ -1105,7 +1105,7 @@ export interface paths {
         };
         /**
          * List pictures in a gallery
-         * @description Get a paginated list of the pictures in an album. This is what backs the 'Last inn mer' button. Public endpoint.
+         * @description Get a paginated list of the pictures in an album. This is what backs the 'Last inn mer' button. Members only.
          */
         get: operations["listGalleryPictures"];
         put?: never;
@@ -1153,7 +1153,7 @@ export interface paths {
         };
         /**
          * Get gallery
-         * @description Get a single album by slug (or ID). Pictures are fetched separately via /api/galleries/{slug}/pictures. Public endpoint.
+         * @description Get a single album by slug (or ID). Pictures are fetched separately via /api/galleries/{slug}/pictures. Members only.
          */
         get: operations["getGallery"];
         put?: never;
@@ -3545,6 +3545,8 @@ export interface components {
             capacity: number | null;
             /** @description Can this event give strikes for late cancellation or no-show? */
             canCauseStrikes: boolean;
+            /** @description Number of people signed up (registered, attended or no-show). Public, unlike the roster itself, so the open event page can show how many are going without naming them. */
+            registeredCount: number;
             /** @description Event image URL (nullable) */
             image: string | null;
             /** @description Alt text for the event image (nullable) */
@@ -7426,6 +7428,15 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Forbidden - Filtering by status requires event admin permissions */
             403: {
                 headers: {
@@ -8416,6 +8427,15 @@ export interface operations {
                     "application/json": components["schemas"]["GalleryList"];
                 };
             };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     createGallery: {
@@ -8481,6 +8501,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GalleryPictureList"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
             /** @description Not Found - Gallery not found */
@@ -8655,6 +8684,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Gallery"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
             /** @description Not Found - Gallery not found */


### PR DESCRIPTION
## Hva

Fire ting som var åpne for alle besøkende er nå bak innlogging.

- **`/kontrakt`, `/galleri`, `/opptak`** får `beforeLoad`-vakt og sender utloggede til `/login` med `redirectTo`. Galleri og opptak lå allerede under «For Medlemmer» i menyen, men var åpne for alle som hadde URL-en.
- **Galleri-API-et** (`GET /api/galleries`, `/:slug`, `/:slug/pictures`) krever nå innlogging, så sidevakten ikke bare er kosmetikk.
- **`GET /api/event/:eventId/registration`** krever nå innlogging. Før kunne hvem som helst bla seg gjennom navn og profilbilde på alle påmeldte til ethvert arrangement.

## Antall påmeldte er fortsatt offentlig

Den åpne arrangementssiden hentet tellingen fra `totalCount` på deltakerlisten. Den ville blitt 0 for utloggede, så antallet ligger nå som `registeredCount` på arrangementet selv — samme statuser (`registered`, `attended`, `no_show`) som listen teller. Hvor mange som kommer er offentlig, hvem de er er det ikke.

## Verifisert

- `bun run typecheck`, `bun run lint`, `bun run build` — grønt
- `bunx vitest run src/test/event src/test/gallery` — 114 tester grønne, inkludert nye:
  - anonym mot deltakerlisten gir 401, mens arrangementet fortsatt oppgir `registeredCount: 1`
  - vanlig innlogget medlem ser navn, men ikke e-post/status/betaling/ventelisteplass
  - anonym mot galleriliste, album og bilder gir 401
- Kvark dev-server: `/galleri`, `/galleri/:slug`, `/opptak` og `/kontrakt` redirecter utlogget til `/login?redirectTo=…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)