### PR TITLE
fix(kontrakt): retter signeringsflyten etter HS-testing

### DIFF
--- a/apps/api/src/lib/contract/pdf.ts
+++ b/apps/api/src/lib/contract/pdf.ts
@@ -13,6 +13,7 @@
 
 import type { SignaturePlacement } from "@photon/db/schema";
 import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+import sharp from "sharp";
 
 export type StampContractInput = {
     /** The original, unsigned contract PDF. */
@@ -45,6 +46,34 @@ function formatDateTime(date: Date): string {
     });
 }
 
+/**
+ * Crop the transparent margin off a signature PNG.
+ *
+ * Both signature inputs hand us a fixed-size canvas with the strokes somewhere
+ * in the middle, so most of the image is empty. Stamped as-is the ink lands in
+ * the middle of the placement box and reads as floating above the line the
+ * admin aimed at, no matter how precisely the box was placed. Trimming makes
+ * the PNG's edges the ink's edges, so the placement box means what it looks
+ * like it means.
+ *
+ * Falls back to the original bytes if the image cannot be trimmed — a
+ * misaligned signature beats a failed signing.
+ */
+async function trimSignature(png: Uint8Array): Promise<Uint8Array> {
+    try {
+        const trimmed = await sharp(Buffer.from(png))
+            .trim({
+                background: { r: 0, g: 0, b: 0, alpha: 0 },
+                threshold: 10,
+            })
+            .png()
+            .toBuffer();
+        return new Uint8Array(trimmed);
+    } catch {
+        return png;
+    }
+}
+
 export async function stampContractPdf(
     input: StampContractInput,
 ): Promise<Buffer> {
@@ -58,14 +87,25 @@ export async function stampContractPdf(
         const placement = input.signaturePlacement;
         const page = pages[placement.page];
         if (page) {
-            const image = await pdf.embedPng(input.signaturePng);
+            const image = await pdf.embedPng(
+                await trimSignature(input.signaturePng),
+            );
             const { width: W, height: H } = page.getSize();
-            const w = placement.wPct * W;
-            const h = placement.hPct * H;
+            const boxW = placement.wPct * W;
+            const boxH = placement.hPct * H;
+            // top-left origin (browser) → bottom-left origin (pdf-lib)
+            const boxBottom = H - placement.yPct * H - boxH;
+
+            // Fit inside the box without distorting the handwriting, then rest
+            // the ink on the box's bottom edge and centre it horizontally —
+            // that edge is the signature line, the way a pen would sit on it.
+            const scale = Math.min(boxW / image.width, boxH / image.height);
+            const w = image.width * scale;
+            const h = image.height * scale;
+
             page.drawImage(image, {
-                x: placement.xPct * W,
-                // top-left origin (browser) → bottom-left origin (pdf-lib)
-                y: H - placement.yPct * H - h,
+                x: placement.xPct * W + (boxW - w) / 2,
+                y: boxBottom,
                 width: w,
                 height: h,
             });

--- a/apps/kvark/src/routes/_app/kontrakt.tsx
+++ b/apps/kvark/src/routes/_app/kontrakt.tsx
@@ -9,11 +9,13 @@ import {
     CardHeader,
     CardTitle,
 } from "@tihlde/ui/ui/card";
+import { Checkbox } from "@tihlde/ui/ui/checkbox";
 import { Field, FieldLabel } from "@tihlde/ui/ui/field";
 import { Input } from "@tihlde/ui/ui/input";
+import { Label } from "@tihlde/ui/ui/label";
 import { SignatureInput } from "@tihlde/ui/ui/signature-input";
 import { Download } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { authClientWithRedirect, authQueryOptions } from "#/api/auth";
 import {
@@ -41,7 +43,9 @@ function KontraktPage() {
     const { data: contract } = useSuspenseQuery(getActiveContractQuery());
 
     return (
-        <div className="container mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-8">
+        /* Bredere enn resten av appen på store skjermer: en A4-side i en
+           3xl-spalte blir for liten til å leses uten å zoome. */
+        <div className="container mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-8 lg:max-w-5xl">
             <div className="flex flex-col gap-1">
                 <h1>Frivillighetskontrakt</h1>
                 <p>
@@ -67,9 +71,11 @@ function KontraktPage() {
 }
 
 function KontraktViewer({ contract }: { contract: ActiveContract }) {
-    const [hasScrolledToEnd, setHasScrolledToEnd] = useState(false);
-    const containerRef = useRef<HTMLDivElement>(null);
-    const sentinelRef = useRef<HTMLDivElement>(null);
+    // Bekreftelse framfor en scrollesperre: kontrakten vises i en iframe, så vi
+    // ser ikke at noen scroller inne i den. Sperren målte i praksis bare noen
+    // få piksler i den ytre boksen, og løste seg selv eller aldri avhengig av
+    // nettleserens avrunding.
+    const [hasRead, setHasRead] = useState(false);
 
     const { data: session } = useQuery(authQueryOptions);
     const { data: signature } = useQuery(getMySignatureQuery());
@@ -85,22 +91,6 @@ function KontraktViewer({ contract }: { contract: ActiveContract }) {
     useEffect(() => {
         if (session?.user?.name) setSignedName(session.user.name);
     }, [session?.user?.name]);
-
-    useEffect(() => {
-        const container = containerRef.current;
-        const sentinel = sentinelRef.current;
-        if (!container || !sentinel) return;
-
-        const observer = new IntersectionObserver(
-            ([entry]) => {
-                if (entry?.isIntersecting) setHasScrolledToEnd(true);
-            },
-            { root: container, threshold: 0.1 },
-        );
-
-        observer.observe(sentinel);
-        return () => observer.disconnect();
-    }, []);
 
     if (signature?.hasSigned) {
         const signedAt = signature.signedAt
@@ -137,6 +127,16 @@ function KontraktViewer({ contract }: { contract: ActiveContract }) {
 
     const isLoggedIn = Boolean(session);
 
+    const blockedReason = !signedName.trim()
+        ? "Fyll inn fullt navn."
+        : !signatureDataUrl
+          ? "Skriv eller tegn signaturen din."
+          : !hasRead
+            ? "Huk av for at du har lest kontrakten."
+            : signContract.isPending
+              ? "Signerer …"
+              : null;
+
     return (
         <Card>
             <CardHeader>
@@ -150,31 +150,22 @@ function KontraktViewer({ contract }: { contract: ActiveContract }) {
                 </div>
             </CardHeader>
             <CardContent className="flex flex-col gap-4">
-                <div
-                    ref={containerRef}
-                    className="w-full overflow-y-auto"
-                    style={{ height: "65vh" }}
-                >
+                {/* Høy nok til at en A4-side er lesbar uten å zoome. Lavere på
+                    små skjermer, så signeringsfeltene ikke havner utenfor. */}
+                <div className="h-[70vh] w-full lg:h-[85vh]">
                     {contract.downloadUrl ? (
                         <iframe
                             src={contract.downloadUrl}
                             title={contract.title}
                             className="h-full w-full"
                         />
-                    ) : (
-                        <div style={{ height: "200vh" }} />
-                    )}
-                    <div ref={sentinelRef} style={{ height: "4px" }} />
+                    ) : null}
                 </div>
-                {!hasScrolledToEnd && (
-                    <p>
-                        Scroll til bunnen av kontrakten for å aktivere
-                        signeringsknappen.
-                    </p>
-                )}
                 {signContract.isError && <p>{signContract.error.message}</p>}
                 {isLoggedIn ? (
-                    <>
+                    // Skjemaet følger ikke den brede spalten — inndatafelt på
+                    // over 1000 px er verre å bruke, ikke bedre.
+                    <div className="flex w-full max-w-2xl flex-col gap-4">
                         <Field>
                             <FieldLabel htmlFor="signed-name">
                                 Fullt navn
@@ -190,13 +181,21 @@ function KontraktViewer({ contract }: { contract: ActiveContract }) {
                             name={signedName}
                             onChange={setSignatureDataUrl}
                         />
+                        <Label className="flex items-start gap-3">
+                            <Checkbox
+                                className="shrink-0"
+                                checked={hasRead}
+                                disabled={signContract.isPending}
+                                onCheckedChange={(checked) =>
+                                    setHasRead(checked === true)
+                                }
+                            />
+                            <span>
+                                Jeg har lest og godtar frivillighetskontrakten
+                            </span>
+                        </Label>
                         <Button
-                            disabled={
-                                !hasScrolledToEnd ||
-                                !signedName.trim() ||
-                                !signatureDataUrl ||
-                                signContract.isPending
-                            }
+                            disabled={Boolean(blockedReason)}
                             onClick={() =>
                                 signatureDataUrl &&
                                 signContract.mutate({
@@ -208,7 +207,12 @@ function KontraktViewer({ contract }: { contract: ActiveContract }) {
                         >
                             Signer kontrakt
                         </Button>
-                    </>
+                        {/* Uten dette var en deaktivert knapp det eneste
+                            signalet, og testerne gjettet på hvorfor. */}
+                        {blockedReason && !signContract.isPending && (
+                            <p>{blockedReason}</p>
+                        )}
+                    </div>
                 ) : (
                     <Button
                         render={

--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -1,4 +1,8 @@
 import { authQueryOptions, sessionHasScopedPermission } from "#/api/auth";
+import {
+    getActiveContractQuery,
+    getMySignatureQuery,
+} from "#/api/queries/contracts";
 import { getUnreadNotificationCountQuery } from "#/api/queries/notifications";
 import { getUserProfileQuery } from "#/api/queries/user";
 import { ProfileLinksSection } from "#/components/profile-links-section";
@@ -39,6 +43,18 @@ function RouteComponent() {
     const { data: unreadNotifications } = useQuery({
         ...getUnreadNotificationCountQuery(),
         enabled: isOwnProfile && session?.user?.isPendingApproval !== true,
+    });
+
+    // Kontraktbanneret gjelder bare egen profil, så begge kallene hoppes over
+    // på andres. Begge nøklene deles med /kontrakt, så signeringen der
+    // invaliderer banneret her uten et ekstra kall.
+    const { data: activeContract } = useQuery({
+        ...getActiveContractQuery(),
+        enabled: isOwnProfile,
+    });
+    const { data: mySignature } = useQuery({
+        ...getMySignatureQuery(),
+        enabled: isOwnProfile,
     });
 
     const links: ProfileLink[] = [];
@@ -91,7 +107,12 @@ function RouteComponent() {
                 </div>
             ) : null}
             <ProfileLinksSection links={links} />
-            {isOwnProfile ? <ContractBanner signature={null} /> : null}
+            {isOwnProfile ? (
+                <ContractBanner
+                    hasActiveContract={Boolean(activeContract)}
+                    signature={mySignature}
+                />
+            ) : null}
 
             {/* Gruppene vises direkte i stedet for et telle-kort. Kortet så
                 klikkbart ut uten å være det, og på andres profil var det alt
@@ -156,8 +177,20 @@ function RouteComponent() {
     );
 }
 
-function ContractBanner({ signature }: { signature: SignatureStatus | null }) {
-    if (signature?.hasSigned) return null;
+/**
+ * Vises bare når det finnes en aktiv kontrakt som ikke er signert. Uten
+ * `signature` er statusen fortsatt ukjent — da sier vi ingenting, framfor å
+ * påstå at den ikke er signert.
+ */
+function ContractBanner({
+    hasActiveContract,
+    signature,
+}: {
+    hasActiveContract: boolean;
+    signature: SignatureStatus | undefined;
+}) {
+    if (!hasActiveContract) return null;
+    if (!signature || signature.hasSigned) return null;
 
     return (
         <Alert>

--- a/packages/ui/src/components/complex/pdf-placement/pdf-placement.tsx
+++ b/packages/ui/src/components/complex/pdf-placement/pdf-placement.tsx
@@ -149,7 +149,7 @@ export function PdfPlacement({
                 <span className="text-muted-foreground text-xs">
                     {placing
                         ? `Klikk i dokumentet for å plassere «${SLOT_BY_KEY[placing].label}»`
-                        : "Plasser feltene på dokumentet (navn og dato er valgfritt):"}
+                        : "Plasser feltene på dokumentet. Signaturen står på nederste kant av boksen — legg den på signaturlinja. Navn og dato er valgfritt."}
                 </span>
                 {SLOTS.map((slot) => (
                     <Button


### PR DESCRIPTION
Fire funn fra testrunden med HS i går.

## 1. Profilen sa alltid «Frivillighetskontrakt ikke signert»

Banneret fikk `signature={null}` hardkodet, så det viste seg uansett status — også for folk som nettopp hadde signert. Det var ikke caching, slik vi først trodde; derfor så det likt ut på en annen konto.

Henter nå statusen. To regler til på kjøpet: banneret vises ikke før statusen er lastet (ellers blinker «ikke signert» ved hver innlasting), og ikke i det hele tatt når det ikke finnes en aktiv kontrakt å signere. Begge kallene hopper over på andres profiler.

## 2. Signaturen fløt over signaturlinja

Uansett hvor presist feltet ble plassert. To årsaker: signatur-PNG-en er en fast 640×160-flate med blekket midt i og mye tom luft rundt, og den ble strukket til boksens sideforhold og forankret på toppen. Blekket havnet dermed midt i boksen, et stykke over linja.

Beskjærer nå de gjennomsiktige margene med `sharp`, beholder sideforholdet, og hviler blekket på boksens **nederste kant** — den kanten er signaturlinja.

Målt på en test-PDF med en tegnet linje: blekket slutter på y=752 px mens linja ligger på y=752,8 px (100 dpi). PNG-en krymper 640×160 → 300×40 ved beskjæring.

Plasseringsverktøyet sier nå hva regelen er, så man slipper å gjette. Merk at eksisterende plasseringer sannsynligvis må justeres én gang, siden regelen gikk fra «midt i boksen» til «på bunnkanten».

## 3. Scrollesperren slo til tilfeldig

Knappen var av og til deaktivert uten forklaring. Kontrakten vises i en iframe, så scrolling inne i den er usynlig for oss — sperren målte i praksis fire piksler i den ytre boksen, og løste seg selv eller aldri avhengig av nettleserens avrunding. Den beviste altså ikke at noen hadde lest kontrakten, men blokkerte vilkårlig.

Erstattet med en avkryssingsboks: «Jeg har lest og godtar frivillighetskontrakten». Knappen sier nå hvorfor den er deaktivert («Fyll inn fullt navn.» / «Skriv eller tegn signaturen din.» / «Huk av for at du har lest kontrakten.»).

## 4. Dokumentet var for lite på desktop

Siden er bredere på store skjermer og visningen høyere. Skjemaet holder seg på lesbar bredde i stedet for å strekke seg over hele spalten.

| | Før | Etter |
|---|---|---|
| Desktop (1440×900) | ~720 × 585 px | **960 × 765 px** |
| Mobil (375×812) | 311 × 528 px | 311 × 568 px |

Rundt 75 % mer flate til dokumentet på desktop, uten horisontal scroll noen av stedene.

## Verifisering

- Punkt 1 og 3 kjørt gjennom i nettleseren mot lokal API: usignert → banner vises; signerte i UI-et → banneret borte; ingen aktiv kontrakt → banneret holder seg borte. Avkryssingen aktiverer knappen, og signeringen går gjennom.
- Punkt 2 målt på en rasterisert PDF, som over.
- Punkt 4 målt i DOM-en på 1440×900 og 375×812.
- `typecheck`, `lint`, `format`, kvark-build og de 6 kontrakt-integrasjonstestene er grønne etter rebase på `main`.

Selve PDF-en er blank i skjermbildene mine — nettleseren i testpanelet laster ned PDF-er i stedet for å vise dem. Verdt at noen ser på den faktiske gjengivelsen på mobil.

## Ikke med her

Det er fortsatt ingen måte å slette gamle kontraktversjoner eller testsignaturer på fra UI-et — `revoke-signature` er scopet per gruppe + bruker, og det finnes ikke noe slette-endepunkt for selve kontrakten. Testdata må ryddes i databasen. Tas separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)