### PR TITLE
fix(kvark): gi arrangementskort vertikal luft i listevisning

### DIFF
--- a/apps/kvark/src/components/group-events-tab.tsx
+++ b/apps/kvark/src/components/group-events-tab.tsx
@@ -67,7 +67,7 @@ export function GroupEventsTab({ slug }: GroupEventsTabProps) {
                         : "Gruppen har ingen tidligere arrangementer."}
                 </p>
             ) : (
-                <ul className="flex flex-col gap-4 sm:gap-1">
+                <ul className="flex flex-col gap-3">
                     {events.map((event) => (
                         <li key={event.id}>
                             <EventCard

--- a/apps/kvark/src/routes/_app/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.index.tsx
@@ -218,9 +218,7 @@ function EventsPage() {
                         />
                     ) : (
                         <Stagger
-                            render={
-                                <ul className="flex flex-col gap-4 sm:gap-1" />
-                            }
+                            render={<ul className="flex flex-col gap-3" />}
                         >
                             {events.map((event) => (
                                 <li key={event.id}>


### PR DESCRIPTION
## Hva

Arrangementskortene i listevisning lå praktisk talt limt sammen på desktop: listene brukte `gap-4 sm:gap-1`, altså 4px fra `sm` og oppover.

Begge listene bruker nå `gap-3` (12px), på linje med medlemslisten i gruppeoversikten (`gap-2`, men litt mer luft passer bedre til de høyere kortene — valgt sammen med Mathias).

- `apps/kvark/src/routes/_app/arrangementer.index.tsx` — /arrangementer
- `apps/kvark/src/components/group-events-tab.tsx` — arrangementsfanen på gruppesider

## Verifisert

- Kjørt i dev-preview: `<ul>` på /arrangementer har `row-gap: 12px`, og kortene har synlig luft.
- `bun run lint` og `bun run format` er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)