### PR TITLE
fix(kvark): behold lenkesemantikk for knapper som rendrer <Link>

### DIFF
--- a/apps/kvark/src/components/event-rules-consent.tsx
+++ b/apps/kvark/src/components/event-rules-consent.tsx
@@ -89,7 +89,6 @@ function RulesLink() {
         <Button
             size="sm"
             variant="outline"
-            nativeButton={false}
             render={
                 <a
                     href={EVENT_RULES_URL}

--- a/apps/kvark/src/components/group-admission-card.tsx
+++ b/apps/kvark/src/components/group-admission-card.tsx
@@ -80,7 +80,6 @@ export function GroupAdmissionCard({
                         <Button
                             variant="ghost"
                             className="w-full"
-                            nativeButton={false}
                             render={
                                 <Link
                                     to="/grupper/$slug"
@@ -144,7 +143,6 @@ function AdmissionAction({
             return (
                 <Button
                     className="w-full"
-                    nativeButton={false}
                     render={
                         formId ? (
                             <Link

--- a/apps/kvark/src/components/group-form-row.tsx
+++ b/apps/kvark/src/components/group-form-row.tsx
@@ -32,7 +32,6 @@ export function GroupFormRow({ form, canManage, onEdit }: GroupFormRowProps) {
                     <Button
                         variant="outline"
                         size="sm"
-                        nativeButton={false}
                         render={
                             <Link
                                 to="/sporreskjema/$id"
@@ -55,7 +54,6 @@ export function GroupFormRow({ form, canManage, onEdit }: GroupFormRowProps) {
                             <Button
                                 variant="outline"
                                 size="sm"
-                                nativeButton={false}
                                 render={
                                     <Link
                                         to="/sporreskjema/$id/svar"

--- a/apps/kvark/src/components/icon-action-button.tsx
+++ b/apps/kvark/src/components/icon-action-button.tsx
@@ -24,9 +24,6 @@ export function IconActionButton({
                         variant="ghost"
                         size="icon"
                         aria-label={label}
-                        // `render` bytter ut knappen med en lenke, og da må
-                        // Base UI vite at elementet ikke er en <button>.
-                        nativeButton={!render}
                         onClick={onClick}
                         render={render}
                     >

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -174,7 +174,6 @@ function EventDetailPage() {
                     <Button
                         variant="ghost"
                         size="sm"
-                        nativeButton={false}
                         render={<Link to="/arrangementer" />}
                     >
                         <ArrowLeft />

--- a/apps/kvark/src/routes/_app/bedrift.index.tsx
+++ b/apps/kvark/src/routes/_app/bedrift.index.tsx
@@ -62,7 +62,6 @@ function CompanyLandingPage() {
                     <Button
                         size="lg"
                         className="mt-4"
-                        nativeButton={false}
                         render={<Link to="/bedrift" hash="kontakt" />}
                     >
                         Meld interesse
@@ -108,7 +107,6 @@ function CompanyLandingPage() {
                             action={
                                 <Button
                                     variant="link"
-                                    nativeButton={false}
                                     render={<Link to="/bedrift/studiene" />}
                                 >
                                     Les mer
@@ -235,7 +233,6 @@ function JobPreview() {
             <Button
                 variant="link"
                 className="self-end"
-                nativeButton={false}
                 render={<Link to="/annonser" />}
             >
                 Se alle stillinger

--- a/apps/kvark/src/routes/_app/bedrift.studiene.tsx
+++ b/apps/kvark/src/routes/_app/bedrift.studiene.tsx
@@ -50,7 +50,6 @@ function StudiesPage() {
                 <Button
                     size="lg"
                     className="mt-2"
-                    nativeButton={false}
                     render={<Link to="/bedrift" hash="kontakt" />}
                 >
                     Kontakt oss

--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -243,7 +243,6 @@ function HeroActions() {
             <div className="flex flex-wrap items-center justify-center gap-2">
                 <Button
                     size="lg"
-                    nativeButton={false}
                     render={<Link to="/profil/$id" params={{ id: "me" }} />}
                 >
                     Min profil
@@ -254,17 +253,12 @@ function HeroActions() {
 
     return (
         <div className="flex flex-wrap items-center justify-center gap-2">
-            <Button
-                size="lg"
-                nativeButton={false}
-                render={<Link to="/login" />}
-            >
+            <Button size="lg" render={<Link to="/login" />}>
                 Logg inn
             </Button>
             <Button
                 size="lg"
                 variant="outline"
-                nativeButton={false}
                 render={<Link to="/register" />}
             >
                 Opprett bruker

--- a/apps/kvark/src/routes/_app/ny-student.tsx
+++ b/apps/kvark/src/routes/_app/ny-student.tsx
@@ -84,7 +84,6 @@ function NewStudentPage() {
                     </p>
                     <div className="flex flex-col gap-2 sm:flex-row">
                         <Button
-                            nativeButton={false}
                             render={
                                 <a
                                     href={FADDERUKA_URL}
@@ -98,7 +97,6 @@ function NewStudentPage() {
                         </Button>
                         <Button
                             variant="outline"
-                            nativeButton={false}
                             render={
                                 isAuthenticated ? (
                                     <Link to="/opptak" />
@@ -127,7 +125,6 @@ function NewStudentPage() {
                 </p>
                 <div className="flex flex-col gap-2 sm:flex-row">
                     <Button
-                        nativeButton={false}
                         render={
                             <a
                                 href={FADDERUKA_URL}
@@ -140,14 +137,12 @@ function NewStudentPage() {
                     </Button>
                     <Button
                         variant="outline"
-                        nativeButton={false}
                         render={<Link to="/arrangementer" />}
                     >
                         Hva skjer i fadderuka?
                     </Button>
                     <Button
                         variant="ghost"
-                        nativeButton={false}
                         render={
                             <a
                                 href={NEW_STUDENT_WIKI_URL}

--- a/apps/kvark/src/routes/_app/nyheter.$slug.tsx
+++ b/apps/kvark/src/routes/_app/nyheter.$slug.tsx
@@ -55,7 +55,6 @@ function NewsDetailPage() {
                     <Button
                         variant="ghost"
                         size="sm"
-                        nativeButton={false}
                         render={<Link to="/nyheter" />}
                     >
                         <ArrowLeft />
@@ -82,7 +81,6 @@ function NewsDetailPage() {
                                 <Button
                                     variant="outline"
                                     size="sm"
-                                    nativeButton={false}
                                     render={
                                         <Link
                                             to="/admin/nyheter"

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -288,7 +288,6 @@ function NavButton({
             variant={isActive ? "default" : "ghost"}
             size={size}
             className={className}
-            nativeButton={false}
             render={<Link {...item.link} />}
         >
             <item.icon />

--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -171,7 +171,6 @@ function ContractBanner({ signature }: { signature: SignatureStatus | null }) {
                 <Button
                     size="sm"
                     variant="outline"
-                    nativeButton={false}
                     render={<Link to="/kontrakt" />}
                 >
                     Gå til kontrakt

--- a/apps/kvark/src/routes/_app/profil/$id/sporreskjemaer.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/sporreskjemaer.tsx
@@ -84,7 +84,6 @@ function Evaluations() {
                             </CardHeader>
                             <CardContent>
                                 <Button
-                                    nativeButton={false}
                                     render={
                                         <Link
                                             to="/sporreskjema/$id"

--- a/apps/kvark/src/routes/_app/sporreskjema.$id.tsx
+++ b/apps/kvark/src/routes/_app/sporreskjema.$id.tsx
@@ -167,7 +167,6 @@ function AlreadyAnswered() {
                 <Button
                     variant="outline"
                     className="w-full"
-                    nativeButton={false}
                     render={<Link to="/" />}
                 >
                     Gå til forsiden
@@ -175,7 +174,6 @@ function AlreadyAnswered() {
                 <Button
                     variant="outline"
                     className="w-full"
-                    nativeButton={false}
                     render={<Link to="/profil/$id" params={{ id: "me" }} />}
                 >
                     Gå til profilen din

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -849,7 +849,6 @@ function FormsTab({ eventId }: { eventId: string }) {
                                         <Button
                                             variant="outline"
                                             size="sm"
-                                            nativeButton={false}
                                             render={
                                                 <Link
                                                     to="/sporreskjema/$id"

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -1,5 +1,8 @@
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
+import { isValidElement } from "react";
 
 import { cn } from "#/lib/utils";
 
@@ -46,19 +49,80 @@ const buttonVariants = cva(
     },
 );
 
+type ButtonProps = ButtonPrimitive.Props & VariantProps<typeof buttonVariants>;
+
 function Button({
     className,
     variant = "default",
     size = "default",
+    nativeButton,
+    render,
     ...props
-}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+}: ButtonProps) {
+    const classNames = cn(buttonVariants({ variant, size, className }));
+
+    // Base UI is explicit that links "have their own semantics and should not
+    // be rendered as buttons through the `render` prop": routed through
+    // ButtonPrimitive they either warn (`nativeButton` defaults to true, and
+    // the element turns out not to be a `<button>`) or get `role="button"`
+    // slapped on, which hides the link from screen readers. So a link only
+    // borrows the styling — the anchor keeps its own semantics.
+    if (isLinkRender(render)) {
+        return <ButtonLink {...props} className={classNames} render={render} />;
+    }
+
     return (
         <ButtonPrimitive
             data-slot="button"
-            className={cn(buttonVariants({ variant, size, className }))}
+            className={classNames}
+            render={render}
+            // Any other non-`<button>` render element (a `<div>`, a `<span>`)
+            // does want Base UI's button semantics — it just has to say so, or
+            // Base UI warns. Infer it instead of asking every call site; an
+            // explicit prop still wins, and a render *function* is opaque here
+            // so it keeps the native default.
+            nativeButton={nativeButton ?? isNativeButtonRender(render)}
             {...props}
         />
     );
+}
+
+function ButtonLink({
+    className,
+    render,
+    ...props
+}: Omit<ButtonProps, "nativeButton" | "variant" | "size" | "className"> & {
+    className?: string;
+}) {
+    return useRender({
+        defaultTagName: "a",
+        render: render as useRender.ComponentProps<"a">["render"],
+        props: mergeProps<"a">(
+            { className },
+            props as useRender.ComponentProps<"a">,
+        ),
+        state: { slot: "button" },
+    });
+}
+
+function isLinkRender(render: ButtonProps["render"]) {
+    if (!isValidElement<{ href?: unknown; to?: unknown }>(render)) {
+        return false;
+    }
+
+    // `<a href>` and TanStack Router's `<Link to>` — the two ways this codebase
+    // renders a button that navigates. A destination is what makes it a link:
+    // an `<a>` without one is just a clickable element, and does want Base UI's
+    // button semantics (`role="button"`, keyboard activation).
+    return render.props.href !== undefined || render.props.to !== undefined;
+}
+
+function isNativeButtonRender(render: ButtonProps["render"]) {
+    if (isValidElement(render)) {
+        return render.type === "button";
+    }
+
+    return true;
 }
 
 export { Button, buttonVariants };

--- a/packages/ui/src/components/ui/pagination.tsx
+++ b/packages/ui/src/components/ui/pagination.tsx
@@ -53,7 +53,6 @@ function PaginationLink({
             variant={isActive ? "outline" : "ghost"}
             size={size}
             className={cn(className)}
-            nativeButton={false}
             render={
                 <a
                     aria-current={isActive ? "page" : undefined}


### PR DESCRIPTION
## Problem

Hver `<Button render={<Link ... />}>` i `apps/kvark` logget en Base UI-feil i konsollen:

> Base UI: A component that acts as a button expected a native `<button>` because the `nativeButton` prop is true.

Dette er ikke innført av en nylig endring — det er ren a11y-/konsollhygiene.

## Hvorfor ikke bare `nativeButton={false}`

Det fjerner advarselen, men Base UI setter da `role="button"` på anchoren (se `useButton`), så skjermlesere sier «knapp» i stedet for «lenke». Base UI-dokumentasjonen er tydelig:

> "Links (`<a>`) have their own semantics and should not be rendered as buttons through the `render` prop."

## Løsning

`packages/ui/src/components/ui/button.tsx` velger nå vei ut fra render-elementet:

- **Lenke** (`href` eller TanStack sin `to` er satt) → anchoren rendres direkte via `useRender` + `mergeProps` med `buttonVariants`-klassene og `data-slot="button"`. Ingen `ButtonPrimitive`, ingen `role`, ingen `type` — lenka beholder egen semantikk.
- **Andre ikke-`<button>`-elementer** (`<div>`, `<span>`) går fortsatt gjennom `ButtonPrimitive`, men `nativeButton` utledes (`render.type === "button"`) i stedet for at hvert kallsted må si det. Eksplisitt prop vinner fortsatt; en render-*funksjon* er ugjennomsiktig og beholder native-standarden.
- En `<a>` **uten** destinasjon regnes bevisst som et klikkbart element, ikke en lenke, og beholder `role="button"` + tastaturaktivering.

Siden wrapperen håndterer dette nå, er de 27 overflødige `nativeButton={false}`-propsene fjernet (16 filer), i tillegg til `nativeButton={!render}` i `icon-action-button.tsx`.

## Verifisert

- `bun run typecheck`, `bun run lint`, `bun run format`, `bun run build` — grønt (kun eksisterende lint-warnings i `apps/api`).
- Nettleser (dev-server + API på :4100, innlogget): `/`, `/admin`, `/admin/arrangementer` (26 lenkeknapper), `/arrangementer/<slug>`, `/ny-student`, `/bedrift`, `/bedrift/studiene`, `/motetid` — **0 Base UI-feil i konsollen**, `a[role=button]` = 0 overalt, ingen nye React-attributtvarsler, og stilene er uendret (sjekket computed background/padding/høyde + skjermbilder).
- Komposisjon: `TooltipTrigger` rundt `Button render={<Link/>}` i `IconActionButton` — tooltip åpner fortsatt på hover, og klikk navigerer klientsidig.

## Verdt å vite

1. Én forekomst av samme feiltype gjenstår, men den er ikke en lenke: `PopoverTrigger render={<InputGroup/>}` i `packages/ui/src/components/ui/time-picker.tsx:255`. `nativeButton={false}` der ville gitt `role="button"` på en div med tekstfelt inni — verre enn advarselen. Bør fikses med en ekte trigger-knapp i gruppa.
2. `<Button disabled render={<Link/>}>` ville nå rendre `disabled` som et dødt attributt på anchoren (`disabled:`-CSS-variantene treffer uansett ikke anchors). Ingen kallsteder gjør dette i dag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)