### PR TITLE
fix(kvark): bredere tilgangsdialoger på desktop

### DIFF
--- a/apps/kvark/src/routes/admin/roller.tsx
+++ b/apps/kvark/src/routes/admin/roller.tsx
@@ -724,7 +724,7 @@ function MemberPermissionsDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-xl">
+            <DialogContent className="sm:max-w-2xl">
                 <DialogHeader>
                     <DialogTitle>Tilganger for alle medlemmer</DialogTitle>
                 </DialogHeader>
@@ -932,7 +932,7 @@ function LeaderPermissionsDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-xl">
+            <DialogContent className="sm:max-w-2xl">
                 <DialogHeader>
                     <DialogTitle>Rediger ledertilganger</DialogTitle>
                 </DialogHeader>
@@ -1097,7 +1097,7 @@ function PositionDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-xl">
+            <DialogContent className="sm:max-w-2xl">
                 <DialogHeader>
                     <DialogTitle>
                         {position ? `Rediger «${position.name}»` : "Nytt verv"}


### PR DESCRIPTION
## Hva

Tilgangsdialogene i `/admin/roller` var smale på desktop, så etiketter som «Arrangementer» og «Søknader – idrettsstøtte» brøt over to linjer.

## Hvorfor

`DialogContent` i `@tihlde/ui` har `sm:max-w-sm` som default. Den responsive varianten slår `max-w-xl` (uten prefiks), så dialogene ble 384 px fra 640 px oppover uansett. Fikset ved å bruke `sm:max-w-2xl`, som tailwind-merge lar overstyre defaulten.

Gjelder alle tre dialogene med tilgangsrutenett: «Tilganger for alle medlemmer», «Rediger ledertilganger» og «Nytt verv».

## Verifisert

- Målt i nettleseren: dialogen er nå 672 px, og alle etikettene står på én linje i 3-kolonners rutenettet.
- `bun run lint` — bare forhåndseksisterende warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)