### PR TITLE
feat(users): vis e-postadressen til en bruker for admin

### DIFF
--- a/apps/api/src/routes/user/get.ts
+++ b/apps/api/src/routes/user/get.ts
@@ -1,3 +1,4 @@
+import { hasPermission } from "@photon/auth/rbac";
 import { HTTPException } from "hono/http-exception";
 import { isMemberAudience } from "~/lib/auth";
 import { HTTPAppException } from "~/lib/errors";
@@ -11,9 +12,12 @@ import { userProfileSchema } from "./schema";
  * Another member's profile.
  *
  * Deliberately narrower than the session: bio, links, study and group
- * memberships are what a profile page shows, while e-mail, gender, allergies
- * and the notification settings stay private. Any signed-in member may look up
- * any other — the group member lists already link here.
+ * memberships are what a profile page shows, while gender, allergies and the
+ * notification settings stay private. Any signed-in member may look up any
+ * other — the group member lists already link here.
+ *
+ * E-posten er unntaket: den følger med for en admin med `users:view`, som er
+ * de samme som ser den i brukerlista. For alle andre er den null.
  *
  * En bruker som venter på godkjenning når bare sin egen profil. De trenger den
  * for å komme til innstillinger og til «Logg ut»; andres profiler er fortsatt
@@ -42,7 +46,8 @@ export const getUserRoute = route().get(
         .build(),
     requireAuthAllowPending,
     async (c) => {
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const identifier = c.req.param("id");
         const viewer = c.get("user");
 
@@ -53,6 +58,7 @@ export const getUserRoute = route().get(
                 id: true,
                 name: true,
                 username: true,
+                email: true,
                 image: true,
                 createdAt: true,
             },
@@ -72,6 +78,12 @@ export const getUserRoute = route().get(
                 "Kontoen din venter på godkjenning fra en administrator.",
             );
         }
+
+        // Adressen er den eneste veien til et medlem utenfor nettsiden, og en
+        // admin har den allerede i brukerlista. Du ser alltid din egen.
+        const canSeeEmail =
+            user.id === viewer.id ||
+            (await hasPermission(ctx, viewer.id, "users:view"));
 
         const [settings, memberships, history] = await Promise.all([
             db.query.userSettings.findFirst({
@@ -127,6 +139,7 @@ export const getUserRoute = route().get(
             id: user.id,
             name: user.name,
             username: user.username ?? null,
+            email: canSeeEmail ? user.email : null,
             // The uploaded avatar wins over the one Feide handed us, same as
             // the session's `settings.imageUrl ?? user.image`.
             image: settings?.imageUrl ?? user.image ?? null,

--- a/apps/api/src/routes/user/list.ts
+++ b/apps/api/src/routes/user/list.ts
@@ -153,15 +153,11 @@ export const listUsersRoute = route().get(
             totalCount,
             pages: totalPages,
             nextPage: page + 1 >= totalPages ? null : page + 1,
-            items: rows.map(({ banned, email, ...row }) => ({
+            items: rows.map(({ banned, ...row }) => ({
                 ...row,
                 // `banned` is nullable in Better Auth's schema; only an
                 // explicit true means deactivated.
                 isActive: banned !== true,
-                // An admin deciding on a stranger has nothing else to go on —
-                // no study programme, no Feide, just the address they typed.
-                // Everyone else's address stays out of a list this broad.
-                email: row.approvalStatus === "pending" ? email : null,
                 createdAt: row.createdAt.toISOString(),
             })),
         } satisfies z.infer<typeof userListResponseSchema>);

--- a/apps/api/src/routes/user/schema.ts
+++ b/apps/api/src/routes/user/schema.ts
@@ -297,7 +297,7 @@ export const userListItemSchema = Schema(
         }),
         email: z.string().nullable().meta({
             description:
-                "Only filled in for accounts awaiting approval, where it is the one thing an admin has to judge them on. Null otherwise.",
+                "The account's e-mail address. Shown to the admins who hold 'users:view', who need it both to judge a stranger waiting for approval and to get hold of an ordinary member.",
         }),
         createdAt: z
             .string()
@@ -321,9 +321,10 @@ export const userListResponseSchema = Schema(
 );
 
 /**
- * What one member may see about another. Deliberately excludes e-mail, gender,
+ * What one member may see about another. Deliberately excludes gender,
  * allergies and notification settings — those belong to the session, not to a
- * profile page someone else is looking at.
+ * profile page someone else is looking at. E-mail is the one exception, and
+ * only for an admin holding `users:view`, who sees it in the user list anyway.
  */
 export const userProfileSchema = Schema(
     "UserProfile",
@@ -331,6 +332,10 @@ export const userProfileSchema = Schema(
         id: z.string().meta({ description: "User ID" }),
         name: z.string().meta({ description: "User display name" }),
         username: z.string().nullable().meta({ description: "Username" }),
+        email: z.string().nullable().meta({
+            description:
+                "The user's e-mail address. Only filled in for viewers holding 'users:view', and for the user themselves. Null for everyone else — it is not part of the public profile.",
+        }),
         image: z.string().nullable().meta({
             description:
                 "Profile image URL — the uploaded avatar when there is one, otherwise the one from Feide",

--- a/apps/api/src/test/user-list.test.ts
+++ b/apps/api/src/test/user-list.test.ts
@@ -50,6 +50,9 @@ describe("user list", () => {
             const listed = allBody.items.find((u) => u.id === studying.user.id);
             expect(listed?.studyProgram).toBe("Listeingeniør");
             expect(listed?.studyStartYear).toBe(2023);
+            // Adressen er med for alle, ikke bare de som venter på godkjenning
+            // — den er den eneste veien til et medlem utenfor nettsiden.
+            expect(listed?.email).toBe("listme@test.com");
             expect(allBody.totalCount).toBeGreaterThanOrEqual(2);
 
             // Search matches username as well as name.

--- a/apps/api/src/test/user-profile-email.test.ts
+++ b/apps/api/src/test/user-profile-email.test.ts
@@ -1,0 +1,39 @@
+import { expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * E-posten på en profil er ikke medlemsinnhold: den vises for deg selv, og for
+ * en admin med `users:view` — de samme som ser den i brukerlista. Et vanlig
+ * medlem som ser på en annens profil skal ikke få den.
+ */
+integrationTest(
+    "shows a profile e-mail to the user themselves and to users:view, not to other members",
+    async ({ ctx }) => {
+        const target = await ctx.utils.createTestUser();
+
+        const own = await ctx.utils.clientForUser(target);
+        const ownResponse = await own.api.user[":id"].$get({
+            param: { id: target.id },
+        });
+        expect(ownResponse.status).toBe(200);
+        expect((await ownResponse.json()).email).toBe(target.email);
+
+        const admin = await ctx.utils.createTestUser();
+        await ctx.utils.giveUserPermissions(admin, ["users:view"]);
+        const adminClient = await ctx.utils.clientForUser(admin);
+        const adminResponse = await adminClient.api.user[":id"].$get({
+            param: { id: target.id },
+        });
+        expect(adminResponse.status).toBe(200);
+        expect((await adminResponse.json()).email).toBe(target.email);
+
+        const member = await ctx.utils.createTestUser();
+        const memberClient = await ctx.utils.clientForUser(member);
+        const memberResponse = await memberClient.api.user[":id"].$get({
+            param: { id: target.id },
+        });
+        expect(memberResponse.status).toBe(200);
+        expect((await memberResponse.json()).email).toBeNull();
+    },
+    500_000,
+);

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -109,9 +109,12 @@ function RouteComponent() {
     const studyLabel = formatStudyLabel(deriveStudy(profile.groups));
     const user: ProfileHeaderUser = {
         name: profile.name,
-        // E-post er ikke en del av den offentlige profilen — den vises bare for
-        // deg selv, der den uansett ligger i sesjonen.
-        email: isOwnProfile ? (session?.user.email ?? undefined) : undefined,
+        // E-post er ikke en del av den offentlige profilen. Din egen ligger i
+        // sesjonen; på en annens profil sender API-et den bare til en admin med
+        // `users:view`, og null til alle andre.
+        email: isOwnProfile
+            ? (session?.user.email ?? undefined)
+            : (profile.email ?? undefined),
         avatarUrl: profile.image ?? undefined,
         programme: studyLabel,
         links: buildProfileLinks(profile.githubUrl, profile.linkedinUrl),

--- a/apps/kvark/src/routes/admin/brukere.tsx
+++ b/apps/kvark/src/routes/admin/brukere.tsx
@@ -431,11 +431,13 @@ function AllUsersTable({
                                                         <span className="text-sm font-medium">
                                                             {user.name}
                                                         </span>
-                                                        {/* E-posten er det
-                                                        eneste en admin har å
-                                                        vurdere en ukjent på, og
-                                                        API-et sender den bare
-                                                        for de som venter. */}
+                                                        {/* E-posten er den
+                                                        eneste veien til et
+                                                        medlem utenfor
+                                                        nettsiden, og det eneste
+                                                        en admin har å vurdere
+                                                        en ukjent som venter
+                                                        på. */}
                                                         {user.email && (
                                                             <span className="text-sm text-muted-foreground">
                                                                 {user.email}

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -5754,7 +5754,7 @@ export interface components {
             isActive: boolean;
             /** @description 'pending' for a self-registered account still waiting for an admin, 'approved' once one said yes. Null for accounts that never needed approving — Feide logins and members migrated from Lepton. */
             approvalStatus: ("pending" | "approved") | null;
-            /** @description Only filled in for accounts awaiting approval, where it is the one thing an admin has to judge them on. Null otherwise. */
+            /** @description The account's e-mail address. Shown to the admins who hold 'users:view', who need it both to judge a stranger waiting for approval and to get hold of an ordinary member. */
             email: string | null;
             /** @description Account creation timestamp */
             createdAt: string;
@@ -5817,6 +5817,8 @@ export interface components {
             name: string;
             /** @description Username */
             username: string | null;
+            /** @description The user's e-mail address. Only filled in for viewers holding 'users:view', and for the user themselves. Null for everyone else — it is not part of the public profile. */
+            email: string | null;
             /** @description Profile image URL — the uploaded avatar when there is one, otherwise the one from Feide */
             image: string | null;
             /** @description Free-text bio */


### PR DESCRIPTION
En admin kunne ikke se e-postadressen til et medlem. Brukerlista nullet den ut for alle andre enn de som ventet på godkjenning, og profilsiden tok den ikke med i det hele tatt.

Adressen er den eneste veien til et medlem utenfor nettsiden — og den samme adressen alle utsendinger fra systemet går til.

## Endringer

- `GET /user` sender adressen for alle brukere, ikke bare de som venter. Endepunktet krever fortsatt `users:view`, så det er samme krets som før.
- `GET /user/:id` tar med adressen når du ser på din egen profil, eller når du har `users:view`. For alle andre er feltet `null` — den er ikke blitt en del av den offentlige profilen.
- Frontend viser den i profilheaderen (visningen med mailto-lenke fantes fra før). Brukerlista viste den allerede under navnet, og fyller seg nå for alle rader.

## Verifisering

- Ny integrasjonstest dekker alle tre tilfellene på profilen: deg selv, `users:view`, og et vanlig medlem → `null`. `user-list.test.ts` asserterer at en godkjent bruker får med adressen.
- Kjørt i nettleseren mot lokal API og dev-databasen, innlogget som root: `/profil/<annen bruker>` viser adressen under navnet, og `/admin/brukere` viser den på alle rader.
- `typecheck` og `format` grønt, ingen nye lint-funn.

## Ikke med

Medlemslista per gruppe henter fra gruppemedlem-endepunktet, som fortsatt ikke sender adressen.

Merk at det finnes bare én adresse per bruker (`auth_user.email`). En Feide-innlogging som kobles til en eksisterende konto overskriver den ikke, og lagrer heller ikke NTNU-adressen ved siden av — så det er ingen «andre» adresse å vise. Egen varslingsadresse ved siden av innloggingsadressen ville vært en ny kolonne og et eget valg om hvilken utsendingene bruker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)