### PR TITLE
fix(auth): la Feide koble seg til uverifiserte kontoer, og drep passordet

### DIFF
--- a/apps/api/src/test/feide/unproven-credentials.test.ts
+++ b/apps/api/src/test/feide/unproven-credentials.test.ts
@@ -1,8 +1,13 @@
-import { revokeUnprovenCredentials } from "@photon/auth/feide";
+import {
+    passwordSetupRedirect,
+    revokeUnprovenCredentials,
+} from "@photon/auth/feide";
 import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { integrationTest } from "~/test/config/integration";
+
+const FRONTEND = "https://tihlde.org";
 
 const credentialsOf = (
     db: Parameters<typeof revokeUnprovenCredentials>[0],
@@ -111,4 +116,51 @@ describe("revokeUnprovenCredentials", () => {
             expect(revoked).toBe(false);
         },
     );
+});
+
+/**
+ * Losing a password silently is how someone finds out on the day Feide is down
+ * and the password form is the only way in. These cover where they get sent
+ * instead.
+ */
+describe("passwordSetupRedirect", () => {
+    it("carries the original destination along", () => {
+        expect(
+            passwordSetupRedirect("https://tihlde.org/arrangementer", FRONTEND),
+        ).toBe("https://tihlde.org/velg-passord?redirectTo=%2Farrangementer");
+    });
+
+    it("keeps the query string of where they were headed", () => {
+        expect(
+            passwordSetupRedirect(
+                "https://tihlde.org/arrangementer?side=2",
+                FRONTEND,
+            ),
+        ).toBe(
+            "https://tihlde.org/velg-passord?redirectTo=%2Farrangementer%3Fside%3D2",
+        );
+    });
+
+    it("refuses to carry a destination on another origin", () => {
+        // An off-site location is either an error URL or something we should
+        // not be bouncing a signed-in member through.
+        expect(
+            passwordSetupRedirect("https://example.com/whatever", FRONTEND),
+        ).toBe("https://tihlde.org/velg-passord?redirectTo=%2F");
+    });
+
+    it("leaves the redirect alone when it already points at the setup page", () => {
+        // A first-ever Feide login gets there on its own via
+        // `newUserCallbackURL`; rewriting would nest redirectTo into itself.
+        expect(
+            passwordSetupRedirect(
+                "https://tihlde.org/velg-passord?redirectTo=%2F",
+                FRONTEND,
+            ),
+        ).toBeNull();
+    });
+
+    it("gives up on a location it cannot parse", () => {
+        expect(passwordSetupRedirect("not-a-url", FRONTEND)).toBeNull();
+    });
 });

--- a/apps/api/src/test/feide/unproven-credentials.test.ts
+++ b/apps/api/src/test/feide/unproven-credentials.test.ts
@@ -127,7 +127,9 @@ describe("passwordSetupRedirect", () => {
     it("carries the original destination along", () => {
         expect(
             passwordSetupRedirect("https://tihlde.org/arrangementer", FRONTEND),
-        ).toBe("https://tihlde.org/velg-passord?redirectTo=%2Farrangementer");
+        ).toBe(
+            "https://tihlde.org/velg-passord?redirectTo=%2Farrangementer&passwordRevoked=1",
+        );
     });
 
     it("keeps the query string of where they were headed", () => {
@@ -137,7 +139,7 @@ describe("passwordSetupRedirect", () => {
                 FRONTEND,
             ),
         ).toBe(
-            "https://tihlde.org/velg-passord?redirectTo=%2Farrangementer%3Fside%3D2",
+            "https://tihlde.org/velg-passord?redirectTo=%2Farrangementer%3Fside%3D2&passwordRevoked=1",
         );
     });
 
@@ -146,7 +148,9 @@ describe("passwordSetupRedirect", () => {
         // not be bouncing a signed-in member through.
         expect(
             passwordSetupRedirect("https://example.com/whatever", FRONTEND),
-        ).toBe("https://tihlde.org/velg-passord?redirectTo=%2F");
+        ).toBe(
+            "https://tihlde.org/velg-passord?redirectTo=%2F&passwordRevoked=1",
+        );
     });
 
     it("leaves the redirect alone when it already points at the setup page", () => {
@@ -154,7 +158,7 @@ describe("passwordSetupRedirect", () => {
         // `newUserCallbackURL`; rewriting would nest redirectTo into itself.
         expect(
             passwordSetupRedirect(
-                "https://tihlde.org/velg-passord?redirectTo=%2F",
+                "https://tihlde.org/velg-passord?redirectTo=%2F&passwordRevoked=1",
                 FRONTEND,
             ),
         ).toBeNull();

--- a/apps/api/src/test/feide/unproven-credentials.test.ts
+++ b/apps/api/src/test/feide/unproven-credentials.test.ts
@@ -1,0 +1,114 @@
+import { revokeUnprovenCredentials } from "@photon/auth/feide";
+import { schema } from "@photon/db";
+import { and, eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+const credentialsOf = (
+    db: Parameters<typeof revokeUnprovenCredentials>[0],
+    userId: string,
+) =>
+    db
+        .select({ id: schema.account.id })
+        .from(schema.account)
+        .where(
+            and(
+                eq(schema.account.userId, userId),
+                eq(schema.account.providerId, "credential"),
+            ),
+        );
+
+/**
+ * Anyone may register `<username>@stud.ntnu.no` without proving they own it,
+ * so an unverified account is evidence of nothing. These cover the rule that
+ * stops a password planted on such an account from surviving the Feide login
+ * that would otherwise verify — and thereby arm — it.
+ *
+ * Note that `createTestUser` verifies every row in the table, so each case sets
+ * the flag it actually wants afterwards, scoped to its own user.
+ */
+describe("revokeUnprovenCredentials", () => {
+    integrationTest(
+        "deletes the password and every session of an unverified account",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser("planted@stud.ntnu.no");
+            await ctx.db
+                .update(schema.user)
+                .set({ emailVerified: false })
+                .where(eq(schema.user.id, user.id));
+
+            await ctx.db.insert(schema.session).values({
+                id: crypto.randomUUID(),
+                userId: user.id,
+                token: crypto.randomUUID(),
+                expiresAt: new Date(Date.now() + 60_000),
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+
+            const revoked = await revokeUnprovenCredentials(ctx.db, user.id);
+
+            expect(revoked).toBe(true);
+            expect(await credentialsOf(ctx.db, user.id)).toHaveLength(0);
+
+            const sessions = await ctx.db
+                .select({ id: schema.session.id })
+                .from(schema.session)
+                .where(eq(schema.session.userId, user.id));
+            expect(sessions).toHaveLength(0);
+        },
+    );
+
+    integrationTest(
+        "leaves a verified account's password alone",
+        async ({ ctx }) => {
+            // Proving the mailbox is what makes the password theirs, and that
+            // proof has already happened — linking Feide must not undo it.
+            const user = await ctx.utils.createTestUser("proven@stud.ntnu.no");
+            await ctx.db
+                .update(schema.user)
+                .set({ emailVerified: true })
+                .where(eq(schema.user.id, user.id));
+
+            const revoked = await revokeUnprovenCredentials(ctx.db, user.id);
+
+            expect(revoked).toBe(false);
+            expect(await credentialsOf(ctx.db, user.id)).toHaveLength(1);
+        },
+    );
+
+    integrationTest(
+        "reports nothing revoked when there was no password to take",
+        async ({ ctx }) => {
+            // The ordinary first Feide login for a brand-new member: no
+            // credential row exists, so there is nothing to revoke — and the
+            // member must not be told their password was removed.
+            const user = await ctx.utils.createTestUser(
+                "feide-only@stud.ntnu.no",
+            );
+            await ctx.db
+                .update(schema.user)
+                .set({ emailVerified: false })
+                .where(eq(schema.user.id, user.id));
+            await ctx.db
+                .delete(schema.account)
+                .where(eq(schema.account.userId, user.id));
+
+            const revoked = await revokeUnprovenCredentials(ctx.db, user.id);
+
+            expect(revoked).toBe(false);
+        },
+    );
+
+    integrationTest(
+        "does nothing for a user that no longer exists",
+        async ({ ctx }) => {
+            const revoked = await revokeUnprovenCredentials(
+                ctx.db,
+                "no-such-user",
+            );
+
+            expect(revoked).toBe(false);
+        },
+    );
+});

--- a/apps/kvark/src/routes/_auth/velg-passord.tsx
+++ b/apps/kvark/src/routes/_auth/velg-passord.tsx
@@ -133,7 +133,7 @@ function ChoosePasswordCard() {
                 </CardTitle>
                 <CardDescription>
                     {passwordRevoked
-                        ? `Det gamle passordet ble fjernet fordi e-posten på kontoen aldri ble bekreftet. Du er logget inn med Feide nå${username ? `, som ${username}` : ""} — velg et nytt passord, eller hopp over og bruk Feide.`
+                        ? `Det gamle passordet ble fjernet fordi e-posten på kontoen aldri ble bekreftet. Du er logget inn med Feide nå${username ? `, som ${username}` : ""}. Velg et nytt passord.`
                         : username
                           ? `Brukernavnet ditt er ${username}. Velg et passord, så kommer du inn selv om Feide er nede.`
                           : "Velg et passord, så kommer du inn selv om Feide er nede."}
@@ -186,11 +186,20 @@ function ChoosePasswordCard() {
                         </form.SubmitButton>
                     </form.AppForm>
                 </CardContent>
-                <CardFooter className="justify-center">
-                    <Button type="button" variant="link" onClick={leave}>
-                        Hopp over
-                    </Button>
-                </CardFooter>
+                {/* Skipping stays a first-class answer for an account that
+                    never had a password — Feide alone is a fine login. It is
+                    not one for an account whose password was just taken away:
+                    leaving without setting a new one is how someone ends up
+                    with Feide as their only way in, which is precisely what
+                    this page exists to prevent. The layout's nav bar is still
+                    there, so nobody is trapped. */}
+                {!passwordRevoked && (
+                    <CardFooter className="justify-center">
+                        <Button type="button" variant="link" onClick={leave}>
+                            Hopp over
+                        </Button>
+                    </CardFooter>
+                )}
             </form>
         </Card>
     );

--- a/apps/kvark/src/routes/_auth/velg-passord.tsx
+++ b/apps/kvark/src/routes/_auth/velg-passord.tsx
@@ -36,7 +36,15 @@ import { formHandlers, useAppForm } from "#/hooks/form";
  */
 export const Route = createFileRoute("/_auth/velg-passord")({
     component: ChoosePasswordPage,
-    validateSearch: z.object({ redirectTo: z.string().optional() }),
+    validateSearch: z.object({
+        redirectTo: z.string().optional(),
+        /**
+         * Set by the Feide callback when linking deleted an unproven password.
+         * Only decides which copy to show — nothing here grants anything, so a
+         * hand-typed value costs nothing.
+         */
+        passwordRevoked: z.coerce.boolean().optional(),
+    }),
 });
 
 const choosePasswordSchema = z
@@ -82,7 +90,7 @@ function ChoosePasswordSkeleton() {
 }
 
 function ChoosePasswordCard() {
-    const { redirectTo } = Route.useSearch();
+    const { redirectTo, passwordRevoked } = Route.useSearch();
     const { data: auth } = useSuspenseQuery(authQueryOptions);
     const mutation = useMutation(setPasswordMutation);
 
@@ -113,11 +121,22 @@ function ChoosePasswordCard() {
     return (
         <Card>
             <CardHeader>
-                <CardTitle>Vil du også kunne logge inn med passord?</CardTitle>
+                {/* Two different situations land here. Offering a password as
+                    a bonus is right for an account that never had one, and
+                    wrong for someone whose password was just deleted — for
+                    them "hopp over" closes their only non-Feide way in, and
+                    they would not know that. */}
+                <CardTitle>
+                    {passwordRevoked
+                        ? "Velg et nytt passord"
+                        : "Vil du også kunne logge inn med passord?"}
+                </CardTitle>
                 <CardDescription>
-                    {username
-                        ? `Brukernavnet ditt er ${username}. Velg et passord, så kommer du inn selv om Feide er nede.`
-                        : "Velg et passord, så kommer du inn selv om Feide er nede."}
+                    {passwordRevoked
+                        ? `Det gamle passordet ble fjernet fordi e-posten på kontoen aldri ble bekreftet. Du er logget inn med Feide nå${username ? `, som ${username}` : ""} — velg et nytt passord, eller hopp over og bruk Feide.`
+                        : username
+                          ? `Brukernavnet ditt er ${username}. Velg et passord, så kommer du inn selv om Feide er nede.`
+                          : "Velg et passord, så kommer du inn selv om Feide er nede."}
                 </CardDescription>
             </CardHeader>
             <form {...formHandlers(form)} className="flex flex-col gap-4">

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -1410,12 +1410,136 @@ export async function revokeUnprovenCredentials(
      */
     await db.delete(session).where(eq(session.userId, userId));
 
+    noteRevokedPassword(userId);
+
     console.warn(
         `Revoked ${revoked.length} unproven credential account(s) for user ${userId} on Feide link: the password predated any proof of the address.`,
     );
 
     return true;
 }
+
+/**
+ * Users whose password was just revoked, so the callback can send them on to
+ * set a new one.
+ *
+ * The revocation happens in a database hook, several layers below the response;
+ * the redirect can only be rewritten in the `after` hook. Nothing in the
+ * request context is shared between the two, hence this hand-off. Entries are
+ * read once and expire on their own, so a login that never reaches the after
+ * hook — a crash, a rewritten redirect — cannot strand a note that misdirects a
+ * later login by the same member.
+ */
+const revokedPasswords = new Map<string, number>();
+
+/** How long a hand-off stays valid. Generous; the two hooks are milliseconds apart. */
+const REVOKED_PASSWORD_TTL_MS = 60_000;
+
+function noteRevokedPassword(userId: string): void {
+    const now = Date.now();
+    for (const [id, at] of revokedPasswords) {
+        if (now - at > REVOKED_PASSWORD_TTL_MS) revokedPasswords.delete(id);
+    }
+    revokedPasswords.set(userId, now);
+}
+
+function consumeRevokedPassword(userId: string): boolean {
+    const at = revokedPasswords.get(userId);
+    if (at === undefined) return false;
+
+    revokedPasswords.delete(userId);
+    return Date.now() - at <= REVOKED_PASSWORD_TTL_MS;
+}
+
+/**
+ * Where to send a member whose password was taken away by the login they just
+ * completed, or null to leave the redirect alone.
+ *
+ * `redirectTo` carries the destination they were originally headed for, so
+ * setting a password — or skipping it — still lands them where they meant to
+ * go. Exported for testing.
+ */
+export function passwordSetupRedirect(
+    location: string,
+    frontendUrl: string,
+): string | null {
+    let current: URL;
+    let frontend: URL;
+    try {
+        current = new URL(location);
+        frontend = new URL(frontendUrl);
+    } catch {
+        return null;
+    }
+
+    // A first-ever Feide login already goes here via `newUserCallbackURL`.
+    if (current.pathname === "/velg-passord") {
+        return null;
+    }
+
+    const target = new URL("/velg-passord", frontend);
+
+    /**
+     * Only a destination on our own site is worth carrying over: anything else
+     * is either an error URL or something we should not be bouncing through.
+     */
+    target.searchParams.set(
+        "redirectTo",
+        current.origin === frontend.origin
+            ? `${current.pathname}${current.search}`
+            : "/",
+    );
+
+    return target.toString();
+}
+
+/**
+ * Rewrites the Feide callback's redirect for a member whose password was just
+ * revoked, so they are told rather than left to find out.
+ *
+ * Better Auth sends first-time Feide *sign-ups* to `newUserCallbackURL` and
+ * everyone else to the plain callback, with no signal in between for "linked,
+ * and the old password is gone". Without this they land on the website looking
+ * signed in, and discover the password is missing the day Feide is unreachable
+ * — which is exactly the day the password form is the only way in.
+ *
+ * Mutating `responseHeaders` is what actually moves them: `c.redirect()` puts
+ * `location` on the very Headers object the response is built from, so the
+ * rewrite lands even though the endpoint has already thrown.
+ */
+export const redirectToPasswordSetupAfterRevoke: (
+    middlewareCtx: MiddlewareContext<
+        MiddlewareOptions,
+        AuthContext & {
+            returned?: unknown;
+            responseHeaders?: Headers;
+        }
+    >,
+    frontendUrl: string,
+) => void = (middlewareContext, frontendUrl) => {
+    if (
+        !middlewareContext.path.startsWith("/oauth2/callback") ||
+        middlewareContext.params.providerId !== FEIDE_PROVIDER_ID
+    ) {
+        return;
+    }
+
+    const session = middlewareContext.context.newSession;
+    if (!session || !consumeRevokedPassword(session.user.id)) {
+        return;
+    }
+
+    const headers = middlewareContext.context.responseHeaders;
+    const location = headers?.get("location");
+    if (!headers || !location) {
+        return;
+    }
+
+    const next = passwordSetupRedirect(location, frontendUrl);
+    if (next) {
+        headers.set("location", next);
+    }
+};
 
 /**
  * Read the OpenID profile Dataporten holds for an access token.

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -1490,6 +1490,15 @@ export function passwordSetupRedirect(
             : "/",
     );
 
+    /**
+     * The page defaults to offering a password as a *bonus* — right for a
+     * Feide account that never had one, and misleading for someone whose
+     * password was just deleted. Telling it which it is, is the difference
+     * between "hopp over" being a free choice and it quietly closing their
+     * only non-Feide way in.
+     */
+    target.searchParams.set("passwordRevoked", "1");
+
     return target.toString();
 }
 

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -15,6 +15,7 @@ import {
     group,
     groupMembership,
     role,
+    session,
     studyProgram,
     studyProgramMembership,
     user,
@@ -33,6 +34,11 @@ export type AuthCreateContext = {
  * BetterAuth provider ID for Feide
  */
 const FEIDE_PROVIDER_ID = "feide";
+
+/**
+ * BetterAuth provider ID for the email/password login it manages itself.
+ */
+const CREDENTIAL_PROVIDER_ID = "credential";
 
 /**
  * Program codes from the Feide API that are part of TIHLDE
@@ -1334,6 +1340,81 @@ export async function resolveMigratedEmail(
         .limit(1);
 
     return feideLink ? null : match.email;
+}
+
+/**
+ * Drop every credential and session an account collected before anyone proved
+ * they control its address.
+ *
+ * Self-registration writes the `user` row before the verification mail is even
+ * sent, and the address is only ever *claimed* — never proven. So an
+ * `emailVerified: false` row carries no evidence that the password on it
+ * belongs to the student the address names. Anyone can register
+ * `<someone-elses-username>@stud.ntnu.no`, pick a password, and wait; NTNU
+ * usernames are derived from names and are trivially guessable.
+ *
+ * The plant is inert while it sits there. `requireEmailVerification` blocks
+ * password sign-in, and sign-up skips auto sign-in for the same reason, so the
+ * row holds no session either. What arms it is the *victim's own* Feide login:
+ * Better Auth links the provider, then flips `emailVerified` to true because
+ * the addresses match — and from that moment the planted password works.
+ *
+ * Feide proves who the human is. It proves nothing about who typed a password
+ * into that row last week, so the password does not survive the link. Better
+ * Auth applies the identical rule to its own email-primary proofs — see
+ * `revokeUnprovenAccountAccess`, used by magic link and email OTP. The OAuth
+ * path never got it, which is why `requireLocalEmailVerified` guards that path
+ * by refusing to link at all. Refusing is what stranded 15 new students in
+ * August 2026: the guard cannot tell "I registered myself and forgot" from
+ * "someone registered this for me", and the self-service way out mails a link
+ * to an NTNU inbox first-year students cannot open yet.
+ *
+ * A *verified* account keeps its password untouched. Proving the mailbox is
+ * exactly what makes that password theirs, and that proof already happened.
+ *
+ * Returns whether anything was revoked, so the caller can tell the member.
+ */
+export async function revokeUnprovenCredentials(
+    db: NodePgDatabase<DbSchema>,
+    userId: string,
+): Promise<boolean> {
+    const [owner] = await db
+        .select({ emailVerified: user.emailVerified })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1);
+
+    if (!owner || owner.emailVerified) {
+        return false;
+    }
+
+    const revoked = await db
+        .delete(account)
+        .where(
+            and(
+                eq(account.userId, userId),
+                eq(account.providerId, CREDENTIAL_PROVIDER_ID),
+            ),
+        )
+        .returning({ id: account.id });
+
+    if (revoked.length === 0) {
+        return false;
+    }
+
+    /**
+     * Belt and braces: an unverified account cannot hold a session today,
+     * because sign-up skips auto sign-in whenever verification is required.
+     * That is one config flag away from changing, and a session left standing
+     * would outlive the password just deleted.
+     */
+    await db.delete(session).where(eq(session.userId, userId));
+
+    console.warn(
+        `Revoked ${revoked.length} unproven credential account(s) for user ${userId} on Feide link: the password predated any proof of the address.`,
+    );
+
+    return true;
 }
 
 /**

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -24,7 +24,7 @@ import { user } from "@photon/db/schema";
 import type { EmailService, CacheService } from "@photon/core/services";
 import { env } from "@photon/core/env";
 import { getUserPermissions } from "./rbac/permissions";
-import { feidePlugin, syncFeideHook } from "./feide";
+import { feidePlugin, revokeUnprovenCredentials, syncFeideHook } from "./feide";
 
 /**
  * Feide is a genuine third-party identity provider: it only works once a Feide
@@ -363,10 +363,60 @@ export function createAuth(options: CreateAuthOptions) {
                  * Only relaxes the *explicit* link routes, where a session
                  * already proves the local account and the provider proves the
                  * Feide identity. The implicit linking done during sign-in
-                 * never consults this flag, so `requireLocalEmailVerified`
-                 * still guards that path untouched.
+                 * never consults this flag — that path is governed by
+                 * `requireLocalEmailVerified` below.
                  */
                 allowDifferentEmails: true,
+
+                /**
+                 * Let a Feide login attach itself to an account whose address
+                 * was never verified.
+                 *
+                 * Better Auth defaults this to true, and for good reason: an
+                 * unverified row may have been planted by someone else, and
+                 * linking would hand the victim an account carrying a stranger's
+                 * password. Refusing to link is the cheap defence.
+                 *
+                 * It is also the wrong trade here. Registration demands a
+                 * `@stud.ntnu.no` address, so a first-year student's only
+                 * address on file is the NTNU mailbox they cannot open yet in
+                 * August — which is where both the verification mail and the
+                 * password reset go. The guard therefore strands exactly the
+                 * people it cannot distinguish from an attacker, and every one
+                 * of them becomes a manual ticket. 15 sat stuck during fadderuka
+                 * 2026.
+                 *
+                 * The threat is answered instead by taking the password away
+                 * rather than refusing the link — see the `account.create`
+                 * database hook below and {@link revokeUnprovenCredentials}. A
+                 * planted password is deleted by the very login that used to arm
+                 * it, so the member gets in and the attacker gets nothing.
+                 */
+                requireLocalEmailVerified: false,
+            },
+        },
+
+        /**
+         * Runs on the row Better Auth is about to write for a Feide link.
+         *
+         * Deliberately `before` and not `after`: `create.after` hooks are queued
+         * until the transaction settles, by which point the linking code has
+         * already flipped `emailVerified` to true — and the revocation, which
+         * keys off exactly that flag, would find nothing to do and silently
+         * no-op. Running before the insert means the flag still reflects what
+         * was proven *prior* to this login, which is the question being asked.
+         */
+        databaseHooks: {
+            account: {
+                create: {
+                    before: async (data) => {
+                        if (data.providerId !== "feide") return;
+                        await revokeUnprovenCredentials(
+                            options.services.db,
+                            data.userId,
+                        );
+                    },
+                },
             },
         },
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -24,7 +24,12 @@ import { user } from "@photon/db/schema";
 import type { EmailService, CacheService } from "@photon/core/services";
 import { env } from "@photon/core/env";
 import { getUserPermissions } from "./rbac/permissions";
-import { feidePlugin, revokeUnprovenCredentials, syncFeideHook } from "./feide";
+import {
+    feidePlugin,
+    redirectToPasswordSetupAfterRevoke,
+    revokeUnprovenCredentials,
+    syncFeideHook,
+} from "./feide";
 
 /**
  * Feide is a genuine third-party identity provider: it only works once a Feide
@@ -502,6 +507,22 @@ export function createAuth(options: CreateAuthOptions) {
             }),
             after: createAuthMiddleware(async (ctx) => {
                 if (!isFeideConfigured) return;
+
+                // Sends a member whose password was just revoked on to set a
+                // new one. Runs before the sync so a failing sync cannot cost
+                // them the notice; own try for the same reason in reverse.
+                try {
+                    redirectToPasswordSetupAfterRevoke(
+                        ctx,
+                        options.urls.frontend,
+                    );
+                } catch (error) {
+                    console.error(
+                        "Failed to redirect to password setup after credential revoke:",
+                        error,
+                    );
+                }
+
                 // Syncs the user's TIHLDE study-program memberships after a
                 // successful Feide callback; a no-op for every other request.
                 //


### PR DESCRIPTION
## Problemet

En Feide-innlogging nekter å koble seg til en konto med `email_verified = false`. Better Auths `requireLocalEmailVerified` er `true` som default, og Photon overstyrer den ikke:

```js
// better-auth/dist/oauth2/link-account.mjs:23
const requireLocalEmailVerified = accountLinking?.requireLocalEmailVerified ?? true;
if (!isTrustedProvider && !userInfo.emailVerified
    || requireLocalEmailVerified && !dbUser.user.emailVerified || ...) {
    return { error: "account not linked" };
}
```

Resultatet er `account_not_linked` → redirect til `/login`. Brukeren opplever det som at ingenting skjer.

Guarden finnes av en god grunn. Registrering krever `@stud.ntnu.no`, men *beviser* ikke at du eier adressen — raden opprettes før verifiseringsmailen sendes. Så hvem som helst kan registrere `<noen-andres-brukernavn>@stud.ntnu.no`, sette et passord og vente. Passordet er dødt så lenge det ligger der (`requireEmailVerification` blokkerer innlogging, og sign-up hopper over auto-sign-in). Det som armerer det er offerets **egen** Feide-innlogging: koblingen flipper `emailVerified` til true, og det plantede passordet begynner å virke.

Men å nekte koblingen er feil pris. Førsteårsstudenter har bare NTNU-adressen på konto, og det er dit både verifiseringsmailen og passordresetten går — en innboks de ikke får åpnet i august. Guarden strander dermed nøyaktig de menneskene den ikke klarer å skille fra en angriper.

Prod bekrefter mønsteret:

| | antall |
|---|---|
| Feide-koblet, `email_verified = true` | 251 |
| Feide-koblet, `email_verified = false` | **0** |
| uverifisert uten Feide-kobling | 1 629 |

Ingen har noen gang blitt koblet uten verifisert e-post. 15 nye studenter satt fast under fadderuka 2026, hver av dem en manuell henvendelse til Index.

## Løsningen

Ta passordet i stedet for å nekte koblingen.

- `requireLocalEmailVerified: false` — koblingen får skje.
- En `databaseHooks.account.create.before`-hook kjører `revokeUnprovenCredentials` når en Feide-rad skrives: er kontoen uverifisert, slettes `credential`-raden og alle sesjoner.
- After-hooken sender medlemmet til `/velg-passord`, med `redirectTo` satt til der de opprinnelig skulle.
- Siden forteller dem hvorfor de er der, og lar dem ikke gå videre uten å sette et nytt passord.

Den innloggingen som før armerte et plantet passord, sletter det nå i stedet. Angriperen sitter igjen med ingenting; medlemmet kommer inn og setter nytt passord.

En **verifisert** konto beholder passordet urørt — der er beviset på adressen allerede avlagt, og det er nettopp det som gjør passordet deres.

Dette er samme regel Better Auth selv bruker for sine e-postbaserte bevis (`revokeUnprovenAccountAccess`, brukt av magic link og e-post-OTP). OAuth-stien manglet den bare, og løste det med den konservative guarden i stedet.

### Hvorfor `before` og ikke `after`

`create.after`-hooks køes via `queueAfterTransactionHook` til transaksjonen er ferdig. Da har koblingskoden allerede flippet `emailVerified` til true, og revokeringen — som nettopp keyer på det flagget — ville stille funnet ingenting å gjøre. `before` kjører synkront før innsettingen, mens flagget fortsatt sier hva som var bevist *før* denne innloggingen.

### Hvorfor redirecten er med

Revokeringen tar passord som folk faktisk bruker. **1 538 migrerte brukere har `email_verified = false` og et Lepton-passord de kan.** Ett konkret tilfelle: `eliasval` fikk «brukeren må aktiveres» ved innlogging, og den meldingen kastes *etter* passordsjekken — han kjenner altså passordet sitt. Uten redirecten ville hans første Feide-innlogging tatt det uten et ord.

Rewriten skjer ved å mutere `location` på `responseHeaders` i after-hooken. Det virker fordi `c.redirect()` setter headeren på nettopp det Headers-objektet svaret bygges fra (`APIError` holder det ved referanse, og `toResponse` leser derfra), så endringen treffer selv om endepunktet allerede har kastet redirecten.

Overleveringen fra database-hooken til after-hooken går via en kortlevd `Map`: revokeringen skjer flere lag under responsen, og de to hookene deler ingen request-kontekst. Oppføringer leses én gang og utløper etter 60 sekunder, så en innlogging som aldri når after-hooken kan ikke etterlate en lapp som feilsender en senere innlogging fra samme medlem.

### Teksten på /velg-passord

Siden var skrevet for én situasjon: en Feide-konto som aldri hadde passord — «Vil du også kunne logge inn med passord?». For de som nettopp mistet passordet sitt er «også» misvisende; de ville trykket «Hopp over» og dermed lukket sin eneste ikke-Feide-vei inn uten å vite det.

Callbacken setter derfor `passwordRevoked` på redirecten, og siden bytter tittel og forklaring. I den varianten er «Hopp over» også skjult: alle skal ha et eget passord, og Feide skal ikke bli primærinnloggingen. Nye Feide-brukere beholder knappen — de har aldri hatt passord, og for dem er Feide alene en fungerende innlogging. Ingen står fast uansett, siden layoutets navigasjonslinje ligger under kortet.

## Verifisering

- `bun run typecheck` ✅
- `bun run build` ✅
- `bun run lint` / `format` ✅ (ingen nye advarsler)
- Full testsuite: **521 tester i 74 filer** ✅
- Ny testfil `apps/api/src/test/feide/unproven-credentials.test.ts` — 9 tester: revokering (sletter passord + sesjoner for uverifisert konto, lar verifisert konto være i fred, rapporterer ingenting revokert når det ikke fantes passord, no-op for ukjent bruker) og redirect (bærer med destinasjonen inkl. query, nekter fremmed origin, lar `/velg-passord` være i fred, gir opp på uparsbar URL).
- Nettleserverifisert mot lokal dev: begge tekstvariantene rendrer riktig, «Hopp over» er borte i revokert-varianten og beholdt i standardvarianten.

Flyten er også gjennomgått for tre ting som kunne ha ødelagt den, og ingen gjør det: `_auth`-layoutet har ingen guard som kaster ut innloggede, `createSession` kjøres etter koblingen så den nye sesjonen overlever slettingen av gamle, og `/koble-feide` no-oper fordi den krever en sesjon som igjen krever verifisert e-post.

## Ikke dekket

Selve header-rewriten er verifisert mot Better Auth- og better-call-kildene, men ikke kjørt gjennom en ekte OAuth-callback i test — det ville krevd å simulere hele Dataporten-flyten. Verdt en manuell røyktest mot dev etter merge: logg inn med Feide som en uverifisert bruker med passord, og bekreft at du lander på `/velg-passord` uten «Hopp over».