### PR TITLE
fix(kvark): vis arrangementer i adminpanelet for gruppeledere

### DIFF
--- a/apps/kvark/src/api/auth.ts
+++ b/apps/kvark/src/api/auth.ts
@@ -5,6 +5,7 @@ import { getQueryClient } from "#/integrations/tanstack-query";
 import { createIsomorphicFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
 import { createPhotonAuthClient } from "@photon/auth/client";
+import { LEADER_BASELINE_PERMISSIONS } from "@photon/auth/rbac/leader-baseline";
 
 export const clientAuthInstance = createPhotonAuthClient({
     baseUrl: import.meta.env.VITE_AUTH_BASE_URL ?? "https://photon.tihlde.org",
@@ -20,13 +21,57 @@ export class AuthError extends Error {
     }
 }
 
+type SessionWithPermissions = {
+    permissions?: string[] | null;
+    groups?: { slug: string; role: string }[] | null;
+};
+
+/**
+ * Add the permissions that come with leading a group.
+ *
+ * Server-side, `LEADER_BASELINE_PERMISSIONS` is granted to every leader for
+ * their own group, scoped to it — arranging is the job, not something someone
+ * has to be granted per group. The session already carries the resulting
+ * strings, but only as of the API that computed them: a member promoted to
+ * leader, or an API that has not caught up, would leave the admin panel
+ * hiding work the leader is allowed to do.
+ *
+ * Deriving them again from `session.groups` keeps the UI in step with the
+ * server rule instead of with one particular deploy of it. It can only ever
+ * show a leader their own group's arrangementer — the API is still what
+ * decides, and it applies the very same list.
+ */
+export function withLeaderPermissions<
+    T extends SessionWithPermissions | null | undefined,
+>(session: T): T {
+    if (!session) return session;
+
+    const ledGroups = (session.groups ?? []).filter(
+        (group) => group.role === "leader",
+    );
+    if (ledGroups.length === 0) return session;
+
+    const leaderGrants = ledGroups.flatMap((group) =>
+        LEADER_BASELINE_PERMISSIONS.map(
+            (permission) => `${permission}@group:${group.slug}`,
+        ),
+    );
+
+    return {
+        ...session,
+        permissions: [
+            ...new Set([...(session.permissions ?? []), ...leaderGrants]),
+        ],
+    };
+}
+
 export const getAuthSession = createIsomorphicFn()
     .client(async () => {
         const session = await clientAuthInstance.getSession();
         if (session.error) {
             throw new AuthError(`Failed to get session: ${session.error}`);
         }
-        return session.data;
+        return withLeaderPermissions(session.data);
     })
     .server(async () => {
         const session = await clientAuthInstance.getSession({
@@ -38,7 +83,7 @@ export const getAuthSession = createIsomorphicFn()
         if (session.error) {
             throw new AuthError(`Failed to get session: ${session.error}`);
         }
-        return session.data;
+        return withLeaderPermissions(session.data);
     });
 
 /**

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -7,6 +7,7 @@
         ".": "./src/index.ts",
         "./rbac": "./src/rbac/permissions/index.ts",
         "./rbac/registry": "./src/rbac/permissions/registry.ts",
+        "./rbac/leader-baseline": "./src/rbac/leader-baseline.ts",
         "./roles": "./src/rbac/roles/index.ts",
         "./oauth-verify": "./src/oauth-verify.ts",
         "./feide": "./src/feide.ts",

--- a/packages/auth/src/rbac/leader-baseline.ts
+++ b/packages/auth/src/rbac/leader-baseline.ts
@@ -1,0 +1,44 @@
+/**
+ * What EVERY group leader holds for their own group, regardless of what is
+ * stored in `group.leaderPermissions`.
+ *
+ * Running a group means running its arrangementer: putting them up, fixing
+ * them, taking them down, and handling who shows up. That is the job, not a
+ * privilege someone has to be granted per group — so it lives here rather
+ * than in a column that starts empty and has to be filled in 60 times (and
+ * once more for every new group).
+ *
+ * Payments are view-only on purpose: a leader running a paid arrangement has
+ * to see who has paid, but moving money back out is a separate decision and
+ * stays with whoever holds `events:payments:refund`.
+ *
+ * Deliberately NOT included, because they are not "arranging an event":
+ * refunding payments, handing out prikker by hand, and publishing news. Those
+ * still come from `leaderPermissions`, a verv, or a role.
+ *
+ * `events:manage` is left out for the same reason, even though it reads like
+ * the natural fit: the strike routes accept it as an alternative to
+ * `events:strikes:*`, so granting it here would hand every leader the power
+ * to hand out prikker. Every other route that takes `events:manage` takes
+ * `events:update` too, which is in the list, so nothing is lost.
+ *
+ * This module deliberately imports nothing: the frontend reads the same list
+ * to work out what a leader may do (`@photon/auth/rbac/leader-baseline`), and
+ * pulling in the database layer for a string array would drag the server into
+ * the browser bundle.
+ */
+export const LEADER_BASELINE_PERMISSIONS = [
+    "events:view",
+    "events:create",
+    "events:update",
+    "events:delete",
+    "events:registrations:view",
+    "events:registrations:create",
+    "events:registrations:delete",
+    // Registering oppmøte on the group's own arrangementer
+    "events:registrations:checkin",
+    "events:registrations:manage",
+    "events:feedback:view",
+    // Seeing who has paid — never events:payments:refund
+    "events:payments:view",
+] as const;

--- a/packages/auth/src/rbac/permissions/checker.ts
+++ b/packages/auth/src/rbac/permissions/checker.ts
@@ -23,6 +23,9 @@ import {
     matchesPermission,
     parsePermission,
 } from "../permission-parser";
+import { LEADER_BASELINE_PERMISSIONS } from "../leader-baseline";
+
+export { LEADER_BASELINE_PERMISSIONS };
 
 type DbCtx = { db: NodePgDatabase<DbSchema> };
 
@@ -101,46 +104,6 @@ async function getPermissionsFromPositions(
         ),
     );
 }
-
-/**
- * What EVERY group leader holds for their own group, regardless of what is
- * stored in `group.leaderPermissions`.
- *
- * Running a group means running its arrangementer: putting them up, fixing
- * them, taking them down, and handling who shows up. That is the job, not a
- * privilege someone has to be granted per group — so it lives here rather
- * than in a column that starts empty and has to be filled in 60 times (and
- * once more for every new group).
- *
- * Payments are view-only on purpose: a leader running a paid arrangement has
- * to see who has paid, but moving money back out is a separate decision and
- * stays with whoever holds `events:payments:refund`.
- *
- * Deliberately NOT included, because they are not "arranging an event":
- * refunding payments, handing out prikker by hand, and publishing news. Those
- * still come from `leaderPermissions`, a verv, or a role.
- *
- * `events:manage` is left out for the same reason, even though it reads like
- * the natural fit: the strike routes accept it as an alternative to
- * `events:strikes:*`, so granting it here would hand every leader the power
- * to hand out prikker. Every other route that takes `events:manage` takes
- * `events:update` too, which is in the list, so nothing is lost.
- */
-export const LEADER_BASELINE_PERMISSIONS = [
-    "events:view",
-    "events:create",
-    "events:update",
-    "events:delete",
-    "events:registrations:view",
-    "events:registrations:create",
-    "events:registrations:delete",
-    // Registering oppmøte on the group's own arrangementer
-    "events:registrations:checkin",
-    "events:registrations:manage",
-    "events:feedback:view",
-    // Seeing who has paid — never events:payments:refund
-    "events:payments:view",
-] as const;
 
 /**
  * Get all permissions a user receives from LEADING a group.


### PR DESCRIPTION
## Problemet

En gruppeleder så bare **Grupper** og **Roller og verv** i adminpanelet — de to eneste oppføringene med `allowGroupLeader`. Arrangementer var borte, så de kom aldri fram til å opprette arrangementer på vegne av gruppa si. (Og nei, de kan ikke gi seg selv rettigheten via Roller heller.)

Serveren gir hver leder `LEADER_BASELINE_PERMISSIONS` scoped til gruppa (69a60c1), så strengene *skal* ligge i sesjonen. Men klienten stolte blindt på at API-et hadde regnet dem ut, og da er panelet bare så oppdatert som den API-en som svarte.

## Endringen

Kvark utleder nå de samme rettighetene selv fra `session.groups`, i `getAuthSession` — altså før både loader-context og query-cache.

- Ny, importfri `packages/auth/src/rbac/leader-baseline.ts`, eksportert som `@photon/auth/rbac/leader-baseline`, så frontend kan lese lista uten å dra databaselaget inn i bundlen. `checker.ts` re-eksporterer den; **backend-oppførselen er uendret**.
- `withLeaderPermissions` i `apps/kvark/src/api/auth.ts` legger på `<permission>@group:<slug>` for hver gruppe man leder.

Fordi alle gatene (`useAnyScopePermission`, `useCanActForGroup`, `useCanActOnResource`) leser samme liste, treffer det hele kjeden på én gang: sidebar, dashboard-snarveien, «Nytt arrangement», arrangørgruppe-velgeren, redigering, oppmøte og betalingsoversikt. Prikker og refusjon er fortsatt utenfor, som før.

Det kan aldri vise en leder mer enn egen gruppes arrangementer, og API-et avgjør fortsatt — det bruker nøyaktig samme liste.

## Verifisert

- Lokalt som en bruker uten roller og uten rettigheter, satt som leder av `plask`: sidebaren viser Arrangementer, og arrangørgruppe-nedtrekket inneholder bare TIHLDE Plask.
- `apps/api/src/test/event/group-scoped-access.test.ts` — 5/5 grønne.
- `bun run typecheck`, `bun run lint`, `bun run format`, `bun run build`.

## Til reviewer: prod kjører eldre kode enn siste tag

Uavhengig av denne PR-en: `https://photon.tihlde.org/openapi` mangler både `baseline` på `GroupLeaderPermissions` og `/api/user/{id}/approve`, som begge ligger i `2026-08-11.release-1`. API-imaget har altså ikke rullet ut. I prod har 59 av 60 grupper tom `leader_permissions`, så 41 av 42 ledere har null event-rettigheter til utrullingen faktisk skjer — denne PR-en dekker dem i mellomtiden, men utrullingen bør sjekkes separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)