### PR TITLE
feat(auth): la besøkende lage bruker som en admin må godkjenne

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -36,7 +36,29 @@ export function userFromClaims(sub: string, payload: Record<string, unknown>) {
         banReason: null,
         banExpires: null,
         settings: null,
+        approvalStatus: null,
+        isPendingApproval: false,
         createdAt: now,
         updatedAt: now,
     } as unknown as AuthUser;
+}
+
+/**
+ * Whether a signed-in user counts as one of us for the purposes of seeing
+ * member-only content.
+ *
+ * "Logged in" stopped meaning "member" the day anyone could sign themselves up
+ * with a private address. Someone still waiting for an admin sees what a
+ * visitor sees; everyone else — Feide logins, migrated members, approved
+ * sign-ups — is unchanged.
+ *
+ * Note this is about *visibility*, not about what a user may do: the ability to
+ * register for an event, propose a fine and so on hangs off permissions, and a
+ * pending account simply holds no role that grants them.
+ */
+export function isMemberAudience(
+    user: { approvalStatus?: string | null } | null | undefined,
+): boolean {
+    if (!user) return false;
+    return user.approvalStatus !== "pending";
 }

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -45,17 +45,23 @@ async function sessionFromVerifiedToken(
     if (!user) return null;
 
     // Mirror the shape `customSession` builds, so bearer- and cookie-authenticated
-    // requests see the same user object.
+    // requests see the same user object. `approvedAt`/`approvedBy` are left out
+    // for that reason: they are an admin's audit trail, not something a session
+    // has any use for, and the cookie path does not carry them.
+    const { approvedAt: _approvedAt, approvedBy: _approvedBy, ...rest } = user;
     return {
         user: {
-            ...user,
+            ...rest,
             settings: settings
                 ? {
                       ...settings,
                       allergies: settings.allergies.map((a) => a.allergySlug),
                   }
                 : null,
-        } as AuthUser,
+            // `customSession` computes this rather than storing it, so a
+            // bearer-authenticated request has to compute it too.
+            isPendingApproval: user.approvalStatus === "pending",
+        } as unknown as AuthUser,
         session: session as AuthSession,
     };
 }
@@ -78,6 +84,27 @@ function setVerifiedOAuthClient(
 }
 
 /**
+ * Turn away an account that is still waiting for an admin to approve it.
+ *
+ * Anyone can sign themselves up with a private address, so authentication on
+ * its own no longer says the caller belongs here. Rather than teaching every
+ * route the difference, the rule sits in `requireAuth`: signing in gets you
+ * your own account and nothing else until someone approves you. Routes a
+ * pending user genuinely needs — their own settings, their password, linking
+ * Feide — opt out with `requireAuthAllowPending`.
+ *
+ * Public pages are unaffected: they use `captureAuth`, which never calls this.
+ */
+function assertApproved(user: AuthUser): void {
+    const status = (user as { approvalStatus?: string | null }).approvalStatus;
+    if (status === "pending") {
+        throw HTTPAppException.Forbidden(
+            "Kontoen din venter på godkjenning fra en administrator.",
+        );
+    }
+}
+
+/**
  * Requires either a valid OAuth access token or a Better Auth session cookie.
  * OAuth tokens are verified locally against our JWKS, then hydrated to the
  * same user/session shape that cookie-authenticated requests receive.
@@ -87,10 +114,17 @@ function setVerifiedOAuthClient(
  *   - OAuth access tokens from `/api/auth/oauth2/token` (third-party apps)
  *
  * Both use the same JWKS, the same audience, and the same issuer.
+ *
+ * `allowPendingApproval` lets an account that has not been approved yet
+ * through — only for the handful of routes that exist to serve exactly that
+ * person, such as their own settings.
  */
-export const requireAuth = describeMiddleware(
+const authMiddleware = (options: { allowPendingApproval: boolean }) =>
     createMiddleware<{ Variables: AuthVariables & { logger: LoggerType } }>(
         async (c, next) => {
+            const guard = (user: AuthUser) => {
+                if (!options.allowPendingApproval) assertApproved(user);
+            };
             const { auth } = c.get("ctx");
             const bearer = getBearerTokenFromHeader(
                 c.req.header("Authorization"),
@@ -105,6 +139,7 @@ export const requireAuth = describeMiddleware(
                     verified,
                 );
                 if (hydrated) {
+                    guard(hydrated.user);
                     c.set("user", hydrated.user);
                     c.set("session", hydrated.session);
                     setVerifiedOAuthClient(c, verified);
@@ -148,13 +183,36 @@ export const requireAuth = describeMiddleware(
             });
             if (!session) throw HTTPAppException.Unauthorized();
 
+            guard(session.user as AuthUser);
             c.set("user", session.user);
             c.set("session", session.session);
             c.set("logger", c.get("logger").child({ userId: session.user.id }));
 
             await next();
         },
-    ),
+    );
+
+export const requireAuth = describeMiddleware(
+    authMiddleware({ allowPendingApproval: false }),
+    describeMiddlewareRoute()
+        .errorResponses([
+            HTTPAppException.Unauthorized(),
+            HTTPAppException.Forbidden(
+                "Kontoen din venter på godkjenning fra en administrator.",
+            ),
+        ])
+        .getSpec(),
+);
+
+/**
+ * `requireAuth`, minus the approval requirement.
+ *
+ * For routes that serve the signed-in person themselves — settings, password,
+ * onboarding, linking a Feide account. Locking someone out of those while they
+ * wait would leave them with an account they cannot even finish setting up.
+ */
+export const requireAuthAllowPending = describeMiddleware(
+    authMiddleware({ allowPendingApproval: true }),
     describeMiddlewareRoute()
         .errorResponses([HTTPAppException.Unauthorized()])
         .getSpec(),

--- a/apps/api/src/routes/account-link/sync.ts
+++ b/apps/api/src/routes/account-link/sync.ts
@@ -2,7 +2,7 @@ import { NoFeideAccountError, syncFeideForUser } from "@photon/auth/feide";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { requireAuth } from "~/middleware/auth";
+import { requireAuthAllowPending } from "~/middleware/auth";
 import { accountLinkSyncResponseSchema } from "./schema";
 
 /**
@@ -50,7 +50,7 @@ export const accountLinkSyncRoute = route().post(
             description: "Feide could not be reached",
         })
         .build(),
-    requireAuth,
+    requireAuthAllowPending,
     async (c) => {
         const user = c.get("user");
         const { db } = c.get("ctx");

--- a/apps/api/src/routes/event/get.ts
+++ b/apps/api/src/routes/event/get.ts
@@ -1,6 +1,7 @@
 import { schema } from "@photon/db";
 import { and, eq, inArray } from "drizzle-orm";
 import type z from "zod";
+import { isMemberAudience } from "~/lib/auth";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "../../lib/route";
 import { captureAuth } from "../../middleware/auth";
@@ -73,10 +74,11 @@ export const getRoute = route().get(
 
         const user = c.get("user");
 
-        // Members-only events are hidden from unauthenticated (non-member)
-        // callers. Any authenticated user counts as a member. Respond 404
-        // rather than 403 so the event's existence isn't leaked.
-        if (event.visibility === "members" && !user) {
+        // Members-only events are hidden from callers who are not members —
+        // which includes a signed-in account still waiting for an admin to
+        // approve it. Respond 404 rather than 403 so the event's existence
+        // isn't leaked.
+        if (event.visibility === "members" && !isMemberAudience(user)) {
             return c.json("The event was not found", 404);
         }
 

--- a/apps/api/src/routes/event/list.ts
+++ b/apps/api/src/routes/event/list.ts
@@ -13,6 +13,7 @@ import {
 } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import type z from "zod";
+import { isMemberAudience } from "~/lib/auth";
 import { describeRoute } from "~/lib/openapi";
 import { captureAuth } from "../../middleware/auth";
 import { route } from "../../lib/route";
@@ -86,9 +87,11 @@ export const listRoute = route().get(
             ordering,
         } = c.req.valid("query");
 
-        // Members-only events are hidden from unauthenticated (non-member)
-        // callers. Any authenticated user counts as a member.
-        const isMember = !!c.get("user");
+        // Members-only events are hidden from callers who are not members.
+        // Being signed in is not enough on its own: anyone may sign themselves
+        // up on the website, and until an admin approves them they see exactly
+        // what a visitor sees.
+        const isMember = isMemberAudience(c.get("user"));
 
         const filters = and(
             ...[

--- a/apps/api/src/routes/user/approve.ts
+++ b/apps/api/src/routes/user/approve.ts
@@ -1,0 +1,127 @@
+import { assignUserRole } from "@photon/auth/roles";
+import { env } from "@photon/core/env";
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { HTTPException } from "hono/http-exception";
+import { describeRoute } from "~/lib/openapi";
+import { route } from "~/lib/route";
+import { requireAccess } from "~/middleware/access";
+import { requireAuth } from "~/middleware/auth";
+import { approveUserResponseSchema } from "./schema";
+
+/**
+ * Approve an account someone made for themselves on the website.
+ *
+ * Self-registration hands out no membership: the person picks a private
+ * address and a password, and until an admin says otherwise they see what any
+ * visitor sees. Approving is what turns that into a member — it grants the
+ * `member` role, which is the same baseline an active student gets from Feide,
+ * and with it the right to register for events and read members-only pages.
+ *
+ * The mail is sent last and its failure is swallowed: the approval is the
+ * thing that matters, and a mail server having a bad afternoon must not roll
+ * it back or make the admin think it did not take.
+ *
+ * There is no "unapprove". Taking membership away from someone is what
+ * `PATCH /:id/status` (deactivate) and role management are for; putting an
+ * account back in a queue it has already left would only be confusing.
+ */
+export const approveUserRoute = route().post(
+    "/:id/approve",
+    describeRoute({
+        tags: ["users"],
+        summary: "Approve a self-registered account",
+        operationId: "approveUser",
+        description:
+            "Grants the 'member' role to an account that signed itself up on the website and is waiting for approval, and tells the person by e-mail. Requires 'users:manage'.",
+    })
+        .schemaResponse({
+            statusCode: 200,
+            schema: approveUserResponseSchema,
+            description: "Account approved",
+        })
+        .badRequest({
+            description: "The account is not waiting for approval",
+        })
+        .notFound({ description: "User not found" })
+        .unauthorized()
+        .forbidden({ description: "Requires users:manage" })
+        .build(),
+    requireAuth,
+    requireAccess({ permission: "users:manage" }),
+    async (c) => {
+        const ctx = c.get("ctx");
+        const { db } = ctx;
+        const logger = c.get("logger");
+        const userId = c.req.param("id");
+        const approver = c.get("user");
+
+        const user = await db.query.user.findFirst({
+            where: eq(schema.user.id, userId),
+            columns: {
+                id: true,
+                name: true,
+                email: true,
+                approvalStatus: true,
+            },
+        });
+
+        if (!user) {
+            throw new HTTPException(404, {
+                message: `User "${userId}" not found`,
+            });
+        }
+
+        if (user.approvalStatus !== "pending") {
+            throw new HTTPException(400, {
+                message:
+                    user.approvalStatus === "approved"
+                        ? "Denne brukeren er allerede godkjent"
+                        : "Denne brukeren venter ikke på godkjenning",
+            });
+        }
+
+        await db.transaction(async (tx) => {
+            const txCtx = { ...ctx, db: tx };
+            await assignUserRole(txCtx, userId, "member");
+            await tx
+                .update(schema.user)
+                .set({
+                    approvalStatus: "approved",
+                    approvedAt: new Date(),
+                    approvedBy: approver.id,
+                    updatedAt: new Date(),
+                })
+                .where(eq(schema.user.id, userId));
+        });
+
+        try {
+            await ctx.email.sendEmailTemplate(
+                {
+                    from: env.MAIL_FROM,
+                    to: user.email,
+                    subject: "Brukeren din i TIHLDE er godkjent",
+                },
+                "AccountApprovedEmail",
+                {
+                    name: user.name,
+                    loginUrl: `${env.WEBSITE_URL}/login`,
+                    logoUrl: `${env.WEBSITE_URL}/logo512.png`,
+                },
+            );
+        } catch (error) {
+            logger.error(
+                { err: error, userId },
+                "Failed to queue account approval email",
+            );
+        }
+
+        return c.json(
+            {
+                message: "Account approved",
+                approvalStatus: "approved" as const,
+            },
+            200,
+        );
+    },
+);

--- a/apps/api/src/routes/user/index.ts
+++ b/apps/api/src/routes/user/index.ts
@@ -2,6 +2,7 @@ import { route } from "~/lib/route";
 import { allergyRoutes } from "./allergy";
 import { getUserAllergiesRoute } from "./allergy/get-for-user";
 import { updateUserAllergiesRoute } from "./allergy/update-for-user";
+import { approveUserRoute } from "./approve";
 import { deleteUserRoute } from "./delete";
 import { getUserRoute } from "./get";
 import { listUsersRoute } from "./list";
@@ -21,6 +22,7 @@ export const userRoutes = route()
     .route("/", getUserAllergiesRoute)
     .route("/", updateUserAllergiesRoute)
     .route("/", updateUserStatusRoute)
+    .route("/", approveUserRoute)
     .route("/", deleteUserRoute)
     // Last: `/:id` is a catch-all and would otherwise swallow `/search`.
     .route("/", getUserRoute);

--- a/apps/api/src/routes/user/list.ts
+++ b/apps/api/src/routes/user/list.ts
@@ -38,8 +38,14 @@ export const listUsersRoute = route().get(
     validator("query", PaginationSchema.extend(userListQuerySchema.shape)),
     async (c) => {
         const { db } = c.get("ctx");
-        const { page, pageSize, search, study, studyStartYear } =
-            c.req.valid("query");
+        const {
+            page,
+            pageSize,
+            search,
+            study,
+            studyStartYear,
+            approvalStatus,
+        } = c.req.valid("query");
 
         /**
          * Study programme and cohort mirror the group-member list: they are a
@@ -98,6 +104,9 @@ export const listUsersRoute = route().get(
             studyStartYear === undefined
                 ? undefined
                 : eq(cohort.startYear, studyStartYear),
+            approvalStatus
+                ? eq(schema.user.approvalStatus, approvalStatus)
+                : undefined,
         );
 
         const countRows = await db
@@ -120,11 +129,22 @@ export const listUsersRoute = route().get(
                 createdAt: schema.user.createdAt,
                 studyProgram: studyProgram.name,
                 studyStartYear: cohort.startYear,
+                approvalStatus: schema.user.approvalStatus,
+                email: schema.user.email,
             })
             .from(schema.user)
             .leftJoin(studyProgram, eq(studyProgram.userId, schema.user.id))
             .leftJoin(cohort, eq(cohort.userId, schema.user.id))
-            .orderBy(asc(schema.user.name), asc(schema.user.id))
+            /**
+             * The approval queue is a worklist, so it is ordered by how long
+             * someone has been kept waiting. Everything else is a directory,
+             * where alphabetical is what you want.
+             */
+            .orderBy(
+                ...(approvalStatus === "pending"
+                    ? [asc(schema.user.createdAt), asc(schema.user.id)]
+                    : [asc(schema.user.name), asc(schema.user.id)]),
+            )
             .limit(pageSize)
             .offset(getPageOffset(page, pageSize))
             .where(where);
@@ -133,11 +153,15 @@ export const listUsersRoute = route().get(
             totalCount,
             pages: totalPages,
             nextPage: page + 1 >= totalPages ? null : page + 1,
-            items: rows.map(({ banned, ...row }) => ({
+            items: rows.map(({ banned, email, ...row }) => ({
                 ...row,
                 // `banned` is nullable in Better Auth's schema; only an
                 // explicit true means deactivated.
                 isActive: banned !== true,
+                // An admin deciding on a stranger has nothing else to go on —
+                // no study programme, no Feide, just the address they typed.
+                // Everyone else's address stays out of a list this broad.
+                email: row.approvalStatus === "pending" ? email : null,
                 createdAt: row.createdAt.toISOString(),
             })),
         } satisfies z.infer<typeof userListResponseSchema>);

--- a/apps/api/src/routes/user/me/password/set.ts
+++ b/apps/api/src/routes/user/me/password/set.ts
@@ -2,7 +2,7 @@ import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { requireAuth } from "~/middleware/auth";
+import { requireAuthAllowPending } from "~/middleware/auth";
 import {
     setPasswordInputSchema,
     setPasswordResponseSchema,
@@ -45,7 +45,7 @@ export const setPasswordRoute = route().post(
             description: "The account already has a password",
         })
         .build(),
-    requireAuth,
+    requireAuthAllowPending,
     validator("json", setPasswordInputSchema),
     async (c) => {
         const user = c.get("user");

--- a/apps/api/src/routes/user/me/settings/get.ts
+++ b/apps/api/src/routes/user/me/settings/get.ts
@@ -2,7 +2,7 @@ import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { getUserSettings } from "~/lib/user/settings";
-import { requireAuth } from "~/middleware/auth";
+import { requireAuthAllowPending } from "~/middleware/auth";
 import { userSettingsResponseSchema } from "../../schema";
 
 export const getSettingsRoute = route().get(
@@ -24,7 +24,7 @@ export const getSettingsRoute = route().get(
                 "User settings do not exist (user needs to complete onboarding)",
         })
         .build(),
-    requireAuth,
+    requireAuthAllowPending,
     async (c) => {
         const userId = c.get("user").id;
         const ctx = c.get("ctx");

--- a/apps/api/src/routes/user/me/settings/onboard.ts
+++ b/apps/api/src/routes/user/me/settings/onboard.ts
@@ -3,7 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { createUserSettings } from "~/lib/user/settings";
-import { requireAuth } from "~/middleware/auth";
+import { requireAuthAllowPending } from "~/middleware/auth";
 import { onboardUserInputSchema, userSettingsSchema } from "../../schema";
 
 export const onboardRoute = route().post(
@@ -22,7 +22,7 @@ export const onboardRoute = route().post(
         })
         .badRequest({ description: "User has already completed onboarding" })
         .build(),
-    requireAuth,
+    requireAuthAllowPending,
     validator("json", onboardUserInputSchema),
     async (c) => {
         const userId = c.get("user").id;

--- a/apps/api/src/routes/user/me/settings/update.ts
+++ b/apps/api/src/routes/user/me/settings/update.ts
@@ -2,7 +2,7 @@ import { validator } from "hono-openapi";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { updateUserSettings } from "~/lib/user/settings";
-import { requireAuth } from "~/middleware/auth";
+import { requireAuthAllowPending } from "~/middleware/auth";
 import {
     updateUserSettingsInputSchema,
     updateUserSettingsResponseSchema,
@@ -24,7 +24,7 @@ export const updateSettingsRoute = route().patch(
         })
         .badRequest({ description: "Invalid input" })
         .build(),
-    requireAuth,
+    requireAuthAllowPending,
     validator("json", updateUserSettingsInputSchema),
     async (c) => {
         const userId = c.get("user").id;

--- a/apps/api/src/routes/user/register.ts
+++ b/apps/api/src/routes/user/register.ts
@@ -147,14 +147,16 @@ export const registerUserRoute = route().post(
 
         let userId: string;
         try {
-            const signUp = () =>
-                auth.api.signUpEmail({ body: { name, email, password } });
+            // Always wrapped, whether or not a username was named: the wrapper
+            // is also what marks the sign-up as trusted, and a trusted sign-up
+            // skips the admin approval a website sign-up waits for. The caller
+            // has already been vouched for by an API key with 'users:create'.
             // A named username is passed out-of-band rather than in the body:
             // `/sign-up/email` is public, so a body-supplied one would let
             // anyone claim a student's NTNU username. See `runTrustedSignUp`.
-            const result = chosenUsername
-                ? await runTrustedSignUp(chosenUsername, signUp)
-                : await signUp();
+            const result = await runTrustedSignUp(chosenUsername, () =>
+                auth.api.signUpEmail({ body: { name, email, password } }),
+            );
             userId = result.user.id;
         } catch (err) {
             // Better Auth reports the @stud.ntnu.no rule, a weak password and

--- a/apps/api/src/routes/user/schema.ts
+++ b/apps/api/src/routes/user/schema.ts
@@ -241,6 +241,10 @@ export const userListQuerySchema = z.object({
     studyStartYear: z.coerce.number().int().optional().meta({
         description: "Filter by cohort (STUDYYEAR group), e.g. 2023",
     }),
+    approvalStatus: z.enum(["pending", "approved"]).optional().meta({
+        description:
+            "Show only accounts with this approval status. 'pending' is the queue of self-registered accounts waiting for an admin.",
+    }),
 });
 
 export const userListItemSchema = Schema(
@@ -262,9 +266,25 @@ export const userListItemSchema = Schema(
             description:
                 "False when the account is deactivated — the member cannot sign in.",
         }),
+        approvalStatus: z.enum(["pending", "approved"]).nullable().meta({
+            description:
+                "'pending' for a self-registered account still waiting for an admin, 'approved' once one said yes. Null for accounts that never needed approving — Feide logins and members migrated from Lepton.",
+        }),
+        email: z.string().nullable().meta({
+            description:
+                "Only filled in for accounts awaiting approval, where it is the one thing an admin has to judge them on. Null otherwise.",
+        }),
         createdAt: z
             .string()
             .meta({ description: "Account creation timestamp" }),
+    }),
+);
+
+export const approveUserResponseSchema = Schema(
+    "ApproveUser",
+    z.object({
+        message: z.string(),
+        approvalStatus: z.literal("approved"),
     }),
 );
 

--- a/apps/api/src/test/user-approval.test.ts
+++ b/apps/api/src/test/user-approval.test.ts
@@ -1,0 +1,225 @@
+import { createTestingRole, getUserRoles } from "@photon/auth/roles";
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import {
+    type IntegrationTestContext,
+    integrationTest,
+} from "~/test/config/integration";
+
+/**
+ * Self-registration on the website, and the approval that turns it into a
+ * membership.
+ *
+ * Anyone may sign up with a private address now. What that buys them on its own
+ * is an account and nothing else: no member role, no members-only pages, no
+ * event registration. An admin approving them is what changes that, and these
+ * tests are mostly about the "and nothing else" half holding.
+ */
+describe("self-registration and approval", () => {
+    /** Sign up over plain HTTP, the way the website does. */
+    async function signUp(
+        ctx: IntegrationTestContext,
+        body: {
+            name: string;
+            email: string;
+            password: string;
+            username?: string;
+        },
+    ) {
+        return await ctx.app.request("/api/auth/sign-up/email", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+        });
+    }
+
+    async function userByEmail(ctx: IntegrationTestContext, email: string) {
+        const [row] = await ctx.db
+            .select()
+            .from(schema.user)
+            .where(eq(schema.user.email, email));
+        return row;
+    }
+
+    integrationTest(
+        "a private address is accepted, and the account waits for approval",
+        async ({ ctx }) => {
+            const res = await signUp(ctx, {
+                name: "Kari Nordmann",
+                email: "kari.nordmann@gmail.com",
+                password: "hemmeligpassord",
+            });
+
+            expect(res.status).toBe(200);
+
+            const row = await userByEmail(ctx, "kari.nordmann@gmail.com");
+            // The username is the local part, dot and all — narrowing it to
+            // "karinordmann" would produce exactly the shape NTNU hands out.
+            expect(row?.username).toBe("kari.nordmann");
+            expect(row?.approvalStatus).toBe("pending");
+        },
+    );
+
+    integrationTest(
+        "a taken username is rejected, and naming one gets past it",
+        async ({ ctx }) => {
+            await signUp(ctx, {
+                name: "Kari Nordmann",
+                email: "kari.nordmann@gmail.com",
+                password: "hemmeligpassord",
+            });
+
+            const collision = await signUp(ctx, {
+                name: "Kari Andersen",
+                email: "kari.nordmann@outlook.com",
+                password: "hemmeligpassord",
+            });
+            expect(collision.status).toBe(409);
+            expect(await collision.text()).toContain("opptatt");
+
+            const named = await signUp(ctx, {
+                name: "Kari Andersen",
+                email: "kari.nordmann@outlook.com",
+                password: "hemmeligpassord",
+                username: "kari.andersen",
+            });
+            expect(named.status).toBe(200);
+
+            const row = await userByEmail(ctx, "kari.nordmann@outlook.com");
+            expect(row?.username).toBe("kari.andersen");
+        },
+    );
+
+    integrationTest(
+        "a stud address keeps its NTNU username, whatever the body asks for",
+        async ({ ctx }) => {
+            const res = await signUp(ctx, {
+                name: "Ola Nordmann",
+                email: "olanor@stud.ntnu.no",
+                password: "hemmeligpassord",
+                // A student must not be able to claim someone else's NTNU
+                // username by typing it here.
+                username: "someoneelse",
+            });
+
+            expect(res.status).toBe(200);
+            const row = await userByEmail(ctx, "olanor@stud.ntnu.no");
+            expect(row?.username).toBe("olanor");
+        },
+    );
+
+    integrationTest(
+        "a pending account is turned away from routes that require a member",
+        async ({ ctx }) => {
+            const pending = await ctx.utils.createTestUser();
+            await ctx.db
+                .update(schema.user)
+                .set({ approvalStatus: "pending" })
+                .where(eq(schema.user.id, pending.id));
+
+            const client = await ctx.utils.clientForUser(pending);
+
+            // Their own settings stay reachable — they have to be able to
+            // finish setting the account up while they wait. (404 here means
+            // "no settings row yet", which is a different question; what
+            // matters is that the approval guard did not turn them away.)
+            const res = await client.api.user.me.settings.$get();
+            expect(res.status).not.toBe(403);
+
+            const other = await ctx.utils.createTestUser();
+            const denied = await client.api.user[":id"].$get({
+                param: { id: other.id },
+            });
+            expect(denied.status).toBe(403);
+        },
+    );
+
+    integrationTest(
+        "members-only events stay hidden until the account is approved",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.createTestEvent({
+                title: "Internt medlemsmøte",
+                visibility: "members",
+            });
+
+            const pending = await ctx.utils.createTestUser();
+            await ctx.db
+                .update(schema.user)
+                .set({ approvalStatus: "pending" })
+                .where(eq(schema.user.id, pending.id));
+            const client = await ctx.utils.clientForUser(pending);
+
+            const res = await client.api.event.$get({ query: {} });
+            expect(res.status).toBe(200);
+            const body = (await res.json()) as {
+                items: { title: string }[];
+            };
+            expect(
+                body.items.some((e) => e.title === "Internt medlemsmøte"),
+            ).toBe(false);
+        },
+    );
+
+    integrationTest(
+        "approving grants the member role and closes the queue entry",
+        async ({ ctx }) => {
+            // The role approval hands out. Seeded for real in `seedRbac`, but
+            // an integration database starts empty.
+            await createTestingRole(ctx, {
+                name: "member",
+                permissions: ["events:registrations:create"],
+                description: "Baseline member role",
+                position: 2,
+            });
+
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["users:manage"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            const pending = await ctx.utils.createTestUser();
+            await ctx.db
+                .update(schema.user)
+                .set({ approvalStatus: "pending" })
+                .where(eq(schema.user.id, pending.id));
+
+            const res = await client.api.user[":id"].approve.$post({
+                param: { id: pending.id },
+            });
+            expect(res.status).toBe(200);
+
+            const [row] = await ctx.db
+                .select()
+                .from(schema.user)
+                .where(eq(schema.user.id, pending.id));
+            expect(row?.approvalStatus).toBe("approved");
+            expect(row?.approvedAt).not.toBeNull();
+            expect(row?.approvedBy).toBe(admin.id);
+            expect(await getUserRoles(ctx, pending.id)).toContain("member");
+
+            // Approving twice is a mistake worth naming, not a silent no-op.
+            const again = await client.api.user[":id"].approve.$post({
+                param: { id: pending.id },
+            });
+            expect(again.status).toBe(400);
+        },
+    );
+
+    integrationTest("approving requires users:manage", async ({ ctx }) => {
+        const caller = await ctx.utils.createTestUser();
+        await ctx.utils.giveUserPermissions(caller, ["users:view"]);
+        const client = await ctx.utils.clientForUser(caller);
+
+        const pending = await ctx.utils.createTestUser();
+        await ctx.db
+            .update(schema.user)
+            .set({ approvalStatus: "pending" })
+            .where(eq(schema.user.id, pending.id));
+
+        const res = await client.api.user[":id"].approve.$post({
+            param: { id: pending.id },
+        });
+        expect(res.status).toBe(403);
+    });
+});

--- a/apps/kvark/src/api/auth.ts
+++ b/apps/kvark/src/api/auth.ts
@@ -466,15 +466,23 @@ export const signUpEmailMutationOptions = mutationOptions({
         name,
         email,
         password,
+        username,
     }: {
         name: string;
         email: string;
         password: string;
+        /**
+         * Only for sign-ups with a private address, and only when the one
+         * derived from the address is taken. A stud address always yields the
+         * NTNU username, and the server ignores anything sent alongside it.
+         */
+        username?: string;
     }) => {
         const result = await clientAuthInstance.signUp.email({
             name,
             email,
             password,
+            ...(username ? { username } : {}),
         });
         if (result.error) {
             throw new Error(result.error.message ?? "Registrering feilet");

--- a/apps/kvark/src/api/queries/user.ts
+++ b/apps/kvark/src/api/queries/user.ts
@@ -24,6 +24,11 @@ export type UserListFilters = {
     study?: string;
     /** Cohort (STUDYYEAR group), e.g. 2023. */
     studyStartYear?: number;
+    /**
+     * "pending" er køen av selvregistrerte brukere som venter på at en
+     * administrator godkjenner dem.
+     */
+    approvalStatus?: "pending" | "approved";
 };
 
 /**
@@ -46,6 +51,9 @@ export const getUsersInfiniteQuery = (
                     ...(filters.studyStartYear === undefined
                         ? {}
                         : { studyStartYear: filters.studyStartYear }),
+                    ...(filters.approvalStatus
+                        ? { approvalStatus: filters.approvalStatus }
+                        : {}),
                 },
             }),
         initialPageParam: 0,
@@ -173,6 +181,24 @@ export const updateUserStatusMutation = mutationOptions({
             params: { id: userId },
             json: { isActive, ...(reason ? { reason } : {}) },
         }),
+    onSuccess(_, __, ___, ctx) {
+        ctx.client.invalidateQueries({
+            queryKey: [...UserQueryKeys.listInfinite],
+            exact: false,
+        });
+    },
+});
+
+/**
+ * Godkjenn en bruker som har registrert seg selv.
+ *
+ * Gir `member`-rollen — den samme en student får av Feide — og sender en
+ * e-post om at brukeren er klar til bruk. Uten dette står kontoen uten roller
+ * og kommer ingen vei.
+ */
+export const approveUserMutation = mutationOptions({
+    mutationFn: ({ userId }: { userId: string }) =>
+        apiClient.post("/api/user/{id}/approve", { params: { id: userId } }),
     onSuccess(_, __, ___, ctx) {
         ctx.client.invalidateQueries({
             queryKey: [...UserQueryKeys.listInfinite],

--- a/apps/kvark/src/components/pending-approval-notice.tsx
+++ b/apps/kvark/src/components/pending-approval-notice.tsx
@@ -1,0 +1,22 @@
+import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
+import { Hourglass } from "lucide-react";
+
+/**
+ * Vises over hele appen til en bruker som har registrert seg selv og venter på
+ * at en administrator godkjenner kontoen.
+ *
+ * Uten den ville ventetiden føltes som en feil: påmeldingsknappen mangler, og
+ * medlemssidene er tomme, uten at noe forklarer hvorfor.
+ */
+export function PendingApprovalNotice() {
+    return (
+        <Alert>
+            <Hourglass className="size-4" />
+            <AlertTitle>Brukeren din venter på godkjenning</AlertTitle>
+            <AlertDescription>
+                Du kan se det alle andre ser. Når en administrator har godkjent
+                deg, får du e-post og kan melde deg på arrangementer.
+            </AlertDescription>
+        </Alert>
+    );
+}

--- a/apps/kvark/src/components/site-nav-items.ts
+++ b/apps/kvark/src/components/site-nav-items.ts
@@ -8,7 +8,18 @@ import type { NavItem } from "#/components/site-header";
  * auth pages. Lives outside the layouts so every shell that shows navigation
  * shows the same navigation.
  */
-export function useSiteNavItems(isAuthenticated: boolean): NavItem[] {
+/**
+ * @param isAuthenticated Om noen er logget inn i det hele tatt.
+ * @param isMember Om den innloggede faktisk er medlem. En selvregistrert bruker
+ *   som venter på godkjenning er logget inn, men hver side under «For
+ *   Medlemmer» svarer 403 for dem — så menyen skjules i stedet for å tilby
+ *   lenker som bare fører til en feilmelding. Standard `true` holder kallere
+ *   som ikke bryr seg om skillet uendret.
+ */
+export function useSiteNavItems(
+    isAuthenticated: boolean,
+    isMember: boolean = true,
+): NavItem[] {
     // Vis "Ny student" i navmenyen fra og med juni til og med august
     const month = new Date().getMonth();
     const isNewStudentTime = month >= 5 && month <= 7;
@@ -83,7 +94,7 @@ export function useSiteNavItems(isAuthenticated: boolean): NavItem[] {
                           },
                       ]
                     : []),
-                ...(isAuthenticated
+                ...(isAuthenticated && isMember
                     ? [
                           {
                               kind: "group",
@@ -140,7 +151,7 @@ export function useSiteNavItems(isAuthenticated: boolean): NavItem[] {
                       ]
                     : []),
             ] as NavItem[],
-        [isAuthenticated, isNewStudentTime],
+        [isAuthenticated, isMember, isNewStudentTime],
     );
 
     return navItems;

--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { authQueryOptions } from "#/api/auth";
 import { EventRulesConsent } from "#/components/event-rules-consent";
 import { NotificationBell } from "#/components/notification-bell";
+import { PendingApprovalNotice } from "#/components/pending-approval-notice";
 import { SiteBottomBar } from "#/components/site-bottom-bar";
 import { SiteFooter } from "#/components/site-footer";
 import { SiteHeader } from "#/components/site-header";
@@ -28,7 +29,11 @@ function AppLayout() {
           }
         : null;
     const isAuthenticated = Boolean(currentUser);
-    const navItems = useSiteNavItems(isAuthenticated);
+    // En selvregistrert bruker kan logge inn med én gang, men er ikke medlem
+    // før noen har sagt ja. Det må stå et sted de faktisk ser det — og
+    // medlemsmenyen skjules, siden hver side der svarer 403 for dem.
+    const isPendingApproval = session?.user?.isPendingApproval === true;
+    const navItems = useSiteNavItems(isAuthenticated, !isPendingApproval);
 
     return (
         // The bottom padding keeps the footer clear of the fixed bottom bar,
@@ -41,6 +46,11 @@ function AppLayout() {
                 // innloggede — ellers ville hver besøkende få en 401.
                 actions={isAuthenticated ? <NotificationBell /> : null}
             />
+            {isPendingApproval ? (
+                <div className="container mx-auto px-4 pt-4">
+                    <PendingApprovalNotice />
+                </div>
+            ) : null}
             {eventRules.mustAccept ? (
                 <div className="container mx-auto px-4 pt-4">
                     <EventRulesConsent

--- a/apps/kvark/src/routes/_auth/register.tsx
+++ b/apps/kvark/src/routes/_auth/register.tsx
@@ -28,20 +28,26 @@ export const Route = createFileRoute("/_auth/register")({
     component: RegisterPage,
 });
 
-// Kept identical to STUD_NTNU_EMAIL_PATTERN in @photon/auth, which is the
-// actual enforcement point — this only moves the error next to the field.
-const STUD_NTNU_EMAIL_PATTERN =
-    /^([a-z0-9]+(?:[._-][a-z0-9]+)*)@stud\.ntnu\.no$/;
+// Mirrors SELF_CHOSEN_USERNAME_PATTERN in @photon/auth, which is the actual
+// enforcement point — this only moves the error next to the field.
+const SELF_CHOSEN_USERNAME_PATTERN = /^[a-z0-9][a-z0-9._-]{1,28}[a-z0-9]$/;
 
 const registerSchema = z
     .object({
         name: z.string().min(1, { error: "Navn kan ikke være tom" }),
-        email: z
-            .email({ error: "Ugyldig e-post" })
+        email: z.email({ error: "Ugyldig e-post" }),
+        // Only shown once the server says the derived one is taken, so an
+        // empty value is normal and means "use the one from the address".
+        username: z
+            .string()
+            .trim()
             .refine(
-                (email) =>
-                    STUD_NTNU_EMAIL_PATTERN.test(email.trim().toLowerCase()),
-                { error: "Du må bruke din @stud.ntnu.no-adresse" },
+                (value) =>
+                    value.length === 0 ||
+                    SELF_CHOSEN_USERNAME_PATTERN.test(value.toLowerCase()),
+                {
+                    error: "3–30 tegn: små bokstaver, tall, punktum, bindestrek eller understrek",
+                },
             ),
         password: z
             .string()
@@ -78,6 +84,14 @@ function RegisterPage() {
 
     const signUpMutation = useMutation(signUpEmailMutationOptions);
 
+    /**
+     * The username field appears only after the server has rejected the one it
+     * derived from the address. Asking everyone up front for something we can
+     * work out ourselves is a field most people would have to think about for
+     * no reason.
+     */
+    const [needsUsername, setNeedsUsername] = useState(false);
+
     const form = useAppForm({
         validators: {
             onChange: registerSchema,
@@ -86,15 +100,31 @@ function RegisterPage() {
         defaultValues: {
             name: "",
             email: "",
+            username: "",
             password: "",
             confirmPassword: "",
         },
         async onSubmit({ value }) {
-            const data = await signUpMutation.mutateAsync({
-                name: value.name,
-                email: value.email,
-                password: value.password,
-            });
+            let data: Awaited<ReturnType<typeof signUpMutation.mutateAsync>>;
+            try {
+                data = await signUpMutation.mutateAsync({
+                    name: value.name,
+                    email: value.email,
+                    password: value.password,
+                    username: value.username.trim() || undefined,
+                });
+            } catch (error) {
+                // The server answers a taken username with a message naming it;
+                // that is the cue to ask for one instead of only showing the
+                // error and leaving no way to act on it.
+                if (
+                    error instanceof Error &&
+                    error.message.includes("opptatt")
+                ) {
+                    setNeedsUsername(true);
+                }
+                throw error;
+            }
 
             if ("url" in data && data.url) {
                 window.location.href = data.url;
@@ -123,7 +153,9 @@ function RegisterPage() {
                         <CardDescription>
                             Vi har sendt en bekreftelseslenke til{" "}
                             {form.state.values.email}. Følg lenken for å
-                            fullføre registreringen.
+                            fullføre registreringen. Deretter godkjenner en
+                            administrator brukeren din — du får en e-post når
+                            det er gjort.
                         </CardDescription>
                     </CardHeader>
                     <CardFooter>
@@ -144,7 +176,9 @@ function RegisterPage() {
             <CardHeader>
                 <CardTitle>Opprett bruker</CardTitle>
                 <CardDescription>
-                    Registrer deg med Feide for å delta på arrangementer.
+                    Er du student, registrer deg med Feide — da er du medlem med
+                    én gang. Andre kan lage bruker med e-post, og en
+                    administrator godkjenner den.
                 </CardDescription>
             </CardHeader>
 
@@ -162,7 +196,7 @@ function RegisterPage() {
                         className="mx-auto"
                         onClick={() => setShowEmailForm(true)}
                     >
-                        Kan du ikke bruke Feide?
+                        Har du ikke Feide?
                     </Button>
                 )}
             </CardContent>
@@ -189,11 +223,23 @@ function RegisterPage() {
                                         label="E-post"
                                         type="email"
                                         autoComplete="email"
-                                        description="Bruk din @stud.ntnu.no-adresse. Brukernavnet ditt blir det som står før @."
+                                        description="Studenter bruker @stud.ntnu.no. Andre kan bruke privat e-post. Brukernavnet ditt blir det som står før @."
                                         required
                                     />
                                 )}
                             </form.AppField>
+                            {needsUsername && (
+                                <form.AppField name="username">
+                                    {(field) => (
+                                        <field.InputField
+                                            label="Brukernavn"
+                                            autoComplete="username"
+                                            description="Brukernavnet fra e-postadressen din er opptatt. Velg et annet."
+                                            required
+                                        />
+                                    )}
+                                </form.AppField>
+                            )}
                             <form.AppField name="password">
                                 {(field) => (
                                     <field.PasswordField

--- a/apps/kvark/src/routes/admin/brukere.tsx
+++ b/apps/kvark/src/routes/admin/brukere.tsx
@@ -56,6 +56,7 @@ import { Stagger } from "@tihlde/ui/ui/motion";
 
 import { searchUsersQuery } from "#/api/queries/roles";
 import {
+    approveUserMutation,
     deleteUserMutation,
     getAllergiesQuery,
     getUserAllergiesQuery,
@@ -221,6 +222,12 @@ function AllUsersTable({
     const [search, setSearch] = useState("");
     const [study, setStudy] = useState<string>(ALL);
     const [year, setYear] = useState<string>(ALL);
+    /**
+     * Køen av selvregistrerte som venter på godkjenning. Uten et eget filter
+     * ville de forsvunnet blant to tusen andre — de har verken studie eller
+     * kull å søke dem opp med.
+     */
+    const [approval, setApproval] = useState<string>(ALL);
     const [editing, setEditing] = useState<{
         id: string;
         name: string;
@@ -239,6 +246,13 @@ function AllUsersTable({
         id: string;
         name: string;
         username: string | null;
+        /** Avvisning av en søknad, ikke sletting av et medlem. */
+        isPending: boolean;
+    } | null>(null);
+    const [approving, setApproving] = useState<{
+        id: string;
+        name: string;
+        email: string | null;
     } | null>(null);
 
     /**
@@ -271,8 +285,14 @@ function AllUsersTable({
             study:
                 study === ALL ? undefined : study === NO_STUDY ? "none" : study,
             studyStartYear: year === ALL ? undefined : Number(year),
+            approvalStatus:
+                approval === ALL
+                    ? undefined
+                    : (approval as "pending" | "approved"),
         }),
     );
+
+    const showingPendingQueue = approval === "pending";
 
     const users = useMemo(
         () => (data?.pages ?? []).flatMap((page) => page.items),
@@ -321,6 +341,24 @@ function AllUsersTable({
                         }))}
                     />
                 </Field>
+                <Field>
+                    <FieldLabel htmlFor="user-filter-approval">
+                        Godkjenning
+                    </FieldLabel>
+                    <FilterSelect
+                        id="user-filter-approval"
+                        value={approval}
+                        onValueChange={setApproval}
+                        allLabel="Alle brukere"
+                        options={[
+                            {
+                                value: "pending",
+                                label: "Venter på godkjenning",
+                            },
+                            { value: "approved", label: "Godkjent" },
+                        ]}
+                    />
+                </Field>
             </div>
 
             {isPending ? (
@@ -344,7 +382,9 @@ function AllUsersTable({
             ) : (
                 <>
                     <p className="text-sm">
-                        Viser {users.length} av {totalCount} brukere
+                        {showingPendingQueue
+                            ? `${totalCount} venter på godkjenning`
+                            : `Viser ${users.length} av ${totalCount} brukere`}
                     </p>
                     <Card>
                         <CardContent className="p-0">
@@ -380,21 +420,38 @@ function AllUsersTable({
                                                             )}
                                                         </AvatarFallback>
                                                     </Avatar>
-                                                    <span className="text-sm font-medium">
-                                                        {user.name}
-                                                    </span>
+                                                    <div className="flex flex-col">
+                                                        <span className="text-sm font-medium">
+                                                            {user.name}
+                                                        </span>
+                                                        {/* E-posten er det
+                                                        eneste en admin har å
+                                                        vurdere en ukjent på, og
+                                                        API-et sender den bare
+                                                        for de som venter. */}
+                                                        {user.email && (
+                                                            <span className="text-sm text-muted-foreground">
+                                                                {user.email}
+                                                            </span>
+                                                        )}
+                                                    </div>
                                                 </div>
                                             </TableCell>
                                             <TableCell>
                                                 {user.username ?? "—"}
                                             </TableCell>
                                             <TableCell>
-                                                {user.isActive ? (
-                                                    "Aktiv"
-                                                ) : (
+                                                {!user.isActive ? (
                                                     <Badge variant="destructive">
                                                         Arkivert
                                                     </Badge>
+                                                ) : user.approvalStatus ===
+                                                  "pending" ? (
+                                                    <Badge variant="secondary">
+                                                        Venter
+                                                    </Badge>
+                                                ) : (
+                                                    "Aktiv"
                                                 )}
                                             </TableCell>
                                             <TableCell>
@@ -409,6 +466,29 @@ function AllUsersTable({
                                             {hasActions && (
                                                 <TableCell>
                                                     <div className="flex justify-end gap-1">
+                                                        {/* Godkjenning står
+                                                        først: for en som
+                                                        venter, er det den
+                                                        eneste handlingen som
+                                                        betyr noe. */}
+                                                        {canEditCohort &&
+                                                            user.approvalStatus ===
+                                                                "pending" && (
+                                                                <Button
+                                                                    size="sm"
+                                                                    onClick={() =>
+                                                                        setApproving(
+                                                                            {
+                                                                                id: user.id,
+                                                                                name: user.name,
+                                                                                email: user.email,
+                                                                            },
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    Godkjenn
+                                                                </Button>
+                                                            )}
                                                         {canEditCohort && (
                                                             <>
                                                                 <Button
@@ -472,11 +552,17 @@ function AllUsersTable({
                                                                             name: user.name,
                                                                             username:
                                                                                 user.username,
+                                                                            isPending:
+                                                                                user.approvalStatus ===
+                                                                                "pending",
                                                                         },
                                                                     )
                                                                 }
                                                             >
-                                                                Slett
+                                                                {user.approvalStatus ===
+                                                                "pending"
+                                                                    ? "Avvis"
+                                                                    : "Slett"}
                                                             </Button>
                                                         )}
                                                     </div>
@@ -526,6 +612,14 @@ function AllUsersTable({
                 }}
             />
 
+            <ApproveUserDialog
+                user={approving}
+                open={approving !== null}
+                onOpenChange={(open) => {
+                    if (!open) setApproving(null);
+                }}
+            />
+
             <DeleteUserDialog
                 user={deleting}
                 open={deleting !== null}
@@ -534,6 +628,76 @@ function AllUsersTable({
                 }}
             />
         </div>
+    );
+}
+
+/**
+ * Godkjenn en bruker som har registrert seg selv på nettsiden.
+ *
+ * Handlingen er liten å utføre og lett å angre — rollen kan fjernes igjen i
+ * /admin/roller — så dialogen spør bare én gang, og sier hva godkjenningen
+ * faktisk gir.
+ */
+function ApproveUserDialog({
+    user,
+    open,
+    onOpenChange,
+}: {
+    user: { id: string; name: string; email: string | null } | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const [error, setError] = useState<string | null>(null);
+    const approve = useMutation(approveUserMutation);
+
+    async function handleApprove() {
+        if (!user) return;
+        setError(null);
+        try {
+            await approve.mutateAsync({ userId: user.id });
+            onOpenChange(false);
+        } catch (err) {
+            setError(await extractErrorMessage(err));
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Godkjenn bruker</DialogTitle>
+                    <DialogDescription>
+                        {user?.name}
+                        {user?.email ? ` · ${user.email}` : ""}
+                    </DialogDescription>
+                </DialogHeader>
+                <FieldDescription>
+                    Brukeren blir medlem: kan melde seg på arrangementer og se
+                    medlemssidene. De får en e-post om at kontoen er godkjent.
+                </FieldDescription>
+                {error && (
+                    <p className="text-sm text-destructive" role="alert">
+                        {error}
+                    </p>
+                )}
+                <DialogFooter>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Avbryt
+                    </Button>
+                    <Button
+                        type="button"
+                        onClick={handleApprove}
+                        disabled={approve.isPending}
+                    >
+                        Godkjenn
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
     );
 }
 
@@ -549,10 +713,22 @@ function DeleteUserDialog({
     open,
     onOpenChange,
 }: {
-    user: { id: string; name: string; username: string | null } | null;
+    user: {
+        id: string;
+        name: string;
+        username: string | null;
+        isPending: boolean;
+    } | null;
     open: boolean;
     onOpenChange: (open: boolean) => void;
 }) {
+    /**
+     * Å avvise en som venter er ikke det samme som å slette et medlem: kontoen
+     * har ingen påmeldinger, bøter eller vervhistorikk å miste, bare en
+     * e-postadresse noen tastet inn. Da er avskrivingen av navnet ren
+     * friksjon.
+     */
+    const isRejection = user?.isPending === true;
     const [confirmation, setConfirmation] = useState("");
     const [error, setError] = useState<string | null>(null);
     const remove = useMutation(deleteUserMutation);
@@ -569,6 +745,7 @@ function DeleteUserDialog({
     // Brukernavnet er kortere og entydig; navnet brukes når det mangler.
     const expected = user?.username ?? user?.name ?? "";
     const confirmed =
+        isRejection ||
         confirmation.trim().toLowerCase() === expected.toLowerCase();
 
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -589,30 +766,40 @@ function DeleteUserDialog({
             <DialogContent>
                 <form onSubmit={handleSubmit} className="flex flex-col gap-4">
                     <DialogHeader>
-                        <DialogTitle>Slett konto</DialogTitle>
+                        <DialogTitle>
+                            {isRejection ? "Avvis bruker" : "Slett konto"}
+                        </DialogTitle>
                         <DialogDescription>{user?.name}</DialogDescription>
                     </DialogHeader>
-                    <FieldGroup>
-                        <Field>
-                            <FieldLabel htmlFor="delete-confirmation">
-                                Skriv «{expected}» for å bekrefte
-                            </FieldLabel>
-                            <Input
-                                id="delete-confirmation"
-                                value={confirmation}
-                                onChange={(event) =>
-                                    setConfirmation(event.target.value)
-                                }
-                                autoComplete="off"
-                            />
-                            <FieldDescription>
-                                Kontoen slettes for godt, sammen med
-                                påmeldinger, betalinger, bøter, medlemskap og
-                                vervhistorikk. Dette kan ikke angres — velg
-                                Arkiver i stedet hvis historikken skal beholdes.
-                            </FieldDescription>
-                        </Field>
-                    </FieldGroup>
+                    {isRejection ? (
+                        <FieldDescription>
+                            Kontoen slettes, og personen får ingen beskjed. De
+                            kan registrere seg på nytt med samme e-postadresse.
+                        </FieldDescription>
+                    ) : (
+                        <FieldGroup>
+                            <Field>
+                                <FieldLabel htmlFor="delete-confirmation">
+                                    Skriv «{expected}» for å bekrefte
+                                </FieldLabel>
+                                <Input
+                                    id="delete-confirmation"
+                                    value={confirmation}
+                                    onChange={(event) =>
+                                        setConfirmation(event.target.value)
+                                    }
+                                    autoComplete="off"
+                                />
+                                <FieldDescription>
+                                    Kontoen slettes for godt, sammen med
+                                    påmeldinger, betalinger, bøter, medlemskap
+                                    og vervhistorikk. Dette kan ikke angres —
+                                    velg Arkiver i stedet hvis historikken skal
+                                    beholdes.
+                                </FieldDescription>
+                            </Field>
+                        </FieldGroup>
+                    )}
                     {error && (
                         <p className="text-sm text-destructive" role="alert">
                             {error}
@@ -631,7 +818,7 @@ function DeleteUserDialog({
                             variant="destructive"
                             disabled={!confirmed || remove.isPending}
                         >
-                            Slett for godt
+                            {isRejection ? "Avvis" : "Slett for godt"}
                         </Button>
                     </DialogFooter>
                 </form>

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -650,6 +650,22 @@ export async function syncBaselineRoles(
     if (target === "member") {
         if (memberRole) await assign(memberRole.id);
         if (alumniRole) await remove(alumniRole.id);
+
+        /**
+         * Feide answers the question an admin would otherwise have to: this is
+         * an active student on a TIHLDE programme. Someone who signed up on the
+         * website and only later logged in with Feide should not be left
+         * sitting in the approval queue after that.
+         *
+         * Only ever moves pending -> approved, so an account that never needed
+         * approving keeps its null and stays out of the queue's history.
+         */
+        await tx
+            .update(user)
+            .set({ approvalStatus: "approved", approvedAt: new Date() })
+            .where(
+                and(eq(user.id, userId), eq(user.approvalStatus, "pending")),
+            );
     } else if (target === "alumni") {
         if (alumniRole) await assign(alumniRole.id);
         if (memberRole) await remove(memberRole.id);
@@ -1319,12 +1335,37 @@ export async function resolveMigratedEmail(
     }
 
     const [match] = await db
-        .select({ id: user.id, email: user.email })
+        .select({
+            id: user.id,
+            email: user.email,
+            approvalStatus: user.approvalStatus,
+        })
         .from(user)
         .where(eq(user.username, username))
         .limit(1);
 
     if (!match) {
+        return null;
+    }
+
+    /**
+     * An account someone made for themselves with a private address picked its
+     * own username, and nothing stops that pick from being a real student's
+     * NTNU username. Handing this login to it would not merely confuse the two
+     * — it would drop the student into a stranger's account, with the
+     * stranger's password still on it. Better Auth then falls back to matching
+     * on the address Feide gave us, which is the correct behaviour for someone
+     * who has never been here before.
+     *
+     * Migrated Lepton members carry no approval status, so this leaves the
+     * case the function exists for untouched. A self-registered *student* is
+     * matched as normal: the username came from their own stud address, so it
+     * is theirs by the same proof Feide is about to supply.
+     */
+    if (
+        match.approvalStatus !== null &&
+        !match.email.trim().toLowerCase().endsWith("@stud.ntnu.no")
+    ) {
         return null;
     }
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -17,7 +17,7 @@ import {
     oauthProviderAuthServerMetadata,
     oauthProviderOpenIdConfigMetadata,
 } from "@better-auth/oauth-provider";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { DbSchema } from "@photon/db";
 import { user } from "@photon/db/schema";
@@ -44,8 +44,13 @@ const isFeideConfigured = Boolean(
 );
 
 /**
- * Self-registration is restricted to NTNU student addresses, and the username
- * is the local part of that address (`olanor@stud.ntnu.no` -> `olanor`).
+ * A student address, whose local part is the NTNU username
+ * (`olanor@stud.ntnu.no` -> `olanor`).
+ *
+ * Self-registration is no longer restricted to these — anyone may sign up with
+ * a private address and wait for an admin to approve them — but a stud address
+ * still gets special treatment: the username is taken from it and nothing else,
+ * because that is the value a later Feide login matches the account on.
  *
  * Deliberately scoped to the public `/sign-up/email` endpoint rather than a
  * `databaseHooks.user.create` hook: every other creation path (dev seeding,
@@ -79,30 +84,75 @@ export function usernameFromStudentEmail(
 const USERNAME_PATTERN = /^[a-z0-9]{1,15}$/;
 
 /**
- * A username chosen by a trusted server-side caller, for the duration of one
- * `signUpEmail` call.
+ * Shape a username may have when the person picks it themselves, signing up
+ * with a private address.
+ *
+ * Wider than `USERNAME_PATTERN` on purpose. Private addresses routinely have
+ * local parts like `ola.nordmann`, and that is what the username is derived
+ * from — narrowing it by stripping the dot would turn `ola.nordmann` into
+ * `olanordmann`, which is exactly the shape NTNU hands out and therefore the
+ * shape most likely to collide with a real student's username later.
+ */
+const SELF_CHOSEN_USERNAME_PATTERN = /^[a-z0-9][a-z0-9._-]{1,28}[a-z0-9]$/;
+
+/**
+ * Username a self-registration derives from the local part of `email`, or
+ * undefined when that local part is not a usable username.
+ *
+ * Only used for addresses that are not stud ones; a stud address goes through
+ * `usernameFromStudentEmail`, whose stricter rule is what a Feide login later
+ * matches on.
+ */
+export function usernameFromEmailLocalPart(
+    email: string | undefined,
+): string | undefined {
+    if (typeof email !== "string") return undefined;
+    const localPart = email.trim().toLowerCase().split("@")[0] ?? "";
+    return SELF_CHOSEN_USERNAME_PATTERN.test(localPart) ? localPart : undefined;
+}
+
+/** Normalised form of a username typed into the sign-up form. */
+function normaliseUsername(value: unknown): string | undefined {
+    if (typeof value !== "string") return undefined;
+    const trimmed = value.trim().toLowerCase();
+    return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * A sign-up performed by a trusted server-side caller, for the duration of one
+ * `signUpEmail` call. `username`, when present, is used as-is.
  *
  * Fadderuka registers brand-new students during fadderuka, and many of them
  * have not been given their @stud.ntnu.no address yet — so the address cannot
  * be what the username is derived from. They type their Feide username instead,
  * which is what makes a later Feide login land on the same account.
  *
- * Deliberately NOT read from the request body. `/sign-up/email` is a public
- * HTTP endpoint, so a body-supplied username would let anyone claim a student's
- * NTNU username before that student ever registers. Async-local storage cannot
+ * The store is also what tells the two kinds of sign-up apart afterwards: a
+ * trusted caller has already established the person's right to an account, so
+ * their account is not marked as awaiting approval, while a sign-up arriving
+ * over plain HTTP always is.
+ *
+ * A trusted username is deliberately NOT read from the request body. A
+ * body-supplied one would let anyone claim a student's NTNU username before
+ * that student ever registers — see the sign-up hook, which only honours a
+ * body username for addresses NTNU did not issue. Async-local storage cannot
  * be reached over HTTP: only code inside `runTrustedSignUp` sees it, and the
  * one caller is the API-key route that has already checked `users:create`.
  */
-const trustedSignUpStore = new AsyncLocalStorage<{ username: string }>();
+const trustedSignUpStore = new AsyncLocalStorage<{ username?: string }>();
 
 /**
- * Run `fn` with `username` marked as trusted, so the sign-up hook uses it
- * instead of deriving one from the e-mail address.
+ * Run `fn` as a trusted sign-up: the account skips admin approval, and
+ * `username` — when given — is used instead of deriving one from the address.
  */
 export function runTrustedSignUp<T>(
-    username: string,
+    username: string | undefined,
     fn: () => Promise<T>,
 ): Promise<T> {
+    if (username === undefined) {
+        return trustedSignUpStore.run({}, fn);
+    }
+
     const normalised = username.trim().toLowerCase();
     if (!USERNAME_PATTERN.test(normalised)) {
         throw new APIError("BAD_REQUEST", {
@@ -456,17 +506,52 @@ export function createAuth(options: CreateAuthOptions) {
                         : "";
 
                 /**
-                 * A trusted server-side caller may name the username outright;
-                 * everyone else still has to prove it with a stud address.
-                 * See `runTrustedSignUp` for why this cannot come from the body.
+                 * How the account gets its username:
+                 *
+                 * - Trusted caller naming one: used as-is. See
+                 *   `runTrustedSignUp` for why this cannot come from the body.
+                 * - Stud address: the local part, and only that. It is the
+                 *   student's NTNU username, and a later Feide login finds the
+                 *   account by it — so it is not the signer-upper's to choose.
+                 * - Anything else (a private address, someone who is not a
+                 *   student yet): the local part too, but they may name their
+                 *   own instead. Local parts are not unique across providers,
+                 *   so a collision has to have a way out, and the account has
+                 *   no NTNU identity to protect anyway.
                  */
                 const trusted = trustedSignUpStore.getStore();
+                const studUsername = usernameFromStudentEmail(email);
+                const chosenUsername = trusted
+                    ? undefined
+                    : normaliseUsername(ctx.body?.username);
+
+                if (chosenUsername && !studUsername) {
+                    if (
+                        !SELF_CHOSEN_USERNAME_PATTERN.test(chosenUsername) ||
+                        chosenUsername.length > 30
+                    ) {
+                        throw new APIError("BAD_REQUEST", {
+                            message:
+                                "Brukernavnet må være 3–30 tegn og kan bare inneholde små bokstaver, tall, punktum, bindestrek og understrek.",
+                        });
+                    }
+                }
+
                 const derivedUsername =
-                    trusted?.username ?? usernameFromStudentEmail(email);
+                    trusted?.username ??
+                    studUsername ??
+                    (chosenUsername || usernameFromEmailLocalPart(email));
+
                 if (!derivedUsername) {
+                    // Reachable two ways: a trusted caller passing a
+                    // non-stud address with no username, and a private address
+                    // whose local part is not a usable username (`a@b.no`,
+                    // `ola+tihlde@…`). Only the second can happen over HTTP,
+                    // and the answer to it is to name a username.
                     throw new APIError("BAD_REQUEST", {
-                        message:
-                            "Registrering krever en @stud.ntnu.no-adresse.",
+                        message: trusted
+                            ? "Registrering krever en @stud.ntnu.no-adresse."
+                            : "Vi klarte ikke å lage et brukernavn fra e-postadressen din. Velg et selv.",
                     });
                 }
 
@@ -493,12 +578,15 @@ export function createAuth(options: CreateAuthOptions) {
                 if (takenBy) {
                     throw new APIError("CONFLICT", {
                         message:
-                            "Det finnes allerede en bruker med dette NTNU-brukernavnet. Logg inn med Feide i stedet, eller bruk «glemt passord».",
+                            trusted || studUsername
+                                ? "Det finnes allerede en bruker med dette NTNU-brukernavnet. Logg inn med Feide i stedet, eller bruk «glemt passord»."
+                                : `Brukernavnet «${derivedUsername}» er opptatt. Velg et annet.`,
                     });
                 }
 
-                // Never taken from the request body: it is either derived from
-                // the address, or named by a trusted server-side caller.
+                // For a stud address and for a trusted caller this is never the
+                // body's to decide; for a private address the body is exactly
+                // where a chosen username is allowed to come from.
                 return {
                     context: {
                         body: { ...ctx.body, email, username: derivedUsername },
@@ -506,6 +594,48 @@ export function createAuth(options: CreateAuthOptions) {
                 };
             }),
             after: createAuthMiddleware(async (ctx) => {
+                /**
+                 * An account someone made for themselves on the website waits
+                 * for an admin before it counts as a member.
+                 *
+                 * Written here rather than at creation time because the value
+                 * depends on *how* the endpoint was called, and the sign-up
+                 * body has no room for something the caller must not control.
+                 * The row is found by e-mail: it is unique, the before-hook has
+                 * already normalised it, and the account was created moments
+                 * ago by this very request.
+                 *
+                 * Only ever fills in a status that is missing, so re-running it
+                 * can never demote an approved member back to pending.
+                 */
+                if (
+                    ctx.path === "/sign-up/email" &&
+                    !trustedSignUpStore.getStore()
+                ) {
+                    const email = ctx.body?.email;
+                    if (typeof email === "string" && email.length > 0) {
+                        try {
+                            await options.services.db
+                                .update(user)
+                                .set({ approvalStatus: "pending" })
+                                .where(
+                                    and(
+                                        eq(
+                                            user.email,
+                                            email.trim().toLowerCase(),
+                                        ),
+                                        isNull(user.approvalStatus),
+                                    ),
+                                );
+                        } catch (error) {
+                            console.error(
+                                "Failed to mark a self-registered account as awaiting approval:",
+                                error,
+                            );
+                        }
+                    }
+                }
+
                 if (!isFeideConfigured) return;
 
                 // Sends a member whose password was just revoked on to set a
@@ -603,7 +733,7 @@ export function createAuth(options: CreateAuthOptions) {
             customSession(async ({ user, session }) => {
                 const db = options.services.db;
 
-                const [settings, permissions, groups] = await Promise.all([
+                const [settings, permissions, groups, row] = await Promise.all([
                     db.query.userSettings.findFirst({
                         where: (s, { eq }) => eq(s.userId, user.id),
                         with: { allergies: { columns: { allergySlug: true } } },
@@ -613,11 +743,26 @@ export function createAuth(options: CreateAuthOptions) {
                         where: (gm, { eq }) => eq(gm.userId, user.id),
                         with: { group: true },
                     }),
+                    /**
+                     * Read separately because `approvalStatus` is ours, not
+                     * part of Better Auth's user model — the session `user` it
+                     * hands this callback carries only the columns it knows.
+                     * The frontend needs it to tell a member from someone still
+                     * waiting for an admin, and every request already has the
+                     * session in hand, so this is the cheapest place to answer
+                     * it once.
+                     */
+                    db.query.user.findFirst({
+                        where: (u, { eq }) => eq(u.id, user.id),
+                        columns: { approvalStatus: true },
+                    }),
                 ]);
 
                 return {
                     user: {
                         ...user,
+                        approvalStatus: row?.approvalStatus ?? null,
+                        isPendingApproval: row?.approvalStatus === "pending",
                         settings: settings
                             ? {
                                   ...settings,

--- a/packages/db/drizzle/0045_white_doctor_faustus.sql
+++ b/packages/db/drizzle/0045_white_doctor_faustus.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "auth_user" ADD COLUMN "approval_status" text;--> statement-breakpoint
+ALTER TABLE "auth_user" ADD COLUMN "approved_at" timestamp;--> statement-breakpoint
+ALTER TABLE "auth_user" ADD COLUMN "approved_by" text;--> statement-breakpoint
+CREATE INDEX "user_approvalStatus_idx" ON "auth_user" USING btree ("approval_status");

--- a/packages/db/drizzle/meta/0045_snapshot.json
+++ b/packages/db/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,6845 @@
+{
+  "id": "97170cae-8b97-4c86-ba47-25a633f27dde",
+  "prevId": "31aa6c0d-76bf-4688-a323-3dfcdfbf0f67",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apikey_api_key": {
+      "name": "apikey_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_api_key_created_by_user_id_auth_user_id_fk": {
+          "name": "apikey_api_key_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "apikey_api_key",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "apikey_api_key_key_hash_unique": {
+          "name": "apikey_api_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "application_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "submitted_by_id": {
+          "name": "submitted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_asset_key": {
+          "name": "pdf_asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_comment": {
+          "name": "internal_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled_by_id": {
+          "name": "handled_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled_at": {
+          "name": "handled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_submitted_by_id_created_at_index": {
+          "name": "application_submitted_by_id_created_at_index",
+          "columns": [
+            {
+              "expression": "submitted_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_type_status_created_at_index": {
+          "name": "application_type_status_created_at_index",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_submitted_by_id_auth_user_id_fk": {
+          "name": "application_submitted_by_id_auth_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "submitted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_handled_by_id_auth_user_id_fk": {
+          "name": "application_handled_by_id_auth_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "handled_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_attachment": {
+      "name": "application_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "application_attachment_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_attachment_application_id_index": {
+          "name": "application_attachment_application_id_index",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_attachment_application_id_application_id_fk": {
+          "name": "application_attachment_application_id_application_id_fk",
+          "tableFrom": "application_attachment",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_company_contact": {
+      "name": "application_company_contact",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semesters": {
+          "name": "semesters",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_company_contact_application_id_application_id_fk": {
+          "name": "application_company_contact_application_id_application_id_fk",
+          "tableFrom": "application_company_contact",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_expense": {
+      "name": "application_expense",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cc_email": {
+          "name": "cc_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_nok": {
+          "name": "amount_nok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expense_date": {
+          "name": "expense_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_type": {
+          "name": "budget_type",
+          "type": "application_budget_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_expense_application_id_application_id_fk": {
+          "name": "application_expense_application_id_application_id_fk",
+          "tableFrom": "application_expense",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_expense_group_slug_org_group_slug_fk": {
+          "name": "application_expense_group_slug_org_group_slug_fk",
+          "tableFrom": "application_expense",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_hs_case": {
+      "name": "application_hs_case",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_name": {
+          "name": "case_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_type": {
+          "name": "case_type",
+          "type": "application_case_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_hs_case_application_id_application_id_fk": {
+          "name": "application_hs_case_application_id_application_id_fk",
+          "tableFrom": "application_hs_case",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_support": {
+      "name": "application_support",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_description": {
+          "name": "event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_nok": {
+          "name": "total_amount_nok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_link": {
+          "name": "budget_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_support_application_id_application_id_fk": {
+          "name": "application_support_application_id_application_id_fk",
+          "tableFrom": "application_support",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_support_group_slug_org_group_slug_fk": {
+          "name": "application_support_group_slug_org_group_slug_fk",
+          "tableFrom": "application_support",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_file": {
+      "name": "asset_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "asset_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_file_uploaded_by_id_auth_user_id_fk": {
+          "name": "asset_file_uploaded_by_id_auth_user_id_fk",
+          "tableFrom": "asset_file",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_file_key_unique": {
+          "name": "asset_file_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_session_id_auth_session_id_fk": {
+          "name": "auth_oauth_access_token_session_id_auth_session_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_refresh_id_auth_oauth_refresh_token_id_fk": {
+          "name": "auth_oauth_access_token_refresh_id_auth_oauth_refresh_token_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_token_unique": {
+          "name": "auth_oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_client": {
+      "name": "auth_oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_client_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_client_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_client",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_client_client_id_unique": {
+          "name": "auth_oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_refresh_token": {
+      "name": "auth_oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_refresh_token_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_refresh_token_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_refresh_token_session_id_auth_session_id_fk": {
+          "name": "auth_oauth_refresh_token_session_id_auth_session_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_refresh_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_refresh_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_refresh_token_token_unique": {
+          "name": "auth_oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_session_token_unique": {
+          "name": "auth_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_approvalStatus_idx": {
+          "name": "user_approvalStatus_idx",
+          "columns": [
+            {
+              "expression": "approval_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_user_email_unique": {
+          "name": "auth_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "auth_user_username_unique": {
+          "name": "auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banner_banner": {
+      "name": "banner_banner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_text": {
+          "name": "link_text",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_from": {
+          "name": "visible_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visible_until": {
+          "name": "visible_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banner_banner_created_by_user_id_auth_user_id_fk": {
+          "name": "banner_banner_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "banner_banner",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_event": {
+      "name": "event_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lat": {
+          "name": "location_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lng": {
+          "name": "location_lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_waitlist": {
+          "name": "allow_waitlist",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "contact_person_id": {
+          "name": "contact_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_by_user_id": {
+          "name": "update_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_start": {
+          "name": "registration_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_end": {
+          "name": "registration_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_deadline": {
+          "name": "cancellation_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_registration_closed": {
+          "name": "is_registration_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_paid_event": {
+          "name": "is_paid_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_signing_up": {
+          "name": "requires_signing_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_grace_period_minutes": {
+          "name": "payment_grace_period_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions_allowed": {
+          "name": "reactions_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizer_group_slug": {
+          "name": "organizer_group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforces_previous_strikes": {
+          "name": "enforces_previous_strikes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_cause_strikes": {
+          "name": "can_cause_strikes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "no_show_processed_at": {
+          "name": "no_show_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_allow_prioritized": {
+          "name": "only_allow_prioritized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restricted_to_institute_id": {
+          "name": "restricted_to_institute_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "event_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_event_category_slug_event_category_slug_fk": {
+          "name": "event_event_category_slug_event_category_slug_fk",
+          "tableFrom": "event_event",
+          "tableTo": "event_category",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_event_contact_person_id_auth_user_id_fk": {
+          "name": "event_event_contact_person_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "contact_person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_created_by_user_id_auth_user_id_fk": {
+          "name": "event_event_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_update_by_user_id_auth_user_id_fk": {
+          "name": "event_event_update_by_user_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "update_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_organizer_group_slug_org_group_slug_fk": {
+          "name": "event_event_organizer_group_slug_org_group_slug_fk",
+          "tableFrom": "event_event",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "organizer_group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_restricted_to_institute_id_org_institute_id_fk": {
+          "name": "event_event_restricted_to_institute_id_org_institute_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "org_institute",
+          "columnsFrom": [
+            "restricted_to_institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_event_slug_unique": {
+          "name": "event_event_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_category": {
+      "name": "event_category",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_favorite": {
+      "name": "event_favorite",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_favorite_user_id_auth_user_id_fk": {
+          "name": "event_favorite_user_id_auth_user_id_fk",
+          "tableFrom": "event_favorite",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_favorite_event_id_event_event_id_fk": {
+          "name": "event_favorite_event_id_event_event_id_fk",
+          "tableFrom": "event_favorite",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_favorite_user_id_event_id_pk": {
+          "name": "event_favorite_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_feedback": {
+      "name": "event_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_feedback_event_id_event_event_id_fk": {
+          "name": "event_feedback_event_id_event_event_id_fk",
+          "tableFrom": "event_feedback",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_feedback_user_id_auth_user_id_fk": {
+          "name": "event_feedback_user_id_auth_user_id_fk",
+          "tableFrom": "event_feedback",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_payment": {
+      "name": "event_payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOK'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_payment_id": {
+          "name": "provider_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "received_payment_at": {
+          "name": "received_payment_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_payment_event_id_event_event_id_fk": {
+          "name": "event_payment_event_id_event_event_id_fk",
+          "tableFrom": "event_payment",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_payment_user_id_auth_user_id_fk": {
+          "name": "event_payment_user_id_auth_user_id_fk",
+          "tableFrom": "event_payment",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_pool": {
+      "name": "event_priority_pool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority_score": {
+          "name": "priority_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_pool_event_id_event_event_id_fk": {
+          "name": "event_priority_pool_event_id_event_event_id_fk",
+          "tableFrom": "event_priority_pool",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_pool_group": {
+      "name": "event_priority_pool_group",
+      "schema": "",
+      "columns": {
+        "priority_pool_id": {
+          "name": "priority_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_pool_group_priority_pool_id_event_priority_pool_id_fk": {
+          "name": "event_priority_pool_group_priority_pool_id_event_priority_pool_id_fk",
+          "tableFrom": "event_priority_pool_group",
+          "tableTo": "event_priority_pool",
+          "columnsFrom": [
+            "priority_pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_priority_pool_group_group_slug_org_group_slug_fk": {
+          "name": "event_priority_pool_group_group_slug_org_group_slug_fk",
+          "tableFrom": "event_priority_pool_group",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_priority_pool_group_priority_pool_id_group_slug_pk": {
+          "name": "event_priority_pool_group_priority_pool_id_group_slug_pk",
+          "columns": [
+            "priority_pool_id",
+            "group_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reaction": {
+      "name": "event_reaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reaction_user_id_auth_user_id_fk": {
+          "name": "event_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "event_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reaction_event_id_event_event_id_fk": {
+          "name": "event_reaction_event_id_event_event_id_fk",
+          "tableFrom": "event_reaction",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_reaction_user_id_event_id_pk": {
+          "name": "event_reaction_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_registration": {
+      "name": "event_registration",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "waitlist_position": {
+          "name": "waitlist_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended_at": {
+          "name": "attended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_photo": {
+          "name": "allow_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_registration_event_id_event_event_id_fk": {
+          "name": "event_registration_event_id_event_event_id_fk",
+          "tableFrom": "event_registration",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_registration_user_id_auth_user_id_fk": {
+          "name": "event_registration_user_id_auth_user_id_fk",
+          "tableFrom": "event_registration",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_registration_user_id_event_id_pk": {
+          "name": "event_registration_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_strike": {
+      "name": "event_strike",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_strike_event_id_event_event_id_fk": {
+          "name": "event_strike_event_id_event_event_id_fk",
+          "tableFrom": "event_strike",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_strike_user_id_auth_user_id_fk": {
+          "name": "event_strike_user_id_auth_user_id_fk",
+          "tableFrom": "event_strike",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_form": {
+      "name": "form_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_answer": {
+      "name": "form_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_text": {
+          "name": "answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_answer_submission_id_form_submission_id_fk": {
+          "name": "form_answer_submission_id_form_submission_id_fk",
+          "tableFrom": "form_answer",
+          "tableTo": "form_submission",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_answer_field_id_form_field_id_fk": {
+          "name": "form_answer_field_id_form_field_id_fk",
+          "tableFrom": "form_answer",
+          "tableTo": "form_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_answer_option": {
+      "name": "form_answer_option",
+      "schema": "",
+      "columns": {
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_answer_option_answer_id_form_answer_id_fk": {
+          "name": "form_answer_option_answer_id_form_answer_id_fk",
+          "tableFrom": "form_answer_option",
+          "tableTo": "form_answer",
+          "columnsFrom": [
+            "answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_answer_option_option_id_form_option_id_fk": {
+          "name": "form_answer_option_option_id_form_option_id_fk",
+          "tableFrom": "form_answer_option",
+          "tableTo": "form_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_event_form": {
+      "name": "form_event_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_event_form_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_event_form_form_id_form_form_id_fk": {
+          "name": "form_event_form_form_id_form_form_id_fk",
+          "tableFrom": "form_event_form",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_event_form_event_id_event_event_id_fk": {
+          "name": "form_event_form_event_id_event_event_id_fk",
+          "tableFrom": "form_event_form",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_type": {
+          "name": "unique_event_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_field": {
+      "name": "form_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_field_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_field_form_id_form_form_id_fk": {
+          "name": "form_field_form_id_form_form_id_fk",
+          "tableFrom": "form_field",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_group_form": {
+      "name": "form_group_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_receiver_on_submit": {
+          "name": "email_receiver_on_submit",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_submit_multiple": {
+          "name": "can_submit_multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_open_for_submissions": {
+          "name": "is_open_for_submissions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "only_for_group_members": {
+          "name": "only_for_group_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_group_form_form_id_form_form_id_fk": {
+          "name": "form_group_form_form_id_form_form_id_fk",
+          "tableFrom": "form_group_form",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_group_form_group_slug_org_group_slug_fk": {
+          "name": "form_group_form_group_slug_org_group_slug_fk",
+          "tableFrom": "form_group_form",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_form": {
+          "name": "unique_group_form",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "group_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_option": {
+      "name": "form_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_option_field_id_form_field_id_fk": {
+          "name": "form_option_field_id_form_field_id_fk",
+          "tableFrom": "form_option",
+          "tableTo": "form_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_submission": {
+      "name": "form_submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_submission_form_id_form_form_id_fk": {
+          "name": "form_submission_form_id_form_form_id_fk",
+          "tableFrom": "form_submission",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_submission_user_id_auth_user_id_fk": {
+          "name": "form_submission_user_id_auth_user_id_fk",
+          "tableFrom": "form_submission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gallery_album": {
+      "name": "gallery_album",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gallery_album_event_id_event_event_id_fk": {
+          "name": "gallery_album_event_id_event_event_id_fk",
+          "tableFrom": "gallery_album",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gallery_album_created_by_user_id_auth_user_id_fk": {
+          "name": "gallery_album_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "gallery_album",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gallery_album_slug_unique": {
+          "name": "gallery_album_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gallery_picture": {
+      "name": "gallery_picture",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gallery_picture_album_id_idx": {
+          "name": "gallery_picture_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gallery_picture_album_id_gallery_album_id_fk": {
+          "name": "gallery_picture_album_id_gallery_album_id_fk",
+          "tableFrom": "gallery_picture",
+          "tableTo": "gallery_album",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_contract": {
+      "name": "org_contract",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signature_placement": {
+          "name": "signature_placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_placement": {
+          "name": "name_placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_contract_created_by_user_id_auth_user_id_fk": {
+          "name": "org_contract_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_contract",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_contract_signature": {
+      "name": "org_contract_signature",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signed_name": {
+          "name": "signed_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_pdf_key": {
+          "name": "signed_pdf_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_pdf_hash": {
+          "name": "signed_pdf_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_file_key": {
+          "name": "signature_file_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signer_ip": {
+          "name": "signer_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer_ua": {
+          "name": "signer_ua",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contract_signature_unique_idx": {
+          "name": "contract_signature_unique_idx",
+          "columns": [
+            {
+              "expression": "contract_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_contract_signature_contract_id_org_contract_id_fk": {
+          "name": "org_contract_signature_contract_id_org_contract_id_fk",
+          "tableFrom": "org_contract_signature",
+          "tableTo": "org_contract",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_contract_signature_user_id_auth_user_id_fk": {
+          "name": "org_contract_signature_user_id_auth_user_id_fk",
+          "tableFrom": "org_contract_signature",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_fine": {
+      "name": "org_fine",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "law_id": {
+          "name": "law_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defense": {
+          "name": "defense",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "org_fine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_fine_user_id_auth_user_id_fk": {
+          "name": "org_fine_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_fine_group_slug_org_group_slug_fk": {
+          "name": "org_fine_group_slug_org_group_slug_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_fine_law_id_org_group_law_id_fk": {
+          "name": "org_fine_law_id_org_group_law_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "org_group_law",
+          "columnsFrom": [
+            "law_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_fine_created_by_user_id_auth_user_id_fk": {
+          "name": "org_fine_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_fine_approved_by_user_id_auth_user_id_fk": {
+          "name": "org_fine_approved_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group": {
+      "name": "org_group",
+      "schema": "",
+      "columns": {
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fine_info": {
+          "name": "fine_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fines_activated": {
+          "name": "fines_activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fines_admin_id": {
+          "name": "fines_admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leader_role_id": {
+          "name": "leader_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leader_permissions": {
+          "name": "leader_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "org_group_permission_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'leader_only'"
+        },
+        "contract_signing_required": {
+          "name": "contract_signing_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "institute_id": {
+          "name": "institute_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_fines_admin_id_auth_user_id_fk": {
+          "name": "org_group_fines_admin_id_auth_user_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "fines_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_group_role_id_rbac_role_id_fk": {
+          "name": "org_group_role_id_rbac_role_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "rbac_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_group_leader_role_id_rbac_role_id_fk": {
+          "name": "org_group_leader_role_id_rbac_role_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "rbac_role",
+          "columnsFrom": [
+            "leader_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_group_institute_id_org_institute_id_fk": {
+          "name": "org_group_institute_id_org_institute_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "org_institute",
+          "columnsFrom": [
+            "institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_law": {
+      "name": "org_group_law",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paragraph": {
+          "name": "paragraph",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_law_group_slug_org_group_slug_fk": {
+          "name": "org_group_law_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_law",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_membership": {
+      "name": "org_group_membership",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_group_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_membership_user_id_auth_user_id_fk": {
+          "name": "org_group_membership_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_membership_group_slug_org_group_slug_fk": {
+          "name": "org_group_membership_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_membership",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_group_membership_user_id_group_slug_pk": {
+          "name": "org_group_membership_user_id_group_slug_pk",
+          "columns": [
+            "user_id",
+            "group_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_membership_history": {
+      "name": "org_group_membership_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_membership_history_group_slug_idx": {
+          "name": "group_membership_history_group_slug_idx",
+          "columns": [
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_membership_history_user_id_idx": {
+          "name": "group_membership_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_membership_history_stint_idx": {
+          "name": "group_membership_history_stint_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_group_membership_history_user_id_auth_user_id_fk": {
+          "name": "org_group_membership_history_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_membership_history",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_membership_history_group_slug_org_group_slug_fk": {
+          "name": "org_group_membership_history_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_membership_history",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_position": {
+      "name": "org_group_position",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "org_group_position_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'group'"
+        },
+        "linked_group_slug": {
+          "name": "linked_group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_position_group_slug_org_group_slug_fk": {
+          "name": "org_group_position_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_position",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_linked_group_slug_org_group_slug_fk": {
+          "name": "org_group_position_linked_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_position",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "linked_group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_position_holder": {
+      "name": "org_group_position_holder",
+      "schema": "",
+      "columns": {
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_position_holder_position_id_org_group_position_id_fk": {
+          "name": "org_group_position_holder_position_id_org_group_position_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "org_group_position",
+          "columnsFrom": [
+            "position_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_holder_user_id_auth_user_id_fk": {
+          "name": "org_group_position_holder_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_holder_granted_by_auth_user_id_fk": {
+          "name": "org_group_position_holder_granted_by_auth_user_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_institute": {
+      "name": "org_institute",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_institute_slug_unique": {
+          "name": "org_institute_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_study_program": {
+      "name": "org_study_program",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feide_code": {
+          "name": "feide_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "org_study_program_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_study_program_slug_unique": {
+          "name": "org_study_program_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "org_study_program_feide_code_unique": {
+          "name": "org_study_program_feide_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feide_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_study_program_membership": {
+      "name": "org_study_program_membership",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_program_id": {
+          "name": "study_program_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_year_source": {
+          "name": "start_year_source",
+          "type": "org_study_year_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_campus": {
+          "name": "confirmed_campus",
+          "type": "org_campus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_study_program_membership_user_id_auth_user_id_fk": {
+          "name": "org_study_program_membership_user_id_auth_user_id_fk",
+          "tableFrom": "org_study_program_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_study_program_membership_study_program_id_org_study_program_id_fk": {
+          "name": "org_study_program_membership_study_program_id_org_study_program_id_fk",
+          "tableFrom": "org_study_program_membership",
+          "tableTo": "org_study_program",
+          "columnsFrom": [
+            "study_program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_study_program_membership_user_id_study_program_id_pk": {
+          "name": "org_study_program_membership_user_id_study_program_id_pk",
+          "columns": [
+            "user_id",
+            "study_program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_role": {
+      "name": "rbac_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rbac_role_name_unique": {
+          "name": "rbac_role_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_user_permission": {
+      "name": "rbac_user_permission",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'*'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rbac_user_permission_user_id_auth_user_id_fk": {
+          "name": "rbac_user_permission_user_id_auth_user_id_fk",
+          "tableFrom": "rbac_user_permission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_user_permission_granted_by_auth_user_id_fk": {
+          "name": "rbac_user_permission_granted_by_auth_user_id_fk",
+          "tableFrom": "rbac_user_permission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rbac_user_permission_user_id_permission_scope_pk": {
+          "name": "rbac_user_permission_user_id_permission_scope_pk",
+          "columns": [
+            "user_id",
+            "permission",
+            "scope"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_user_role": {
+      "name": "rbac_user_role",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rbac_user_role_user_id_auth_user_id_fk": {
+          "name": "rbac_user_role_user_id_auth_user_id_fk",
+          "tableFrom": "rbac_user_role",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_user_role_role_id_rbac_role_id_fk": {
+          "name": "rbac_user_role_role_id_rbac_role_id_fk",
+          "tableFrom": "rbac_user_role",
+          "tableTo": "rbac_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rbac_user_role_user_id_role_id_pk": {
+          "name": "rbac_user_role_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_notification": {
+      "name": "notification_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_notification_user_id_auth_user_id_fk": {
+          "name": "notification_notification_user_id_auth_user_id_fk",
+          "tableFrom": "notification_notification",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_news": {
+      "name": "news_news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emojis_allowed": {
+          "name": "emojis_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_news_created_by_user_id_auth_user_id_fk": {
+          "name": "news_news_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "news_news",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_reaction": {
+      "name": "news_reaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "news_id": {
+          "name": "news_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_reaction_user_id_auth_user_id_fk": {
+          "name": "news_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "news_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "news_reaction_news_id_news_news_id_fk": {
+          "name": "news_reaction_news_id_news_news_id_fk",
+          "tableFrom": "news_reaction",
+          "tableTo": "news_news",
+          "columnsFrom": [
+            "news_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "news_reaction_user_id_news_id_pk": {
+          "name": "news_reaction_user_id_news_id_pk",
+          "columns": [
+            "user_id",
+            "news_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_job_post": {
+      "name": "job_job_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingress": {
+          "name": "ingress",
+          "type": "varchar(800)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_continuously_hiring": {
+          "name": "is_continuously_hiring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_start": {
+          "name": "class_start",
+          "type": "user_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'first'"
+        },
+        "class_end": {
+          "name": "class_end",
+          "type": "user_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fifth'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_job_post_created_by_user_id_auth_user_id_fk": {
+          "name": "job_job_post_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "job_job_post",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_allergy": {
+      "name": "user_allergy",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_user_setting_allergy": {
+      "name": "user_user_setting_allergy",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergy_slug": {
+          "name": "allergy_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_user_setting_allergy_user_id_user_settings_user_id_fk": {
+          "name": "user_user_setting_allergy_user_id_user_settings_user_id_fk",
+          "tableFrom": "user_user_setting_allergy",
+          "tableTo": "user_settings",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_user_setting_allergy_allergy_slug_user_allergy_slug_fk": {
+          "name": "user_user_setting_allergy_allergy_slug_user_allergy_slug_fk",
+          "tableFrom": "user_user_setting_allergy",
+          "tableTo": "user_allergy",
+          "columnsFrom": [
+            "allergy_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_user_setting_allergy_user_id_allergy_slug_pk": {
+          "name": "user_user_setting_allergy_user_id_allergy_slug_pk",
+          "columns": [
+            "user_id",
+            "allergy_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "user_gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allows_photos_by_default": {
+          "name": "allows_photos_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_event_rules": {
+          "name": "accepts_event_rules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_description": {
+          "name": "bio_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_mail_communication": {
+          "name": "receive_mail_communication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_onboarded": {
+          "name": "is_onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_auth_user_id_fk": {
+          "name": "user_settings_user_id_auth_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.toddel_issue": {
+      "name": "toddel_issue",
+      "schema": "",
+      "columns": {
+        "edition": {
+          "name": "edition",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qrcode_qr_code": {
+      "name": "qrcode_qr_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "qrcode_qr_code_user_id_auth_user_id_fk": {
+          "name": "qrcode_qr_code_user_id_auth_user_id_fk",
+          "tableFrom": "qrcode_qr_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_event": {
+      "name": "motetid_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_mode": {
+          "name": "date_mode",
+          "type": "motetid_date_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DATES'"
+        },
+        "dates": {
+          "name": "dates",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_duration": {
+          "name": "slot_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "motetid_event_created_by_id_index": {
+          "name": "motetid_event_created_by_id_index",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_event_created_by_id_auth_user_id_fk": {
+          "name": "motetid_event_created_by_id_auth_user_id_fk",
+          "tableFrom": "motetid_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "motetid_event_slug_unique": {
+          "name": "motetid_event_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_google_credential": {
+      "name": "motetid_google_credential",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "motetid_google_credential_user_id_auth_user_id_fk": {
+          "name": "motetid_google_credential_user_id_auth_user_id_fk",
+          "tableFrom": "motetid_google_credential",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_participant": {
+      "name": "motetid_participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "motetid_participant_event_id_user_id_index": {
+          "name": "motetid_participant_event_id_user_id_index",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "motetid_participant_user_id_index": {
+          "name": "motetid_participant_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_participant_event_id_motetid_event_id_fk": {
+          "name": "motetid_participant_event_id_motetid_event_id_fk",
+          "tableFrom": "motetid_participant",
+          "tableTo": "motetid_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "motetid_participant_user_id_auth_user_id_fk": {
+          "name": "motetid_participant_user_id_auth_user_id_fk",
+          "tableFrom": "motetid_participant",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_slot": {
+      "name": "motetid_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "motetid_slot_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "motetid_slot_participant_id_date_time_index": {
+          "name": "motetid_slot_participant_id_date_time_index",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "motetid_slot_event_id_date_time_index": {
+          "name": "motetid_slot_event_id_date_time_index",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_slot_participant_id_motetid_participant_id_fk": {
+          "name": "motetid_slot_participant_id_motetid_participant_id_fk",
+          "tableFrom": "motetid_slot",
+          "tableTo": "motetid_participant",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "motetid_slot_event_id_motetid_event_id_fk": {
+          "name": "motetid_slot_event_id_motetid_event_id_fk",
+          "tableFrom": "motetid_slot",
+          "tableTo": "motetid_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.application_attachment_kind": {
+      "name": "application_attachment_kind",
+      "schema": "public",
+      "values": [
+        "receipt",
+        "budget",
+        "attachment"
+      ]
+    },
+    "public.application_budget_type": {
+      "name": "application_budget_type",
+      "schema": "public",
+      "values": [
+        "social_budget",
+        "group_budget",
+        "approved_hs_application",
+        "approved_idkom_application"
+      ]
+    },
+    "public.application_case_type": {
+      "name": "application_case_type",
+      "schema": "public",
+      "values": [
+        "discussion",
+        "decision",
+        "orientation"
+      ]
+    },
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "in_progress",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.application_type": {
+      "name": "application_type",
+      "schema": "public",
+      "values": [
+        "expense",
+        "support",
+        "sports_support",
+        "hs_case",
+        "company_contact"
+      ]
+    },
+    "public.asset_status": {
+      "name": "asset_status",
+      "schema": "public",
+      "values": [
+        "staged",
+        "ready"
+      ]
+    },
+    "public.asset_visibility": {
+      "name": "asset_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "private"
+      ]
+    },
+    "public.event_visibility": {
+      "name": "event_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "members"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "refunded",
+        "failed"
+      ]
+    },
+    "public.event_registration_status": {
+      "name": "event_registration_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "waitlisted",
+        "cancelled",
+        "attended",
+        "no_show",
+        "pending"
+      ]
+    },
+    "public.form_event_form_type": {
+      "name": "form_event_form_type",
+      "schema": "public",
+      "values": [
+        "survey",
+        "evaluation"
+      ]
+    },
+    "public.form_field_type": {
+      "name": "form_field_type",
+      "schema": "public",
+      "values": [
+        "text_answer",
+        "multiple_select",
+        "single_select"
+      ]
+    },
+    "public.org_campus": {
+      "name": "org_campus",
+      "schema": "public",
+      "values": [
+        "trondheim",
+        "gjovik",
+        "alesund"
+      ]
+    },
+    "public.org_fine_status": {
+      "name": "org_fine_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "paid",
+        "rejected"
+      ]
+    },
+    "public.org_group_membership_role": {
+      "name": "org_group_membership_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "leader"
+      ]
+    },
+    "public.org_group_permission_mode": {
+      "name": "org_group_permission_mode",
+      "schema": "public",
+      "values": [
+        "leader_only",
+        "member",
+        "custom"
+      ]
+    },
+    "public.org_group_position_scope": {
+      "name": "org_group_position_scope",
+      "schema": "public",
+      "values": [
+        "group",
+        "global"
+      ]
+    },
+    "public.org_group_type": {
+      "name": "org_group_type",
+      "schema": "public",
+      "values": [
+        "studyyear",
+        "interestgroup",
+        "committee",
+        "study",
+        "private",
+        "board",
+        "subgroup",
+        "tihlde"
+      ]
+    },
+    "public.org_study_program_type": {
+      "name": "org_study_program_type",
+      "schema": "public",
+      "values": [
+        "bachelor",
+        "master"
+      ]
+    },
+    "public.org_study_year_source": {
+      "name": "org_study_year_source",
+      "schema": "public",
+      "values": [
+        "feide",
+        "assumed",
+        "manual",
+        "migrated"
+      ]
+    },
+    "public.job_type": {
+      "name": "job_type",
+      "schema": "public",
+      "values": [
+        "full_time",
+        "part_time",
+        "summer_job",
+        "other"
+      ]
+    },
+    "public.user_class": {
+      "name": "user_class",
+      "schema": "public",
+      "values": [
+        "first",
+        "second",
+        "third",
+        "fourth",
+        "fifth",
+        "alumni"
+      ]
+    },
+    "public.user_gender": {
+      "name": "user_gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other"
+      ]
+    },
+    "public.motetid_date_mode": {
+      "name": "motetid_date_mode",
+      "schema": "public",
+      "values": [
+        "DATES",
+        "WEEKDAYS"
+      ]
+    },
+    "public.motetid_slot_status": {
+      "name": "motetid_slot_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "IF_NEEDED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1786133632759,
       "tag": "0044_quick_gressill",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1786438246608,
+      "tag": "0045_white_doctor_faustus",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -10,23 +10,47 @@ import {
 
 const pgTable = pgTableCreator((name) => `auth_${name}`);
 
-export const user = pgTable("user", {
-    id: text("id").primaryKey(),
-    name: text("name").notNull(),
-    email: text("email").notNull().unique(),
-    emailVerified: boolean("email_verified").default(false).notNull(),
-    image: text("image"),
-    createdAt: timestamp("created_at").notNull(),
-    updatedAt: timestamp("updated_at")
-        .$onUpdate(() => new Date())
-        .notNull(),
-    role: text("role"),
-    banned: boolean("banned").default(false),
-    banReason: text("ban_reason"),
-    banExpires: timestamp("ban_expires"),
-    username: text("username").unique(),
-    displayUsername: text("display_username"),
-});
+/**
+ * Where an account stands with a human approver.
+ *
+ * - `null`: nobody has to approve it. Feide logins, the Lepton migration, the
+ *   Fadderuka route and seeds all land here — the account's right to exist is
+ *   already established by the system that made it.
+ * - `pending`: someone signed themselves up on the website. They can log in and
+ *   see what any visitor sees, and nothing more, until an admin approves them.
+ * - `approved`: an admin (or a later Feide login) confirmed them, and the
+ *   `member` role was granted.
+ *
+ * Kept as a column rather than "has no roles yet", because roles come and go
+ * for other reasons and only this says *why* someone has none.
+ */
+export const APPROVAL_STATUSES = ["pending", "approved"] as const;
+export type ApprovalStatus = (typeof APPROVAL_STATUSES)[number];
+
+export const user = pgTable(
+    "user",
+    {
+        id: text("id").primaryKey(),
+        name: text("name").notNull(),
+        email: text("email").notNull().unique(),
+        emailVerified: boolean("email_verified").default(false).notNull(),
+        image: text("image"),
+        createdAt: timestamp("created_at").notNull(),
+        updatedAt: timestamp("updated_at")
+            .$onUpdate(() => new Date())
+            .notNull(),
+        role: text("role"),
+        banned: boolean("banned").default(false),
+        banReason: text("ban_reason"),
+        banExpires: timestamp("ban_expires"),
+        username: text("username").unique(),
+        displayUsername: text("display_username"),
+        approvalStatus: text("approval_status").$type<ApprovalStatus>(),
+        approvedAt: timestamp("approved_at"),
+        approvedBy: text("approved_by"),
+    },
+    (table) => [index("user_approvalStatus_idx").on(table.approvalStatus)],
+);
 
 export const session = pgTable(
     "session",

--- a/packages/email/src/template/account-approved.tsx
+++ b/packages/email/src/template/account-approved.tsx
@@ -1,0 +1,64 @@
+import {
+    Body,
+    Button,
+    Container,
+    Head,
+    Heading,
+    Html,
+    Img,
+    Text,
+} from "@react-email/components";
+import React from "react";
+import { emailStyles } from "./styles";
+
+export interface AccountApprovedEmailProps {
+    /** The member's name, so the mail does not open with "Hei,". */
+    name: string;
+    /** Link to the login page. */
+    loginUrl: string;
+    logoUrl: string;
+}
+
+/**
+ * Sent when an admin approves an account that signed itself up on the website.
+ *
+ * The person has been able to log in the whole time — what changed is what they
+ * can do — so the mail leads with that rather than with "welcome".
+ */
+export const AccountApprovedEmail = ({
+    name,
+    loginUrl,
+    logoUrl,
+}: AccountApprovedEmailProps) => (
+    <Html>
+        <Head />
+        <Body style={emailStyles.main}>
+            <Container style={emailStyles.container}>
+                <Img
+                    src={logoUrl}
+                    width="100"
+                    height="100"
+                    alt="TIHLDE Logomark"
+                    style={emailStyles.logo}
+                />
+                <Heading style={emailStyles.heading}>
+                    Brukeren din er godkjent
+                </Heading>
+                <Text style={emailStyles.paragraph}>
+                    Hei {name}! En administrator har godkjent brukeren din på
+                    tihlde.org.
+                </Text>
+                <Text style={emailStyles.paragraph}>
+                    Nå kan du melde deg på arrangementer og se sidene som er
+                    forbeholdt medlemmer.
+                </Text>
+                <Button style={emailStyles.button} href={loginUrl}>
+                    Logg inn
+                </Button>
+            </Container>
+            <Text style={emailStyles.footer}>Levert av INDEX</Text>
+        </Body>
+    </Html>
+);
+
+export default AccountApprovedEmail;

--- a/packages/email/src/template/index.tsx
+++ b/packages/email/src/template/index.tsx
@@ -1,3 +1,4 @@
+import AccountApprovedEmail from "./account-approved";
 import AccountLinkHelpEmail from "./account-link-help";
 import ApplicationDecidedEmail from "./application-decided";
 import ApplicationReceiptEmail from "./application-receipt";
@@ -21,6 +22,7 @@ import type { ComponentProps, ReactElement } from "react";
 type EmailTemplateComponent<TProps> = (props: TProps) => ReactElement;
 
 const EMAIL_TEMPLATES = {
+    AccountApprovedEmail,
     AccountLinkHelpEmail,
     ApplicationDecidedEmail,
     ApplicationReceiptEmail,
@@ -65,6 +67,7 @@ export async function renderEmailTemplate<TName extends EmailTemplateName>(
 }
 
 export {
+    AccountApprovedEmail,
     AccountLinkHelpEmail,
     ApplicationDecidedEmail,
     ApplicationReceiptEmail,

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2548,6 +2548,26 @@ export interface paths {
         patch: operations["updateUserStatus"];
         trace?: never;
     };
+    "/api/user/{id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve a self-registered account
+         * @description Grants the 'member' role to an account that signed itself up on the website and is waiting for approval, and tells the person by e-mail. Requires 'users:manage'.
+         */
+        post: operations["approveUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/user/{id}": {
         parameters: {
             query?: never;
@@ -5712,6 +5732,10 @@ export interface components {
             studyStartYear: number | null;
             /** @description False when the account is deactivated — the member cannot sign in. */
             isActive: boolean;
+            /** @description 'pending' for a self-registered account still waiting for an admin, 'approved' once one said yes. Null for accounts that never needed approving — Feide logins and members migrated from Lepton. */
+            approvalStatus: ("pending" | "approved") | null;
+            /** @description Only filled in for accounts awaiting approval, where it is the one thing an admin has to judge them on. Null otherwise. */
+            email: string | null;
             /** @description Account creation timestamp */
             createdAt: string;
         };
@@ -5749,6 +5773,11 @@ export interface components {
             isActive: boolean;
             /** @description Why the account was deactivated. Ignored when activating. */
             reason?: string;
+        };
+        ApproveUser: {
+            message: string;
+            /** @constant */
+            approvalStatus: "approved";
         };
         UserProfile: {
             /** @description User ID */
@@ -5828,6 +5857,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     createApiKey: {
@@ -5854,6 +5892,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5893,6 +5940,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Not Found - API key not found */
             404: {
                 headers: {
@@ -5925,6 +5981,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5975,6 +6040,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Not Found - API key not found */
             404: {
                 headers: {
@@ -6007,6 +6081,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6074,6 +6157,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     listMyApplications: {
@@ -6098,6 +6190,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6145,6 +6246,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     createSupportApplication: {
@@ -6178,6 +6288,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6225,6 +6344,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     createHsCaseApplication: {
@@ -6265,6 +6393,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     listApplications: {
@@ -6296,12 +6433,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -6325,6 +6464,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6362,6 +6510,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6407,12 +6564,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found */
             404: {
@@ -6456,12 +6615,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found */
             404: {
@@ -6494,6 +6655,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6656,12 +6826,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -6696,12 +6868,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -6734,12 +6908,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Banner not found */
             404: {
@@ -6783,12 +6959,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Banner not found */
             404: {
@@ -6997,12 +7175,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires events:strikes:view or events:manage permission, unless reading your own strikes */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -7037,12 +7217,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires events:strikes:create or events:manage permission */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - User or event not found */
             404: {
@@ -7085,6 +7267,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     deleteStrike: {
@@ -7116,12 +7307,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires events:strikes:delete or events:manage permission */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Strike not found */
             404: {
@@ -7165,6 +7358,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Not Found - Event not found */
             404: {
                 headers: {
@@ -7194,6 +7396,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7271,12 +7482,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Missing events:create for the organizing group (or globally) */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -7313,12 +7526,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - You must be the event creator or have events:update/events:manage permission */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Not found */
             404: {
@@ -7380,12 +7595,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - You must be the event creator or have events:delete permission */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Event with the specified ID does not exist */
             404: {
@@ -7439,12 +7656,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Filtering by status requires event admin permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -7481,12 +7700,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - User has not accepted the event rules, owes an answer to an evaluation, or the event only allows members covered by a priority pool or members of a specific institute to register */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Event not found */
             404: {
@@ -7531,6 +7752,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     setRegistrationAttendance: {
@@ -7567,12 +7797,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires events:update or events:manage permission */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Registration not found */
             404: {
@@ -7616,6 +7848,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7675,12 +7916,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires permission to view the event's payments */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -7721,12 +7964,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires events:payments:refund */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Payment not found on this event */
             404: {
@@ -7819,6 +8064,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Not Found - Event not found */
             404: {
                 headers: {
@@ -7868,12 +8122,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Cant create form for specified event */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Event not found */
             404: {
@@ -7914,12 +8170,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Evaluation forms require attendance */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Form not found */
             404: {
@@ -7950,6 +8208,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7990,6 +8257,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     getForm: {
@@ -8014,6 +8290,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8059,12 +8344,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Form not found */
             404: {
@@ -8108,12 +8395,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Form not found */
             404: {
@@ -8153,12 +8442,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found */
             404: {
@@ -8198,12 +8489,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Form not found */
             404: {
@@ -8247,12 +8540,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Cannot submit to this form */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Form not found */
             404: {
@@ -8299,12 +8594,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Form not found */
             404: {
@@ -8345,12 +8642,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Submission not found */
             404: {
@@ -8388,6 +8687,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8438,6 +8746,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     createGallery: {
@@ -8471,12 +8788,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -8507,6 +8826,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8556,12 +8884,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Gallery not found */
             404: {
@@ -8602,12 +8932,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Gallery or picture not found */
             404: {
@@ -8652,12 +8984,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Gallery or picture not found */
             404: {
@@ -8690,6 +9024,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8735,12 +9078,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Gallery not found */
             404: {
@@ -8784,12 +9129,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Gallery not found */
             404: {
@@ -8834,6 +9181,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     deleteNotification: {
@@ -8858,6 +9214,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8900,6 +9265,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8974,6 +9348,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     listMyGroups: {
@@ -8996,6 +9379,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9068,12 +9460,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not a group leader or missing groups:delete permission */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group with the specified slug does not exist */
             404: {
@@ -9124,12 +9518,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not a group leader or missing groups:update permission */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group with the specified slug does not exist */
             404: {
@@ -9178,12 +9574,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to view fines for this group */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found, or fines not activated for it */
             404: {
@@ -9234,12 +9632,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to create fines for this group */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group or user not found */
             404: {
@@ -9279,12 +9679,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to view fines for this group */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found, or fines not activated for it */
             404: {
@@ -9331,12 +9733,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to view fines for this group */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found, or fines not activated for it */
             404: {
@@ -9387,12 +9791,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to settle this group's fines */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found, or fines not activated for it */
             404: {
@@ -9437,12 +9843,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to settle this group's fines */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found, or fines not activated for it */
             404: {
@@ -9483,12 +9891,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to view this fine */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Fine or group not found */
             404: {
@@ -9527,12 +9937,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to delete this fine */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Fine or group not found */
             404: {
@@ -9584,12 +9996,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to update this fine */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Fine or group not found */
             404: {
@@ -9629,12 +10043,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to view laws for this group */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found */
             404: {
@@ -9678,12 +10094,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to manage laws for this group */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found */
             404: {
@@ -9722,12 +10140,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to manage laws for this group */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Law or group not found */
             404: {
@@ -9772,12 +10192,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to manage laws for this group */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Law or group not found */
             404: {
@@ -9900,6 +10322,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Not Found - Group not found */
             404: {
                 headers: {
@@ -9930,6 +10361,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9980,6 +10420,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Not Found - Group, user, or membership not found */
             404: {
                 headers: {
@@ -10018,12 +10467,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - The group is private and you are not a member */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found */
             404: {
@@ -10074,12 +10525,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to create positions, or tried to grant permissions the creator does not hold */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found */
             404: {
@@ -10120,12 +10573,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to delete this position */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Position not found */
             404: {
@@ -10177,12 +10632,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to update this position */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Position not found */
             404: {
@@ -10234,12 +10691,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to assign this position */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Position not found */
             404: {
@@ -10288,12 +10747,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to manage this position */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Position not found */
             404: {
@@ -10340,12 +10801,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized to manage this group */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found */
             404: {
@@ -10396,12 +10859,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Not authorized, or granting permissions you lack */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found */
             404: {
@@ -10441,12 +10906,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - The group is private and you are not a member */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found */
             404: {
@@ -10490,12 +10957,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found */
             404: {
@@ -10553,6 +11022,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Not Found - No active contract */
             404: {
                 headers: {
@@ -10582,6 +11060,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10622,6 +11109,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10677,6 +11173,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Not Found - No active contract, or not signed yet */
             404: {
                 headers: {
@@ -10713,12 +11218,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - No active contract, or not signed yet */
             404: {
@@ -10756,12 +11263,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -10803,12 +11312,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -10841,12 +11352,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Contract not found */
             404: {
@@ -10886,12 +11399,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Group not found */
             404: {
@@ -10932,12 +11447,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Signature not found */
             404: {
@@ -10975,6 +11492,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     createMotetidEvent: {
@@ -11001,6 +11527,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11070,6 +11605,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Not Found - Event not found */
             404: {
                 headers: {
@@ -11120,6 +11664,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
             /** @description Not Found - Event not found */
             404: {
                 headers: {
@@ -11159,6 +11712,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     motetidGoogleCallback: {
@@ -11179,6 +11741,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11220,6 +11791,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11292,6 +11872,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     getNews: {
@@ -11353,12 +11942,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - News article not found */
             404: {
@@ -11403,12 +11994,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - News article not found */
             404: {
@@ -11453,12 +12046,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Reactions not allowed on this news article */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - News article not found */
             404: {
@@ -11492,6 +12087,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11566,12 +12170,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Conflict - that edition already exists */
             409: {
@@ -11611,12 +12217,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Issue not found */
             404: {
@@ -11667,12 +12275,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Issue not found */
             404: {
@@ -11703,6 +12313,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11743,6 +12362,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     deleteQRCode: {
@@ -11768,6 +12396,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11811,12 +12448,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires roles:view */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -11858,12 +12497,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires roles:create, or tried to grant unheld permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -11896,12 +12537,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient hierarchy */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Role not found */
             404: {
@@ -11952,12 +12595,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient hierarchy or unheld permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Role not found */
             404: {
@@ -12001,12 +12646,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient hierarchy */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Role or user not found */
             404: {
@@ -12047,12 +12694,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient hierarchy */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Role not found */
             404: {
@@ -12134,6 +12783,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     getJob: {
@@ -12194,12 +12852,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Job posting not found */
             404: {
@@ -12243,12 +12903,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Insufficient permissions */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - Job posting not found */
             404: {
@@ -12449,6 +13111,15 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
         };
     };
     listAllergies: {
@@ -12555,12 +13226,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires users:view or roles:assign */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -12577,6 +13250,8 @@ export interface operations {
                 study?: string;
                 /** @description Filter by cohort (STUDYYEAR group), e.g. 2023 */
                 studyStartYear?: number;
+                /** @description Show only accounts with this approval status. 'pending' is the queue of self-registered accounts waiting for an admin. */
+                approvalStatus?: "pending" | "approved";
             };
             header?: never;
             path?: never;
@@ -12602,12 +13277,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires users:view */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
         };
     };
@@ -12644,12 +13321,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires users:manage */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - User not found */
             404: {
@@ -12689,12 +13368,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires users:manage */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - User not found */
             404: {
@@ -12745,12 +13426,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires users:manage */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - User not found */
             404: {
@@ -12801,12 +13484,68 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires users:manage */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Not Found - User not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
                 content?: never;
+            };
+        };
+    };
+    approveUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Account approved */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApproveUser"];
+                };
+            };
+            /** @description Bad Request - The account is not waiting for approval */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - User not found */
             404: {
@@ -12839,6 +13578,15 @@ export interface operations {
             };
             /** @description Authentication required */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -12889,12 +13637,14 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
-            /** @description Forbidden - Requires users:delete */
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
             };
             /** @description Not Found - User not found */
             404: {

--- a/packages/sdk/src/generated/schemas.ts
+++ b/packages/sdk/src/generated/schemas.ts
@@ -21,6 +21,7 @@ export type ApplicationDetail = Schemas["ApplicationDetail"];
 export type ApplicationList = Schemas["ApplicationList"];
 export type ApplicationOptions = Schemas["ApplicationOptions"];
 export type ApplicationSummary = Schemas["ApplicationSummary"];
+export type ApproveUser = Schemas["ApproveUser"];
 export type AssetMetadata = Schemas["AssetMetadata"];
 export type AssignGroupPosition = Schemas["AssignGroupPosition"];
 export type AssignRole = Schemas["AssignRole"];

--- a/packages/sdk/src/generated/session-types.ts
+++ b/packages/sdk/src/generated/session-types.ts
@@ -4,6 +4,8 @@
 
 export type ExtendedSession = {
     user: {
+        approvalStatus: "pending" | "approved" | null;
+        isPendingApproval: boolean;
         settings: {
             allergies: string[];
             createdAt: Date;


### PR DESCRIPTION
Åpner selvregistrering for folk uten Feide, med en godkjenningskø i adminpanelet.

## Hva

- **Registrering med privat e-post.** Sign-up-hooken tar imot hvilken som helst adresse. Brukernavnet utledes fra lokaldelen (`kari.ekstern@gmail.com` → `kari.ekstern`); er det opptatt, svarer serveren 409 og registreringsskjemaet folder ut et brukernavn-felt. Stud-adresser beholder den gamle regelen — brukernavnet er NTNU-brukernavnet uansett hva skjemaet sender, siden det er koblingen en senere Feide-innlogging finner kontoen på.
- **Ventestatus.** Ny kolonne `approval_status` på `auth_user` (migrasjon 0045). Selvregistrering setter `pending`. Fadderuka-ruta og Feide-innlogging gjør det ikke — de er allerede vouchet for.
- **Sperren ligger i `requireAuth`,** ikke i hver rute, så en ny medlemsrute ikke kan glemme den. Ventende kontoer får 403. Rutene som betjener personen selv (innstillinger, passord, onboarding, Feide-kobling) bruker `requireAuthAllowPending`. Arrangementslista og -detaljene fikk sin egen fiks: de regnet «innlogget = medlem».
- **Godkjenning.** `POST /api/user/{id}/approve` gir `member`-rollen, stempler godkjenner og sender e-post. I /admin/brukere: eget «Venter på godkjenning»-filter, «Venter»-merke, e-post under navnet (bare for de som venter), og Godkjenn/Avvis. Avvis sletter kontoen uten avskriving av navnet — det finnes ingen historikk å miste.
- **Frontend:** banner over hele appen mens man venter, og «For Medlemmer»-menyen skjules, siden hver side der ville svart 403.

## Sikkerhet

`resolveMigratedEmail` slo opp enhver konto med samme brukernavn. En utenforstående som tok et NTNU-brukernavn ville dermed fanget studentens Feide-innlogging inn i sin egen konto — med sitt eget passord fortsatt på. Selvregistrerte kontoer med privat adresse ignoreres nå der.

Restrisiko: en slik squatter blokkerer fortsatt studentens passord-innlogging (Feide virker). Verdt en oppfølging hvis det skjer i praksis.

## Verifisert

`typecheck`, `lint` (0 feil), `build` og hele suiten (530 tester, 7 nye i `user-approval.test.ts`) er grønne. Hele flyten kjørt i nettleseren mot lokal API: registrering → kollisjon → eget brukernavn → innlogging med banner → 403 på medlemsruter og medlemsarrangement skjult → admin godkjenner → `member`-rolle i databasen og e-posten rendret → samme bruker ser medlemsarrangementet.

## Merk

Studenter som registrerer seg med e-post havner nå også i køen. De hadde uansett ingen roller før — forskjellen er at de kan godkjennes uten å måtte innom Feide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)