### PR TITLE
fix(kvark): gruppeledere kommer inn i adminpanelet

### DIFF
--- a/apps/kvark/src/hooks/use-permission.ts
+++ b/apps/kvark/src/hooks/use-permission.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import {
     authQueryOptions,
@@ -123,6 +123,27 @@ export function useIsGroupLeaderOf(slug: string): boolean {
         session?.groups?.some(
             (group) => group.slug === slug && group.role === "leader",
         ),
+    );
+}
+
+/**
+ * The slugs of every group the current user leads.
+ *
+ * For listings that must be narrowed to what the viewer may act on. Leadership
+ * is membership, not a permission string, so it cannot be read out of
+ * `session.permissions` the way {@link useCanActForGroup} reads a grant.
+ */
+export function useLedGroupSlugs(): ReadonlySet<string> {
+    const { data: session } = useQuery(authQueryOptions);
+    const groups = session?.groups;
+    return useMemo(
+        () =>
+            new Set(
+                (groups ?? [])
+                    .filter((group) => group.role === "leader")
+                    .map((group) => group.slug),
+            ),
+        [groups],
     );
 }
 

--- a/apps/kvark/src/routes/admin.tsx
+++ b/apps/kvark/src/routes/admin.tsx
@@ -164,10 +164,15 @@ const sidebarMenuGroups: SidebarGroup[] = [
                 permission: ADMIN_SECTION_PERMISSIONS.brukere,
             },
             {
+                // Lederen av en gruppe kommer hit uten noen global groups:*-
+                // rettighet — API-et lar lederen redigere sin egen gruppe
+                // (`ownership: isGroupLeader`). Sida viser bare gruppene
+                // vedkommende faktisk kan røre.
                 label: "Grupper",
                 icon: Users2Icon,
                 link: linkOptions({ to: "/admin/grupper" }),
                 permission: ADMIN_SECTION_PERMISSIONS.grupper,
+                allowGroupLeader: true,
             },
             {
                 label: "Prikker",

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -81,7 +81,9 @@ import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import {
     useAnyScopePermission,
+    useCanActForGroup,
     useIsGroupLeaderOf,
+    useLedGroupSlugs,
     useScopedPermission,
 } from "#/hooks/use-permission";
 import { groupTypeLabel } from "#/lib/group";
@@ -106,6 +108,17 @@ const GROUP_TYPE_TABS = [
 
 type TabType = (typeof GROUP_TYPE_TABS)[number]["type"];
 
+/**
+ * Everything this page lets you do to a single group. Holding one of these for
+ * a group — or leading it — is what makes the group worth listing here at all.
+ */
+const GROUP_ADMIN_PERMISSIONS = [
+    "groups:update",
+    "groups:manage",
+    "contracts:view",
+    "contracts:manage",
+] as const;
+
 function GrupperAdminPage() {
     const { data: allGroups } = useSuspenseQuery(getGroupsQuery(0));
     const [tab, setTab] = useState<TabType>("SUBGROUP");
@@ -113,7 +126,16 @@ function GrupperAdminPage() {
     const [createOpen, setCreateOpen] = useState(false);
     const canCreate = useAnyScopePermission(["groups:create", "groups:manage"]);
 
-    const groups = allGroups.filter((group) => group.type === tab);
+    // The listing endpoint is public, so the narrowing happens here: someone
+    // holding `groups:update@group:nok` administers NoK, not Index. A global
+    // grant satisfies every group, so admins still see all of them.
+    const canActForGroup = useCanActForGroup(GROUP_ADMIN_PERMISSIONS);
+    const ledSlugs = useLedGroupSlugs();
+    const groups = allGroups.filter(
+        (group) =>
+            group.type === tab &&
+            (canActForGroup(group.slug) || ledSlugs.has(group.slug)),
+    );
 
     return (
         <Stagger
@@ -151,7 +173,7 @@ function GrupperAdminPage() {
                 <AdminEmptyState
                     icon={UsersIcon}
                     title="Ingen grupper"
-                    description="Fant ingen grupper av denne typen."
+                    description="Du administrerer ingen grupper av denne typen."
                 />
             ) : (
                 <div className="flex flex-col gap-4">
@@ -357,15 +379,16 @@ function GroupCard({
 
     const updateGroup = useMutation(updateGroupMutation);
     const { uploadImage, isUploading } = useImageUploader();
-    // The scope is known here, so this is exactly the check the API runs:
-    // `groups:update` globally or granted for this very group.
-    const canEdit = useScopedPermission(
-        ["groups:update", "groups:manage"],
-        `group:${group.slug}`,
-    );
+    const isLeader = useIsGroupLeaderOf(group.slug);
+    // Speiler PATCH /groups/:slug nøyaktig: `groups:update` globalt eller for
+    // denne gruppa, eller å være lederen dens (`ownership: isGroupLeader`).
+    const canEdit =
+        useScopedPermission(
+            ["groups:update", "groups:manage"],
+            `group:${group.slug}`,
+        ) || isLeader;
     // Medlemslista speiler fjern-endepunktet: `groups:manage` for denne gruppa,
     // eller å være lederen dens.
-    const isLeader = useIsGroupLeaderOf(group.slug);
     const canManageMembers =
         useScopedPermission("groups:manage", `group:${group.slug}`) || isLeader;
 


### PR DESCRIPTION
## Problem

API-et har hele tiden latt lederen av en gruppe redigere sin egen gruppe — `PATCH /groups/:slug` bruker `requireAccess({ ownership: isGroupLeader })`. UI-et gjorde det ikke: både «Grupper» i sidebaren og «Rediger»-knappen krevde `groups:update`/`groups:manage`. En gruppeleder uten globale rettigheter kunne derfor ikke bytte logo eller gruppebilde, selv om backend ville godtatt det.

## Endring

- `allowGroupLeader: true` på Grupper-seksjonen, slik «Roller og verv» allerede har.
- `canEdit` speiler nå API-et nøyaktig: scoped `groups:update`/`groups:manage`, eller lederskap.
- Gruppelista filtreres til det du faktisk kan administrere. En leder ser sin egen gruppe, ikke alle andres. En global rettighet treffer hver gruppe, så admins ser fortsatt alt.
- Ny `useLedGroupSlugs()` — lederskap er medlemskap og ligger ikke i `session.permissions`.

## Verifisering

Lokal API + Kvark, innlogget som en bruker som leder Index.

Som root: alle undergrupper i lista, «Ny gruppe» synlig — ingen regresjon.

Med rollene midlertidig fjernet, så lederskapet på Index var eneste tilgang (`leader_permissions` er tom):

- sidebaren viste kun «Grupper» og «Roller og verv»
- lista viste kun Index, med «Rediger»; «Ny gruppe» borte
- rediger-panelet viste Logo- og Gruppebilde-feltene
- `PATCH /api/groups/index` → 200
- `PATCH /api/groups/nok` → 403 «requires permission: groups:update»

`typecheck`, `lint` og `format` er grønne.

Ikke testet ende-til-ende: selve filvalget i opplastingen (nettleserverktøyet kan ikke velge fil). Opplastingsendepunktet krever bare innlogging, og lagringen går gjennom samme PATCH som ga 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)