### PR TITLE
feat(kvark): opprett-knapper der admins faktisk står

### DIFF
--- a/apps/kvark/src/components/group-events-tab.tsx
+++ b/apps/kvark/src/components/group-events-tab.tsx
@@ -1,6 +1,9 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Button } from "@tihlde/ui/ui/button";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
+import { PlusIcon } from "lucide-react";
 import { useState } from "react";
 
 import { getEventsInfiniteQuery } from "#/api/queries/events";
@@ -19,9 +22,14 @@ const PERIODS: { value: EventPeriod; label: string }[] = [
 type GroupEventsTabProps = {
     /** Slug of the group whose events to list. */
     slug: string;
+    /** Whether the viewer may arrange events for THIS group. */
+    canCreateEvent?: boolean;
 };
 
-export function GroupEventsTab({ slug }: GroupEventsTabProps) {
+export function GroupEventsTab({
+    slug,
+    canCreateEvent = false,
+}: GroupEventsTabProps) {
     const [period, setPeriod] = useState<EventPeriod>("kommende");
 
     const { data, isPending, hasNextPage, fetchNextPage, isFetchingNextPage } =
@@ -39,18 +47,36 @@ export function GroupEventsTab({ slug }: GroupEventsTabProps) {
             <GroupPageHeader
                 title="Arrangementer"
                 action={
-                    <Tabs
-                        value={period}
-                        onValueChange={(next) => setPeriod(next as EventPeriod)}
-                    >
-                        <TabsList>
-                            {PERIODS.map((p) => (
-                                <TabsTrigger key={p.value} value={p.value}>
-                                    {p.label}
-                                </TabsTrigger>
-                            ))}
-                        </TabsList>
-                    </Tabs>
+                    <div className="flex flex-wrap items-center justify-end gap-2">
+                        <Tabs
+                            value={period}
+                            onValueChange={(next) =>
+                                setPeriod(next as EventPeriod)
+                            }
+                        >
+                            <TabsList>
+                                {PERIODS.map((p) => (
+                                    <TabsTrigger key={p.value} value={p.value}>
+                                        {p.label}
+                                    </TabsTrigger>
+                                ))}
+                            </TabsList>
+                        </Tabs>
+                        {canCreateEvent ? (
+                            <Button
+                                size="sm"
+                                render={
+                                    <Link
+                                        to="/admin/arrangementer/ny"
+                                        search={{ gruppe: slug }}
+                                    />
+                                }
+                            >
+                                <PlusIcon className="size-4" />
+                                Nytt arrangement
+                            </Button>
+                        ) : null}
+                    </div>
                 }
             />
 

--- a/apps/kvark/src/components/group-page-header.tsx
+++ b/apps/kvark/src/components/group-page-header.tsx
@@ -7,7 +7,9 @@ type GroupPageHeaderProps = {
 
 export function GroupPageHeader({ title, action }: GroupPageHeaderProps) {
     return (
-        <div className="flex items-center justify-between gap-3">
+        // Wrapper på smale skjermer: uten det krymper tittelen til den
+        // brekker midt i ordet for å gi plass til handlingsknappene.
+        <div className="flex flex-wrap items-center justify-between gap-3">
             <h2 className="text-2xl">{title}</h2>
             {action}
         </div>

--- a/apps/kvark/src/components/page-header.tsx
+++ b/apps/kvark/src/components/page-header.tsx
@@ -1,0 +1,34 @@
+import { Reveal } from "@tihlde/ui/ui/motion";
+import type { ReactNode } from "react";
+
+type PageHeaderProps = {
+    title: string;
+    description?: ReactNode;
+    action?: ReactNode;
+};
+
+/**
+ * Shared header for the public list pages: a title, an optional supporting
+ * description, and an optional action slot (usually a create button) aligned
+ * to the end.
+ *
+ * Mirrors `AdminPageHeader`, but keeps the `Reveal` wrapper the public pages
+ * animate their headers with.
+ */
+export function PageHeader({ title, description, action }: PageHeaderProps) {
+    return (
+        <Reveal
+            render={
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between" />
+            }
+        >
+            <div className="flex flex-col gap-1">
+                <h1 className="text-3xl">{title}</h1>
+                {description && (
+                    <p className="text-muted-foreground">{description}</p>
+                )}
+            </div>
+            {action && <div className="flex shrink-0 gap-2">{action}</div>}
+        </Reveal>
+    );
+}

--- a/apps/kvark/src/routes/_app/annonser.index.tsx
+++ b/apps/kvark/src/routes/_app/annonser.index.tsx
@@ -1,6 +1,8 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
+import { Button } from "@tihlde/ui/ui/button";
+import { Stagger } from "@tihlde/ui/ui/motion";
+import { PlusIcon } from "lucide-react";
 import { useState } from "react";
 
 import { getJobsQuery } from "#/api/queries/jobs";
@@ -11,7 +13,12 @@ import {
     type JobFiltersValue,
     type JobType,
 } from "#/components/job-filters";
+import { PageHeader } from "#/components/page-header";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import { formatClassRange, formatJobDeadline, formatJobType } from "#/lib/job";
+
+/** Module-level so the permission lookup keeps a stable identity. */
+const JOB_CREATE_PERMISSIONS = ["jobs:create", "jobs:manage"] as const;
 
 export const Route = createFileRoute("/_app/annonser/")({
     component: JobsPage,
@@ -40,15 +47,31 @@ function JobsPage() {
 
     const { data } = useSuspenseQuery(getJobsQuery(0));
     const jobs = data.items;
+    // Any-scope: scopet er ukjent på en offentlig liste, og API-et avviser
+    // uansett den enkelte forespørselen som ikke treffer.
+    const canCreateJob = useAnyScopePermission(JOB_CREATE_PERMISSIONS);
 
     return (
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
-            <Reveal render={<div className="flex flex-col gap-1" />}>
-                <h1 className="text-3xl">Stillingsannonser</h1>
-                <p className="text-muted-foreground">
-                    Finn relevante jobber for studenter
-                </p>
-            </Reveal>
+            <PageHeader
+                title="Stillingsannonser"
+                description="Finn relevante jobber for studenter"
+                action={
+                    canCreateJob ? (
+                        <Button
+                            render={
+                                <Link
+                                    to="/admin/annonser"
+                                    search={{ ny: true }}
+                                />
+                            }
+                        >
+                            <PlusIcon className="size-4" />
+                            Ny annonse
+                        </Button>
+                    ) : null
+                }
+            />
 
             <div className="grid gap-6 md:grid-cols-[20rem_minmax(0,1fr)]">
                 <aside>

--- a/apps/kvark/src/routes/_app/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.index.tsx
@@ -1,7 +1,9 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
+import { Button } from "@tihlde/ui/ui/button";
+import { Stagger } from "@tihlde/ui/ui/motion";
 import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
+import { PlusIcon } from "lucide-react";
 import { useDeferredValue, useMemo, useState } from "react";
 import z from "zod";
 
@@ -15,11 +17,16 @@ import {
     type EventFiltersValue,
 } from "#/components/event-filters";
 import { LoadMoreButton } from "#/components/load-more-button";
+import { PageHeader } from "#/components/page-header";
 import { useDebouncedValue } from "#/hooks/use-debounced-value";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import { formatEventDateTime } from "#/lib/event";
 import { ACTIVITY_CATEGORIES, EVENT_CATEGORIES } from "#/lib/event-categories";
 
 const SEARCH_DEBOUNCE_MS = 300;
+
+/** Module-level so the permission lookup keeps a stable identity. */
+const EVENT_CREATE_PERMISSIONS = ["events:create", "events:manage"] as const;
 
 const ALL_CATEGORIES = { value: "all", label: "Alle kategorier" };
 
@@ -141,6 +148,10 @@ function EventsPage() {
         );
     const events = data.pages.flatMap((page) => page.items);
     const totalCount = data.pages[0]?.totalCount ?? 0;
+    // Any-scope: scopet er ukjent på en offentlig liste, og et gruppe-scopet
+    // events:create er en ekte tilgang. API-et avviser uansett den enkelte
+    // forespørselen som ikke treffer.
+    const canCreateEvent = useAnyScopePermission(EVENT_CREATE_PERMISSIONS);
 
     const changeView = (next: EventView) => {
         navigate({
@@ -152,12 +163,18 @@ function EventsPage() {
 
     return (
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
-            <Reveal render={<div className="flex flex-col gap-1" />}>
-                <h1 className="text-3xl">Arrangementer</h1>
-                <p className="text-muted-foreground">
-                    Finn arrangementer for våren 2026
-                </p>
-            </Reveal>
+            <PageHeader
+                title="Arrangementer"
+                description="Finn arrangementer for våren 2026"
+                action={
+                    canCreateEvent ? (
+                        <Button render={<Link to="/admin/arrangementer/ny" />}>
+                            <PlusIcon className="size-4" />
+                            Nytt arrangement
+                        </Button>
+                    ) : null
+                }
+            />
 
             <div className="grid gap-6 md:grid-cols-[20rem_minmax(0,1fr)]">
                 <aside>

--- a/apps/kvark/src/routes/_app/galleri.index.tsx
+++ b/apps/kvark/src/routes/_app/galleri.index.tsx
@@ -1,12 +1,22 @@
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Button } from "@tihlde/ui/ui/button";
 import { Empty, EmptyDescription, EmptyTitle } from "@tihlde/ui/ui/empty";
-import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
+import { Stagger } from "@tihlde/ui/ui/motion";
+import { PlusIcon } from "lucide-react";
 
 import { authClientWithRedirect } from "#/api/auth";
 import { getGalleriesInfiniteQuery } from "#/api/queries/galleries";
 import { GalleryCard } from "#/components/gallery-card";
 import { LoadMoreButton } from "#/components/load-more-button";
+import { PageHeader } from "#/components/page-header";
+import { useAnyScopePermission } from "#/hooks/use-permission";
+
+/** Module-level so the permission lookup keeps a stable identity. */
+const GALLERY_CREATE_PERMISSIONS = [
+    "galleries:create",
+    "galleries:manage",
+] as const;
 
 export const Route = createFileRoute("/_app/galleri/")({
     component: GalleriesPage,
@@ -22,15 +32,31 @@ function GalleriesPage() {
         useSuspenseInfiniteQuery(getGalleriesInfiniteQuery());
 
     const galleries = data.pages.flatMap((page) => page.items);
+    // Any-scope: scopet er ukjent på en offentlig liste, og API-et avviser
+    // uansett den enkelte forespørselen som ikke treffer.
+    const canCreateGallery = useAnyScopePermission(GALLERY_CREATE_PERMISSIONS);
 
     return (
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
-            <Reveal render={<div className="flex flex-col gap-1" />}>
-                <h1 className="text-3xl">Galleri</h1>
-                <p className="text-muted-foreground">
-                    Bilder fra arrangementene våre
-                </p>
-            </Reveal>
+            <PageHeader
+                title="Galleri"
+                description="Bilder fra arrangementene våre"
+                action={
+                    canCreateGallery ? (
+                        <Button
+                            render={
+                                <Link
+                                    to="/admin/galleri"
+                                    search={{ ny: true }}
+                                />
+                            }
+                        >
+                            <PlusIcon className="size-4" />
+                            Nytt galleri
+                        </Button>
+                    ) : null
+                }
+            />
 
             {galleries.length === 0 ? (
                 <Empty>

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -95,6 +95,9 @@ import { extractErrorMessage } from "#/lib/api-error";
 import { useDebounced } from "#/lib/use-debounced";
 import { errorStatus } from "#/lib/utils";
 
+/** Module-level so the permission lookup keeps a stable identity. */
+const EVENT_CREATE_PERMISSIONS = ["events:create", "events:manage"] as const;
+
 const searchSchema = z.object({
     tab: z
         .enum([
@@ -221,6 +224,13 @@ function GroupDetail() {
     // group manage forms on every other group's page.
     const hasFormsPermission = usePermission(["forms:create", "forms:manage"]);
     const canManageForms = hasFormsPermission || isLeader;
+    // Arrangementer er scopet på samme måte: lederskap alene gir ikke
+    // events:create — det avhenger av gruppens leaderPermissions — så vi
+    // spør om selve tilgangen for nettopp denne gruppen.
+    const canCreateEvent = useScopedPermission(
+        EVENT_CREATE_PERMISSIONS,
+        `group:${slug}`,
+    );
     const isMember = useIsGroupMemberOf(slug);
     const isRoot = usePermission("root");
 
@@ -627,7 +637,10 @@ function GroupDetail() {
                         />
                     ) : null}
                     {activeTab === "arrangementer" ? (
-                        <GroupEventsTab slug={slug} />
+                        <GroupEventsTab
+                            slug={slug}
+                            canCreateEvent={canCreateEvent}
+                        />
                     ) : null}
                     {activeTab === "boter" ? (
                         <GroupFinesTab

--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -82,6 +82,7 @@ function Home() {
                     title="Nyheter"
                     actionLabel={canCreateNews ? "Ny nyhet" : undefined}
                     actionTo="/admin/nyheter"
+                    actionSearch={{ ny: true }}
                 />
                 <Suspense fallback={<NewsSkeleton />}>
                     <NewsSection />
@@ -277,11 +278,14 @@ function SectionHeader({
     title,
     actionLabel,
     actionTo,
+    actionSearch,
 }: {
     title: string;
     actionLabel?: string;
     /** Målruta for handlingsknappen. Uten den rendres ingen knapp. */
     actionTo?: LinkProps["to"];
+    /** Søkeparametre til målruta, f.eks. `{ ny: true }` for en dialog. */
+    actionSearch?: LinkProps["search"];
 }) {
     return (
         <Reveal
@@ -294,7 +298,7 @@ function SectionHeader({
                 <Button
                     variant="ghost"
                     size="sm"
-                    render={<Link to={actionTo} />}
+                    render={<Link to={actionTo} search={actionSearch} />}
                 >
                     <Plus />
                     {actionLabel}

--- a/apps/kvark/src/routes/_app/nyheter.index.tsx
+++ b/apps/kvark/src/routes/_app/nyheter.index.tsx
@@ -1,11 +1,18 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { Button } from "@tihlde/ui/ui/button";
+import { PlusIcon } from "lucide-react";
 
-import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
+import { Stagger } from "@tihlde/ui/ui/motion";
 
 import { getNewsQuery } from "#/api/queries/news";
 import { NewsCard } from "#/components/news-card";
+import { PageHeader } from "#/components/page-header";
+import { useAnyScopePermission } from "#/hooks/use-permission";
 import { formatNewsDateRelative } from "#/lib/news";
+
+/** Module-level so the permission lookup keeps a stable identity. */
+const NEWS_CREATE_PERMISSIONS = ["news:create", "news:manage"] as const;
 
 export const Route = createFileRoute("/_app/nyheter/")({
     component: NewsPage,
@@ -16,15 +23,32 @@ export const Route = createFileRoute("/_app/nyheter/")({
 function NewsPage() {
     const { data } = useSuspenseQuery(getNewsQuery(0));
     const news = data.items;
+    // Scopet er ukjent på en offentlig liste, så any-scope er riktig her:
+    // et gruppe-scopet news:create er en ekte tilgang, og API-et avviser
+    // uansett den enkelte forespørselen som ikke treffer.
+    const canCreateNews = useAnyScopePermission(NEWS_CREATE_PERMISSIONS);
 
     return (
         <div className="container mx-auto flex w-full flex-col gap-6 px-4 py-8">
-            <Reveal render={<div className="flex flex-col gap-1" />}>
-                <h1 className="text-3xl">Nyheter</h1>
-                <p className="text-muted-foreground">
-                    Siste nytt fra TIHLDE og undergruppene
-                </p>
-            </Reveal>
+            <PageHeader
+                title="Nyheter"
+                description="Siste nytt fra TIHLDE og undergruppene"
+                action={
+                    canCreateNews ? (
+                        <Button
+                            render={
+                                <Link
+                                    to="/admin/nyheter"
+                                    search={{ ny: true }}
+                                />
+                            }
+                        >
+                            <PlusIcon className="size-4" />
+                            Ny nyhet
+                        </Button>
+                    ) : null
+                }
+            />
 
             <Stagger
                 render={

--- a/apps/kvark/src/routes/admin/annonser.tsx
+++ b/apps/kvark/src/routes/admin/annonser.tsx
@@ -96,9 +96,11 @@ const CLASS_LABELS: Record<UserClass, string> = {
 
 // `?rediger=<id>` gjør redigeringsdialogen adresserbar, slik at «Rediger
 // annonse» på annonsesiden kan lenke rett til riktig annonse i stedet for å
-// slippe deg av på listen.
+// slippe deg av på listen. `?ny` gjør det samme for opprettelsesdialogen,
+// slik at «Ny annonse» andre steder i appen lander rett i skjemaet.
 const searchSchema = z.object({
     rediger: z.string().optional().catch(undefined),
+    ny: z.boolean().optional().catch(undefined),
 });
 
 export const Route = createFileRoute("/admin/annonser")({
@@ -114,7 +116,7 @@ export const Route = createFileRoute("/admin/annonser")({
 
 function JobsAdminPage() {
     const canCreate = useAnyScopePermission(["jobs:create", "jobs:manage"]);
-    const { rediger } = Route.useSearch();
+    const { rediger, ny } = Route.useSearch();
     const navigate = Route.useNavigate();
     const [search, setSearch] = useState("");
     const [jobType, setJobType] = useState<JobType | "all">("all");
@@ -123,11 +125,20 @@ function JobsAdminPage() {
         { mode: "create" } | { mode: "edit"; job: JobListItem } | null
     >(null);
 
+    // `canCreate` er false ved første render på en kald sidelast, siden
+    // sesjonen ikke er hentet enda. Derfor en effekt og ikke en lazy
+    // initialisering. Lukking fjerner `ny` fra URL-en, så dialogen tvinges
+    // ikke opp igjen etterpå.
+    useEffect(() => {
+        if (!ny || !canCreate) return;
+        setDialog({ mode: "create" });
+    }, [ny, canCreate]);
+
     function closeDialog() {
         setDialog(null);
         // Ellers ville dialogen åpnet seg igjen med en gang, siden id-en
         // fortsatt sto i URL-en.
-        if (rediger) navigate({ search: {}, replace: true });
+        if (rediger || ny) navigate({ search: {}, replace: true });
     }
 
     return (

--- a/apps/kvark/src/routes/admin/arrangementer.ny.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.ny.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { addHours } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
+import z from "zod";
 
 import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { XCircle } from "lucide-react";
@@ -24,8 +25,16 @@ import {
 import { nextWholeHour } from "#/lib/date";
 import { useDebounced } from "#/lib/use-debounced";
 
+// `?gruppe=<slug>` lar «Nytt arrangement» på en gruppeside sende deg hit med
+// gruppa allerede valgt som arrangør, i stedet for å be deg velge den om
+// igjen. Slug-er vi ikke får arrangere for hoppes stille over — se under.
+const searchSchema = z.object({
+    gruppe: z.string().optional().catch(undefined),
+});
+
 export const Route = createFileRoute("/admin/arrangementer/ny")({
     component: NewEventPage,
+    validateSearch: searchSchema,
     loader: async ({ context }) => {
         await Promise.all([
             context.queryClient.ensureQueryData(getGroupsQuery(0)),
@@ -90,7 +99,17 @@ function NewEventPage() {
     );
     const { data: institutes } = useSuspenseQuery(getInstitutesQuery());
 
-    const [values, setValues] = useState<EventFormValues>(emptyValues);
+    // Forhåndsvalget fra `?gruppe` godtas bare hvis gruppa faktisk står i
+    // lista over. En gammel bokmerket lenke, eller en rettighet som er
+    // trukket tilbake, gir ellers et arrangørfelt med en verdi som ikke
+    // finnes blant valgene. Da starter vi heller tomt, som vanlig.
+    const { gruppe } = Route.useSearch();
+    const [values, setValues] = useState<EventFormValues>(() => ({
+        ...emptyValues,
+        organizerGroupSlug: groups.some((group) => group.slug === gruppe)
+            ? (gruppe ?? "")
+            : "",
+    }));
     const [uploadError, setUploadError] = useState<string | null>(null);
 
     const debouncedLocation = useDebounced(values.location, 250);

--- a/apps/kvark/src/routes/admin/galleri.tsx
+++ b/apps/kvark/src/routes/admin/galleri.tsx
@@ -48,7 +48,7 @@ import {
     Trash2Icon,
     XCircle,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
@@ -63,6 +63,8 @@ import {
 } from "#/api/queries/galleries";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import z from "zod";
+
 import { useAnyScopePermission } from "#/hooks/use-permission";
 import { assetPublicUrl } from "#/lib/assets";
 import { imageDropzoneLabels } from "#/lib/image";
@@ -73,8 +75,15 @@ const dropzoneLabels = {
     defaultPlaceholder: "Klikk eller dra bilder hit for å laste opp",
 };
 
+// `?ny` gjør opprettelsesdialogen adresserbar, slik at «Nytt galleri» andre
+// steder i appen lander rett i skjemaet i stedet for på listen.
+const searchSchema = z.object({
+    ny: z.boolean().optional().catch(undefined),
+});
+
 export const Route = createFileRoute("/admin/galleri")({
     component: GalleryAdminPage,
+    validateSearch: searchSchema,
     loader: async ({ context }) => {
         await Promise.all([
             context.queryClient.ensureQueryData(getGalleriesQuery(0)),
@@ -93,9 +102,27 @@ function GalleryAdminPage() {
         "galleries:pictures:create",
         "galleries:manage",
     ]);
+    const { ny } = Route.useSearch();
+    const navigate = Route.useNavigate();
     const [dialog, setDialog] = useState<
         { mode: "create" } | { mode: "edit"; gallery: Gallery } | null
     >(null);
+
+    // `canCreateGallery` er false ved første render på en kald sidelast,
+    // siden sesjonen ikke er hentet enda. Derfor en effekt og ikke en lazy
+    // initialisering. Lukking fjerner `ny` fra URL-en, så dialogen tvinges
+    // ikke opp igjen etterpå.
+    useEffect(() => {
+        if (!ny || !canCreateGallery) return;
+        setDialog({ mode: "create" });
+    }, [ny, canCreateGallery]);
+
+    function closeDialog() {
+        setDialog(null);
+        // Ellers ville dialogen åpnet seg igjen med en gang, siden `ny`
+        // fortsatt sto i URL-en.
+        if (ny) navigate({ search: {}, replace: true });
+    }
 
     return (
         <Stagger
@@ -125,7 +152,7 @@ function GalleryAdminPage() {
                 open={dialog !== null}
                 gallery={dialog?.mode === "edit" ? dialog.gallery : null}
                 onOpenChange={(open) => {
-                    if (!open) setDialog(null);
+                    if (!open) closeDialog();
                 }}
             />
         </Stagger>

--- a/apps/kvark/src/routes/admin/index.tsx
+++ b/apps/kvark/src/routes/admin/index.tsx
@@ -70,7 +70,7 @@ function DashboardPage() {
                 description="Oversikt over innhold og administrasjon i Kvark."
                 action={
                     canCreateEvents ? (
-                        <Button render={<Link to="/admin/arrangementer" />}>
+                        <Button render={<Link to="/admin/arrangementer/ny" />}>
                             <PlusIcon className="size-4" />
                             Nytt arrangement
                         </Button>
@@ -204,7 +204,9 @@ function QuickActions() {
                 {canCreateNews ? (
                     <Button
                         variant="outline"
-                        render={<Link to="/admin/nyheter" />}
+                        render={
+                            <Link to="/admin/nyheter" search={{ ny: true }} />
+                        }
                     >
                         <NewspaperIcon className="size-4" />
                         Ny nyhet
@@ -213,7 +215,9 @@ function QuickActions() {
                 {canCreateJobs ? (
                     <Button
                         variant="outline"
-                        render={<Link to="/admin/annonser" />}
+                        render={
+                            <Link to="/admin/annonser" search={{ ny: true }} />
+                        }
                     >
                         <BriefcaseBusinessIcon className="size-4" />
                         Ny annonse

--- a/apps/kvark/src/routes/admin/nyheter.tsx
+++ b/apps/kvark/src/routes/admin/nyheter.tsx
@@ -47,9 +47,11 @@ import { useAnyScopePermission } from "#/hooks/use-permission";
 
 // `?rediger=<id>` gjør redigeringsdialogen adresserbar, slik at «Rediger
 // nyhet» på nyhetssiden kan lenke rett til riktig artikkel i stedet for å
-// slippe deg av på listen.
+// slippe deg av på listen. `?ny` gjør det samme for opprettelsesdialogen,
+// slik at «Ny nyhet» andre steder i appen lander rett i skjemaet.
 const searchSchema = z.object({
     rediger: z.string().optional().catch(undefined),
+    ny: z.boolean().optional().catch(undefined),
 });
 
 export const Route = createFileRoute("/admin/nyheter")({
@@ -63,17 +65,26 @@ export const Route = createFileRoute("/admin/nyheter")({
 
 function NewsAdminPage() {
     const canCreate = useAnyScopePermission(["news:create", "news:manage"]);
-    const { rediger } = Route.useSearch();
+    const { rediger, ny } = Route.useSearch();
     const navigate = Route.useNavigate();
     const [dialog, setDialog] = useState<
         { mode: "create" } | { mode: "edit"; news: NewsListItem } | null
     >(null);
 
+    // `canCreate` er false ved første render på en kald sidelast, siden
+    // sesjonen ikke er hentet enda. Derfor en effekt og ikke en lazy
+    // initialisering. Lukking fjerner `ny` fra URL-en, så dialogen tvinges
+    // ikke opp igjen etterpå.
+    useEffect(() => {
+        if (!ny || !canCreate) return;
+        setDialog({ mode: "create" });
+    }, [ny, canCreate]);
+
     function closeDialog() {
         setDialog(null);
         // Ellers ville dialogen åpnet seg igjen med en gang, siden id-en
         // fortsatt sto i URL-en.
-        if (rediger) navigate({ search: {}, replace: true });
+        if (rediger || ny) navigate({ search: {}, replace: true });
     }
 
     return (


### PR DESCRIPTION
## Hva

Admins måtte navigere manuelt inn i `/admin/...` for å opprette noe, selv når de sto rett ved innholdet. Nå ligger handlingen der brukeren allerede er.

- **Gruppesidens arrangement-fane** har fått «Nytt arrangement». Lenken tar med `?gruppe=<slug>`, og opprettelsessiden forhåndsvelger arrangørgruppen — ett steg mindre.
- **De offentlige listesidene** `/arrangementer`, `/nyheter`, `/annonser` og `/galleri` har fått opprett-knapp, på linje med forsiden.
- **`?ny`** åpner opprettelsesdialogen direkte på nyheter/annonser/galleri, etter mønster av eksisterende `?rediger`. Før måtte man trykke «Ny nyhet» to ganger.

## Tilgangsstyring

Gruppefanen bruker `useScopedPermission(["events:create","events:manage"], group:<slug>)` — den **scopede** varianten, ikke any-scope. Knappen vises derfor aldri på en gruppe du ikke kan arrangere for. `grupper.$slug.tsx` har en eksplisitt kommentar om en tidligere bug der en any-scope-sjekk lot gruppe-handlinger lekke inn på andre gruppers sider; dette unngår samme felle.

De offentlige listesidene bruker any-scope, siden scopet ikke er kjent der — samme resonnement som forsiden allerede bygger på. API-et håndhever uansett den enkelte forespørselen.

Et `?gruppe=<slug>` man ikke har rettigheter for (gammelt bokmerke, delt lenke) hoppes stille over: skjemaet åpner med tomt arrangørfelt i stedet for en Select med en verdi som ikke finnes blant valgene.

## To ting funnet under verifisering i nettleser

1. `?ny` virket ved klikk, men **ikke ved kald sidelast** — sesjonen er ikke hentet ved første render, så permission-sjekken var `false` og dialogen åpnet aldri. Løst med en effekt i stedet for lazy state (samme grunn som `?rediger` bruker en).
2. På mobil ble fanetittelen klemt til «Arrangem/enter», fordi `GroupPageHeader` ikke wrappet når action-sloten har både faner og knapp. La til `flex-wrap` — gjelder alle gruppefanene.

## Ryddet på kjøpet

- Admin-dashbordets «Nytt arrangement» pekte på lista, ikke opprettelsessiden.
- Ny delt `PageHeader` erstatter fire kopier av samme header-markup.

## Verifisering

`bun run typecheck`, `bun run lint` (ingen nye kvark-varsler) og `bun run build` er grønne.

I nettleseren, innlogget: knapp og forhåndsvalgt arrangør fra en gruppeside, `?gruppe=finnes-ikke` gir tomt felt uten krasj, alle tre dialoger åpner og rydder URL-en ved lukking, mobil-layout ok. **Utlogget vises ingen knapper** — testet ved å logge ut og inn igjen.

Én begrensning verdt å vite: den lokale testbrukeren er `root`, så scoped vs. any-scope lot seg ikke skille empirisk på en gruppeside (root ser knappen overalt, korrekt). Den negative stien er bekreftet utlogget, og hooken er den samme som `canEditGroup` bruker rett ved siden av.

## Ikke i denne PR-en

Alle knapper som rendres som lenker (34 steder, pre-eksisterende) logger et Base UI-varsel om manglende native button-semantikk. Verdt én egen opprydding — ikke noe å avvike fra husmønsteret på her.

🤖 Generated with [Claude Code](https://claude.com/claude-code)