### PR TITLE
refactor(kvark): endre "Opptak" til "Kontrakt" i admin-sidemenyen

### DIFF
--- a/apps/kvark/src/routes/admin.tsx
+++ b/apps/kvark/src/routes/admin.tsx
@@ -192,7 +192,7 @@ const sidebarMenuGroups: SidebarGroup[] = [
                 allowGroupLeader: true,
             },
             {
-                label: "Opptak",
+                label: "Kontrakt",
                 icon: FileUserIcon,
                 link: linkOptions({ to: "/admin/opptak" }),
                 permission: ADMIN_SECTION_PERMISSIONS.opptak,


### PR DESCRIPTION
Endrer kun etiketten i admin-sidemenyen fra "Opptak" til "Kontrakt".

Ruten (`/admin/opptak`), permissions og den offentlige menyen er urørt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)