### PR TITLE
fix(profil): la ventende bruker nå egen profil og logge ut

### DIFF
--- a/apps/api/src/routes/user/get.ts
+++ b/apps/api/src/routes/user/get.ts
@@ -1,8 +1,10 @@
 import { HTTPException } from "hono/http-exception";
+import { isMemberAudience } from "~/lib/auth";
+import { HTTPAppException } from "~/lib/errors";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { deriveStudyFromGroups } from "~/lib/user/study";
-import { requireAuth } from "~/middleware/auth";
+import { requireAuthAllowPending } from "~/middleware/auth";
 import { userProfileSchema } from "./schema";
 
 /**
@@ -12,6 +14,10 @@ import { userProfileSchema } from "./schema";
  * memberships are what a profile page shows, while e-mail, gender, allergies
  * and the notification settings stay private. Any signed-in member may look up
  * any other — the group member lists already link here.
+ *
+ * En bruker som venter på godkjenning når bare sin egen profil. De trenger den
+ * for å komme til innstillinger og til «Logg ut»; andres profiler er fortsatt
+ * medlemsinnhold.
  */
 export const getUserRoute = route().get(
     "/:id",
@@ -28,11 +34,17 @@ export const getUserRoute = route().get(
             description: "User profile",
         })
         .notFound({ description: "User not found" })
+        .errorResponses([
+            HTTPAppException.Forbidden(
+                "Kontoen din venter på godkjenning fra en administrator.",
+            ),
+        ])
         .build(),
-    requireAuth,
+    requireAuthAllowPending,
     async (c) => {
         const { db } = c.get("ctx");
         const identifier = c.req.param("id");
+        const viewer = c.get("user");
 
         const user = await db.query.user.findFirst({
             where: (user, { eq, or }) =>
@@ -50,6 +62,15 @@ export const getUserRoute = route().get(
             throw new HTTPException(404, {
                 message: `User "${identifier}" not found`,
             });
+        }
+
+        // En bruker som venter på godkjenning slipper inn på sin egen profil,
+        // og bare den. Uten dette har de ingen vei til profilsiden — som er
+        // det eneste stedet man kan logge ut.
+        if (!isMemberAudience(viewer) && user.id !== viewer.id) {
+            throw HTTPAppException.Forbidden(
+                "Kontoen din venter på godkjenning fra en administrator.",
+            );
         }
 
         const [settings, memberships, history] = await Promise.all([

--- a/apps/api/src/test/user-approval.test.ts
+++ b/apps/api/src/test/user-approval.test.ts
@@ -127,6 +127,13 @@ describe("self-registration and approval", () => {
             const res = await client.api.user.me.settings.$get();
             expect(res.status).not.toBe(403);
 
+            // Their own profile too: det er den eneste siden i Kvark der man
+            // finner «Logg ut», så en 403 der låser dem inne i kontoen.
+            const own = await client.api.user[":id"].$get({
+                param: { id: pending.id },
+            });
+            expect(own.status).toBe(200);
+
             const other = await ctx.utils.createTestUser();
             const denied = await client.api.user[":id"].$get({
                 param: { id: other.id },

--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -43,8 +43,14 @@ function AppLayout() {
                 navItems={navItems}
                 user={currentUser}
                 // Bjella spør etter uleste varsler, så den vises bare for
-                // innloggede — ellers ville hver besøkende få en 401.
-                actions={isAuthenticated ? <NotificationBell /> : null}
+                // innloggede — ellers ville hver besøkende få en 401. Den som
+                // venter på godkjenning får 403 på samme kall, og har uansett
+                // ingen varsler ennå.
+                actions={
+                    isAuthenticated && !isPendingApproval ? (
+                        <NotificationBell />
+                    ) : null
+                }
             />
             {isPendingApproval ? (
                 <div className="container mx-auto px-4 pt-4">

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -98,6 +98,9 @@ function RouteComponent() {
     const { data: profile } = useSuspenseQuery(getUserProfileQuery(id));
     const { data: session } = useQuery(authQueryOptions);
     const isOwnProfile = session?.user.id === profile.id;
+    // Fanene under henter medlemsdata og svarer 403 for en bruker som venter
+    // på godkjenning. De skjules, slik at profilsiden — og «Logg ut» — funker.
+    const isPendingApproval = session?.user?.isPendingApproval === true;
     const isAdmin = useIsAdmin();
     const updateSettings = useMutation(updateUserSettingsMutation);
     const [bioOpen, setBioOpen] = useState(false);
@@ -131,7 +134,7 @@ function RouteComponent() {
                     link: linkOptions({ to: "/profil/$id", params: { id } }),
                     exact: true,
                 },
-                ...(isOwnProfile
+                ...(isOwnProfile && !isPendingApproval
                     ? [
                           {
                               label: "Arrangementer",
@@ -151,7 +154,7 @@ function RouteComponent() {
                         params: { id },
                     }),
                 },
-                ...(isOwnProfile
+                ...(isOwnProfile && !isPendingApproval
                     ? [
                           {
                               label: "Prikker",
@@ -169,6 +172,10 @@ function RouteComponent() {
                                   params: { id },
                               }),
                           },
+                      ]
+                    : []),
+                ...(isOwnProfile
+                    ? [
                           {
                               label: "Innstillinger",
                               icon: Settings,
@@ -308,6 +315,20 @@ function ProfileNav({
                             <NavButton item={item} size="sm" />
                         </li>
                     ))}
+                    {/* Også på mobil — ellers finnes det ingen vei ut av
+                        kontoen på en telefon. */}
+                    {onLogout ? (
+                        <li className="shrink-0">
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={onLogout}
+                            >
+                                <LogOut />
+                                Logg ut
+                            </Button>
+                        </li>
+                    ) : null}
                 </ul>
             </nav>
 

--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -34,10 +34,11 @@ function RouteComponent() {
     const isOwnProfile = session?.user.id === profile.id;
 
     // Varselmerket vises bare på egen profil, så andres profiler skal heller
-    // ikke koste et kall til det innloggede-scopede endepunktet.
+    // ikke koste et kall til det innloggede-scopede endepunktet. Den som venter
+    // på godkjenning får 403 på det kallet, så det hoppes over.
     const { data: unreadNotifications } = useQuery({
         ...getUnreadNotificationCountQuery(),
-        enabled: isOwnProfile,
+        enabled: isOwnProfile && session?.user?.isPendingApproval !== true,
     });
 
     const links: ProfileLink[] = [];


### PR DESCRIPTION
## Problem

En bruker som har registrert seg selv og venter på godkjenning fikk 403 på profilsiden. Det er det eneste stedet i Kvark man finner «Logg ut» — så de satt fast i kontoen uten å komme seg ut.

## Endring

**API**
- `GET /api/user/:id` bruker `requireAuthAllowPending`, men slipper en ventende bruker inn kun på sin egen profil. Andres profiler svarer fortsatt 403.

**Kvark**
- Fanene Arrangementer, Prikker og Spørreskjemaer skjules for ventende brukere — de endepunktene svarer 403 uansett. Igjen står Oversikt, Medlemskap, Innstillinger og «Logg ut».
- «Logg ut» lagt til i mobilraden. Den lå bare i desktop-sidemenyen, så på telefon fantes det ingen vei ut av kontoen i det hele tatt — også for vanlige medlemmer.
- Varselbjella i headeren og varseltellingen på profiloversikten hoppes over for ventende brukere; begge ga 403.

## Verifisert

- `bun run typecheck` og `bun run format` grønt.
- `user-approval.test.ts` 7/7, med ny assert på at egen profil gir 200 og andres 403.
- Manuelt mot lokal API + dev-DB med testbrukeren satt til `pending`: profilsiden lastet, riktige faner, «Logg ut» logget faktisk ut, og mobilraden viste Logg ut.

## Merk

En ventende bruker som klikker seg inn på en annen person fra en gruppeside får fortsatt en 403-feilside. Det er uendret oppførsel, ikke noe denne PR-en innfører.

🤖 Generated with [Claude Code](https://claude.com/claude-code)