### PR TITLE
feat(grupper): la gruppetype og underkategori endres

### DIFF
--- a/apps/kvark/src/components/group-edit-dialog.tsx
+++ b/apps/kvark/src/components/group-edit-dialog.tsx
@@ -15,6 +15,13 @@ import {
     FieldLabel,
 } from "@tihlde/ui/ui/field";
 import { Input } from "@tihlde/ui/ui/input";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@tihlde/ui/ui/select";
 import { Separator } from "@tihlde/ui/ui/separator";
 import { Switch } from "@tihlde/ui/ui/switch";
 import { RichEditor } from "@tihlde/ui/complex/markdown";
@@ -26,12 +33,23 @@ import {
     MemberSingleCombobox,
     type ComboboxMember,
 } from "#/components/user-combobox";
-import type { Group } from "#/lib/group";
+import {
+    canEditGroupType,
+    GROUP_SUBTYPE_OPTIONS,
+    GROUP_TYPE_OPTIONS,
+    groupSubtypeValue,
+    supportsGroupSubtype,
+    type Group,
+} from "#/lib/group";
 
 export type GroupEditValues = {
     name: string;
     description: string;
     contactEmail: string;
+    /** Utelatt for automatisk genererte grupper, som ikke kan bytte type. */
+    type?: string;
+    /** Bare satt når typen har en underkategori (interessegrupper). */
+    subtype?: string | null;
     finesActivated: boolean;
     finesAdminId: string | null;
     finesInfo: string;
@@ -57,6 +75,8 @@ export function GroupEditDialog({
     const [name, setName] = useState(group.name);
     const [description, setDescription] = useState(group.description);
     const [contactEmail, setContactEmail] = useState(group.contactEmail);
+    const [type, setType] = useState(group.type ?? "");
+    const [subtype, setSubtype] = useState(groupSubtypeValue(group.subtype));
     const [finesActivated, setFinesActivated] = useState(
         group.finesActivated ?? false,
     );
@@ -70,6 +90,8 @@ export function GroupEditDialog({
         setName(group.name);
         setDescription(group.description);
         setContactEmail(group.contactEmail);
+        setType(group.type ?? "");
+        setSubtype(groupSubtypeValue(group.subtype));
         setFinesActivated(group.finesActivated ?? false);
         setFinesInfo(group.finesInfo ?? "");
         setFinesAdmin(
@@ -77,12 +99,24 @@ export function GroupEditDialog({
         );
     }, [open, group, members]);
 
+    const typeEditable = canEditGroupType(group.type ?? "");
+    const hasSubtype = supportsGroupSubtype(type);
+
     function handleSubmit(event: React.FormEvent) {
         event.preventDefault();
         onSubmit({
             name: name.trim(),
             description,
             contactEmail: contactEmail.trim(),
+            ...(typeEditable
+                ? {
+                      type,
+                      // Underkategorien hører til interessegrupper. Blir gruppa
+                      // noe annet, tømmes den — ellers ville en gammel
+                      // «IDRETTSGRUPPE» blitt liggende igjen usynlig.
+                      subtype: hasSubtype ? subtype : null,
+                  }
+                : {}),
             finesActivated,
             finesAdminId: finesAdmin?.id ?? null,
             finesInfo,
@@ -150,6 +184,73 @@ export function GroupEditDialog({
                                 }
                             />
                         </Field>
+                        {typeEditable ? (
+                            <Field>
+                                <FieldLabel htmlFor="group-type">
+                                    Gruppetype
+                                </FieldLabel>
+                                <Select
+                                    items={[...GROUP_TYPE_OPTIONS]}
+                                    value={type}
+                                    onValueChange={(value) =>
+                                        setType(value ?? type)
+                                    }
+                                >
+                                    <SelectTrigger id="group-type">
+                                        <SelectValue placeholder="Velg type" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {GROUP_TYPE_OPTIONS.map((option) => (
+                                            <SelectItem
+                                                key={option.value}
+                                                value={option.value}
+                                            >
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <FieldDescription>
+                                    Bestemmer hvor gruppen står i
+                                    organisasjonskartet.
+                                </FieldDescription>
+                            </Field>
+                        ) : null}
+                        {typeEditable && hasSubtype ? (
+                            <Field>
+                                <FieldLabel htmlFor="group-subtype">
+                                    Underkategori
+                                </FieldLabel>
+                                <Select
+                                    items={[...GROUP_SUBTYPE_OPTIONS]}
+                                    value={subtype}
+                                    onValueChange={(value) =>
+                                        setSubtype(
+                                            (value as typeof subtype) ??
+                                                subtype,
+                                        )
+                                    }
+                                >
+                                    <SelectTrigger id="group-subtype">
+                                        <SelectValue placeholder="Velg underkategori" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {GROUP_SUBTYPE_OPTIONS.map((option) => (
+                                            <SelectItem
+                                                key={option.value}
+                                                value={option.value}
+                                            >
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <FieldDescription>
+                                    Idrettsgrupper får sin egen seksjon i
+                                    organisasjonskartet.
+                                </FieldDescription>
+                            </Field>
+                        ) : null}
 
                         <Separator />
 

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -25,6 +25,8 @@ export type Group = {
     /** Logo: kvadratisk merke, vises i avatarer og kort. */
     logoUrl?: string;
     type?: string;
+    /** Underkategori under `type`. I dag bare for interessegrupper. */
+    subtype?: string | null;
     leader?: string;
     finesInfo?: string;
     finesActivated?: boolean;
@@ -142,6 +144,67 @@ export function groupTypeLabel(type: string): string {
 }
 
 /**
+ * Gruppetypene som kan settes fra grensesnittet, i den rekkefølgen de vises.
+ *
+ * Klassetrinn, studier, TIHLDE og private bøtelag står ikke her: de lages
+ * automatisk, og å endre typen deres ville koblet gruppa fra logikken som
+ * vedlikeholder den. {@link canEditGroupType} avgjør hvem som får velge.
+ */
+export const EDITABLE_GROUP_TYPES = [
+    "SUBGROUP",
+    "COMMITTEE",
+    "BOARD",
+    "INTERESTGROUP",
+    "SPORTSTEAM",
+] as const;
+
+export type EditableGroupType = (typeof EDITABLE_GROUP_TYPES)[number];
+
+/** Valgene til en gruppetype-nedtrekksliste, med norske navn. */
+export const GROUP_TYPE_OPTIONS = EDITABLE_GROUP_TYPES.map((value) => ({
+    value,
+    label: groupTypeLabel(value),
+}));
+
+/**
+ * Om typen til gruppa kan endres. Automatisk genererte grupper står fast —
+ * se {@link EDITABLE_GROUP_TYPES}.
+ */
+export function canEditGroupType(type: string): boolean {
+    return (EDITABLE_GROUP_TYPES as readonly string[]).includes(
+        type.toUpperCase(),
+    );
+}
+
+/**
+ * Interessegruppenes andre akse: en vanlig gruppe eller en idrettsgruppe.
+ * Organisasjonskartet viser de to som hver sin seksjon, og ingenting annet
+ * skiller dem — typen er INTERESTGROUP for begge.
+ */
+export const GROUP_SUBTYPE_OPTIONS = [
+    { value: "GRUPPE", label: "Gruppe" },
+    { value: "IDRETTSGRUPPE", label: "Idrettsgruppe" },
+] as const;
+
+export type GroupSubtype = (typeof GROUP_SUBTYPE_OPTIONS)[number]["value"];
+
+/** Om underkategorien er meningsfull for denne typen. Bare interessegrupper. */
+export function supportsGroupSubtype(type: string): boolean {
+    return type.toUpperCase() === "INTERESTGROUP";
+}
+
+/**
+ * Underkategorien slik nedtrekkslista skal vise den. Gruppene Lepton aldri
+ * kategoriserte har null, og de leses som «Gruppe» — det er også slik
+ * organisasjonskartet plasserer dem.
+ */
+export function groupSubtypeValue(subtype: string | null | undefined) {
+    return subtype?.toUpperCase() === "IDRETTSGRUPPE"
+        ? "IDRETTSGRUPPE"
+        : "GRUPPE";
+}
+
+/**
  * Om gruppa bare er for medlemmene sine.
  *
  * En PRIVAT gruppe (digital transformasjon-faddergruppa er eksempelet) står
@@ -177,6 +240,7 @@ export function mapGroup(group: ApiGroup, leader?: string): Group {
         imageUrl: group.imageUrl ?? undefined,
         logoUrl: group.logoUrl ?? undefined,
         type: group.type,
+        subtype: group.subtype ?? null,
         leader,
         finesInfo: group.finesInfo,
         finesActivated: group.finesActivated,

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -405,6 +405,8 @@ function GroupDetail() {
                     name: values.name,
                     description: values.description,
                     contactEmail: values.contactEmail,
+                    ...(values.type ? { type: values.type } : {}),
+                    ...(values.type ? { subtype: values.subtype } : {}),
                     finesActivated: values.finesActivated,
                     finesAdminId: values.finesAdminId,
                     finesInfo: values.finesInfo,

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -87,7 +87,14 @@ import {
     useLedGroupSlugs,
     useScopedPermission,
 } from "#/hooks/use-permission";
-import { groupTypeLabel } from "#/lib/group";
+import {
+    canEditGroupType,
+    GROUP_SUBTYPE_OPTIONS,
+    GROUP_TYPE_OPTIONS,
+    groupSubtypeValue,
+    groupTypeLabel,
+    supportsGroupSubtype,
+} from "#/lib/group";
 
 export const Route = createFileRoute("/admin/grupper")({
     component: GrupperAdminPage,
@@ -98,13 +105,18 @@ export const Route = createFileRoute("/admin/grupper")({
 });
 
 // Kontraktsignering gjelder kun verv (undergrupper, komiteer, styrer,
-// interessegrupper). Automatisk genererte grupper (klassetrinn, studier,
-// TIHLDE) og private bøtelag skal ikke administreres her.
+// interessegrupper, idrettslag). Automatisk genererte grupper (klassetrinn,
+// studier, TIHLDE) og private bøtelag skal ikke administreres her.
+//
+// Fanene dekker de samme typene som kan velges i redigeringen
+// (EDITABLE_GROUP_TYPES), slik at en gruppe som bytter type fortsatt står i
+// en fane etterpå.
 const GROUP_TYPE_TABS = [
     { type: "SUBGROUP", label: "Undergrupper" },
     { type: "COMMITTEE", label: "Komiteer" },
     { type: "BOARD", label: "Styrer" },
     { type: "INTERESTGROUP", label: "Interessegrupper" },
+    { type: "SPORTSTEAM", label: "Idrettslag" },
 ] as const;
 
 type TabType = (typeof GROUP_TYPE_TABS)[number]["type"];
@@ -227,6 +239,7 @@ function CreateGroupDialog({
     const [slugTouched, setSlugTouched] = useState(false);
     const [description, setDescription] = useState("");
     const [type, setType] = useState<TabType>(defaultType);
+    const [subtype, setSubtype] = useState<string>("GRUPPE");
     const [error, setError] = useState<string | null>(null);
 
     const createGroup = useMutation(createGroupMutation);
@@ -245,6 +258,7 @@ function CreateGroupDialog({
                     name,
                     slug,
                     type,
+                    ...(supportsGroupSubtype(type) ? { subtype } : {}),
                     description: description || undefined,
                     finesInfo: "",
                     finesActivated: false,
@@ -326,6 +340,38 @@ function CreateGroupDialog({
                                 </SelectContent>
                             </Select>
                         </Field>
+                        {supportsGroupSubtype(type) ? (
+                            <Field>
+                                <FieldLabel htmlFor="group-subtype">
+                                    Underkategori
+                                </FieldLabel>
+                                <Select
+                                    items={[...GROUP_SUBTYPE_OPTIONS]}
+                                    value={subtype}
+                                    onValueChange={(value) =>
+                                        setSubtype(value ?? subtype)
+                                    }
+                                >
+                                    <SelectTrigger id="group-subtype">
+                                        <SelectValue placeholder="Velg underkategori" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {GROUP_SUBTYPE_OPTIONS.map((option) => (
+                                            <SelectItem
+                                                key={option.value}
+                                                value={option.value}
+                                            >
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <FieldDescription>
+                                    Idrettsgrupper får sin egen seksjon i
+                                    organisasjonskartet.
+                                </FieldDescription>
+                            </Field>
+                        ) : null}
                         <Field>
                             <FieldLabel id="group-description-label">
                                 Beskrivelse
@@ -377,6 +423,8 @@ function GroupCard({
     const [requiresSigning, setRequiresSigning] = useState(
         group.contractSigningRequired,
     );
+    const [type, setType] = useState(group.type);
+    const [subtype, setSubtype] = useState(groupSubtypeValue(group.subtype));
     const [logo, setLogo] = useState<File | null>(null);
     const [image, setImage] = useState<File | null>(null);
     const [error, setError] = useState<string | null>(null);
@@ -407,6 +455,16 @@ function GroupCard({
                 slug: group.slug,
                 data: {
                     contractSigningRequired: requiresSigning,
+                    ...(canEditGroupType(group.type)
+                        ? {
+                              type,
+                              // Underkategorien gjelder bare interessegrupper;
+                              // blir gruppa noe annet, må den ryddes bort.
+                              subtype: supportsGroupSubtype(type)
+                                  ? subtype
+                                  : null,
+                          }
+                        : {}),
                     // Omitted when unchanged, so saving the checkbox never
                     // clears the group's existing logo or gruppebilde.
                     ...(logoUrl ? { logoUrl } : {}),
@@ -476,6 +534,75 @@ function GroupCard({
                                 Krev kontraktsignering for denne gruppen
                             </FieldLabel>
                         </Field>
+                        {canEditGroupType(group.type) ? (
+                            <Field>
+                                <FieldLabel htmlFor={`type-${group.slug}`}>
+                                    Gruppetype
+                                </FieldLabel>
+                                <Select
+                                    items={[...GROUP_TYPE_OPTIONS]}
+                                    value={type}
+                                    onValueChange={(value) =>
+                                        setType(value ?? type)
+                                    }
+                                >
+                                    <SelectTrigger id={`type-${group.slug}`}>
+                                        <SelectValue placeholder="Velg type" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {GROUP_TYPE_OPTIONS.map((option) => (
+                                            <SelectItem
+                                                key={option.value}
+                                                value={option.value}
+                                            >
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <FieldDescription>
+                                    Bestemmer hvor gruppen står i
+                                    organisasjonskartet. Gruppen flytter seg til
+                                    fanen for den nye typen.
+                                </FieldDescription>
+                            </Field>
+                        ) : null}
+                        {canEditGroupType(group.type) &&
+                        supportsGroupSubtype(type) ? (
+                            <Field>
+                                <FieldLabel htmlFor={`subtype-${group.slug}`}>
+                                    Underkategori
+                                </FieldLabel>
+                                <Select
+                                    items={[...GROUP_SUBTYPE_OPTIONS]}
+                                    value={subtype}
+                                    onValueChange={(value) =>
+                                        setSubtype(
+                                            (value as typeof subtype) ??
+                                                subtype,
+                                        )
+                                    }
+                                >
+                                    <SelectTrigger id={`subtype-${group.slug}`}>
+                                        <SelectValue placeholder="Velg underkategori" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {GROUP_SUBTYPE_OPTIONS.map((option) => (
+                                            <SelectItem
+                                                key={option.value}
+                                                value={option.value}
+                                            >
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <FieldDescription>
+                                    Idrettsgrupper får sin egen seksjon i
+                                    organisasjonskartet.
+                                </FieldDescription>
+                            </Field>
+                        ) : null}
                         {/* Logo takes a third of the row and the gruppebilde
                             the rest, so the square and the 16:9 frame end up
                             roughly the same height and sit side by side


### PR DESCRIPTION
## Hvorfor

TIHLDE Tråkk står i prod som en vanlig interessegruppe, men er egentlig en idrettsgruppe. Backend-en støttet allerede `type` og `subtype` i `PATCH /groups/:slug` — det fantes bare ingen vei til feltene i grensesnittet, så en feilkategorisert gruppe måtte rettes direkte i databasen.

## Hva som er endret

Alt ligger i frontend (`apps/kvark`), ingen API- eller skjemaendringer.

- **`lib/group.ts`** — felles metadata: `EDITABLE_GROUP_TYPES` (Undergruppe, Komité, Styre, Interessegruppe, Idrettslag), `GROUP_SUBTYPE_OPTIONS` (Gruppe / Idrettsgruppe), `canEditGroupType`, `supportsGroupSubtype`, `groupSubtypeValue`. Visnings-`Group` bærer nå `subtype`.
- **`components/group-edit-dialog.tsx`** — «Gruppetype» og «Underkategori» i rediger-dialogen på gruppesiden.
- **`routes/admin/grupper.tsx`** — samme to feltene i gruppekortet i adminpanelet, underkategori også ved oppretting, og en ny «Idrettslag»-fane.
- **`routes/_app/grupper.$slug.tsx`** — sender feltene videre til `updateGroup`.

## Verdt å vite for review

- **Underkategori vises bare for interessegrupper**, og tømmes (`subtype: null`) hvis gruppa byttes til en annen type — ellers ville en gammel `IDRETTSGRUPPE` blitt liggende igjen usynlig.
- **Automatisk genererte grupper** (klassetrinn, studier, TIHLDE, private bøtelag) får ikke typefeltet i det hele tatt. Å endre typen deres ville koblet dem fra logikken som vedlikeholder dem.
- **Null-subtype leses som «Gruppe»** i nedtrekkslista, som er nøyaktig slik organisasjonskartet allerede plasserer de ukategoriserte gruppene fra Lepton.
- **«Idrettslag»-fanen i adminpanelet** er ny: uten den ville en gruppe som byttes til `SPORTSTEAM` forsvunnet ut av alle faner. Fanene dekker nå de samme typene som kan velges i redigeringen.
- Tilgangsstyringen er uendret — feltene ligger bak de samme sjekkene som resten av dialogen/kortet, som speiler `PATCH /groups/:slug` (`groups:update` globalt eller for gruppa, eller å være leder).

## Verifisert

Mot lokal API + dev-DB (prod er ikke rørt):

- Satte TIHLDE Tråkk til Idrettsgruppe fra rediger-dialogen → `GET /api/groups/trakk` gir `INTERESTGROUP / IDRETTSGRUPPE`.
- Samme endring fram og tilbake fra adminpanelet, med riktig persistering hver gang.
- Organisasjonskartet plasserer Tråkk som node under «Idrettsgrupper».
- Et klassetrinn får ikke typefeltet; en undergruppe får type uten underkategori.
- `bun run typecheck`, `lint`, `format` og `build` er grønne.

Tråkk i prod må endres via grensesnittet etter deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)