### PR TITLE
feat(varsler): send varselets id med push-meldingen

### DIFF
--- a/apps/api/src/lib/notification/index.ts
+++ b/apps/api/src/lib/notification/index.ts
@@ -145,9 +145,19 @@ export async function sendNotification(
     // Push to the user's mobile devices if enabled. The link stays relative:
     // the app maps it to its own routes, and an absolute website URL would
     // send the tap to the browser instead.
+    //
+    // The notification id rides along so a tap in the app marks that exact
+    // row as read. It is absent when the website channel was skipped — then
+    // there is no row to mark, and the push is the whole notification.
     if (shouldSendToPush) {
         await enqueuePushNotification(
-            { userId, title, body: description, link },
+            {
+                userId,
+                title,
+                body: description,
+                link,
+                notificationId: notificationRecord?.id ?? null,
+            },
             ctx,
         );
     }

--- a/apps/api/src/lib/notification/push.ts
+++ b/apps/api/src/lib/notification/push.ts
@@ -18,13 +18,19 @@ export type PushJobData = {
     body: string;
     /** Website-relative link, forwarded to the app so a tap can deep-link. */
     link?: string | null;
+    /**
+     * The stored notification this push belongs to, so a tap in the app can
+     * mark exactly that one as read. Null when the caller skipped the website
+     * channel and no row was written.
+     */
+    notificationId?: string | null;
 };
 
 type ExpoPushMessage = {
     to: string;
     title: string;
     body: string;
-    data: { link?: string | null };
+    data: { link?: string | null; notificationId?: string | null };
     sound: "default";
     channelId: "default";
 };
@@ -74,7 +80,10 @@ export async function deliverPushNotification(
         to: device.token,
         title: data.title,
         body: data.body,
-        data: { link: data.link ?? null },
+        data: {
+            link: data.link ?? null,
+            notificationId: data.notificationId ?? null,
+        },
         sound: "default",
         // Android ignores sound unless the message names a channel; the app
         // creates "default" on startup.

--- a/apps/api/src/test/notification.test.ts
+++ b/apps/api/src/test/notification.test.ts
@@ -169,7 +169,37 @@ describe("push notification devices", () => {
             body: "Du er flyttet opp fra ventelisten",
             link: "/arrangementer/123",
         });
+
+        // The push points at the row it was created from, so a tap in the app
+        // can mark that one as read without guessing from the title.
+        const [stored] = await ctx.db.query.notification.findMany();
+        expect(stored).toBeDefined();
+        expect(jobs[0]?.data.notificationId).toBe(stored?.id);
     });
+
+    integrationTest(
+        "queues a push without a notification id when nothing is stored",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+
+            await sendNotification(
+                {
+                    userId: user.id,
+                    title: "Kun push",
+                    description: "Ingen rad å markere som lest",
+                    sendTo: { website: false, email: false },
+                },
+                ctx,
+            );
+
+            const jobs = await ctx.queue
+                .getQueue<PushJobData>(PUSH_QUEUE_NAME)
+                .getJobs();
+            expect(jobs).toHaveLength(1);
+            expect(jobs[0]?.data.notificationId).toBeNull();
+            expect(await ctx.db.query.notification.findMany()).toHaveLength(0);
+        },
+    );
 
     integrationTest(
         "sends to every device and drops tokens Expo has retired",
@@ -219,6 +249,7 @@ describe("push notification devices", () => {
                         title: "Ny bot",
                         body: "Du har fått en bot",
                         link: "/grupper/drift/boter",
+                        notificationId: "varsel-123",
                     },
                     ctx,
                 );
@@ -227,6 +258,14 @@ describe("push notification devices", () => {
             }
 
             expect(requests).toHaveLength(1);
+
+            // Both the link and the id have to survive into the Expo payload —
+            // they are all the app gets to act on when the push is tapped.
+            const sent = requests[0] as { data: unknown }[];
+            expect(sent[0]?.data).toEqual({
+                link: "/grupper/drift/boter",
+                notificationId: "varsel-123",
+            });
 
             // The dead token is deleted rather than retried: Expo rejects it
             // forever once the app is gone from the device.


### PR DESCRIPTION
## Hva

Push-meldingen bærer nå `notificationId` i `data`, ved siden av `link`.

## Hvorfor

TIHLDE-appen har fått en varselside, og et push-varsel som trykkes skal regnes som lest. Uten id-en i nyttelasten må appen hente de uleste varslene og matche på tittel + tekst + lenke for å finne igjen raden. Det virker som regel, men bommer så snart to varsler ser like ut — og det koster et ekstra API-kall for hvert trykk.

## Detaljer

- `PushJobData` og Expo-meldingens `data` har fått `notificationId`.
- `sendNotification` sender id-en fra raden den nettopp skrev.
- Id-en er `null` når `sendTo.website` er av: da finnes det ingen rad å markere som lest, og push-en *er* hele varselet.

Ingen endring i API-ets kontrakt mot nettsiden — dette gjelder bare det som ligger i push-nyttelasten.

## Testet

`bunx vitest run src/test/notification.test.ts` — 7 tester, alle grønne. To nye dekninger: at jobben peker på raden som ble skrevet, og at id-en er null når ingen rad skrives. Den eksisterende leveransetesten sjekker nå at både lenke og id overlever ut i Expo-nyttelasten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)