### PR TITLE
feat(kvark): flytt slett-knapper inntil lagre og bekreft i egen dialog

### DIFF
--- a/apps/kvark/src/components/confirm-delete-dialog.tsx
+++ b/apps/kvark/src/components/confirm-delete-dialog.tsx
@@ -1,0 +1,63 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@tihlde/ui/ui/alert-dialog";
+import type { ReactNode } from "react";
+
+type ConfirmDeleteDialogProps = {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /** Spørsmål som navngir det som slettes, f.eks. «Slette «Fadderuka»?». */
+    title: ReactNode;
+    /** Én linje om hva som forsvinner, og at det ikke kan angres. */
+    description: ReactNode;
+    /** Handlingen, kort og konkret: «Slett arrangement». */
+    confirmLabel: string;
+    onConfirm: () => void;
+    isPending?: boolean;
+};
+
+/**
+ * Bekreftelse før noe slettes for godt. Erstatter `window.confirm`, slik at
+ * teksten kan si hva som faktisk skjer og knappene ser ut som resten av appen.
+ */
+export function ConfirmDeleteDialog({
+    open,
+    onOpenChange,
+    title,
+    description,
+    confirmLabel,
+    onConfirm,
+    isPending = false,
+}: ConfirmDeleteDialogProps) {
+    return (
+        <AlertDialog open={open} onOpenChange={onOpenChange}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{title}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        {description}
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel variant="outline" size="default">
+                        Avbryt
+                    </AlertDialogCancel>
+                    <AlertDialogAction
+                        variant="destructive"
+                        disabled={isPending}
+                        onClick={onConfirm}
+                    >
+                        {confirmLabel}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}

--- a/apps/kvark/src/components/event-form.tsx
+++ b/apps/kvark/src/components/event-form.tsx
@@ -77,6 +77,8 @@ type EventFormProps = {
     onSubmit: (event: FormEvent<HTMLFormElement>) => void;
     submitLabel: string;
     isSubmitting: boolean;
+    /** Knapp som legger seg til venstre for lagreknappen, f.eks. slett. */
+    secondaryAction?: ReactNode;
     /** Statusmeldinger som vises rett over knappen. */
     children?: ReactNode;
 };
@@ -98,6 +100,7 @@ export function EventForm({
     onSubmit,
     submitLabel,
     isSubmitting,
+    secondaryAction,
     children,
 }: EventFormProps) {
     /** Sist valgte adresse, se `handleLocationChange`. */
@@ -588,7 +591,8 @@ export function EventForm({
 
             {children}
 
-            <div className="flex justify-end">
+            <div className="flex justify-end gap-2">
+                {secondaryAction}
                 <Button
                     type="submit"
                     disabled={isSubmitting || !values.organizerGroupSlug}

--- a/apps/kvark/src/components/group-law-form-dialog.tsx
+++ b/apps/kvark/src/components/group-law-form-dialog.tsx
@@ -14,6 +14,8 @@ import { useEffect, useState } from "react";
 
 import type { Law } from "#/lib/group";
 
+import { ConfirmDeleteDialog } from "#/components/confirm-delete-dialog";
+
 export type LawFormValues = {
     paragraph: number;
     title: string;
@@ -40,6 +42,7 @@ export function GroupLawFormDialog({
     const [title, setTitle] = useState("");
     const [description, setDescription] = useState("");
     const [amount, setAmount] = useState("1");
+    const [confirmDelete, setConfirmDelete] = useState(false);
 
     // Re-seed the fields whenever the dialog opens for a (different) law.
     useEffect(() => {
@@ -163,7 +166,7 @@ export function GroupLawFormDialog({
                         <Button
                             variant="destructive"
                             className="mr-auto"
-                            onClick={onDelete}
+                            onClick={() => setConfirmDelete(true)}
                         >
                             Slett
                         </Button>
@@ -175,6 +178,18 @@ export function GroupLawFormDialog({
                         {law ? "Oppdater" : "Opprett"}
                     </Button>
                 </DialogFooter>
+
+                <ConfirmDeleteDialog
+                    open={confirmDelete}
+                    onOpenChange={setConfirmDelete}
+                    title={`Slette §${law?.paragraph} ${law?.title}?`}
+                    description="Paragrafen fjernes fra gruppens lovverk for godt. Bøter som allerede er gitt blir stående."
+                    confirmLabel="Slett paragraf"
+                    onConfirm={() => {
+                        setConfirmDelete(false);
+                        onDelete?.();
+                    }}
+                />
             </DialogContent>
         </Dialog>
     );

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -62,6 +62,7 @@ import { getInstitutesQuery } from "#/api/queries/institutes";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { AdminStatCard } from "#/components/admin-stat-card";
+import { ConfirmDeleteDialog } from "#/components/confirm-delete-dialog";
 import type { EventFormValues } from "#/components/event-form";
 import { ALL_INSTITUTES, EventForm } from "#/components/event-form";
 import type { NewFormValues } from "#/components/new-form-dialog";
@@ -275,6 +276,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
         valuesFromEvent(event),
     );
     const [uploadError, setUploadError] = useState<string | null>(null);
+    const [confirmDelete, setConfirmDelete] = useState(false);
 
     const debouncedLocation = useDebounced(values.location, 250);
     const { data: addressSuggestions, isFetching: isSearchingAddress } =
@@ -378,13 +380,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
     }
 
     function handleDelete() {
-        if (
-            !window.confirm(
-                `Slette «${event.title}»? Dette kan ikke angres, og alle påmeldinger forsvinner.`,
-            )
-        ) {
-            return;
-        }
+        setConfirmDelete(false);
         removeEvent.mutate(
             { eventId },
             { onSuccess: () => navigate({ to: "/admin/arrangementer" }) },
@@ -421,6 +417,18 @@ function DetailsTab({ eventId }: { eventId: string }) {
                     isUploading ? "Laster opp bilde …" : "Lagre endringer"
                 }
                 isSubmitting={updateEvent.isPending || isUploading}
+                secondaryAction={
+                    canDelete ? (
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            onClick={() => setConfirmDelete(true)}
+                            disabled={removeEvent.isPending}
+                        >
+                            Slett arrangement
+                        </Button>
+                    ) : undefined
+                }
             >
                 {uploadError && (
                     <Alert variant="destructive">
@@ -449,18 +457,15 @@ function DetailsTab({ eventId }: { eventId: string }) {
                 )}
             </EventForm>
 
-            {canDelete && (
-                <div className="flex justify-end">
-                    <Button
-                        type="button"
-                        variant="destructive"
-                        onClick={handleDelete}
-                        disabled={removeEvent.isPending}
-                    >
-                        Slett arrangement
-                    </Button>
-                </div>
-            )}
+            <ConfirmDeleteDialog
+                open={confirmDelete}
+                onOpenChange={setConfirmDelete}
+                title={`Slette «${event.title}»?`}
+                description="Arrangementet og alle påmeldinger slettes for godt. Dette kan ikke angres."
+                confirmLabel="Slett arrangement"
+                isPending={removeEvent.isPending}
+                onConfirm={handleDelete}
+            />
         </div>
     );
 }


### PR DESCRIPTION
## Hva

«Slett arrangement» lå i en egen rad **under** lagreknappen på `/admin/arrangementer/$eventId`, og bekreftet med en `window.confirm`. Nå:

- Knappen ligger **til venstre for «Lagre endringer»**, i samme rad.
- Trykk på slett åpner en egen bekreftelsesdialog i stedet for nettleserens `confirm`.

Ny delt komponent `ConfirmDeleteDialog` (tittel + én linje + `Avbryt` / destruktiv handling), bygget på `AlertDialog` fra `@tihlde/ui`.

Tekstene sier hva som faktisk skjer:

- Arrangement: **«Slette «‹tittel›»?»** — «Arrangementet og alle påmeldinger slettes for godt. Dette kan ikke angres.» — `Avbryt` · `Slett arrangement`
- Lovparagraf: **«Slette §N Tittel?»** — «Paragrafen fjernes fra gruppens lovverk for godt. Bøter som allerede er gitt blir stående.» — `Avbryt` · `Slett paragraf`

## Endringer

- `apps/kvark/src/components/confirm-delete-dialog.tsx` (ny) — delt bekreftelsesdialog.
- `apps/kvark/src/components/event-form.tsx` — ny valgfri `secondaryAction`-prop som rendres i samme rad som submit-knappen, til venstre for den.
- `apps/kvark/src/routes/admin/arrangementer.$eventId.tsx` — slett-knappen flyttet inn i `secondaryAction`; `window.confirm` erstattet av dialogen.
- `apps/kvark/src/components/group-law-form-dialog.tsx` — sletting av lovparagraf hadde **ingen bekreftelse i det hele tatt**; bruker nå samme dialog.

## Avgrensning

En gjennomgang av appen fant bare ett ekte «slett under Lagre»-tilfelle (arrangementsiden). De andre slett-knappene ligger i tabellrader eller nedtrekksmenyer og er derfor urørt.

`gallery-picture-editor-dialog.tsx` har allerede «Slett bilde» til venstre for «Lagre» og bekrefter inline. Koden har en eksplisitt kommentar om at den unngår et tredje dialoglag fordi den åpnes fra lightboxen — den er bevisst latt være.

## Verifisert

- `bun run typecheck` (kun eksisterende `@photon/email`-feil i `packages/core`, urelatert), oxfmt/oxlint rent for de endrede filene.
- I nettleseren mot lokal API: slett-knappen ligger til venstre for lagre, dialogen åpnes, `Avbryt` lukker uten å slette. I lovverksdialogen ble en testparagraf opprettet, slettet gjennom den nye dialogen og bekreftet borte — ingen testdata igjen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)