### PR TITLE
chore: tag-baserte releases, én branch (main)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: release
+description: Slipp en ny prod-release av Photon ved å lage en datobasert release-tag på main. Bruk når noen sier "release", "slipp ny versjon", "deploy til prod", "ship dette", "lag en tag" eller ber om å få dagens main ut i produksjon. Dekker også hvordan man ruller tilbake til en tidligere release.
+---
+
+# Release (tag-basert)
+
+Photon har **én branch: `main`**. Ingen dev-branch, ingen merge-strategi å huske. En release er en tag.
+
+- Alt arbeid: feature-branch → PR → `main`. CI kjører på PR-en.
+- En release: en tag på `main` med formatet `<YYYY-MM-DD>.release-<n>` (f.eks. `2026-08-08.release-1`, `2026-08-08.release-2`, `2026-08-09.release-1`).
+- Taggen — ikke push til main — trigger [deploy.yml](.github/workflows/deploy.yml): bygg → push til GHCR → varsle Drift → publiser GitHub Release med generert changelog.
+- Imaget tagges med release-taggen i tillegg til `latest` og sha, så Drift kan bruke den som markør på containeren.
+
+## Slippe en release
+
+Kjør skriptet — ikke lag taggen for hånd:
+
+```bash
+bun run cut-release
+```
+
+Det gjør alle sjekkene selv: at du står på `main`, at treet er rent, at `main` er i synk med `origin/main`, og at CI faktisk er grønn på commiten som tagges. Det regner ut neste nummer for dagen, viser hvilke commits som slippes siden forrige release, og spør før det pusher.
+
+For å se hva som ville skjedd uten å slippe noe:
+
+```bash
+bun run cut-release --dry-run
+```
+
+Etterpå: følg kjøringen og **rapporter faktisk status**, ikke bare «deployet».
+
+```bash
+gh run list --limit 3
+```
+
+## Ting å ikke gjøre
+
+- **Ikke lag taggen manuelt** med `git tag`. Skriptet finnes fordi sjekkene (CI grønn, i synk med origin, riktig nummer) er lette å glemme, og en feil tag deployer rett i prod.
+- **Ikke gjenbruk eller flytt en tag.** En release-tag er en uforanderlig markør — Drift peker på den. Trenger du å fikse noe, lag en ny tag.
+- **Ikke gjenopprett en `dev`-branch.** Den ble bevisst fjernet: dobbel CI-venting (~20 min i stedet for ~10) og en merge-strategi nye i Index måtte lære. Kommer det en «vi burde ha en staging-branch»-diskusjon, er det en egen avgjørelse — ikke noe man gjør i forbifarten.
+
+## Rulle tilbake
+
+Ingen revert-commit nødvendig — Drift kan peke på et tidligere image, siden hver release har sin egen docker-tag.
+
+```bash
+git tag --list '*.release-*' --sort=-creatordate | head -5
+```
+
+Finn taggen som var grønn, og be Drift deploye `ghcr.io/tihlde/photon:<tag>`. Er problemet i koden, fiks det på `main` som vanlig via PR og slipp en ny release oppå.
+
+## Hvis noe skurrer
+
+- **Taggen ble pushet, men ingen deploy startet.** Sjekk at taggen matcher glob-en i [deploy.yml](.github/workflows/deploy.yml) (`[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].release-*`). En tag som `v1.2.3` trigger ingenting.
+- **Release-noten mangler.** `release_notes`-jobben krever at taggen finnes på remote (`--verify-tag`). Se jobbloggen i kjøringen.
+- **Docker-imaget mangler release-taggen.** Da er `extra_tags`-inputen i `TIHLDE/tihlde-workflows` sin `_ci_ghcr.yml` borte eller endret — den er forutsetningen for at Drift får markøren sin.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,9 @@ name: CI/CD
 on:
     pull_request:
         branches:
-            - dev
             - main
     push:
         branches:
-            - dev
             - main
 
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,18 @@
 name: "build -> push -> deploy"
+
+# Deploy trigges av en release-tag, ikke av push til en branch.
+# Tag-format: <dato>.release-<n>, f.eks. 2026-08-08.release-1.
+# Bruk `bun run cut-release` (scripts/cut-release.sh) for å lage taggen.
+# (`bun run release` er changesets' npm-publisering av @tihlde/sdk — noe annet.)
 on:
     push:
-        branches: [main]
-        paths:
-            - "**"
+        tags:
+            - "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].release-*"
     workflow_dispatch:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: false
 
 jobs:
     build:
@@ -19,12 +23,34 @@ jobs:
         with:
             context: .
             dockerfile: ./infra/docker/Dockerfile
+            # Tagger imaget med release-taggen, så Drift kan bruke den som
+            # deploy-markør på containeren i tillegg til latest + sha.
+            extra_tags: type=ref,event=tag
 
     deploy:
         needs: build
-        if: github.event_name != 'pull_request'
         uses: TIHLDE/tihlde-workflows/.github/workflows/_notify_deploy.yml@main
         with:
             deploy_url: "https://deploy-king.tihlde.org/deploy"
         secrets:
             DEPLOY_RECEIVER_TOKEN: ${{ secrets.DEPLOY_RECEIVER_TOKEN }}
+
+    release_notes:
+        needs: build
+        if: github.event_name == 'push'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Publiser GitHub Release med generert changelog
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh release create "${GITHUB_REF_NAME}" \
+                      --title "${GITHUB_REF_NAME}" \
+                      --generate-notes \
+                      --verify-tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,18 @@ Key dependency chain in `turbo.json`:
 ## Git & GitHub Workflow
 
 - Use **GitHub CLI (`gh`)** for all GitHub operations
-- Do NOT push directly to main/master
+- Do NOT push directly to main
 - Create feature branches for all changes
+
+### Branching & Releases
+
+The repo has **one long-lived branch: `main`**. There is no `dev` branch.
+
+- All work: feature branch → PR → `main`. CI runs on the PR.
+- A release is a **tag**, not a merge: `<YYYY-MM-DD>.release-<n>` (e.g. `2026-08-08.release-1`).
+- Cut a release with `bun run cut-release` — never `git tag` by hand. The script verifies you're on an up-to-date `main`, that the tree is clean, and that CI is green on the commit being tagged.
+- The tag triggers `deploy.yml`: build → push to GHCR → notify Drift → publish a GitHub Release with a generated changelog. The release tag is also applied to the docker image so Drift can use it as a deploy marker.
+- `bun run release` is something else — changesets' npm publish of `@tihlde/sdk`. Don't confuse the two.
 
 ### Commit Message Convention
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
         "sdk:update": "turbo build --filter=@tihlde/sdk && changeset",
         "changeset": "changeset",
         "version-packages": "changeset version",
-        "release": "turbo build --filter=@tihlde/sdk && changeset publish"
+        "release": "turbo build --filter=@tihlde/sdk && changeset publish",
+        "cut-release": "bash scripts/cut-release.sh"
     },
     "devDependencies": {
         "@changesets/changelog-github": "^0.5.2",

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Lager og pusher en release-tag på main. Taggen trigger build -> push -> deploy
+# (.github/workflows/deploy.yml) og publiserer en GitHub Release med changelog.
+#
+# Tag-format: <YYYY-MM-DD>.release-<n>, f.eks. 2026-08-08.release-1
+#
+#   bun run cut-release           # lag neste tag på HEAD av origin/main
+#   bun run cut-release --dry-run # vis hva som ville skjedd
+#
+set -euo pipefail
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+die() {
+    echo "feil: $*" >&2
+    exit 1
+}
+
+command -v gh >/dev/null || die "gh (GitHub CLI) må være installert"
+
+echo "Henter fra origin..."
+git fetch origin --tags --quiet
+
+# --- Sjekker -----------------------------------------------------------------
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[[ "$BRANCH" == "main" ]] || die "du står på '$BRANCH' — releases tagges fra main"
+
+[[ -z "$(git status --porcelain)" ]] || die "arbeidstreet er ikke rent — commit eller stash først"
+
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+[[ "$LOCAL" == "$REMOTE" ]] || die "main er ikke i synk med origin/main — kjør 'git pull' først"
+
+# Ikke tagg en commit CI ikke har godkjent.
+CI_STATUS=$(gh run list --commit "$LOCAL" --workflow "CI/CD" --limit 1 --json conclusion --jq '.[0].conclusion // "mangler"')
+if [[ "$CI_STATUS" != "success" ]]; then
+    echo "advarsel: CI for $(git rev-parse --short HEAD) er '$CI_STATUS', ikke 'success'." >&2
+    read -r -p "Tagge likevel? [y/N] " svar
+    [[ "$svar" == "y" || "$svar" == "Y" ]] || die "avbrutt"
+fi
+
+# --- Regn ut neste tag -------------------------------------------------------
+
+DATE=$(date +%F)
+# Numerisk sortering, ikke leksikografisk — ellers blir release-10 < release-2.
+LAST=$(git tag --list "${DATE}.release-*" | sed "s/^${DATE}\.release-//" | sort -n | tail -1)
+NEXT=$((${LAST:-0} + 1))
+TAG="${DATE}.release-${NEXT}"
+
+git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null && die "taggen ${TAG} finnes allerede"
+
+# --- Vis hva som slippes -----------------------------------------------------
+
+PREV_TAG=$(git tag --list '*.release-*' --sort=-creatordate | head -1)
+echo
+echo "Release:  ${TAG}"
+echo "Commit:   $(git rev-parse --short HEAD)"
+if [[ -n "$PREV_TAG" ]]; then
+    COUNT=$(git rev-list --count "${PREV_TAG}..HEAD")
+    echo "Siden:    ${PREV_TAG} (${COUNT} commits)"
+    echo
+    git log --format='  %h %s' "${PREV_TAG}..HEAD"
+else
+    echo "Siden:    (første release)"
+fi
+echo
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "--dry-run: ingenting ble tagget eller pushet."
+    exit 0
+fi
+
+read -r -p "Dette deployer til prod. Fortsette? [y/N] " svar
+[[ "$svar" == "y" || "$svar" == "Y" ]] || die "avbrutt"
+
+# --- Tagg og push ------------------------------------------------------------
+
+git tag -a "$TAG" -m "Release ${TAG}"
+git push origin "$TAG"
+
+echo
+echo "Pushet ${TAG}. Følg deployet med:"
+echo "  gh run list --limit 3"


### PR DESCRIPTION
Erstatter dev/main-oppsettet med **én branch (`main`)** og datobaserte release-tags, slik Aleks foreslo.

## Hvorfor

- dev→main via GitHub-knappen lager alltid en merge commit som bare finnes på main (GitHub har ingen fast-forward-strategi). Squash er verre — den gjenskaper konflikter.
- Hver endring måtte gjennom to CI-runder: inn i dev, så dev→main. ~20 min i stedet for ~10.
- En fast-forward-strategi løser det, men krever at alle vet at de ikke skal bruke merge-knappen. Én branch + tag krever ingenting av nye i Index.

## Hva

| Fil | Endring |
|---|---|
| `deploy.yml` | Trigger på tag `<YYYY-MM-DD>.release-<n>` i stedet for push til main. Tagger docker-imaget med release-taggen så Drift kan bruke den som deploy-markør. Ny `release_notes`-jobb publiserer GitHub Release med generert changelog. |
| `ci.yml` | Kjører kun mot `main`. |
| `scripts/cut-release.sh` | `bun run cut-release` — regner ut neste tag, sjekker ren main i synk med origin og grønn CI på commiten, viser hva som slippes, spør før push. |
| `.claude/skills/release` | Dokumenterer flyten for Claude Code, inkl. rollback via tidligere image-tag. |
| `CLAUDE.md` | Beskriver den nye modellen. |

`bun run release` er urørt — det er changesets' npm-publisering av `@tihlde/sdk`, noe annet enn en prod-release.

## Avhengighet

Krever TIHLDE/tihlde-workflows#10 (valgfri `extra_tags`-input i `_ci_ghcr.yml`). **Den må merges først**, ellers feiler `build`-jobben på ukjent input. Uten den får imaget bare `latest` + sha, og Drift får ikke markøren sin.

## Merk om CI på denne PR-en

`ci.yml` i denne branchen lytter kun på PR-er mot `main`, mens denne PR-en går mot `dev` — så CI trigger ikke her. Endringene er workflow/script/docs, ingen produktkode. Verifisert lokalt: begge workflow-filene parser som gyldig YAML med forventede triggers, `package.json` er gyldig JSON, `bash -n` på skriptet er rent, og nummereringen er numerisk sortert (release-10 → release-11, ikke release-3).

## Etter merge

Gjenstår som manuelle steg, siden de er irreversible og angår hele teamet:

1. `git push origin origin/dev:main` — siste fast-forward noensinne
2. Bytt default branch til `main` i repo-settings
3. Slett `dev`
4. Første release: `bun run cut-release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)