### PR TITLE
fix(kvark): la stedsfeltet beholde teksten man skriver

### DIFF
--- a/apps/kvark/src/components/address-combobox.tsx
+++ b/apps/kvark/src/components/address-combobox.tsx
@@ -1,12 +1,12 @@
 import {
-    Combobox,
-    ComboboxCollection,
-    ComboboxContent,
-    ComboboxEmpty,
-    ComboboxInput,
-    ComboboxItem,
-    ComboboxList,
-} from "@tihlde/ui/ui/combobox";
+    Autocomplete,
+    AutocompleteCollection,
+    AutocompleteContent,
+    AutocompleteEmpty,
+    AutocompleteInput,
+    AutocompleteItem,
+    AutocompleteList,
+} from "@tihlde/ui/ui/autocomplete";
 
 import type { AddressSuggestion } from "#/api/queries/address";
 
@@ -29,6 +29,10 @@ type AddressComboboxProps = {
 /**
  * Stedsfelt med adressesøk. Dum komponent: forelderen eier både teksten og
  * henting av forslag.
+ *
+ * Bygget på `Autocomplete` og ikke `Combobox`, fordi feltet ikke har noen valgt
+ * verdi — teksten *er* verdien. En `Combobox` uten valgt verdi tømmer feltet
+ * når forslagslista lukkes, som gjorde det umulig å skrive inn et sted.
  */
 export function AddressCombobox({
     id,
@@ -41,34 +45,36 @@ export function AddressCombobox({
     required = false,
 }: AddressComboboxProps) {
     return (
-        <Combobox<AddressSuggestion>
+        <Autocomplete<AddressSuggestion>
             items={suggestions}
             // Treffene er allerede filtrert av Kartverket-søket.
             filter={null}
-            value={null}
-            inputValue={value}
-            onInputValueChange={onValueChange}
-            onValueChange={(next) => {
-                if (next) onSelectSuggestion(next);
-            }}
-            itemToStringLabel={(item) => item.label}
-            itemToStringValue={(item) => item.id}
+            value={value}
+            onValueChange={onValueChange}
+            itemToStringValue={(item) => item.label}
         >
-            <ComboboxInput
+            <AutocompleteInput
                 id={id}
                 required={required}
                 placeholder={placeholder}
                 showTrigger={false}
                 autoComplete="off"
             />
-            <ComboboxContent>
-                <ComboboxList>
-                    <ComboboxEmpty>
+            <AutocompleteContent>
+                <AutocompleteList>
+                    <AutocompleteEmpty>
                         {isSearching ? "Søker…" : "Ingen adresser matcher"}
-                    </ComboboxEmpty>
-                    <ComboboxCollection>
+                    </AutocompleteEmpty>
+                    <AutocompleteCollection>
                         {(item: AddressSuggestion) => (
-                            <ComboboxItem key={item.id} value={item}>
+                            <AutocompleteItem
+                                key={item.id}
+                                value={item}
+                                // Teksten fylles inn av Autocomplete selv;
+                                // dette er kun for å gi forelderen
+                                // koordinatene som hører til adressen.
+                                onClick={() => onSelectSuggestion(item)}
+                            >
                                 <span className="flex min-w-0 flex-col">
                                     <span className="truncate">
                                         {item.street}
@@ -79,11 +85,11 @@ export function AddressCombobox({
                                         </span>
                                     ) : null}
                                 </span>
-                            </ComboboxItem>
+                            </AutocompleteItem>
                         )}
-                    </ComboboxCollection>
-                </ComboboxList>
-            </ComboboxContent>
-        </Combobox>
+                    </AutocompleteCollection>
+                </AutocompleteList>
+            </AutocompleteContent>
+        </Autocomplete>
     );
 }

--- a/apps/kvark/src/components/event-form.tsx
+++ b/apps/kvark/src/components/event-form.tsx
@@ -18,6 +18,7 @@ import {
     SelectValue,
 } from "@tihlde/ui/ui/select";
 import { nb } from "date-fns/locale";
+import { useRef } from "react";
 import type { FormEvent, ReactNode } from "react";
 
 import type { AddressSuggestion } from "#/api/queries/address";
@@ -96,18 +97,27 @@ export function EventForm({
     isSubmitting,
     children,
 }: EventFormProps) {
+    /** Sist valgte adresse, se `handleLocationChange`. */
+    const selectedAddressRef = useRef<EventFormValues["locationCoords"]>(null);
+
     /**
      * Koordinatene følger teksten: så snart brukeren redigerer et valgt
      * adresseforslag er de ikke lenger gyldige for stedet som står i feltet.
+     *
+     * Adressefeltet fyller seg selv med etiketten når et forslag velges, så
+     * dette kjører rett etter `handleSelectAddress` med samme tekst. `values`
+     * er da fortsatt forrige render, og koordinatene ville blitt kastet med én
+     * gang — derfor ligger det sist valgte forslaget i en ref også.
      */
     function handleLocationChange(next: string) {
-        onChange({
-            location: next,
-            locationCoords:
-                values.locationCoords && values.locationCoords.label === next
-                    ? values.locationCoords
-                    : null,
-        });
+        const selected =
+            values.locationCoords?.label === next
+                ? values.locationCoords
+                : selectedAddressRef.current?.label === next
+                  ? selectedAddressRef.current
+                  : null;
+
+        onChange({ location: next, locationCoords: selected });
     }
 
     /**
@@ -136,14 +146,13 @@ export function EventForm({
     ];
 
     function handleSelectAddress(suggestion: AddressSuggestion) {
-        onChange({
-            location: suggestion.label,
-            locationCoords: {
-                label: suggestion.label,
-                lat: suggestion.lat,
-                lng: suggestion.lng,
-            },
-        });
+        const coords = {
+            label: suggestion.label,
+            lat: suggestion.lat,
+            lng: suggestion.lng,
+        };
+        selectedAddressRef.current = coords;
+        onChange({ location: suggestion.label, locationCoords: coords });
     }
 
     return (

--- a/packages/ui/src/components/ui/autocomplete.tsx
+++ b/packages/ui/src/components/ui/autocomplete.tsx
@@ -1,0 +1,46 @@
+import { Autocomplete as AutocompletePrimitive } from "@base-ui/react";
+
+import {
+    ComboboxCollection,
+    ComboboxContent,
+    ComboboxEmpty,
+    ComboboxInput,
+    ComboboxItem,
+    ComboboxList,
+} from "#/components/ui/combobox";
+
+/**
+ * Tekstfelt med forslagsliste, der fritekst er et gyldig svar.
+ *
+ * Forskjellen fra `Combobox` er hvem som eier teksten. `Combobox` husker en
+ * valgt verdi (`selectionMode: "single"`) og synkroniserer feltet mot den når
+ * lista lukkes — står det ingen valgt verdi, blir feltet tømt. Det gjør den
+ * ubrukelig for felt der brukeren kan skrive hva som helst: teksten forsvant
+ * idet forslagslista forsvant.
+ *
+ * `Autocomplete` har ingen valgt verdi (`selectionMode: "none"`). Teksten er
+ * verdien, den kommer inn som `value` og ut som `onValueChange`, og et klikk på
+ * et forslag fyller feltet med forslagets etikett.
+ *
+ * Delene under lista er de samme komponentene som `Combobox` bruker — Base UI
+ * eksporterer dem fra begge, så de er aliaser og ikke kopier, og utseendet
+ * holdes ett sted.
+ */
+const Autocomplete = AutocompletePrimitive.Root;
+
+const AutocompleteInput = ComboboxInput;
+const AutocompleteContent = ComboboxContent;
+const AutocompleteList = ComboboxList;
+const AutocompleteItem = ComboboxItem;
+const AutocompleteCollection = ComboboxCollection;
+const AutocompleteEmpty = ComboboxEmpty;
+
+export {
+    Autocomplete,
+    AutocompleteCollection,
+    AutocompleteContent,
+    AutocompleteEmpty,
+    AutocompleteInput,
+    AutocompleteItem,
+    AutocompleteList,
+};


### PR DESCRIPTION
## Problemet

Man kunne ikke opprette arrangementer: skriver du inn et sted, forsvinner teksten fra feltet et halvt sekund etterpå, og «Sted» er påkrevd.

Adressefeltet var bygget på `Combobox` fra `@tihlde/ui` — Base UI sin combobox i `selectionMode: "single"`, som husker en **valgt verdi**. Feltet har ingen valgt verdi (fritekst som «Digitalt» eller «R1» skal være lov), så det ble brukt med `value={null}`. Når forslagslista lukkes, synkroniserer Base UI inputteksten mot den valgte verdien; `null` gir tom streng, og skjemaet fikk `""` tilbake. Det traff både når man klikket et forslag og når lista bare lukket seg.

## Fiksen

- Ny `Autocomplete`-primitiv i `@tihlde/ui` — Base UI sin `Autocomplete` (`selectionMode: "none"`), som er den riktige komponenten for et felt der teksten *er* verdien. Popup, liste og rader er de samme komponentene `Combobox` bruker, så utseendet ligger fortsatt ett sted.
- `address-combobox.tsx` bruker den: tekst inn som `value`, ut som `onValueChange`, og et klikk på et forslag fyller feltet selv.
- `event-form.tsx`: koordinatene fra et valgt forslag lagres også i en ref. Feltet fyller seg selv rett etter valget, og den påfølgende tekst-endringen leste `values` fra forrige render — kartlenka ville blitt kastet med én gang.

## Verifisert

Lokal dev mot lokal API, i det ekte skjemaet på `/admin/arrangementer/ny`:

- **Før:** skrev «Sjøgangen 2», klikket forslaget → feltet tomt, koordinater `null`. Reprodusert.
- **Etter:** fritekst («Digitalt») overlever Escape og klikk utenfor. Valgt forslag blir stående, og skjemaet viser «Adressen er lenket til kart på arrangementssiden».
- Hele opprettelsen kjørt gjennom skjemaet: raden ble skrevet med `location = "Sjøgangen 2, 7010 Trondheim"` og `location_lat/lng = 63.436223 / 10.399421`. Testdata ryddet bort etterpå.
- `bun run typecheck` 9/9, `bun run build` 4/4, `bun run lint` uten feil, `bun run format` rent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)