### PR TITLE
feat(kvark): kategori som nedtrekksliste og felt for når påmelding åpner

### DIFF
--- a/apps/kvark/src/components/event-form.tsx
+++ b/apps/kvark/src/components/event-form.tsx
@@ -25,6 +25,7 @@ import type { AddressSuggestion } from "#/api/queries/address";
 import { AddressCombobox } from "#/components/address-combobox";
 import { AdminImageField } from "#/components/admin-image-field";
 import { richRegistry } from "#/components/markdown/directives/presets";
+import { ALL_EVENT_CATEGORIES } from "#/lib/event-categories";
 
 /** Sentinel for "no institute restriction" — Select has no empty value. */
 export const ALL_INSTITUTES = "all";
@@ -49,6 +50,8 @@ export type EventFormValues = {
     end: Date | null;
     /** Om arrangementet har påmelding i det hele tatt. */
     requiresSigningUp: boolean;
+    /** Når påmeldingen åpner. */
+    registrationStart: Date | null;
     registrationEnd: Date | null;
     capacity: string;
     visibility: "public" | "members";
@@ -145,6 +148,16 @@ export function EventForm({
             : []),
     ];
 
+    /**
+     * Kapasitet, synlighet og institutt deler én rad på fire kolonner, der
+     * kapasitet er like bred som en tidsvelger over. Uten påmelding faller
+     * kapasitet bort, og de to andre fyller raden i stedet for å la halve
+     * bredden stå tom.
+     */
+    const wideWhenNoCapacity = values.requiresSigningUp
+        ? undefined
+        : "lg:col-span-2";
+
     function handleSelectAddress(suggestion: AddressSuggestion) {
         const coords = {
             label: suggestion.label,
@@ -163,104 +176,121 @@ export function EventForm({
                 </CardHeader>
                 <CardContent>
                     <FieldGroup>
-                        <Field>
-                            <FieldLabel htmlFor="event-title">
-                                Tittel
-                            </FieldLabel>
-                            <Input
-                                id="event-title"
-                                type="text"
-                                required
-                                value={values.title}
-                                onChange={(event) =>
-                                    onChange({ title: event.target.value })
-                                }
-                            />
-                        </Field>
-                        <Field>
-                            <FieldLabel htmlFor="event-category">
-                                Kategori (slug)
-                            </FieldLabel>
-                            <Input
-                                id="event-category"
-                                type="text"
-                                required
-                                value={values.categorySlug}
-                                onChange={(event) =>
-                                    onChange({
-                                        categorySlug: event.target.value,
-                                    })
-                                }
-                                placeholder="sosialt"
-                            />
-                        </Field>
-                        <Field>
-                            <FieldLabel htmlFor="event-organizer">
-                                Arrangørgruppe
-                            </FieldLabel>
-                            <Select
-                                items={groups.map((group) => ({
-                                    value: group.slug,
-                                    label: group.name,
-                                }))}
-                                value={values.organizerGroupSlug}
-                                onValueChange={(value) =>
-                                    onChange({
-                                        organizerGroupSlug: value ?? "",
-                                    })
-                                }
-                            >
-                                <SelectTrigger id="event-organizer">
-                                    <SelectValue placeholder="Velg gruppe" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {groups.map((group) => (
-                                        <SelectItem
-                                            key={group.slug}
-                                            value={group.slug}
-                                        >
-                                            {group.name}
-                                        </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
-                        </Field>
-                        <Field>
-                            <FieldLabel htmlFor="event-contact">
-                                Kontaktperson (valgfritt)
-                            </FieldLabel>
-                            <Select
-                                items={contactPersonOptions}
-                                value={values.contactPersonUserId || NO_CONTACT}
-                                onValueChange={(value) =>
-                                    onChange({
-                                        contactPersonUserId:
-                                            !value || value === NO_CONTACT
-                                                ? ""
-                                                : value,
-                                    })
-                                }
-                            >
-                                <SelectTrigger id="event-contact">
-                                    <SelectValue placeholder="Ingen kontaktperson" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {contactPersonOptions.map((option) => (
-                                        <SelectItem
-                                            key={option.value}
-                                            value={option.value}
-                                        >
-                                            {option.label}
-                                        </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
-                            <FieldDescription>
-                                Vises på arrangementssiden, med e-post for
-                                innloggede medlemmer. Velg blant medlemmene i
-                                arrangørgruppen.
-                            </FieldDescription>
-                        </Field>
+                        <div className="grid gap-4 lg:grid-cols-2">
+                            <Field>
+                                <FieldLabel htmlFor="event-title">
+                                    Tittel
+                                </FieldLabel>
+                                <Input
+                                    id="event-title"
+                                    type="text"
+                                    required
+                                    value={values.title}
+                                    onChange={(event) =>
+                                        onChange({ title: event.target.value })
+                                    }
+                                />
+                            </Field>
+                            <Field>
+                                <FieldLabel htmlFor="event-category">
+                                    Kategori
+                                </FieldLabel>
+                                <Select
+                                    items={ALL_EVENT_CATEGORIES}
+                                    value={values.categorySlug}
+                                    onValueChange={(value) =>
+                                        onChange({ categorySlug: value ?? "" })
+                                    }
+                                >
+                                    <SelectTrigger id="event-category">
+                                        <SelectValue placeholder="Velg kategori" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {ALL_EVENT_CATEGORIES.map(
+                                            (category) => (
+                                                <SelectItem
+                                                    key={category.value}
+                                                    value={category.value}
+                                                >
+                                                    {category.label}
+                                                </SelectItem>
+                                            ),
+                                        )}
+                                    </SelectContent>
+                                </Select>
+                            </Field>
+                        </div>
+                        <div className="grid gap-4 lg:grid-cols-2">
+                            <Field>
+                                <FieldLabel htmlFor="event-organizer">
+                                    Arrangørgruppe
+                                </FieldLabel>
+                                <Select
+                                    items={groups.map((group) => ({
+                                        value: group.slug,
+                                        label: group.name,
+                                    }))}
+                                    value={values.organizerGroupSlug}
+                                    onValueChange={(value) =>
+                                        onChange({
+                                            organizerGroupSlug: value ?? "",
+                                        })
+                                    }
+                                >
+                                    <SelectTrigger id="event-organizer">
+                                        <SelectValue placeholder="Velg gruppe" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {groups.map((group) => (
+                                            <SelectItem
+                                                key={group.slug}
+                                                value={group.slug}
+                                            >
+                                                {group.name}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </Field>
+                            <Field>
+                                <FieldLabel htmlFor="event-contact">
+                                    Kontaktperson (valgfritt)
+                                </FieldLabel>
+                                <Select
+                                    items={contactPersonOptions}
+                                    value={
+                                        values.contactPersonUserId || NO_CONTACT
+                                    }
+                                    onValueChange={(value) =>
+                                        onChange({
+                                            contactPersonUserId:
+                                                !value || value === NO_CONTACT
+                                                    ? ""
+                                                    : value,
+                                        })
+                                    }
+                                >
+                                    <SelectTrigger id="event-contact">
+                                        <SelectValue placeholder="Ingen kontaktperson" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {contactPersonOptions.map((option) => (
+                                            <SelectItem
+                                                key={option.value}
+                                                value={option.value}
+                                            >
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <FieldDescription>
+                                    Vises på arrangementssiden, med e-post for
+                                    innloggede medlemmer. Velg blant medlemmene
+                                    i arrangørgruppen.
+                                </FieldDescription>
+                            </Field>
+                        </div>
                         <Field>
                             <FieldLabel htmlFor="event-location">
                                 Sted
@@ -324,7 +354,26 @@ export function EventForm({
                             </FieldLabel>
                         </Field>
                         {values.requiresSigningUp ? (
-                            <>
+                            <div className="grid gap-4 lg:grid-cols-2">
+                                <Field>
+                                    <FieldLabel htmlFor="event-reg-start">
+                                        Påmelding åpner
+                                    </FieldLabel>
+                                    <DateTimePicker
+                                        id="event-reg-start"
+                                        locale={nb}
+                                        placeholder="Velg dato"
+                                        maxDate={
+                                            values.registrationEnd ??
+                                            values.start ??
+                                            undefined
+                                        }
+                                        value={values.registrationStart}
+                                        onValueChange={(registrationStart) =>
+                                            onChange({ registrationStart })
+                                        }
+                                    />
+                                </Field>
                                 <Field>
                                     <FieldLabel htmlFor="event-reg-end">
                                         Påmeldingsfrist
@@ -333,6 +382,10 @@ export function EventForm({
                                         id="event-reg-end"
                                         locale={nb}
                                         placeholder="Velg dato"
+                                        minDate={
+                                            values.registrationStart ??
+                                            undefined
+                                        }
                                         maxDate={values.start ?? undefined}
                                         value={values.registrationEnd}
                                         onValueChange={(registrationEnd) =>
@@ -340,7 +393,11 @@ export function EventForm({
                                         }
                                     />
                                 </Field>
-                                <Field>
+                            </div>
+                        ) : null}
+                        <div className="grid gap-4 lg:grid-cols-4">
+                            {values.requiresSigningUp ? (
+                                <Field className="lg:col-span-2">
                                     <FieldLabel htmlFor="event-capacity">
                                         Kapasitet (valgfritt)
                                     </FieldLabel>
@@ -356,88 +413,89 @@ export function EventForm({
                                         }
                                     />
                                 </Field>
-                            </>
-                        ) : null}
-                        <Field>
-                            <FieldLabel htmlFor="event-visibility">
-                                Synlighet
-                            </FieldLabel>
-                            <Select
-                                items={[
-                                    { value: "public", label: "Offentlig" },
-                                    {
-                                        value: "members",
-                                        label: "Kun for medlemmer",
-                                    },
-                                ]}
-                                value={values.visibility}
-                                onValueChange={(value) =>
-                                    onChange({
-                                        visibility:
-                                            value === "members"
-                                                ? "members"
-                                                : "public",
-                                    })
-                                }
-                            >
-                                <SelectTrigger id="event-visibility">
-                                    <SelectValue placeholder="Velg synlighet" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="public">
-                                        Offentlig
-                                    </SelectItem>
-                                    <SelectItem value="members">
-                                        Kun for medlemmer
-                                    </SelectItem>
-                                </SelectContent>
-                            </Select>
-                        </Field>
-                        <Field>
-                            <FieldLabel htmlFor="event-institute">
-                                Institutt
-                            </FieldLabel>
-                            <Select
-                                items={[
-                                    {
-                                        value: ALL_INSTITUTES,
-                                        label: "Alle institutt",
-                                    },
-                                    ...institutes.map((institute) => ({
-                                        value: institute.slug,
-                                        label: institute.shortName,
-                                    })),
-                                ]}
-                                value={values.instituteSlug}
-                                onValueChange={(value) =>
-                                    onChange({
-                                        instituteSlug: value ?? ALL_INSTITUTES,
-                                    })
-                                }
-                            >
-                                <SelectTrigger id="event-institute">
-                                    <SelectValue placeholder="Velg institutt" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value={ALL_INSTITUTES}>
-                                        Alle institutt
-                                    </SelectItem>
-                                    {institutes.map((institute) => (
-                                        <SelectItem
-                                            key={institute.slug}
-                                            value={institute.slug}
-                                        >
-                                            {institute.shortName} –{" "}
-                                            {institute.name}
+                            ) : null}
+                            <Field className={wideWhenNoCapacity}>
+                                <FieldLabel htmlFor="event-visibility">
+                                    Synlighet
+                                </FieldLabel>
+                                <Select
+                                    items={[
+                                        { value: "public", label: "Offentlig" },
+                                        {
+                                            value: "members",
+                                            label: "Kun for medlemmer",
+                                        },
+                                    ]}
+                                    value={values.visibility}
+                                    onValueChange={(value) =>
+                                        onChange({
+                                            visibility:
+                                                value === "members"
+                                                    ? "members"
+                                                    : "public",
+                                        })
+                                    }
+                                >
+                                    <SelectTrigger id="event-visibility">
+                                        <SelectValue placeholder="Velg synlighet" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="public">
+                                            Offentlig
                                         </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
-                            <FieldDescription>
-                                Begrenser påmelding til studenter ved dette
-                                instituttet.
-                            </FieldDescription>
-                        </Field>
+                                        <SelectItem value="members">
+                                            Kun for medlemmer
+                                        </SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </Field>
+                            <Field className={wideWhenNoCapacity}>
+                                <FieldLabel htmlFor="event-institute">
+                                    Institutt
+                                </FieldLabel>
+                                <Select
+                                    items={[
+                                        {
+                                            value: ALL_INSTITUTES,
+                                            label: "Alle institutt",
+                                        },
+                                        ...institutes.map((institute) => ({
+                                            value: institute.slug,
+                                            label: institute.shortName,
+                                        })),
+                                    ]}
+                                    value={values.instituteSlug}
+                                    onValueChange={(value) =>
+                                        onChange({
+                                            instituteSlug:
+                                                value ?? ALL_INSTITUTES,
+                                        })
+                                    }
+                                >
+                                    <SelectTrigger id="event-institute">
+                                        <SelectValue placeholder="Velg institutt" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value={ALL_INSTITUTES}>
+                                            Alle institutt
+                                        </SelectItem>
+                                        {institutes.map((institute) => (
+                                            <SelectItem
+                                                key={institute.slug}
+                                                value={institute.slug}
+                                            >
+                                                {institute.shortName} –{" "}
+                                                {institute.name}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <FieldDescription>
+                                    Begrenser påmelding til studenter ved dette
+                                    instituttet.
+                                </FieldDescription>
+                            </Field>
+                        </div>
                         <Field orientation="horizontal" className="gap-3">
                             <Checkbox
                                 id="event-paid"

--- a/apps/kvark/src/lib/event-categories.ts
+++ b/apps/kvark/src/lib/event-categories.ts
@@ -1,0 +1,27 @@
+/**
+ * Kategoriene et arrangement kan ha. Listene er kilden både til filteret i den
+ * offentlige oversikten og til kategorivalget i admin-skjemaet, slik at man
+ * aldri kan opprette et arrangement i en kategori ingen kan filtrere på.
+ *
+ * Slugene må finnes i `category`-tabellen (se `apps/api/src/db/seed/event.ts`);
+ * API-et avviser ukjente slugs.
+ */
+export type EventCategoryOption = { value: string; label: string };
+
+export const EVENT_CATEGORIES: EventCategoryOption[] = [
+    { value: "bedpres", label: "Bedpres" },
+    { value: "sosialt", label: "Sosialt" },
+    { value: "kurs", label: "Kurs" },
+    { value: "fadderuka", label: "Fadderuka" },
+    { value: "annet", label: "Annet" },
+];
+
+export const ACTIVITY_CATEGORIES: EventCategoryOption[] = [
+    { value: "aktivitet", label: "Aktivitet" },
+];
+
+/** Alt som kan velges i skjemaet — begge fanene i oversikten. */
+export const ALL_EVENT_CATEGORIES: EventCategoryOption[] = [
+    ...EVENT_CATEGORIES,
+    ...ACTIVITY_CATEGORIES,
+];

--- a/apps/kvark/src/routes/_app/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.index.tsx
@@ -17,22 +17,11 @@ import {
 import { LoadMoreButton } from "#/components/load-more-button";
 import { useDebouncedValue } from "#/hooks/use-debounced-value";
 import { formatEventDateTime } from "#/lib/event";
+import { ACTIVITY_CATEGORIES, EVENT_CATEGORIES } from "#/lib/event-categories";
 
 const SEARCH_DEBOUNCE_MS = 300;
 
 const ALL_CATEGORIES = { value: "all", label: "Alle kategorier" };
-
-const EVENT_CATEGORIES: Category[] = [
-    { value: "bedpres", label: "Bedpres" },
-    { value: "sosialt", label: "Sosialt" },
-    { value: "kurs", label: "Kurs" },
-    { value: "fadderuka", label: "Fadderuka" },
-    { value: "annet", label: "Annet" },
-];
-
-const ACTIVITY_CATEGORIES: Category[] = [
-    { value: "aktivitet", label: "Aktivitet" },
-];
 
 type EventTab = "arrangementer" | "aktiviteter";
 

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -226,6 +226,7 @@ function valuesFromEvent(event: Event): EventFormValues {
         start: toDate(event.startTime),
         end: toDate(event.endTime),
         requiresSigningUp: event.requiresSigningUp,
+        registrationStart: toDate(event.registrationStart),
         registrationEnd: toDate(event.registrationEnd),
         capacity: event.capacity === null ? "" : String(event.capacity),
         visibility: event.visibility === "members" ? "members" : "public",
@@ -302,7 +303,13 @@ function DetailsTab({ eventId }: { eventId: string }) {
         setUploadError(null);
 
         if (!values.start || !values.end) return;
-        if (values.requiresSigningUp && !values.registrationEnd) return;
+        if (!values.categorySlug) return;
+        if (
+            values.requiresSigningUp &&
+            (!values.registrationStart || !values.registrationEnd)
+        ) {
+            return;
+        }
 
         // Lastes opp først: en feilet opplasting skal ikke lagre resten av
         // endringene med et bilde som mangler.
@@ -332,8 +339,10 @@ function DetailsTab({ eventId }: { eventId: string }) {
             imageAlt: values.imageAlt || null,
             start: values.start.toISOString(),
             end: values.end.toISOString(),
-            registrationStart: null,
             // Uten påmelding avviser API-et både frist og kapasitet.
+            registrationStart: values.requiresSigningUp
+                ? (values.registrationStart?.toISOString() ?? null)
+                : null,
             registrationEnd: values.requiresSigningUp
                 ? (values.registrationEnd?.toISOString() ?? null)
                 : null,

--- a/apps/kvark/src/routes/admin/arrangementer.ny.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.ny.tsx
@@ -65,6 +65,7 @@ const emptyValues: EventFormValues = {
     start: null,
     end: null,
     requiresSigningUp: true,
+    registrationStart: null,
     registrationEnd: null,
     capacity: "",
     visibility: "public",
@@ -134,11 +135,20 @@ function NewEventPage() {
         const startIso = toIso(values.start);
         const endIso = toIso(values.end);
         // Uten påmelding avviser API-et både frist og kapasitet, så de utelates.
+        const registrationStartIso = values.requiresSigningUp
+            ? toIso(values.registrationStart)
+            : null;
         const registrationEndIso = values.requiresSigningUp
             ? toIso(values.registrationEnd)
             : null;
         if (!startIso || !endIso) return;
-        if (values.requiresSigningUp && !registrationEndIso) return;
+        if (!values.categorySlug) return;
+        if (
+            values.requiresSigningUp &&
+            (!registrationStartIso || !registrationEndIso)
+        ) {
+            return;
+        }
 
         // Uploaded first: a failed upload must not leave an event behind that
         // silently lost its cover.
@@ -168,7 +178,7 @@ function NewEventPage() {
                     imageAlt: imageUrl ? values.imageAlt || null : null,
                     start: startIso,
                     end: endIso,
-                    registrationStart: null,
+                    registrationStart: registrationStartIso,
                     registrationEnd: registrationEndIso,
                     cancellationDeadline: null,
                     capacity:


### PR DESCRIPTION
## Hva

Tre endringer i arrangementsskjemaet i admin (`apps/kvark/src/components/event-form.tsx`):

**1. Kategori er nedtrekksliste, ikke fritekst.** Feltet het «Kategori (slug)» og var en vanlig tekstinput, så en skrivefeil først ble fanget av API-et (`Category with slug "..." does not exist`) etter innsending. Kategorilistene som allerede brukes til filtrering i arrangementsoversikten er flyttet ut i `apps/kvark/src/lib/event-categories.ts` og brukes nå både der og i skjemaet — man kan ikke lenger opprette et arrangement i en kategori ingen kan filtrere på. Skjemaet tilbyr alle seks: Bedpres, Sosialt, Kurs, Fadderuka, Annet og Aktivitet.

**2. Nytt felt: «Påmelding åpner».** `registrationStart` fantes i DB og API fra før, men skjemaet sendte alltid `null`. Feltet står til venstre for «Påmeldingsfrist», vises bare når arrangementet har påmelding, og er påkrevd — men fylles ikke ut på forhånd. `minDate`/`maxDate` hindrer at start og frist krysser hverandre.

**3. Tokolonners layout på desktop.** Tittel + Kategori, Arrangørgruppe + Kontaktperson, og Påmelding åpner + Påmeldingsfrist ligger nå parvis. Kapasitet, Synlighet og Institutt deler én rad på fire kolonner, der kapasitet er like bred som en tidsvelger og de to andre tar resten. Skrus påmelding av forsvinner kapasitet, og Synlighet/Institutt fyller raden i stedet for å la halve bredden stå tom. Alt stables i én kolonne på mobil.

## Ingen backend-endring

`registrationStart` er nullable i `event`-tabellen og i `apps/api/src/routes/event/schema.ts` fra før. Ingen migrasjon, ingen nye endepunkter. Kategorilista er hardkodet i frontend, som før — det finnes ikke noe `GET /api/event/categories`.

## Verifisert

- `bun run typecheck` grønt; `lint`/`format` uten nye funn.
- Opprettet et testarrangement lokalt: `POST /api/event` → 201 med `registrationStart` og `categorySlug` i bodyen. Redigeringssiden forhåndsfylte begge, `PUT` → 200 med verdiene i behold. Testarrangementet er slettet igjen.
- Målte feltposisjoner i DOM for å bekrefte radene, både med og uten påmelding.
- Offentlig oversikt filtrerer fortsatt riktig etter at kategorilistene ble flyttet (`GET /api/event?...&category=bedpres`).

## Verdt å vite for review

Eksisterende arrangementer uten `registrationStart` får et tomt felt, og må fylle det ut ved neste lagring dersom arrangementet har påmelding. Det er villet — feltet er påkrevd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)