### PR TITLE
feat(rbac): vis bare personlige tilganger per medlem

### DIFF
--- a/apps/kvark/src/lib/permission-domains.ts
+++ b/apps/kvark/src/lib/permission-domains.ts
@@ -68,7 +68,7 @@ export const PERMISSION_DOMAINS: PermissionDomain[] = [
     },
     {
         slug: "events-refund",
-        label: "Refusjon av betalinger",
+        label: "Refundering",
         // The refund route accepts a global grant only, so offering this per
         // group would be a checkbox that saves and then does nothing.
         groupScopable: false,
@@ -76,7 +76,7 @@ export const PERMISSION_DOMAINS: PermissionDomain[] = [
     },
     {
         slug: "roles",
-        label: "Verv og tilganger",
+        label: "Tilganger",
         groupScopable: true,
         permissions: under("roles"),
     },
@@ -88,13 +88,13 @@ export const PERMISSION_DOMAINS: PermissionDomain[] = [
     },
     {
         slug: "applications-expense",
-        label: "Søknader – utlegg",
+        label: "Utlegg",
         groupScopable: true,
         permissions: under("applications:expense"),
     },
     {
         slug: "applications-support",
-        label: "Søknader – støtte",
+        label: "Støtte til HS",
         groupScopable: true,
         permissions: under("applications:support"),
     },
@@ -106,7 +106,7 @@ export const PERMISSION_DOMAINS: PermissionDomain[] = [
     },
     {
         slug: "applications-hs-case",
-        label: "Søknader – saker til HS",
+        label: "Saker til HS",
         groupScopable: false,
         permissions: under("applications:hs-case"),
     },
@@ -237,4 +237,27 @@ export function summarizePermissions(permissions: string[]): string {
         .map((slug) => DOMAIN_LABELS.get(slug) ?? slug)
         .sort((a, b) => a.localeCompare(b, "nb"));
     return labels.length === 0 ? "Ingen tilganger" : labels.join(", ");
+}
+
+/**
+ * What a holder gets *on top of* what the group already gives every member,
+ * e.g. "+ Arrangementer, Utlegg".
+ *
+ * A verv that repeats an access the whole group has adds nothing, and listing
+ * it on the holder's row reads as if it were personal — usually a leftover
+ * from before the group got the access. Only the difference is shown, and the
+ * plus sign says it is a difference and not the whole picture.
+ */
+export function summarizeExtraPermissions(
+    permissions: string[],
+    covered: Set<string>,
+): string {
+    if (permissions.includes("root")) return "Full tilgang (root)";
+    const labels = [...domainsOf(permissions)]
+        .filter((slug) => !covered.has(slug))
+        .map((slug) => DOMAIN_LABELS.get(slug) ?? slug)
+        .sort((a, b) => a.localeCompare(b, "nb"));
+    return labels.length === 0
+        ? "Ingen egne tilganger"
+        : `+ ${labels.join(", ")}`;
 }

--- a/apps/kvark/src/routes/admin/roller.tsx
+++ b/apps/kvark/src/routes/admin/roller.tsx
@@ -69,6 +69,7 @@ import {
     GROUP_SCOPABLE_DOMAINS,
     PERMISSION_DOMAINS,
     domainsOf,
+    summarizeExtraPermissions,
     summarizePermissions,
     toggleDomain,
 } from "#/lib/permission-domains";
@@ -310,40 +311,12 @@ function GroupPositionsItem({
     group: Group;
     isOpen: boolean;
 }) {
-    const canManage = useCanManagePositions(group.slug);
-    const [createOpen, setCreateOpen] = useState(false);
-
     return (
         <AccordionItem value={group.slug} className="px-4">
-            <div className="flex items-center gap-2">
-                {/* The trigger renders its own header wrapper, so the growth
-                    has to come from a div around it. */}
-                <div className="flex-1">
-                    <AccordionTrigger>{group.name}</AccordionTrigger>
-                </div>
-                {canManage ? (
-                    <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => setCreateOpen(true)}
-                    >
-                        <PlusIcon className="size-4" />
-                        Nytt verv
-                    </Button>
-                ) : null}
-            </div>
+            <AccordionTrigger>{group.name}</AccordionTrigger>
             <AccordionContent>
                 {isOpen ? <PositionsTable groupSlug={group.slug} /> : null}
             </AccordionContent>
-
-            {createOpen && (
-                <PositionDialog
-                    groupSlug={group.slug}
-                    open={createOpen}
-                    onOpenChange={setCreateOpen}
-                    position={null}
-                />
-            )}
         </AccordionItem>
     );
 }
@@ -358,8 +331,22 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
     const unassign = useMutation(unassignPositionMutation);
     const assign = useMutation(assignPositionMutation);
     const [editing, setEditing] = useState<GroupPosition | null>(null);
+    const [createOpen, setCreateOpen] = useState(false);
     const [assignQuery, setAssignQuery] = useState("");
     const [assignFor, setAssignFor] = useState<string | null>(null);
+    // The rows below list only what a holder has beyond the group, so they
+    // need the group's own two lists. Reading them requires managing the
+    // group; without them the column falls back to the full list.
+    const coveredForGroupScope = useGroupCoveredDomains(
+        groupSlug,
+        canManage,
+        "group",
+    );
+    const coveredForGlobalScope = useGroupCoveredDomains(
+        groupSlug,
+        canManage,
+        "global",
+    );
 
     // Holder candidates come from the group's member list (positions require
     // membership) — filtered client-side on name.
@@ -430,23 +417,13 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                     <LeaderRow
                         groupSlug={groupSlug}
                         canManage={canManage}
+                        covered={coveredForGroupScope}
                         leaders={leaders.map((leader) => ({
                             userId: leader.userId,
                             name: leader.user?.name ?? leader.userId,
                             image: leader.user?.image ?? null,
                         }))}
                     />
-
-                    {positions?.length === 0 ? (
-                        <TableRow>
-                            <TableCell colSpan={4}>
-                                <span className="text-sm text-muted-foreground">
-                                    Ingen verv ennå. Opprett det første med
-                                    «Nytt verv».
-                                </span>
-                            </TableCell>
-                        </TableRow>
-                    ) : null}
 
                     {(positions ?? []).map((position) => (
                         <TableRow key={position.id}>
@@ -541,7 +518,16 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                                 </div>
                             </TableCell>
                             <TableCell className="max-w-72 truncate text-sm text-muted-foreground">
-                                {summarizePermissions(position.permissions)}
+                                {canManage
+                                    ? summarizeExtraPermissions(
+                                          position.permissions,
+                                          position.scope === "global"
+                                              ? coveredForGlobalScope
+                                              : coveredForGroupScope,
+                                      )
+                                    : summarizePermissions(
+                                          position.permissions,
+                                      )}
                             </TableCell>
                             <TableCell>
                                 {canManage ? (
@@ -574,8 +560,46 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                             </TableCell>
                         </TableRow>
                     ))}
+
+                    {/* Closing row: the empty state and the create button sit
+                        together, so an empty table says what is missing and
+                        offers the fix in the same line. */}
+                    {canManage || positions?.length === 0 ? (
+                        <TableRow>
+                            <TableCell colSpan={4}>
+                                <div className="flex items-center justify-between gap-2">
+                                    {positions?.length === 0 ? (
+                                        <span className="text-sm text-muted-foreground">
+                                            Ingen verv ennå.
+                                        </span>
+                                    ) : (
+                                        <span />
+                                    )}
+                                    {canManage ? (
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            onClick={() => setCreateOpen(true)}
+                                        >
+                                            <PlusIcon className="size-4" />
+                                            Ny rolle
+                                        </Button>
+                                    ) : null}
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                    ) : null}
                 </TableBody>
             </Table>
+
+            {createOpen && (
+                <PositionDialog
+                    groupSlug={groupSlug}
+                    open={createOpen}
+                    onOpenChange={setCreateOpen}
+                    position={null}
+                />
+            )}
 
             {editing && (
                 <PositionDialog
@@ -822,10 +846,14 @@ function useGroupCoveredDomains(
 function LeaderRow({
     groupSlug,
     canManage,
+    covered,
     leaders,
 }: {
     groupSlug: string;
     canManage: boolean;
+    /** Domains the group already gives every member, and which the leader
+     *  therefore does not get listed for a second time. */
+    covered: Set<string>;
     leaders: { userId: string; name: string; image: string | null }[];
 }) {
     const [editing, setEditing] = useState(false);
@@ -865,7 +893,7 @@ function LeaderRow({
             </TableCell>
             <TableCell className="max-w-72 truncate text-sm text-muted-foreground">
                 {canManage
-                    ? summarizePermissions(permissions)
+                    ? summarizeExtraPermissions(permissions, covered)
                     : "Gruppens ledertilganger"}
             </TableCell>
             <TableCell>


### PR DESCRIPTION
## Hva

På **Verv og tilganger** ble tilgangene hele gruppa har gjentatt på hver enkelt holder. En leder så dermed ut til å ha «Arrangementer» personlig, selv om raden over — «Alle medlemmer» — allerede ga den til alle.

- Verv- og lederrader viser nå bare det holderen har **utover** gruppa, som `+ Refundering, Utlegg`. Er det ingenting eget, står det «Ingen egne tilganger». `root` vises fortsatt som «Full tilgang (root)».
- Et verv med globalt scope måles mot gruppas globale liste, ikke den gruppeinterne — ellers ville en tilgang gruppa bare har for seg selv skjult en som gjelder hele TIHLDE.
- «Alle medlemmer»-raden er uendret; det er der tilgangen faktisk bor. Uten administrasjonstilgang på gruppa vises hele lista uten `+`, siden medlemstilgangene ikke kan leses da (403).

## Ellers

- Kortere navn på boksene: `Søknader – utlegg` → **Utlegg**, `Refusjon av betalinger` → **Refundering**, `Verv og tilganger` → **Tilganger**, `Søknader – saker til HS` → **Saker til HS**, `Søknader – støtte` → **Støtte til HS**.
- Opprett-knappen er flyttet fra accordion-headeren ned i tabellens siste rad, høyrestilt, og heter nå **«Ny rolle»**. Er gruppa uten verv, står «Ingen verv ennå.» på samme linje.

## Testing

Kjørt lokalt mot dev-databasen, innlogget som administrator:

- **Hovedstyret** (11 verv): leder-raden gikk fra «Arrangementer» til «Ingen egne tilganger»; Finansministeren leses som «+ Refundering, Tilganger, Utlegg».
- **Native** (ingen verv): «Ingen verv ennå.» til venstre og «Ny rolle» til høyre i samme rad.
- Ingen konsollfeil. `bun run typecheck`, `bun run lint` og `bun run format` er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)