### PR TITLE
feat(assets): promote-endepunkt for eksterne klienter

### DIFF
--- a/apps/api/src/routes/asset/index.ts
+++ b/apps/api/src/routes/asset/index.ts
@@ -1,9 +1,11 @@
 import { route } from "~/lib/route";
 import { downloadRoute } from "./download";
 import { getRoute } from "./get";
+import { promoteRoute } from "./promote";
 import { uploadRoute } from "./upload";
 
 export const assetRoutes = route()
     .route("/", uploadRoute)
     .route("/", getRoute)
+    .route("/", promoteRoute)
     .route("/", downloadRoute);

--- a/apps/api/src/routes/asset/promote.ts
+++ b/apps/api/src/routes/asset/promote.ts
@@ -1,0 +1,94 @@
+import { HTTPAppException } from "~/lib/errors";
+import { describeRoute } from "~/lib/openapi";
+import { route } from "~/lib/route";
+import { requireAuthOrApiKey } from "~/middleware/auth-or-api-key";
+import { metadataResponseSchema } from "./schema";
+
+/**
+ * Claim an upload so the cleanup cron stops counting the days on it.
+ *
+ * Routes inside Photon promote through {@link promoteAssetUrls} when they store
+ * a URL, and the cron's reference check rescues the ones that forget. Neither
+ * helps an app with its own database: kontres stores the URL in its own
+ * `FAQ.imageUrl`, which nothing here can see, so the picture would be deleted
+ * two days after it was uploaded with no warning anywhere.
+ *
+ * Only the uploader may promote, which is all an external client needs — it
+ * uploaded the file moments earlier with the same token. That also keeps this
+ * from becoming a way to pin down someone else's staged upload.
+ */
+/**
+ * The key is a path (`uploads/2026/08/uuid_name.webp`), so it has to be the
+ * last segment: a `:key{.+}` followed by a literal `/promote` never matches,
+ * because the greedy parameter swallows the suffix and the router does not
+ * backtrack. `GET /metadata/:key` solved it the same way.
+ */
+export const promoteRoute = route().post(
+    "/promote/:key{.+}",
+    describeRoute({
+        tags: ["assets"],
+        summary: "Promote an uploaded asset",
+        operationId: "promoteAsset",
+        description: `Mark an uploaded asset as claimed so it survives the staging cleanup that deletes unclaimed uploads after 2 days.
+
+The key is the full path returned when uploading, e.g. \`uploads/2026/08/uuid_filename.webp\`.
+
+Call this once the URL has been stored somewhere permanent. Routes within Photon do it for you; external clients that keep the URL in their own database must call it themselves.
+
+Only the account that uploaded the asset may promote it. Promoting an already-promoted asset is a no-op and still answers 200.`,
+    })
+        .schemaResponse({
+            statusCode: 200,
+            schema: metadataResponseSchema,
+            description: "Asset promoted",
+        })
+        .notFound({ description: "Asset not found" })
+        .unauthorized()
+        .errorResponses([
+            HTTPAppException.Forbidden(
+                "Du kan bare promotere filer du selv har lastet opp.",
+            ),
+        ])
+        .build(),
+    requireAuthOrApiKey,
+    async (c) => {
+        const { bucket } = c.get("ctx");
+        const key = c.req.param("key");
+
+        const asset = await bucket.getAsset(key);
+
+        if (!asset) {
+            throw HTTPAppException.NotFound("Asset");
+        }
+
+        const user = c.get("user");
+        const apiKey = c.get("apiKey");
+        const callerId = user?.id ?? apiKey?.createdById;
+
+        if (!callerId || asset.uploadedById !== callerId) {
+            throw HTTPAppException.Forbidden(
+                "Du kan bare promotere filer du selv har lastet opp.",
+            );
+        }
+
+        // Already "ready" is the normal outcome of a client retrying, so it is
+        // not an error — but there is also nothing to write.
+        const promoted =
+            asset.status === "ready" ? asset : await bucket.promoteAsset(key);
+
+        if (!promoted) {
+            throw HTTPAppException.NotFound("Asset");
+        }
+
+        return c.json({
+            id: promoted.id,
+            key: promoted.key,
+            originalFilename: promoted.originalFilename,
+            contentType: promoted.contentType,
+            size: promoted.size,
+            status: promoted.status,
+            promotedAt: promoted.promotedAt?.toISOString() ?? null,
+            createdAt: promoted.createdAt.toISOString(),
+        });
+    },
+);

--- a/apps/api/src/test/asset/asset.test.ts
+++ b/apps/api/src/test/asset/asset.test.ts
@@ -715,4 +715,114 @@ describe("Asset Upload/Download System", () => {
         },
         60_000,
     );
+
+    integrationTest(
+        "Promote endpoint claims the uploader's own asset only",
+        async ({ ctx }) => {
+            const { app, bucket } = ctx;
+
+            const { createApiKeyService } =
+                await import("~/lib/service/api-key");
+            const apiKeyService = createApiKeyService(ctx);
+
+            const owner = await ctx.utils.createTestUser();
+            const stranger = await ctx.utils.createTestUser();
+
+            const ownerKey = await apiKeyService.create({
+                name: "Owner key",
+                description: "Promote-test",
+                permissions: ["root"],
+                createdById: owner.id,
+            });
+            const strangerKey = await apiKeyService.create({
+                name: "Stranger key",
+                description: "Promote-test",
+                permissions: ["root"],
+                createdById: stranger.id,
+            });
+
+            const formData = new FormData();
+            formData.append(
+                "file",
+                new Blob([Buffer.from("promote me")], { type: "image/gif" }),
+                "promote.gif",
+            );
+
+            const upload = await app.request("/api/assets", {
+                method: "POST",
+                body: formData,
+                headers: { Authorization: `Bearer ${ownerKey.key}` },
+            });
+            expect(upload.status).toBe(201);
+            const uploaded = (await upload.json()) as { key: string };
+            expect((await bucket.getAsset(uploaded.key))?.status).toBe(
+                "staged",
+            );
+
+            // ===== Someone else may not claim it =====
+            const forbidden = await app.request(
+                `/api/assets/promote/${uploaded.key}`,
+                {
+                    method: "POST",
+                    headers: { Authorization: `Bearer ${strangerKey.key}` },
+                },
+            );
+            expect(forbidden.status).toBe(403);
+            expect((await bucket.getAsset(uploaded.key))?.status).toBe(
+                "staged",
+            );
+
+            // ===== Anonymous callers get nothing =====
+            const anonymous = await app.request(
+                `/api/assets/promote/${uploaded.key}`,
+                { method: "POST" },
+            );
+            expect(anonymous.status).toBe(401);
+
+            // ===== The uploader claims it =====
+            const promoted = await app.request(
+                `/api/assets/promote/${uploaded.key}`,
+                {
+                    method: "POST",
+                    headers: { Authorization: `Bearer ${ownerKey.key}` },
+                },
+            );
+            expect(promoted.status).toBe(200);
+            const body = (await promoted.json()) as {
+                status: string;
+                promotedAt: string | null;
+            };
+            expect(body.status).toBe("ready");
+            expect(body.promotedAt).not.toBeNull();
+
+            const stored = await bucket.getAsset(uploaded.key);
+            expect(stored?.status).toBe("ready");
+            expect(stored?.promotedAt).not.toBeNull();
+
+            // A retry is a no-op, not an error — clients retry on flaky
+            // networks and must not be told the upload is now invalid.
+            const again = await app.request(
+                `/api/assets/promote/${uploaded.key}`,
+                {
+                    method: "POST",
+                    headers: { Authorization: `Bearer ${ownerKey.key}` },
+                },
+            );
+            expect(again.status).toBe(200);
+            expect(
+                (await bucket.getAsset(uploaded.key))?.promotedAt?.getTime(),
+            ).toBe(stored?.promotedAt?.getTime());
+
+            // ===== Unknown key =====
+            const missing = await app.request(
+                "/api/assets/promote/uploads/2026/01/nope.png",
+                {
+                    method: "POST",
+                    headers: { Authorization: `Bearer ${ownerKey.key}` },
+                },
+            );
+            expect(missing.status).toBe(404);
+        },
+        600_000,
+    );
 });

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -392,6 +392,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/assets/promote/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Promote an uploaded asset
+         * @description Mark an uploaded asset as claimed so it survives the staging cleanup that deletes unclaimed uploads after 2 days.
+         *
+         *     The key is the full path returned when uploading, e.g. `uploads/2026/08/uuid_filename.webp`.
+         *
+         *     Call this once the URL has been stored somewhere permanent. Routes within Photon do it for you; external clients that keep the URL in their own database must call it themselves.
+         *
+         *     Only the account that uploaded the asset may promote it. Promoting an already-promoted asset is a no-op and still answers 200.
+         */
+        post: operations["promoteAsset"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/assets/{key}": {
         parameters: {
             query?: never;
@@ -6842,6 +6868,53 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AssetMetadata"];
+                };
+            };
+            /** @description Not Found - Asset not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    promoteAsset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Asset promoted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AssetMetadata"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Du kan bare promotere filer du selv har lastet opp. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
                 };
             };
             /** @description Not Found - Asset not found */


### PR DESCRIPTION
Legger til `POST /api/assets/promote/:key`, så en app med sin egen database kan si fra at den har tatt en opplasting i bruk.

## Hvorfor

Opplastinger lander som `staged`, og opprydningsjobben sletter dem etter to døgn. Rutene inne i Photon promoterer selv når de lagrer en URL, og jobben redder de som glemmer det ved å slå opp i tabellene i `references.ts`.

Ingen av delene hjelper en klient utenfor Photon. KontRes lagrer URL-en i sin egen `FAQ.imageUrl`, som ingenting her kan se inn i, så bildet ville blitt slettet to døgn etter at noen la det inn — uten en feilmelding noe sted. Det er samme felle som tok 10 039 bilder i juli.

## Detaljer

- Bare den som lastet opp filen kan promotere den. Det er alt en ekstern klient trenger — den lastet opp filen med det samme tokenet et øyeblikk før — og det hindrer at endepunktet blir en måte å pinne ned andres staged-opplastinger på.
- Et nytt forsøk på en allerede promotert fil er en no-op og svarer 200, siden klienter prøver på nytt ved ustabilt nett.
- Stien er `/promote/:key`, ikke `/:key/promote`: nøkkelen er en sti, og en grådig `{.+}` etterfulgt av et fast ledd matcher aldri i Hono. `GET /metadata/:key` gjør det samme.

## Testet

Ny integrasjonstest dekker eier, fremmed (403), anonym (401), gjentatt forsøk og ukjent nøkkel. `bun run test -- asset` → 15/15 grønne. Typecheck, lint, format og build er kjørt.

Verifisert ende-til-ende mot en lokal Photon fra KontRes: opplasting → promotering → raden står som `ready` med `promoted_at` satt.

## Merk

Denne må ut **før** [TIHLDE/kontres#196](https://github.com/TIHLDE/kontres/pull/196) deployes — uten endepunktet svarer opplasting i KontRes 502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
