### PR TITLE
feat(kvark): vis påmeldte for medlemmer som selv kan melde seg på

### DIFF
--- a/apps/kvark/src/api/queries/events.ts
+++ b/apps/kvark/src/api/queries/events.ts
@@ -29,6 +29,8 @@ const EventQueryKeys = {
 } as const;
 
 const DEFAULT_PAGE_SIZE = 25;
+/** Det største `pageSize` API-et godtar (`PaginationSchema`). */
+const MAX_PAGE_SIZE = 100;
 
 type EventListFilters = Omit<
     QueryParamsHelper<"get", "/api/event">,
@@ -249,6 +251,33 @@ export const getEventRegistrationsQuery = (
                     ...filters,
                 },
             }),
+    });
+
+/**
+ * Deltakerlisten side for side. Arrangementssiden viser den til alle medlemmer
+ * som selv kan melde seg på, og de største arrangementene har flere påmeldte
+ * enn én side rommer — uten dette så en fadderuke ut som om den hadde 100.
+ */
+export const getEventRegistrationsInfiniteQuery = (
+    eventId: string,
+    pageSize: number = MAX_PAGE_SIZE,
+) =>
+    infiniteQueryOptions({
+        // eventId står før «infinite» slik at på-/avmelding, som invaliderer
+        // `[...registrations, eventId]`, også treffer denne.
+        queryKey: [
+            ...EventQueryKeys.registrations,
+            eventId,
+            "infinite",
+            pageSize,
+        ] as const,
+        queryFn: ({ pageParam }) =>
+            apiClient.get("/api/event/{eventId}/registration", {
+                params: { eventId },
+                searchParams: { page: pageParam, pageSize },
+            }),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) => lastPage.nextPage,
     });
 
 export const registerForEventMutation = mutationOptions({

--- a/apps/kvark/src/components/event-registrants-dialog.tsx
+++ b/apps/kvark/src/components/event-registrants-dialog.tsx
@@ -1,5 +1,6 @@
 import { Avatar, AvatarFallback } from "@tihlde/ui/ui/avatar";
 import { Badge } from "@tihlde/ui/ui/badge";
+import { Button } from "@tihlde/ui/ui/button";
 import {
     Dialog,
     DialogContent,
@@ -17,15 +18,26 @@ type EventRegistrantsDialogProps = {
     trigger: ReactElement;
     title: string;
     registrants: EventRegistrant[];
+    /** Antall påmeldte totalt, når lista er lastet side for side. */
+    totalCount?: number;
+    hasMore?: boolean;
+    isLoadingMore?: boolean;
+    onLoadMore?: () => void;
 };
 
 export function EventRegistrantsDialog({
     trigger,
     title,
     registrants,
+    totalCount,
+    hasMore,
+    isLoadingMore,
+    onLoadMore,
 }: EventRegistrantsDialogProps) {
     const registered = registrants.filter((r) => !r.onWaitlist);
     const waitlist = registrants.filter((r) => r.onWaitlist);
+    // Med paginering er `registered.length` bare det som er lastet så langt.
+    const registeredCount = totalCount ?? registered.length;
 
     return (
         <Dialog>
@@ -34,8 +46,9 @@ export function EventRegistrantsDialog({
                 <DialogHeader>
                     <DialogTitle>Påmeldte til {title}</DialogTitle>
                     <DialogDescription>
-                        {registered.length} påmeldte · {waitlist.length} på
-                        venteliste
+                        {waitlist.length > 0
+                            ? `${registeredCount} påmeldte · ${waitlist.length} på venteliste`
+                            : `${registeredCount} påmeldte`}
                     </DialogDescription>
                 </DialogHeader>
 
@@ -58,6 +71,24 @@ export function EventRegistrantsDialog({
                                     />
                                 ))}
                             </>
+                        ) : null}
+
+                        {registrants.length === 0 ? (
+                            <p className="p-2 text-sm text-muted-foreground">
+                                Ingen er påmeldt ennå.
+                            </p>
+                        ) : null}
+
+                        {hasMore ? (
+                            <Button
+                                variant="ghost"
+                                onClick={onLoadMore}
+                                disabled={isLoadingMore}
+                            >
+                                {isLoadingMore
+                                    ? "Laster …"
+                                    : "Vis flere påmeldte"}
+                            </Button>
                         ) : null}
                     </div>
                 </ScrollArea>

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -1,5 +1,10 @@
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import {
+    useInfiniteQuery,
+    useMutation,
+    useQuery,
+    useSuspenseQuery,
+} from "@tanstack/react-query";
 import { MarkdownView } from "@tihlde/ui/complex/markdown";
 import { Button } from "@tihlde/ui/ui/button";
 import { Separator } from "@tihlde/ui/ui/separator";
@@ -20,7 +25,7 @@ import {
 import { authQueryOptions } from "#/api/auth";
 import {
     getEventByIdQuery,
-    getEventRegistrationsQuery,
+    getEventRegistrationsInfiniteQuery,
     getFavoriteEventsQuery,
     registerForEventMutation,
     unregisterFromEventMutation,
@@ -41,7 +46,7 @@ import { MapLink } from "#/components/map-link";
 import { richRegistry } from "#/components/markdown/directives/presets";
 import { ShareButton } from "#/components/share-button";
 import { useEventRulesConsent } from "#/hooks/use-event-rules-consent";
-import { useCanActOnResource } from "#/hooks/use-permission";
+import { useCanActOnResource, usePermission } from "#/hooks/use-permission";
 import { buildGoogleCalendarUrl } from "#/lib/calendar-url";
 import { buildMapsUrls } from "#/lib/maps";
 import {
@@ -77,11 +82,32 @@ function EventDetailPage() {
         refetchIntervalInBackground: true,
     });
     const { data: session } = useQuery(authQueryOptions);
-    // Deltakerlisten er for medlemmer — utloggede får antallet fra
-    // arrangementet selv, og ville bare fått 401 her.
-    const { data: registrations } = useQuery({
-        ...getEventRegistrationsQuery(event.id, 0),
-        enabled: Boolean(session),
+
+    // Same rule as the API: the permission (a group-scoped one counts), or
+    // having created the event.
+    const isAdmin = useCanActOnResource([
+        "events:update",
+        "events:manage",
+        "events:delete",
+    ])(event.createdById);
+
+    // Deltakerlisten er for medlemmer som selv kan melde seg på: den som kan
+    // stille i rommet får se hvem andre som kommer. Utloggede og alumner får
+    // antallet fra arrangementet selv, og ville bare fått 401/tomt her.
+    const canRegisterSelf = usePermission("events:registrations:create");
+    const canSeeRegistrants =
+        Boolean(session) &&
+        event.requiresSigningUp &&
+        (canRegisterSelf || isAdmin);
+
+    const {
+        data: registrationPages,
+        hasNextPage,
+        isFetchingNextPage,
+        fetchNextPage,
+    } = useInfiniteQuery({
+        ...getEventRegistrationsInfiniteQuery(event.id),
+        enabled: canSeeRegistrants,
     });
 
     const eventRules = useEventRulesConsent();
@@ -99,14 +125,6 @@ function EventDetailPage() {
         favorites?.some((favorite) => favorite.eventId === event.id),
     );
     const organizerSlug = event.organizer?.slug;
-
-    // Same rule as the API: the permission (a group-scoped one counts), or
-    // having created the event.
-    const isAdmin = useCanActOnResource([
-        "events:update",
-        "events:manage",
-        "events:delete",
-    ])(event.createdById);
 
     const registrationState = deriveRegistrationState({
         registration: event.registration,
@@ -126,11 +144,18 @@ function EventDetailPage() {
 
     const price = formatEventPrice(event.isPaidEvent, event.payInfo?.price);
     const registeredCount = event.registeredCount;
-    const registrants = (registrations?.registeredUsers ?? []).map((u) => ({
-        id: u.id,
-        name: u.name,
-        allowPhoto: u.allowPhoto,
-    }));
+    const registrants = (registrationPages?.pages ?? []).flatMap((page) =>
+        page.registeredUsers.map((u) => ({
+            id: u.id,
+            name: u.name,
+            allowPhoto: u.allowPhoto,
+        })),
+    );
+    const registrantsTotalCount = registrationPages?.pages[0]?.totalCount;
+    // API-et gir `nextPage` også for siden etter den siste (sidetallene er
+    // nullbaserte, grensen er ikke), så antallet avgjør når vi er ferdige.
+    const hasMoreRegistrants =
+        hasNextPage && registrants.length < (registrantsTotalCount ?? 0);
 
     // Kun steder som er valgt fra adressesøket har koordinater, og bare de
     // blir en kartlenke.
@@ -374,10 +399,16 @@ function EventDetailPage() {
                             event.registration?.waitlistPosition ?? undefined
                         }
                         headerSlot={
-                            isAdmin ? (
+                            canSeeRegistrants ? (
                                 <EventRegistrantsDialog
                                     title={event.title}
                                     registrants={registrants}
+                                    totalCount={registrantsTotalCount}
+                                    hasMore={hasMoreRegistrants}
+                                    isLoadingMore={isFetchingNextPage}
+                                    onLoadMore={() => {
+                                        void fetchNextPage();
+                                    }}
                                     trigger={
                                         <Button
                                             variant="ghost"


### PR DESCRIPTION
## Hva

Deltakerlista på arrangementssiden var forbeholdt arrangører. Nå ser alle innloggede som selv kan melde seg på — de med `events:registrations:create` (medlems-baseline; alumner har den ikke) — hvem som kommer. Arrangører ser den fortsatt uansett.

## Endringer

- `arrangementer.$slug.tsx`: knappen «Se alle påmeldte» gates på `events:registrations:create` eller arrangør-tilgang, på arrangementer med påmelding.
- `api/queries/events.ts`: ny `getEventRegistrationsInfiniteQuery` (100 per side). Siden hentet før bare de 25 første, så et stort arrangement så ut som om det hadde 25 påmeldte. Nøkkelen ligger under samme prefiks som den pagede lista, så på-/avmelding invaliderer begge.
- `event-registrants-dialog.tsx`: tar imot `totalCount`, «Vis flere påmeldte»-knapp og tom-tilstand.

Ingen API-endring: endepunktet var allerede `requireAuth` og medlemssynlig. E-post, betalingsstatus, ventelisteplass og fotosamtykke er fortsatt admin-felter, og venteliste-påmeldte er ikke med i lista medlemmer får.

## Verifisert

Lokalt mot API + dev-DB, logget inn som en bruker midlertidig degradert til ren `member` (root-rolle, gruppemedlemskap og root-tittel fjernet, alt gjenopprettet etterpå): knappen dukket opp, dialogen viste «258 påmeldte» som stemte med DB, og «Vis flere» lastet 100 → 200 → 258 før knappen forsvant. `typecheck`, `lint` og `format` er grønne.

## Merk

`nextPage` i API-et er off-by-one for nullbaserte sider (`page + 1 > totalPages` gir én ekstra tom side) — samme mønster 14 steder i `apps/api/src/routes`. Dekket over klientsiden her i stedet for å endre paginerings-semantikken for alle klienter; verdt en egen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)