### PR TITLE
chore(deps): oppgrader nodemailer til 9.0.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -150,7 +150,7 @@
         "@dotenvx/dotenvx": "^1.49.0",
         "@photon/email": "workspace:*",
         "bullmq": "catalog:backend",
-        "nodemailer": "^7.0.11",
+        "nodemailer": "^9.0.5",
         "redis": "^5.8.2",
         "zod": "catalog:",
       },
@@ -2601,7 +2601,7 @@
 
     "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
 
-    "nodemailer": ["nodemailer@7.0.13", "", {}, "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw=="],
+    "nodemailer": ["nodemailer@9.0.5", "", {}, "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
         "@dotenvx/dotenvx": "^1.49.0",
         "@photon/email": "workspace:*",
         "bullmq": "catalog:backend",
-        "nodemailer": "^7.0.11",
+        "nodemailer": "^9.0.5",
         "redis": "^5.8.2",
         "zod": "catalog:"
     },


### PR DESCRIPTION
Lukker de seks åpne Dependabot-varslene på `main` (1 high, 4 moderate, 1 low). Alle seks er samme pakke: `nodemailer` i `packages/core`.

## Eksponering

Ingen av de seks er utnyttbare slik vi bruker biblioteket. Transporten opprettes ett sted, `apps/api/src/lib/ctx.ts:168`, med bare host/port/secure/auth, og eneste sendevei er `sendMail` med `to`/`subject`/`html`/`text` i `packages/core/src/services/email/smtp.ts:20`.

| Sev | GHSA | Krever | Vi bruker det? |
|---|---|---|---|
| High | `p6gq-j5cr-w38f` | `raw`-opsjonen | Nei |
| Med | `268h-hp4c-crq3` | `List-*`-headere | Nei |
| Med | `wqvq-jvpq-h66f` | `jsonTransport` | Nei, SMTP |
| Med | `r7g4-qg5f-qqm2` | OAuth2-auth | Nei, user/pass |
| Med | `vvjj-xcjg-gr5g` | transportens `name` | Nei |
| Low | `c7w3-x93f-qmm8` | `envelope.size` | Nei |

`attachments` finnes i `SendOptions`, men ingen kaller sender noen — så heller ingen remote `href`/`path`.

## Bruddendringer 7 → 9

- **8.0.0**: feilkoden `NoAuth` → `ENOAUTH`. Ingen treff på noen av dem i repoet.
- **9.0.0**: TLS-validering ved henting av remote innhold (attachment-URL-er, OAuth2-endepunkt, proxy-CONNECT). Vi henter ingenting remote.

`@types/nodemailer` står på `^7.0.1` (8.0.1 er siste utgitte) og typechecker fint mot runtime 9 — den er ikke rørt.

## Verifisert

- `bun run typecheck` — 9/9 pakker grønt
- `bun run test src/test/email` — 7/7 grønt