### PR TITLE
fix(groups): sett forrige leder ned ved lederbytte

### DIFF
--- a/apps/api/src/lib/group/index.ts
+++ b/apps/api/src/lib/group/index.ts
@@ -9,7 +9,7 @@
 
 import { hasPermission, hasScopedPermission } from "@photon/auth/rbac";
 import { type DbSchema, schema } from "@photon/db";
-import { type InferSelectModel, and, eq, inArray } from "drizzle-orm";
+import { type InferSelectModel, and, eq, inArray, ne } from "drizzle-orm";
 import type { AppContext } from "~/lib/ctx";
 import { HTTPAppException } from "~/lib/errors";
 
@@ -205,11 +205,49 @@ export async function addUserToGroup(
     // grants it and leaving revokes it with nothing to sync.
 
     // Subgroup leaders sit in HS
-    if (role === "leader") {
+    if (membership.role === "leader") {
+        await demoteOtherLeaders(ctx, groupSlug, userId);
         await syncSubgroupLeaderIntoHs(ctx, userId, group);
     }
 
     return membership;
+}
+
+/**
+ * En gruppe har én leder. Sett alle andre ledere ned til vanlig medlem når
+ * `newLeaderId` tar over.
+ *
+ * Uten dette blir den forrige lederen liggende igjen med `role = "leader"`, og
+ * gruppesiden viser bare den første av dem: den andre forsvinner fra både
+ * medlemslista og «tidligere medlemmer», mens profilen hans fortsatt sier
+ * «Leder». Da finnes det heller ingen knapp igjen for å fjerne ham.
+ */
+export async function demoteOtherLeaders(
+    ctx: AppContext,
+    groupSlug: string,
+    newLeaderId: string,
+): Promise<void> {
+    const outgoing = await ctx.db
+        .update(schema.groupMembership)
+        .set({ role: "member", updatedAt: new Date() })
+        .where(
+            and(
+                eq(schema.groupMembership.groupSlug, groupSlug),
+                eq(schema.groupMembership.role, "leader"),
+                ne(schema.groupMembership.userId, newLeaderId),
+            ),
+        )
+        .returning({ userId: schema.groupMembership.userId });
+
+    if (outgoing.length === 0) return;
+
+    // Avgåtte undergruppeledere mister HS-plassen på samme måte som når de
+    // settes ned manuelt eller meldes ut.
+    const group = await getGroup(ctx, groupSlug);
+    if (!group || !isSubgroupType(group.type)) return;
+    for (const { userId } of outgoing) {
+        await syncSubgroupLeaderOutOfHs(ctx, userId, groupSlug);
+    }
 }
 
 /**
@@ -321,13 +359,18 @@ export async function updateGroupMemberRole(
 
     await db
         .update(schema.groupMembership)
-        .set({ role: newRole })
+        .set({ role: newRole, updatedAt: new Date() })
         .where(
             and(
                 eq(schema.groupMembership.userId, userId),
                 eq(schema.groupMembership.groupSlug, groupSlug),
             ),
         );
+
+    // Lederbyttet setter den forrige lederen ned — gruppa har én leder.
+    if (newRole === "leader") {
+        await demoteOtherLeaders(ctx, groupSlug, userId);
+    }
 
     const group = await getGroup(ctx, groupSlug);
 

--- a/apps/api/src/routes/groups/members/update.ts
+++ b/apps/api/src/routes/groups/members/update.ts
@@ -2,7 +2,7 @@ import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
-import { isDerivedGroupType } from "~/lib/group";
+import { isDerivedGroupType, updateGroupMemberRole } from "~/lib/group";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -42,7 +42,8 @@ export const updateMemberRoleRoute = route().patch(
         const body = c.req.valid("json");
         const groupSlug = c.req.param("groupSlug");
         const userId = c.req.param("userId");
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
 
         // Validate group exists
         const group = await db
@@ -83,19 +84,10 @@ export const updateMemberRoleRoute = route().patch(
             });
         }
 
-        // Update role
-        await db
-            .update(schema.groupMembership)
-            .set({
-                role: body.role,
-                updatedAt: new Date(),
-            })
-            .where(
-                and(
-                    eq(schema.groupMembership.userId, userId),
-                    eq(schema.groupMembership.groupSlug, groupSlug),
-                ),
-            );
+        // Goes through the helper rather than a bare UPDATE: it sets the
+        // sitting leader down (a group has one leader) and keeps the HS seat
+        // for subgroup leaders in sync.
+        await updateGroupMemberRole(ctx, userId, groupSlug, body.role);
 
         return c.json(
             {

--- a/apps/api/src/test/groups/members.test.ts
+++ b/apps/api/src/test/groups/members.test.ts
@@ -694,6 +694,126 @@ describe("group members", () => {
         );
 
         integrationTest(
+            "promoting a new leader sets the sitting one down",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+
+                await ctx.utils.giveUserPermissions(user, ["groups:manage"]);
+
+                const group = await ctx.utils.createTestGroup();
+
+                const oldLeader = await ctx.auth.api.createUser({
+                    body: {
+                        email: "old-leader@test.com",
+                        name: "Old Leader",
+                        password: "test123!",
+                    },
+                });
+                const newLeader = await ctx.auth.api.createUser({
+                    body: {
+                        email: "new-leader@test.com",
+                        name: "New Leader",
+                        password: "test123!",
+                    },
+                });
+
+                await ctx.db.insert(schema.groupMembership).values([
+                    {
+                        userId: oldLeader.user.id,
+                        groupSlug: group.slug,
+                        role: "leader",
+                    },
+                    {
+                        userId: newLeader.user.id,
+                        groupSlug: group.slug,
+                        role: "member",
+                    },
+                ]);
+
+                const response = await client.api.groups[":groupSlug"].members[
+                    ":userId"
+                ].$patch({
+                    param: {
+                        groupSlug: group.slug,
+                        userId: newLeader.user.id,
+                    },
+                    json: { role: "leader" },
+                });
+
+                expect(response.status).toBe(200);
+
+                // En gruppe har en leder: den forrige er na vanlig medlem, og
+                // ikke en usynlig ekstra leder som gruppesiden hopper over.
+                const memberships = await ctx.db.query.groupMembership.findMany(
+                    {
+                        where: eq(schema.groupMembership.groupSlug, group.slug),
+                    },
+                );
+                const roleByUser = new Map(
+                    memberships.map((m) => [m.userId, m.role]),
+                );
+                expect(roleByUser.get(newLeader.user.id)).toBe("leader");
+                expect(roleByUser.get(oldLeader.user.id)).toBe("member");
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "adding a member as leader sets the sitting one down",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+
+                await ctx.utils.giveUserPermissions(user, ["groups:manage"]);
+
+                const group = await ctx.utils.createTestGroup();
+
+                const oldLeader = await ctx.auth.api.createUser({
+                    body: {
+                        email: "sitting-leader@test.com",
+                        name: "Sitting Leader",
+                        password: "test123!",
+                    },
+                });
+                const newLeader = await ctx.auth.api.createUser({
+                    body: {
+                        email: "incoming-leader@test.com",
+                        name: "Incoming Leader",
+                        password: "test123!",
+                    },
+                });
+
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: oldLeader.user.id,
+                    groupSlug: group.slug,
+                    role: "leader",
+                });
+
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].members.$post({
+                    param: { groupSlug: group.slug },
+                    json: { userId: newLeader.user.id, role: "leader" },
+                });
+
+                expect(response.status).toBe(201);
+
+                const memberships = await ctx.db.query.groupMembership.findMany(
+                    {
+                        where: eq(schema.groupMembership.groupSlug, group.slug),
+                    },
+                );
+                const roleByUser = new Map(
+                    memberships.map((m) => [m.userId, m.role]),
+                );
+                expect(roleByUser.get(newLeader.user.id)).toBe("leader");
+                expect(roleByUser.get(oldLeader.user.id)).toBe("member");
+            },
+            500_000,
+        );
+
+        integrationTest(
             "successfully updates member role from leader to member",
             async ({ ctx }) => {
                 const user = await ctx.utils.createTestUser();

--- a/apps/kvark/src/components/group-members-tab.tsx
+++ b/apps/kvark/src/components/group-members-tab.tsx
@@ -14,7 +14,11 @@ import type { Member } from "#/lib/group";
 import { cn } from "#/lib/utils";
 
 type GroupMembersTabProps = {
-    leader: Member | null;
+    /**
+     * Normalt én. Skulle det ligge igjen flere ledere i databasen, vises alle
+     * — ellers forsvinner de ekstra fra siden og kan ikke fjernes derfra.
+     */
+    leaders: Member[];
     members: Member[];
     /** Avsluttede medlemskap. Tom liste skjuler seksjonen helt. */
     formerMembers: Member[];
@@ -29,7 +33,7 @@ type GroupMembersTabProps = {
 };
 
 export function GroupMembersTab({
-    leader,
+    leaders,
     members,
     formerMembers,
     isAdmin,
@@ -49,14 +53,20 @@ export function GroupMembersTab({
                 }
             />
 
-            {leader ? (
+            {leaders.length > 0 ? (
                 <div className="flex flex-col gap-2">
                     <h3 className="text-lg">Leder</h3>
-                    <GroupMemberRow
-                        member={leader}
-                        isLeader
-                        onRemove={isAdmin ? onRemove : undefined}
-                    />
+                    <ul className="flex flex-col gap-2">
+                        {leaders.map((m) => (
+                            <li key={m.id}>
+                                <GroupMemberRow
+                                    member={m}
+                                    isLeader
+                                    onRemove={isAdmin ? onRemove : undefined}
+                                />
+                            </li>
+                        ))}
+                    </ul>
                 </div>
             ) : null}
 

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -299,8 +299,8 @@ function GroupDetail() {
         () => sortMembersByName((apiMembers ?? []).map(mapMember)),
         [apiMembers],
     );
-    const leader = useMemo(
-        () => members.find((m) => m.role === "leader") ?? null,
+    const leaders = useMemo(
+        () => members.filter((m) => m.role === "leader"),
         [members],
     );
     const regularMembers = useMemo(
@@ -334,8 +334,8 @@ function GroupDetail() {
         [memberSearchResults, members],
     );
     const group = useMemo(
-        () => mapGroup(apiGroup, leader?.name),
-        [apiGroup, leader],
+        () => mapGroup(apiGroup, leaders[0]?.name),
+        [apiGroup, leaders],
     );
     const fines = useMemo(
         () =>
@@ -584,7 +584,7 @@ function GroupDetail() {
                     {activeTab === "om" ? <GroupOmTab group={group} /> : null}
                     {activeTab === "medlemmer" ? (
                         <GroupMembersTab
-                            leader={leader}
+                            leaders={leaders}
                             members={regularMembers}
                             formerMembers={formerMembers}
                             isAdmin={canManageMembers}


### PR DESCRIPTION
## Bakgrunn

Melding fra Podden: de byttet leder og fjernet Torkil som medlem. Etterpå sto han verken som medlem eller tidligere medlem på gruppesiden, men profilen hans sa fortsatt at han var leder i Podden.

## Årsak

`PATCH /groups/:slug/members/:userId` gjorde en rå `UPDATE` av rollen uten å røre den sittende lederen, så gruppa endte med **to** ledere i basen. Gruppesiden plukker lederen med `members.find(m => m.role === "leader")` og filtrerer bort alle med lederrolle fra medlemslista — sortert på navn kom den nye lederen først, og den gamle forsvant helt fra siden. Dermed fantes det heller ingen fjern-knapp for ham, så «fjerningen» traff aldri noe. Profilen leste rett fra basen og hadde rett.

Ruten brukte i tillegg ikke `updateGroupMemberRole`, så et lederbytte i en undergruppe heller ikke synket HS-plassen.

## Endringer

- `addUserToGroup` og `updateGroupMemberRole` setter alle andre ledere ned til medlem når noen tar over, og avgåtte undergruppeledere mister HS-plassen på samme måte som ved manuell nedsetting
- PATCH-ruten går via `updateGroupMemberRole` i stedet for en rå UPDATE
- Gruppesiden viser alle med lederrolle, så en eventuell ekstra leder aldri blir usynlig og ufjernbar igjen
- To nye integrasjonstester: promotering via PATCH og innmelding som leder setter begge den sittende lederen ned

## Verifisering

- `bun run typecheck`, `bun run lint`, `bun run build` grønt
- 136 gruppetester passerer, inkludert de to nye
- Prod-dataene er ryddet manuelt: Torkil er flyttet til historikken som *medlem*, Podden har én leder. Han var eneste tilfelle med dobbel leder i hele basen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)