### PR TITLE
feat(auth): la enhver gruppeleder styre sin egen gruppes arrangementer

### DIFF
--- a/apps/api/src/routes/groups/positions/leader-permissions.ts
+++ b/apps/api/src/routes/groups/positions/leader-permissions.ts
@@ -7,10 +7,16 @@
  * held by whoever leads the group right now, scoped to that group, and are
  * edited from the same verv table as the group's positions.
  *
+ * What is edited here is the EXTRA set. Arranging the group's own events is
+ * baseline for every leader (LEADER_BASELINE_PERMISSIONS) and is not stored
+ * per group, so it cannot be switched off here — it is returned as `baseline`
+ * so the admin UI can show it rather than claim the leader has nothing.
+ *
  * Guardrails are the position ones, deliberately: managing this is managing a
  * group-scoped verv, and you still cannot hand out what you do not hold.
  */
 
+import { LEADER_BASELINE_PERMISSIONS } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
@@ -34,7 +40,7 @@ export const getLeaderPermissionsRoute = route().get(
         summary: "Get the group leader's permissions",
         operationId: "getGroupLeaderPermissions",
         description:
-            "The permissions held by whoever currently leads the group, scoped to that group. Requires the same rights as managing the group's verv.",
+            "The permissions held by whoever currently leads the group, scoped to that group. `baseline` is what every leader holds regardless of configuration (arranging the group's events); `permissions` is the extra set configured for this group. Requires the same rights as managing the group's verv.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -68,7 +74,10 @@ export const getLeaderPermissionsRoute = route().get(
             });
         }
 
-        return c.json({ permissions: group.permissions ?? [] });
+        return c.json({
+            permissions: group.permissions ?? [],
+            baseline: [...LEADER_BASELINE_PERMISSIONS],
+        });
     },
 );
 
@@ -79,7 +88,7 @@ export const updateLeaderPermissionsRoute = route().patch(
         summary: "Set the group leader's permissions",
         operationId: "updateGroupLeaderPermissions",
         description:
-            "Replace the permissions held by the group's leader. Granted scoped to this group, so they never reach another group's resources. You can only grant permissions you hold yourself for this group.",
+            "Replace the EXTRA permissions held by the group's leader, on top of the baseline every leader holds. Granted scoped to this group, so they never reach another group's resources. You can only grant permissions you hold yourself for this group.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -141,6 +150,9 @@ export const updateLeaderPermissionsRoute = route().patch(
             .where(eq(schema.group.slug, groupSlug))
             .returning({ permissions: schema.group.leaderPermissions });
 
-        return c.json({ permissions: updated?.permissions ?? [] });
+        return c.json({
+            permissions: updated?.permissions ?? [],
+            baseline: [...LEADER_BASELINE_PERMISSIONS],
+        });
     },
 );

--- a/apps/api/src/routes/groups/positions/schema.ts
+++ b/apps/api/src/routes/groups/positions/schema.ts
@@ -115,7 +115,11 @@ export const leaderPermissionsSchema = Schema(
     z.object({
         permissions: z.array(z.string()).meta({
             description:
-                "Permissions held by the group's current leader, scoped to this group",
+                "Extra permissions configured for this group's leader, on top of the baseline. Scoped to this group.",
+        }),
+        baseline: z.array(z.string()).meta({
+            description:
+                "Permissions every group leader holds for their own group, regardless of configuration. Read-only.",
         }),
     }),
 );

--- a/apps/api/src/test/event/group-scoped-access.test.ts
+++ b/apps/api/src/test/event/group-scoped-access.test.ts
@@ -127,4 +127,131 @@ describe("group-scoped event access", () => {
         },
         500_000,
     );
+
+    /**
+     * Arranging the group's own events is baseline for every leader — no
+     * `leaderPermissions` configured, no verv, no role beyond the default.
+     */
+    integrationTest(
+        "leadership alone lets a leader create, update and delete their group's events",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(leader);
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            // Deliberately left with the empty default leaderPermissions.
+            const group = await ctx.utils.createTestGroup({
+                slug: "plask-test",
+            });
+            await ctx.db.insert(schema.groupMembership).values({
+                userId: leader.id,
+                groupSlug: group.slug,
+                role: "leader",
+            });
+
+            const created = await client.api.event.$post({
+                json: eventBody(group.slug),
+            });
+            expect(created.status).toBe(201);
+            const { eventId } = await created.json();
+
+            const updated = await client.api.event[":id"].$put({
+                param: { id: eventId },
+                json: eventBody(group.slug),
+            });
+            expect(updated.status).toBe(200);
+
+            // Someone else's event stays closed.
+            const foreign = await ctx.utils.createTestEvent({
+                organizerGroupSlug: "index",
+            });
+            const foreignUpdate = await client.api.event[":id"].$put({
+                param: { id: foreign.id },
+                json: eventBody("index"),
+            });
+            expect(foreignUpdate.status).toBe(403);
+
+            const deleted = await client.api.event[":eventId"].$delete({
+                param: { eventId },
+            });
+            expect(deleted.status).toBe(200);
+        },
+        500_000,
+    );
+
+    /**
+     * The baseline stops short of money and prikker: a leader sees who has
+     * paid for their own arrangement, but refunds and manual strikes are
+     * someone else's call.
+     */
+    integrationTest(
+        "the leader baseline covers payments:view and check-in, but not refunds or strikes",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(leader);
+            const attendee = await ctx.utils.createTestUser();
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const group = await ctx.utils.createTestGroup({
+                slug: "plask-payments-test",
+            });
+            await ctx.db.insert(schema.groupMembership).values({
+                userId: leader.id,
+                groupSlug: group.slug,
+                role: "leader",
+            });
+
+            const event = await ctx.utils.createTestEvent({
+                organizerGroupSlug: group.slug,
+                isPaidEvent: true,
+            });
+            // "registered", not pending — only a real spot can be checked in.
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: attendee.id,
+                status: "registered",
+            });
+
+            const payments = await client.api.event[":eventId"].payments.$get({
+                param: { eventId: event.id },
+                query: {},
+            });
+            expect(payments.status).toBe(200);
+
+            const checkin = await client.api.event[":eventId"].registration[
+                ":userId"
+            ].attendance.$patch({
+                param: { eventId: event.id, userId: attendee.id },
+                json: { attended: true },
+            });
+            expect(checkin.status).toBe(200);
+
+            // Access is checked before the payment is looked up, so a made-up
+            // id still proves the grant is missing rather than the row.
+            const refund = await client.api.event[":eventId"].payments[
+                ":paymentId"
+            ].refund.$post({
+                param: {
+                    eventId: event.id,
+                    paymentId: "00000000-0000-4000-8000-000000000000",
+                },
+            });
+            expect(refund.status).toBe(403);
+
+            const strike = await client.api.event.strikes.$post({
+                json: {
+                    userId: attendee.id,
+                    eventId: event.id,
+                    count: 1,
+                    reason: "Møtte ikke opp",
+                },
+            });
+            expect(strike.status).toBe(403);
+        },
+        500_000,
+    );
 });

--- a/apps/kvark/src/routes/admin/roller.tsx
+++ b/apps/kvark/src/routes/admin/roller.tsx
@@ -609,6 +609,9 @@ function LeaderRow({
         enabled: canManage,
     });
     const permissions = data?.permissions ?? [];
+    // Every leader arranges their own group's events; the stored set is only
+    // what comes on top. Summarize both, or the table would read "ingen".
+    const baseline = data?.baseline ?? [];
 
     return (
         <TableRow>
@@ -639,7 +642,7 @@ function LeaderRow({
             </TableCell>
             <TableCell className="text-sm text-muted-foreground">
                 {canManage
-                    ? summarizePermissions(permissions)
+                    ? summarizePermissions([...baseline, ...permissions])
                     : "Gruppens ledertilganger"}
             </TableCell>
             <TableCell>
@@ -716,7 +719,10 @@ function LeaderPermissionsDialog({
                         />
                         <p className="text-sm text-muted-foreground">
                             Gjelder bare i denne gruppen, og følger den som til
-                            enhver tid er leder.
+                            enhver tid er leder. Alle ledere kan uansett lage,
+                            endre og slette gruppens arrangementer og styre
+                            påmeldingene — det kommer i tillegg til det du
+                            velger her.
                         </p>
                     </Field>
                     {error ? (

--- a/packages/auth/src/rbac/permissions/checker.ts
+++ b/packages/auth/src/rbac/permissions/checker.ts
@@ -103,13 +103,54 @@ async function getPermissionsFromPositions(
 }
 
 /**
+ * What EVERY group leader holds for their own group, regardless of what is
+ * stored in `group.leaderPermissions`.
+ *
+ * Running a group means running its arrangementer: putting them up, fixing
+ * them, taking them down, and handling who shows up. That is the job, not a
+ * privilege someone has to be granted per group — so it lives here rather
+ * than in a column that starts empty and has to be filled in 60 times (and
+ * once more for every new group).
+ *
+ * Payments are view-only on purpose: a leader running a paid arrangement has
+ * to see who has paid, but moving money back out is a separate decision and
+ * stays with whoever holds `events:payments:refund`.
+ *
+ * Deliberately NOT included, because they are not "arranging an event":
+ * refunding payments, handing out prikker by hand, and publishing news. Those
+ * still come from `leaderPermissions`, a verv, or a role.
+ *
+ * `events:manage` is left out for the same reason, even though it reads like
+ * the natural fit: the strike routes accept it as an alternative to
+ * `events:strikes:*`, so granting it here would hand every leader the power
+ * to hand out prikker. Every other route that takes `events:manage` takes
+ * `events:update` too, which is in the list, so nothing is lost.
+ */
+export const LEADER_BASELINE_PERMISSIONS = [
+    "events:view",
+    "events:create",
+    "events:update",
+    "events:delete",
+    "events:registrations:view",
+    "events:registrations:create",
+    "events:registrations:delete",
+    // Registering oppmøte on the group's own arrangementer
+    "events:registrations:checkin",
+    "events:registrations:manage",
+    "events:feedback:view",
+    // Seeing who has paid — never events:payments:refund
+    "events:payments:view",
+] as const;
+
+/**
  * Get all permissions a user receives from LEADING a group.
  *
- * A group's `leaderPermissions` are held by whoever is its leader right now,
- * scoped to that group ("permission@group:<slug>"). Reading the current
- * leadership here rather than syncing a role on every leadership change means
- * the grant cannot outlive the job — step down and it is gone on the next
- * check.
+ * Every leader gets {@link LEADER_BASELINE_PERMISSIONS} for their group, plus
+ * whatever extra sits in the group's `leaderPermissions`. Both are scoped to
+ * that group ("permission@group:<slug>"), so nothing reaches another group's
+ * resources. Reading the current leadership here rather than syncing a role
+ * on every leadership change means the grant cannot outlive the job — step
+ * down and it is gone on the next check.
  */
 async function getPermissionsFromLeadership(
     ctx: DbCtx,
@@ -131,7 +172,7 @@ async function getPermissionsFromLeadership(
         );
 
     return rows.flatMap((row) =>
-        (row.permissions ?? []).map((p) =>
+        [...LEADER_BASELINE_PERMISSIONS, ...(row.permissions ?? [])].map((p) =>
             formatPermission(p, `group:${row.groupSlug}`),
         ),
     );

--- a/packages/auth/src/rbac/permissions/index.ts
+++ b/packages/auth/src/rbac/permissions/index.ts
@@ -24,6 +24,7 @@ export {
 
 // Permission checking
 export {
+    LEADER_BASELINE_PERMISSIONS,
     getUserPermissions,
     getUserPermissionsWithScope,
     hasPermission,

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1649,7 +1649,7 @@ export interface paths {
         };
         /**
          * Get the group leader's permissions
-         * @description The permissions held by whoever currently leads the group, scoped to that group. Requires the same rights as managing the group's verv.
+         * @description The permissions held by whoever currently leads the group, scoped to that group. `baseline` is what every leader holds regardless of configuration (arranging the group's events); `permissions` is the extra set configured for this group. Requires the same rights as managing the group's verv.
          */
         get: operations["getGroupLeaderPermissions"];
         put?: never;
@@ -1659,7 +1659,7 @@ export interface paths {
         head?: never;
         /**
          * Set the group leader's permissions
-         * @description Replace the permissions held by the group's leader. Granted scoped to this group, so they never reach another group's resources. You can only grant permissions you hold yourself for this group.
+         * @description Replace the EXTRA permissions held by the group's leader, on top of the baseline every leader holds. Granted scoped to this group, so they never reach another group's resources. You can only grant permissions you hold yourself for this group.
          */
         patch: operations["updateGroupLeaderPermissions"];
         trace?: never;
@@ -4787,8 +4787,10 @@ export interface components {
             userId: string;
         };
         GroupLeaderPermissions: {
-            /** @description Permissions held by the group's current leader, scoped to this group */
+            /** @description Extra permissions configured for this group's leader, on top of the baseline. Scoped to this group. */
             permissions: string[];
+            /** @description Permissions every group leader holds for their own group, regardless of configuration. Read-only. */
+            baseline: string[];
         };
         UpdateGroupLeaderPermissions: {
             /** @description Permissions the group's leader holds, scoped to this group. Replaces the existing list. */


### PR DESCRIPTION
## Problemet

Å lede en gruppe ga ingen rettigheter i seg selv. Rettighetene lå i `group.leaderPermissions` — en kolonne som starter tom og må fylles ut per gruppe. I prod var den satt for **1 av 60 grupper** (fadderkom).

Konkret: lederen av TIHLDE Plask har bare `member`-rollen og fikk 403 på å opprette, endre og slette gruppens egne arrangementer. Det samme gjaldt 58 andre gruppeledere.

Rute-logikken var allerede riktig — `create`/`update`/`delete` sjekker rettigheten scoped til arrangørgruppa via `canActOnEventsForGroup`. Det som manglet var at noen faktisk holdt rettigheten.

## Løsningen

Et fast sett, `LEADER_BASELINE_PERMISSIONS`, legges nå på hver gruppe man er leder for, scoped til den gruppa. Det ligger i kode, ikke i data, fordi:

- det gjelder umiddelbart for alle 60 eksisterende grupper — ingen backfill å kjøre eller glemme
- det gjelder alle nye grupper uten at noen må huske å skru det på
- det kan ikke drifte fra hverandre gruppe for gruppe

`leaderPermissions` lever videre som det som kommer **i tillegg** (fadderkom beholder sitt).

| Baseline gir | Baseline gir ikke |
|---|---|
| `events:view/create/update/delete` | `events:manage` |
| `events:registrations:view/create/delete/checkin/manage` | `events:payments:refund` |
| `events:feedback:view` | `events:strikes:*` |
| `events:payments:view` | nyheter, bannere osv. |

## Verdt en ekstra titt fra reviewer

**`events:manage` er bevisst utelatt.** Den leser som den naturlige å ta med, men prikk-rutene godtar den som alternativ til `events:strikes:*` — hadde den vært med, ville hver eneste gruppeleder kunne dele ut prikker manuelt. Testen fanget dette (201 der 403 var ventet). Alle andre ruter som godtar `events:manage` godtar også `events:update`, som er med, så ingenting går tapt.

**Betaling er view-only.** En leder som kjører et betalt arrangement må se hvem som har betalt, men å flytte penger tilbake er en egen avgjørelse. Refusjonsruta har heller ingen eier-bypass.

## UI

Admin-UI-et i /admin/roller ville ellers vist «ingen tilganger» for 59 grupper. `GET`/`PATCH /groups/:slug/leader-permissions` returnerer derfor `baseline` ved siden av `permissions`, verv-tabellen oppsummerer begge, og dialogen sier hva som gjelder uansett.

## Verifisert

- **523 tester grønne**, inkludert to nye i `group-scoped-access.test.ts` som kjører ekte HTTP mot ekte Postgres:
  - en leder uten noen konfigurasjon oppretter → endrer → sletter sin egen gruppes arrangement, og får 403 på en annen gruppes
  - en leder får 200 på betalingslista og på oppmøteregistrering, men 403 på refusjon og på å dele ut prikk
- `typecheck`, `build` og `format` grønne; `lint` har bare forhåndseksisterende advarsler

Ikke verifisert i nettleser — endringen er tilgangslogikk bak API-et, og UI-biten er en tekstlinje. Integrasjonstestene dekker oppførselen bedre enn en manuell innlogging.

## Merk

Dette treffer den som står som `leader` i gruppas medlemsliste. Grupper som i praksis har en leder uten at rollen er satt der, får fortsatt ingenting — verdt en opprydding i prod som egen sak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)