### PR TITLE
fix(db): tidsgrenser på tilkoblingen og crash guard i API-et

### DIFF
--- a/apps/api/src/db/backfill-hs-subgroup-leaders.ts
+++ b/apps/api/src/db/backfill-hs-subgroup-leaders.ts
@@ -27,7 +27,7 @@
  * Run against the target database (uses env.DATABASE_URL):
  *   cd apps/api && bun run src/db/backfill-hs-subgroup-leaders.ts
  */
-import { createDb, type DbSchema, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, type DbSchema, schema } from "@photon/db";
 import { and, eq, type InferSelectModel } from "drizzle-orm";
 import type { AppContext } from "~/lib/ctx";
 import { env } from "~/lib/env";
@@ -113,7 +113,10 @@ async function main() {
     // Backfill only touches the DB; a minimal db-only context avoids the
     // auth/redis/bucket wiring that createAppContext refuses to build in
     // production. Only `db` is read by the code paths below.
-    const db = createDb({ connectionString: env.DATABASE_URL });
+    const db = createDb({
+        connectionString: env.DATABASE_URL,
+        timeouts: DISABLED_TIMEOUTS,
+    });
     const ctx = { db } as unknown as AppContext;
 
     const groups = await ctx.db.select().from(schema.group);

--- a/apps/api/src/db/import-group-logos.ts
+++ b/apps/api/src/db/import-group-logos.ts
@@ -9,7 +9,7 @@
  * Run with:
  *   cd apps/api && bun run src/db/import-group-logos.ts
  */
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { eq, isNotNull } from "drizzle-orm";
 import { env } from "~/lib/env";
 import { createStorageClient } from "~/lib/storage";
@@ -33,7 +33,10 @@ function extensionFor(contentType: string | null, url: string): string {
 }
 
 async function main() {
-    const db = createDb({ connectionString: env.DATABASE_URL });
+    const db = createDb({
+        connectionString: env.DATABASE_URL,
+        timeouts: DISABLED_TIMEOUTS,
+    });
     const bucket = await createStorageClient({ db });
 
     const groups = await db.query.group.findMany({

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,32 @@ import { setupWebhooks } from "./lib/vipps";
 export { createApp } from "./app";
 export type { App } from "./app";
 
+/**
+ * Keep a single stray rejection from taking down the API.
+ *
+ * On 2026-08-13 a `rollback` failed against a connection that had just been
+ * killed, the rejection reached the top level, and Bun exited — turning an
+ * outage that affected database-backed routes into one where even the health
+ * check was gone, with nothing to restart the container. A server that has
+ * hundreds of in-flight requests is better off logging the fault and staying
+ * up: the failing request still fails, everyone else keeps being served.
+ *
+ * These are a safety net, not a place to handle errors. Anything logged here
+ * is a bug in the code that produced the floating promise.
+ */
+function installCrashGuards(): void {
+    process.on("unhandledRejection", (reason) => {
+        console.error("Unhandled promise rejection — server stays up:", reason);
+    });
+
+    process.on("uncaughtException", (error) => {
+        console.error("Uncaught exception — server stays up:", error);
+    });
+}
+
 if (env.NODE_ENV !== "test") {
+    installCrashGuards();
+
     void (await setupWebhooks());
 
     const { createApp } = await import("./app");

--- a/apps/api/src/migrate.ts
+++ b/apps/api/src/migrate.ts
@@ -1,5 +1,5 @@
 import { env } from "@photon/core/env";
-import { createDb } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb } from "@photon/db";
 import {
     findSkippedMigrations,
     readMigrationJournal,
@@ -68,7 +68,11 @@ async function assertNoMigrationsSkipped(
 console.log(`Applying database migrations from ${MIGRATIONS_FOLDER}`);
 
 try {
-    const db = createDb({ connectionString: env.DATABASE_URL });
+    const db = createDb({
+        connectionString: env.DATABASE_URL,
+        // An ALTER TABLE may legitimately run for minutes.
+        timeouts: DISABLED_TIMEOUTS,
+    });
     await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
     await assertNoMigrationsSkipped(db);
     console.log("Database migrations applied");

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -23,6 +23,14 @@ export type DbTimeouts = {
     statementTimeoutMs?: number;
     /** Max time a transaction may sit idle before Postgres kills it. */
     idleInTransactionTimeoutMs?: number;
+    /**
+     * Max wait for a free connection from the pool. The per-connection
+     * timeouts above bound what one query may do; this bounds the queue that
+     * forms in front of them. Without it a saturated pool makes every new
+     * request wait indefinitely — which is what turned three stuck requests
+     * into a site-wide outage.
+     */
+    connectionTimeoutMs?: number;
 };
 
 /**
@@ -33,17 +41,20 @@ export const REQUEST_TIMEOUTS = {
     lockTimeoutMs: 5_000,
     statementTimeoutMs: 15_000,
     idleInTransactionTimeoutMs: 30_000,
+    connectionTimeoutMs: 5_000,
 } as const satisfies DbTimeouts;
 
 /**
  * No timeouts, for migrations and one-off scripts: an `ALTER TABLE` or a bulk
  * import legitimately runs for minutes, and killing it halfway is worse than
- * letting it finish.
+ * letting it finish. A script that starves its own pool should wait rather
+ * than fail, so the connection wait is unbounded here too.
  */
 export const DISABLED_TIMEOUTS = {
     lockTimeoutMs: 0,
     statementTimeoutMs: 0,
     idleInTransactionTimeoutMs: 0,
+    connectionTimeoutMs: 0,
 } as const satisfies DbTimeouts;
 
 function buildOptions(timeouts: DbTimeouts): string {
@@ -81,6 +92,69 @@ function attachErrorHandler(pool: Pool): Pool {
     return pool;
 }
 
+/** How often the pool is sampled for saturation. */
+const SATURATION_SAMPLE_MS = 2_000;
+
+/** How often an ongoing saturation is repeated in the log. */
+const SATURATION_REPEAT_MS = 30_000;
+
+/**
+ * Warn while every connection is checked out and requests are queueing.
+ *
+ * The 2026-08-13 outage was a saturated pool, and nothing said so. The logs
+ * showed healthy traffic, then silence — because a request that never
+ * finishes never logs. From the outside it looked like a dead server, and it
+ * cost an hour to work out that ten connections were held by requests waiting
+ * on a lock. One line saying "all 10 connections busy, 14 requests waiting"
+ * would have pointed straight at it.
+ *
+ * Only fires when the pool is *both* full and has requests queueing: a fully
+ * used pool with nobody waiting is a busy server working as intended.
+ *
+ * The interval is unref'd so it can never hold the process open, and the
+ * sampling is deliberately cheap — the counters are plain numbers on the pool.
+ */
+function watchSaturation(pool: Pool): Pool {
+    const max = pool.options.max ?? 10;
+    let saturatedSince: number | null = null;
+    let lastWarnedAt = 0;
+    let peakWaiting = 0;
+
+    const timer = setInterval(() => {
+        const waiting = pool.waitingCount;
+        const saturated = waiting > 0 && pool.totalCount >= max;
+        const now = Date.now();
+
+        if (saturated) {
+            saturatedSince ??= now;
+            peakWaiting = Math.max(peakWaiting, waiting);
+
+            if (now - lastWarnedAt >= SATURATION_REPEAT_MS) {
+                lastWarnedAt = now;
+                console.warn(
+                    `Postgres pool saturated: all ${max} connections busy, ${waiting} request(s) queueing, ` +
+                        `${Math.round((now - saturatedSince) / 1000)}s so far. ` +
+                        "Something is holding connections open — look for long-running queries and lock waits.",
+                );
+            }
+            return;
+        }
+
+        if (saturatedSince !== null) {
+            console.warn(
+                `Postgres pool recovered after ${Math.round((now - saturatedSince) / 1000)}s, ` +
+                    `peak queue ${peakWaiting} request(s).`,
+            );
+            saturatedSince = null;
+            lastWarnedAt = 0;
+            peakWaiting = 0;
+        }
+    }, SATURATION_SAMPLE_MS);
+
+    timer.unref?.();
+    return pool;
+}
+
 /**
  * Factory function to create a database client.
  * Requires either `connectionString` or `pool`.
@@ -104,18 +178,24 @@ export function createDb(config: {
 
     if (pool) {
         return drizzle({
-            client: attachErrorHandler(pool),
+            client: watchSaturation(attachErrorHandler(pool)),
             ...defaultConfig,
         });
     }
 
     if (connectionString) {
+        const { connectionTimeoutMs = REQUEST_TIMEOUTS.connectionTimeoutMs } =
+            timeouts;
+
         return drizzle({
-            client: attachErrorHandler(
-                new Pool({
-                    connectionString,
-                    options: buildOptions(timeouts),
-                }),
+            client: watchSaturation(
+                attachErrorHandler(
+                    new Pool({
+                        connectionString,
+                        options: buildOptions(timeouts),
+                        connectionTimeoutMillis: connectionTimeoutMs,
+                    }),
+                ),
             ),
             ...defaultConfig,
         });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,7 +1,85 @@
 import { type NodePgDatabase, drizzle } from "drizzle-orm/node-postgres";
-import type { Pool } from "pg";
+import { Pool } from "pg";
 
 import * as schema from "./schema";
+
+/**
+ * Per-connection timeouts, in milliseconds. `0` disables a timeout, which is
+ * also Postgres' own default — and the reason tihlde.org was down for an hour
+ * on 2026-08-13: a Feide callback sat waiting on a row lock in `auth_account`
+ * for 50 minutes, holding one of the pool's connections the whole time. Two
+ * more requests queued behind it, and once all connections were held by
+ * requests waiting on something that never came, every database-backed route
+ * hung. Without a timeout there is nothing that ever breaks such a deadlock.
+ *
+ * These are deliberately shorter than Bun's 10s `idleTimeout`: a request that
+ * blocks this long has already lost its client, so the only thing left to do
+ * is give the connection back to the pool.
+ */
+export type DbTimeouts = {
+    /** Max wait for a row/table lock before giving up. */
+    lockTimeoutMs?: number;
+    /** Max runtime for a single statement. */
+    statementTimeoutMs?: number;
+    /** Max time a transaction may sit idle before Postgres kills it. */
+    idleInTransactionTimeoutMs?: number;
+};
+
+/**
+ * Defaults for a connection that serves HTTP requests. Long-running work
+ * (migrations, bulk imports) must opt out — see `DISABLED_TIMEOUTS`.
+ */
+export const REQUEST_TIMEOUTS = {
+    lockTimeoutMs: 5_000,
+    statementTimeoutMs: 15_000,
+    idleInTransactionTimeoutMs: 30_000,
+} as const satisfies DbTimeouts;
+
+/**
+ * No timeouts, for migrations and one-off scripts: an `ALTER TABLE` or a bulk
+ * import legitimately runs for minutes, and killing it halfway is worse than
+ * letting it finish.
+ */
+export const DISABLED_TIMEOUTS = {
+    lockTimeoutMs: 0,
+    statementTimeoutMs: 0,
+    idleInTransactionTimeoutMs: 0,
+} as const satisfies DbTimeouts;
+
+function buildOptions(timeouts: DbTimeouts): string {
+    const {
+        lockTimeoutMs = REQUEST_TIMEOUTS.lockTimeoutMs,
+        statementTimeoutMs = REQUEST_TIMEOUTS.statementTimeoutMs,
+        idleInTransactionTimeoutMs = REQUEST_TIMEOUTS.idleInTransactionTimeoutMs,
+    } = timeouts;
+
+    // Passed as libpq start-up options so they apply to every connection the
+    // pool opens, including ones created long after startup.
+    return [
+        `-c lock_timeout=${lockTimeoutMs}`,
+        `-c statement_timeout=${statementTimeoutMs}`,
+        `-c idle_in_transaction_session_timeout=${idleInTransactionTimeoutMs}`,
+    ].join(" ");
+}
+
+/**
+ * Idle clients in the pool emit `error` when the connection dies under them —
+ * a Postgres restart, a network blip, or an admin running
+ * `pg_terminate_backend`. Node treats an unhandled `error` event as fatal, so
+ * without this listener a single dead connection takes down the whole server.
+ * That is exactly what happened during the 2026-08-13 incident: terminating
+ * the stuck backends killed the API process and turned a partial outage into a
+ * total one.
+ *
+ * The pool discards the broken client and opens a new one on the next query,
+ * so logging is the correct response.
+ */
+function attachErrorHandler(pool: Pool): Pool {
+    pool.on("error", (error) => {
+        console.error("Postgres pool error on an idle client:", error);
+    });
+    return pool;
+}
 
 /**
  * Factory function to create a database client.
@@ -10,26 +88,35 @@ import * as schema from "./schema";
 export function createDb(config: {
     connectionString?: string;
     pool?: Pool;
+    /**
+     * Per-connection timeouts. Defaults to {@link REQUEST_TIMEOUTS}; pass
+     * {@link DISABLED_TIMEOUTS} for migrations and bulk scripts. Ignored when
+     * `pool` is supplied — configure that pool yourself.
+     */
+    timeouts?: DbTimeouts;
 }): NodePgDatabase<typeof schema> {
     const defaultConfig = {
         casing: "snake_case",
         schema,
     } as const;
 
-    const { connectionString, pool } = config;
+    const { connectionString, pool, timeouts = {} } = config;
 
     if (pool) {
         return drizzle({
-            client: pool,
+            client: attachErrorHandler(pool),
             ...defaultConfig,
         });
     }
 
     if (connectionString) {
         return drizzle({
-            connection: {
-                connectionString: connectionString,
-            },
+            client: attachErrorHandler(
+                new Pool({
+                    connectionString,
+                    options: buildOptions(timeouts),
+                }),
+            ),
             ...defaultConfig,
         });
     }

--- a/packages/lepton-migration/backfill-contact-persons.ts
+++ b/packages/lepton-migration/backfill-contact-persons.ts
@@ -17,7 +17,7 @@
  * Usage: DATABASE_URL=... bun backfill-contact-persons.ts [--commit]
  * Without --commit it reports what it would change and rolls back.
  */
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { and, eq, isNull } from "drizzle-orm";
 
 const commit = process.argv.includes("--commit");
@@ -41,7 +41,10 @@ const main = async () => {
     const entries = Object.entries(manifest.contactPersons);
     console.log(`${entries.length} kontaktpersoner å koble\n`);
 
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     let matched = 0;
     const missingUser: string[] = [];

--- a/packages/lepton-migration/backfill-event-fields.ts
+++ b/packages/lepton-migration/backfill-event-fields.ts
@@ -14,7 +14,7 @@
  *
  *   DATABASE_URL=... bun backfill-event-fields.ts [--commit]
  */
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 
 const commit = process.argv.includes("--commit");
@@ -37,7 +37,10 @@ type LeptonUser = { user_id: string; email: string };
 const asUtc = (value: string): Date =>
     new Date(/Z|[+-]\d{2}:?\d{2}$/.test(value) ? value : `${value}Z`);
 
-const db = createDb({ connectionString: process.env.DATABASE_URL! });
+const db = createDb({
+    connectionString: process.env.DATABASE_URL!,
+    timeouts: DISABLED_TIMEOUTS,
+});
 
 const leptonEvents = (await Bun.file(
     `${tablesDir}/content_event.json`,

--- a/packages/lepton-migration/backfill-fine-images.ts
+++ b/packages/lepton-migration/backfill-fine-images.ts
@@ -22,7 +22,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { S3ObjectStorageService } from "@photon/core/services/storage";
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { eq, inArray } from "drizzle-orm";
 import { char32ToUuid } from "./src/mappings";
 
@@ -58,7 +58,10 @@ const filenameOf = (url: string): string => {
 type LeptonFineRow = { id: string; image: string | null };
 
 const main = async () => {
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     const raw = readFileSync(join(TABLES_DIR, "group_fine.json"), "utf8");
     const leptonFines = JSON.parse(raw) as LeptonFineRow[];

--- a/packages/lepton-migration/backfill-fines-admins.ts
+++ b/packages/lepton-migration/backfill-fines-admins.ts
@@ -18,7 +18,7 @@
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { eq, inArray, isNotNull } from "drizzle-orm";
 import { resolveGroupSlug } from "./src/mappings";
 
@@ -40,7 +40,10 @@ const connectionString = need("DATABASE_URL");
 type LeptonGroupRow = { slug: string; fines_admin_id: string | null };
 
 const main = async () => {
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     const raw = readFileSync(join(TABLES_DIR, "group_group.json"), "utf8");
     const leptonGroups = JSON.parse(raw) as LeptonGroupRow[];

--- a/packages/lepton-migration/backfill-group-subtypes.ts
+++ b/packages/lepton-migration/backfill-group-subtypes.ts
@@ -18,7 +18,7 @@
  *
  * Usage: DATABASE_URL=... bun backfill-group-subtypes.ts [--commit]
  */
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { and, eq, isNull } from "drizzle-orm";
 
 const commit = process.argv.includes("--commit");
@@ -56,7 +56,10 @@ const main = async () => {
         `${groups.length} grupper i Lepton, ${withSubtype.length} med subtype\n`,
     );
 
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     let updated = 0;
     let alreadySet = 0;

--- a/packages/lepton-migration/create-client.ts
+++ b/packages/lepton-migration/create-client.ts
@@ -3,14 +3,17 @@
  * Kjøres én gang: DATABASE_URL=... AUTH_SECRET=... bun create-client.ts
  */
 import { createAuth, drizzleAdapter } from "@photon/auth";
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { ConsoleEmailService } from "@photon/core/services/email";
 import { InMemoryCache } from "@photon/core/services/cache";
 
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) throw new Error("DATABASE_URL mangler");
 
-const db = createDb({ connectionString });
+const db = createDb({
+    connectionString,
+    timeouts: DISABLED_TIMEOUTS,
+});
 const auth = createAuth({
     isDevMode: false,
     secret: process.env.AUTH_SECRET || crypto.randomUUID(),

--- a/packages/lepton-migration/import-content-images.ts
+++ b/packages/lepton-migration/import-content-images.ts
@@ -17,7 +17,7 @@
  *   bun import-content-images.ts [--commit]
  */
 import { S3ObjectStorageService } from "@photon/core/services/storage";
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 
 const commit = process.argv.includes("--commit");
@@ -56,7 +56,10 @@ type Job = {
 };
 
 const main = async () => {
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     const events = await db
         .select({

--- a/packages/lepton-migration/import-events.ts
+++ b/packages/lepton-migration/import-events.ts
@@ -17,7 +17,7 @@
  * Without --commit it rolls back and only reports what it would have written.
  */
 import { buildEventSlugBase, slugifyText } from "@photon/core/slug";
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 
 const CACHE = `${import.meta.dir}/../../../import/cache`;
 const commit = process.argv.includes("--commit");
@@ -67,7 +67,10 @@ const asNumber = (value: unknown): number | null => {
 };
 
 const main = async () => {
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     const categories = await read<LeptonCategory[]>("categories");
     const groups = await read<LeptonGroup[]>("groups");

--- a/packages/lepton-migration/import-group-laws.ts
+++ b/packages/lepton-migration/import-group-laws.ts
@@ -14,7 +14,7 @@
  *   LEPTON_TOKEN=$(cat .lepton-token) DATABASE_URL=... \
  *   bun import-group-laws.ts [--commit]
  */
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { char32ToUuid } from "./src/mappings";
 
 const commit = process.argv.includes("--commit");
@@ -84,7 +84,10 @@ const normalizeId = (id: string): string =>
     id.includes("-") ? id : char32ToUuid(id);
 
 const main = async () => {
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     const groups = await db
         .select({ slug: schema.group.slug })

--- a/packages/lepton-migration/import-membership-histories.ts
+++ b/packages/lepton-migration/import-membership-histories.ts
@@ -26,7 +26,7 @@
  *
  * Usage: DATABASE_URL=... bun import-membership-histories.ts [--commit]
  */
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { resolveGroupSlug } from "./src/mappings";
 
 const commit = process.argv.includes("--commit");
@@ -63,7 +63,10 @@ const main = async () => {
         users.map((u) => [u.user_id, u.email.trim().toLowerCase()]),
     );
 
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     const photonUsers = await db
         .select({ id: schema.user.id, email: schema.user.email })

--- a/packages/lepton-migration/import-memberships.ts
+++ b/packages/lepton-migration/import-memberships.ts
@@ -22,7 +22,7 @@
  *
  * Usage: DATABASE_URL=... bun import-memberships.ts [--commit]
  */
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 import { resolveGroupSlug } from "./src/mappings";
 
@@ -60,7 +60,10 @@ const main = async () => {
         users.map((u) => [u.user_id, u.email.trim().toLowerCase()]),
     );
 
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     const photonUsers = await db
         .select({ id: schema.user.id, email: schema.user.email })

--- a/packages/lepton-migration/import-profile-images.ts
+++ b/packages/lepton-migration/import-profile-images.ts
@@ -20,7 +20,7 @@
  *   bun import-profile-images.ts [--commit]
  */
 import { S3ObjectStorageService } from "@photon/core/services/storage";
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 
 const commit = process.argv.includes("--commit");
@@ -62,7 +62,10 @@ const main = async () => {
     const withImage = users.filter((u) => (u.image ?? "").trim());
     console.log(`${withImage.length} brukere med profilbilde i eksporten\n`);
 
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     const photonUsers = await db
         .select({

--- a/packages/lepton-migration/import-users.ts
+++ b/packages/lepton-migration/import-users.ts
@@ -20,7 +20,7 @@
  */
 import { createAuth, drizzleAdapter } from "@photon/auth";
 import { slugifyText } from "@photon/core/slug";
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { ConsoleEmailService } from "@photon/core/services/email";
 import { InMemoryCache } from "@photon/core/services/cache";
 import { eq } from "drizzle-orm";
@@ -60,7 +60,10 @@ const main = async () => {
 
     console.log(`${users.length} brukere i eksporten\n`);
 
-    const db = createDb({ connectionString });
+    const db = createDb({
+        connectionString,
+        timeouts: DISABLED_TIMEOUTS,
+    });
 
     // Only the commit path needs an auth instance: a dry run is read-only.
     // No redis, no queue, no outbound mail — an in-memory cache and a console

--- a/packages/lepton-migration/src/index.ts
+++ b/packages/lepton-migration/src/index.ts
@@ -17,7 +17,7 @@
  *   --force       Truncate target tables before inserting
  *   --verify-only Run only verification (no migration)
  */
-import { createDb, schema } from "@photon/db";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
 import { createAuth, drizzleAdapter } from "@photon/auth";
 import { env } from "@photon/core/env";
 import { InMemoryCache } from "@photon/core/services/cache";
@@ -111,7 +111,10 @@ async function main() {
     console.log();
 
     // Connect to databases
-    const db = createDb({ connectionString: env.DATABASE_URL });
+    const db = createDb({
+        connectionString: env.DATABASE_URL,
+        timeouts: DISABLED_TIMEOUTS,
+    });
     await connectMySQL(mysqlUrl);
 
     if (verifyOnly) {


### PR DESCRIPTION
## Hvorfor

13. august 2026 lå tihlde.org nede fra 11:35 til 12:40 UTC. Årsaken, bekreftet i Loki:

- `POST /api/auth/oauth2/callback/feide` startet 11:34:43 og hang i **49 min 46 s** (`elapsedMs: 2985874`). Den sto fast på Better Auth sin `update "auth_account" set access_token, ...` — FATAL-en ved terminering sa `where: "while updating tuple (167,10) in relation "auth_account""`.
- To `/api/event/<id>`-requests la seg i kø bak (42–43 min hver).
- Rundt 11:45 var pg-poolen (standard maks 10) tom, og alt som trenger databasen sluttet å svare. `/api`-helsesjekken svarte fortsatt på 30 ms, fordi den ikke spør databasen — derfor så det ut som om serveren var frisk.

Postgres venter for alltid på en lås som standard, og pg-poolen venter for alltid på en ledig forbindelse. Ingenting i systemet kunne bryte dette av seg selv, og ingenting sa fra at det pågikk: en request som aldri blir ferdig logger aldri, så loggene viste frisk trafikk og deretter stillhet.

Da låsene ble ryddet manuelt med `pg_terminate_backend`, feilet en `rollback` mot en død forbindelse, rejection-en nådde toppnivå, og Bun avsluttet. Etter det svarte *alle* ruter 502 — også helsesjekken — og containeren restartet ikke selv.

## Hva som endres

**1. Tidsgrenser på hver tilkobling** (`packages/db/src/index.ts`)

`createDb` sender `lock_timeout=5s`, `statement_timeout=15s` og `idle_in_transaction_session_timeout=30s` som libpq-oppstartsopsjoner, så de gjelder alle forbindelser poolen åpner — også de som opprettes lenge etter oppstart. Grensene er bevisst kortere enn Bun sin `idleTimeout` på 10 s: en request som blokkerer så lenge har uansett mistet klienten sin.

Migrasjoner (`apps/api/src/migrate.ts`) og bulk-skriptene i `packages/lepton-migration` melder seg ut med `DISABLED_TIMEOUTS`.

**2. Crash guard** (`packages/db/src/index.ts` + `apps/api/src/index.ts`)

Poolen får en `error`-handler, så en død idle-forbindelse ikke feller prosessen. API-et logger `unhandledRejection` og `uncaughtException` og holder seg oppe — en server med hundrevis av requests underveis er bedre tjent med å logge feilen enn å dø. Dette er et sikkerhetsnett, ikke et sted å håndtere feil.

**3. Grense på kø-venting** (`connectionTimeoutMs`, 5 s)

Tidsgrensene over avgrenser hva én spørring får gjøre; denne avgrenser køen som danner seg foran forbindelsene. Uten den venter hver nye request i det uendelige når poolen er tom — det var det som gjorde tre fastlåste requests til en nedetid for hele siden. Bulk-skript venter fortsatt ubegrenset.

**4. Varsel når poolen går tom**

En vakt logger når alle forbindelsene er opptatt *og* det står requests i kø, med kølengde og varighet, og logger igjen når det løsner. Den fyrer ikke på en full pool uten kø — det er bare en travel server. Intervallet er `unref`-et, så det kan aldri holde prosessen i live.

Én linje som sa «all 10 connections busy, 14 requests waiting» hadde pekt rett på årsaken 13. august. I stedet tok det en time.

## Verifisering

Alt kjørt mot ekte Postgres, ikke bare typesjekket.

**Låsen brytes.** Én tilkobling holder en radlås i en åpen transaksjon, en annen prøver å skrive til samme rad:

```
OK: ga opp etter 5027 ms — canceling statement due to lock timeout
```

Før denne endringen hang den i det uendelige — nøyaktig mekanismen bak nedetiden.

**Køen avgrenses og metning varsles.** Pool med maks 1 forbindelse, holdt opptatt, med tre requests i kø:

```
Postgres pool saturated: all 1 connections busy, 3 request(s) queueing, 0s so far. ...
køede requests: ["ga opp: timeout exceeded when trying to connect", ...]
Postgres pool recovered after 2s, peak queue 3 request(s).
```

**Innstillingene når fram:**

```
REQUEST_TIMEOUTS  -> lock: 5s | statement: 15s | idle_in_tx: 30s | connection: 5000ms
DISABLED_TIMEOUTS -> lock: 0  | statement: 0   | connection: 0
```

**Crash guard:** en `Promise.reject` og et synkront kast blir begge logget, prosessen lever videre og avslutter med 0.

`bun run typecheck`, `bun run build` og `bun run test` (559 tester, 80 filer) er grønne. Tester bruker PGlite direkte og går ikke gjennom `createDb`, så de er uberørt.

## Det som gjenstår

Dette er sikkerhetsnettet, ikke selve buggen.

Jeg har skannet kodebasen for de to klassiske fellene, og **begge er rene**: ingen steder bruker pool-`db` inne i en `db.transaction`-blokk i stedet for `tx`, og det finnes ingen `fetch` inne i en transaksjon. Better Auth wrapper heller ikke OAuth-callbacken i en transaksjon, så `update auth_account` var etter alt å dømme en autocommit-setning — den var offeret, ikke holderen. Hvem som faktisk holdt raden er borte med backendene som ble drept.

Neste hendelse navngir seg selv med punkt 4. I tillegg bør `log_lock_waits` skrus på i prod-Postgres (den er `off` i dag, og `log_min_duration_statement` er `-1`) — da logger Postgres selv hvem som blokkerer hvem etter `deadlock_timeout`. Det er en konfigendring på drift, ikke en kodeendring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)