### PR TITLE
fix(api): nextPage pekte én side forbi den siste

### DIFF
--- a/apps/api/src/middleware/pagination.ts
+++ b/apps/api/src/middleware/pagination.ts
@@ -76,3 +76,17 @@ export const getPageOffset = (page: number, pageSize: number) =>
  */
 export const getTotalPages = (totalCount: number, pageSize: number) =>
     pageSize > 0 ? Math.ceil(totalCount / pageSize) : 0;
+
+/**
+ * The next page number, or null when `page` is the last one.
+ *
+ * Page numbers are 0-based, so the last page is `totalPages - 1`. Written out
+ * by hand this was repeatedly `page + 1 > totalPages`, which is the 1-based
+ * bound: it handed out one page past the end, and clients had to fetch an
+ * empty list to discover they were done.
+ *
+ * @param page the 0-based page that was just returned
+ * @param totalPages the total number of pages, from {@link getTotalPages}
+ */
+export const getNextPage = (page: number, totalPages: number) =>
+    page + 1 >= totalPages ? null : page + 1;

--- a/apps/api/src/routes/event/list.ts
+++ b/apps/api/src/routes/event/list.ts
@@ -17,7 +17,11 @@ import { isMemberAudience } from "~/lib/auth";
 import { describeRoute } from "~/lib/openapi";
 import { captureAuth } from "../../middleware/auth";
 import { route } from "../../lib/route";
-import { getPageOffset, getTotalPages } from "../../middleware/pagination";
+import {
+    getNextPage,
+    getPageOffset,
+    getTotalPages,
+} from "../../middleware/pagination";
 import {
     eventListFilterSchema,
     type eventListItemSchema,
@@ -174,7 +178,7 @@ export const listRoute = route().get(
         return c.json({
             totalCount: eventCount,
             pages: totalPages,
-            nextPage: page + 1 >= totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             items: returnEvents,
         } satisfies z.infer<typeof eventListResponseSchema>);
     },

--- a/apps/api/src/routes/event/payment/list.ts
+++ b/apps/api/src/routes/event/payment/list.ts
@@ -9,6 +9,7 @@ import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
@@ -107,7 +108,7 @@ export const listEventPaymentsRoute = route().get(
         return c.json({
             totalCount,
             pages: totalPages,
-            nextPage: page + 1 > totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             payments: payments.map((p) => ({
                 id: p.id,
                 userId: p.userId,

--- a/apps/api/src/routes/event/registration/history.ts
+++ b/apps/api/src/routes/event/registration/history.ts
@@ -7,6 +7,7 @@ import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
@@ -83,7 +84,7 @@ export const getMyEventHistoryRoute = route().get(
         const response: z.infer<typeof myEventHistorySchema> = {
             totalCount,
             pages,
-            nextPage: page + 1 < pages ? page + 1 : null,
+            nextPage: getNextPage(page, pages),
             events: rows.map((row) => ({
                 eventId: row.eventId,
                 title: row.title,

--- a/apps/api/src/routes/event/registration/list.ts
+++ b/apps/api/src/routes/event/registration/list.ts
@@ -10,6 +10,7 @@ import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
@@ -196,7 +197,7 @@ export const getAllRegistrationsForEventsRoute = route().get(
         return c.json({
             totalCount: registrationCount,
             pages: totalPages,
-            nextPage: page + 1 > totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             registeredUsers: returnRegistrations,
         } satisfies z.infer<typeof eventRegistrationListResponseSchema>);
     },

--- a/apps/api/src/routes/event/strike/list.ts
+++ b/apps/api/src/routes/event/strike/list.ts
@@ -9,6 +9,7 @@ import { requireAccess } from "~/middleware/access";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
@@ -98,7 +99,7 @@ export const listStrikesRoute = route().get(
         return c.json({
             totalCount,
             pages: totalPages,
-            nextPage: page + 1 > totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             strikes: strikes.map((strike) => ({
                 id: strike.id,
                 userId: strike.userId,

--- a/apps/api/src/routes/feedback/list.ts
+++ b/apps/api/src/routes/feedback/list.ts
@@ -7,6 +7,7 @@ import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
@@ -119,7 +120,7 @@ export const listRoute = route().get(
         return c.json({
             totalCount,
             pages: totalPages,
-            nextPage: page + 1 >= totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             items,
         } satisfies z.infer<typeof feedbackListResponseSchema>);
     },

--- a/apps/api/src/routes/gallery/list.ts
+++ b/apps/api/src/routes/gallery/list.ts
@@ -8,6 +8,7 @@ import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
@@ -89,7 +90,7 @@ export const listRoute = route().get(
         return c.json({
             totalCount,
             pages: totalPages,
-            nextPage: page + 1 >= totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             items: rows.map((row) =>
                 serializeAlbum(
                     row.album,

--- a/apps/api/src/routes/gallery/pictures/list.ts
+++ b/apps/api/src/routes/gallery/pictures/list.ts
@@ -9,6 +9,7 @@ import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
@@ -64,7 +65,7 @@ export const listPicturesRoute = route().get(
         return c.json({
             totalCount,
             pages: totalPages,
-            nextPage: page + 1 >= totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             items: pictures.map((p) => ({
                 id: p.id,
                 albumId: p.albumId,

--- a/apps/api/src/routes/groups/fines/list.ts
+++ b/apps/api/src/routes/groups/fines/list.ts
@@ -8,6 +8,7 @@ import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
@@ -116,7 +117,7 @@ export const listFinesRoute = route().get(
         return c.json({
             totalCount,
             pages: totalPages,
-            nextPage: page + 1 >= totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             fines: fines.map(serializeFineLaw),
         });
     },

--- a/apps/api/src/routes/groups/fines/users.ts
+++ b/apps/api/src/routes/groups/fines/users.ts
@@ -7,6 +7,7 @@ import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
@@ -109,7 +110,7 @@ export const listFineUsersRoute = route().get(
         return c.json({
             totalCount,
             pages: totalPages,
-            nextPage: page + 1 >= totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             users: rows,
         });
     },

--- a/apps/api/src/routes/job/list.ts
+++ b/apps/api/src/routes/job/list.ts
@@ -4,7 +4,11 @@ import { validator } from "hono-openapi";
 import type z from "zod";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { getPageOffset, getTotalPages } from "../../middleware/pagination";
+import {
+    getNextPage,
+    getPageOffset,
+    getTotalPages,
+} from "../../middleware/pagination";
 import {
     jobListFilterSchema,
     type jobListItemSchema,
@@ -112,7 +116,7 @@ export const listRoute = route().get(
         return c.json({
             totalCount: jobCount,
             pages: totalPages,
-            nextPage: page + 1 >= totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             items,
         } satisfies z.infer<typeof jobListResponseSchema>);
     },

--- a/apps/api/src/routes/news/list.ts
+++ b/apps/api/src/routes/news/list.ts
@@ -6,6 +6,7 @@ import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "../../middleware/pagination";
@@ -57,7 +58,7 @@ export const listRoute = route().get(
         return c.json({
             totalCount: newsCount,
             pages: totalPages,
-            nextPage: page + 1 >= totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             items,
         } satisfies z.infer<typeof newsListResponseSchema>);
     },

--- a/apps/api/src/routes/notification/list.ts
+++ b/apps/api/src/routes/notification/list.ts
@@ -3,7 +3,11 @@ import { and, desc, eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import type { z } from "zod";
 import { describeRoute } from "~/lib/openapi";
-import { getPageOffset, getTotalPages } from "~/middleware/pagination";
+import {
+    getNextPage,
+    getPageOffset,
+    getTotalPages,
+} from "~/middleware/pagination";
 import { route } from "../../lib/route";
 import { requireAuth } from "../../middleware/auth";
 import {
@@ -69,7 +73,7 @@ export const listNotificationsRoute = route().get(
         return c.json({
             totalCount: notificationCount,
             pages: totalPages,
-            nextPage: page + 1 > totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             items: returnNotifications,
         } satisfies z.infer<typeof notificationListResponseSchema>);
     },

--- a/apps/api/src/routes/user/list.ts
+++ b/apps/api/src/routes/user/list.ts
@@ -8,6 +8,7 @@ import { requireAccess } from "~/middleware/access";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
+    getNextPage,
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
@@ -152,7 +153,7 @@ export const listUsersRoute = route().get(
         return c.json({
             totalCount,
             pages: totalPages,
-            nextPage: page + 1 >= totalPages ? null : page + 1,
+            nextPage: getNextPage(page, totalPages),
             items: rows.map(({ banned, ...row }) => ({
                 ...row,
                 // `banned` is nullable in Better Auth's schema; only an

--- a/apps/api/src/test/event/registration-list.test.ts
+++ b/apps/api/src/test/event/registration-list.test.ts
@@ -218,4 +218,46 @@ describe("Event registration listing", () => {
         },
         500_000,
     );
+
+    integrationTest(
+        // Regression guard: pages are 0-based, so the last page must report
+        // no next page. It used to point at one page past the end, and the
+        // client had to fetch an empty list to discover it was done.
+        "reports no next page on the last page",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            const event = await ctx.utils.createTestEvent();
+
+            // 3 registrations over pages of 2: pages 0 and 1, nothing after.
+            for (let i = 0; i < 3; i++) {
+                const user = await ctx.utils.createTestUser();
+                await ctx.db.insert(schema.eventRegistration).values({
+                    eventId: event.id,
+                    userId: user.id,
+                    status: "registered",
+                });
+            }
+
+            const member = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(member);
+
+            const first = await client.api.event[":eventId"].registration.$get({
+                param: { eventId: event.id },
+                query: { page: "0", pageSize: "2" },
+            });
+            const firstBody = await first.json();
+            expect(firstBody.totalCount).toBe(3);
+            expect(firstBody.registeredUsers).toHaveLength(2);
+            expect(firstBody.nextPage).toBe(1);
+
+            const last = await client.api.event[":eventId"].registration.$get({
+                param: { eventId: event.id },
+                query: { page: "1", pageSize: "2" },
+            });
+            const lastBody = await last.json();
+            expect(lastBody.registeredUsers).toHaveLength(1);
+            expect(lastBody.nextPage).toBeNull();
+        },
+        500_000,
+    );
 });

--- a/apps/api/src/test/pagination.test.ts
+++ b/apps/api/src/test/pagination.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { getNextPage, getTotalPages } from "~/middleware/pagination";
+
+/**
+ * Page numbers are 0-based, so the last page is `totalPages - 1`. Hand-written
+ * as `page + 1 > totalPages` this handed out one page past the end, and every
+ * "load more" button stayed visible until the client fetched an empty list.
+ */
+describe("getNextPage", () => {
+    it("stops on the last page when it is partially filled", () => {
+        const totalPages = getTotalPages(258, 100); // 3 pages: 0, 1, 2
+        expect(getNextPage(0, totalPages)).toBe(1);
+        expect(getNextPage(1, totalPages)).toBe(2);
+        expect(getNextPage(2, totalPages)).toBeNull();
+    });
+
+    it("stops on the last page when the count divides evenly", () => {
+        const totalPages = getTotalPages(200, 100); // 2 pages: 0, 1
+        expect(getNextPage(0, totalPages)).toBe(1);
+        expect(getNextPage(1, totalPages)).toBeNull();
+    });
+
+    it("has no next page for a single page or an empty result", () => {
+        expect(getNextPage(0, getTotalPages(40, 100))).toBeNull();
+        expect(getNextPage(0, getTotalPages(0, 100))).toBeNull();
+    });
+});


### PR DESCRIPTION
## Feilen

Sidetallene i de paginerte svarene er nullbaserte, men grensen var skrevet som om de var ettbaserte:

```ts
nextPage: page + 1 > totalPages ? null : page + 1,
```

Med 258 påmeldte og `pageSize=100` er `totalPages = 3` og gyldige sider `0`, `1`, `2`. På siste side (`page = 2`) er `3 > 3` usant, så svaret sa `nextPage: 3` — en side som finnes i regnestykket, men ikke i dataene. Det slår til uansett antall: alltid nøyaktig én tom side på slutten.

Ikke gale data, men et bortkastet rundtur-kall, og «Vis flere»-knapper som gates på `nextPage` alene ble stående etter at alt var lastet.

## Endringen

Ny `getNextPage(page, totalPages)` i `middleware/pagination.ts`, ved siden av `getTotalPages`.

Fire endepunkter hadde feil grense og endrer oppførsel:

- `GET /api/event/{eventId}/registration`
- `GET /api/event/{eventId}/payment`
- `GET /api/event/{eventId}/strike`
- `GET /api/notification`

De ti øvrige listene hadde riktig grense fra før og endrer ikke oppførsel — de er lagt om til samme hjelper så neste kopiering ikke gjeninnfører feilen.

## Merk for klienter

Endepunktene over gir nå `nextPage: null` én side tidligere enn før. Klienter som stopper på `nextPage` fungerer likt, bare uten den tomme forespørselen. Kvark leser deltakerlista mot `totalCount` (fra PR #528) og påvirkes ikke.

## Tester

- `src/test/pagination.test.ts`: enhetstester for grensene — delvis fylt siste side, antall som går opp i pageSize, én side, tomt resultat.
- `registration-list.test.ts`: regresjonstest mot endepunktet (3 påmeldte, `pageSize=2` → side 1 svarer `nextPage: null`).

Verifisert at regresjonstesten faktisk fanger feilen: med den gamle grensen feiler den med `expected 2 to be null`. `typecheck`, `lint` og `format` er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)