### PR TITLE
feat(groups): la lederen overføre ledervervet selv, og hold HS-plassene i takt

### DIFF
--- a/apps/api/src/lib/group/index.ts
+++ b/apps/api/src/lib/group/index.ts
@@ -512,9 +512,9 @@ async function syncSubgroupLeaderOutOfHs(
 }
 
 /**
- * Remove `userId` from hs unless they still belong there: they lead another
- * subgroup, or they hold some hs verv (e.g. an AU title). Safe to call for
- * users who are not hs members at all.
+ * Remove `userId` from hs unless they still belong there: they lead hs
+ * itself, they lead another subgroup, or they hold some hs verv (e.g. an AU
+ * title). Safe to call for users who are not hs members at all.
  */
 export async function pruneHsMembershipIfUnwarranted(
     ctx: AppContext,
@@ -522,9 +522,10 @@ export async function pruneHsMembershipIfUnwarranted(
 ): Promise<void> {
     if (!(await isGroupMember(ctx, userId, HS_GROUP_SLUG))) return;
 
-    // Still leader of some subgroup?
+    // Still leader of hs itself, or of some subgroup?
     const memberships = await ctx.db
         .select({
+            slug: schema.groupMembership.groupSlug,
             role: schema.groupMembership.role,
             type: schema.group.type,
         })
@@ -534,7 +535,13 @@ export async function pruneHsMembershipIfUnwarranted(
             eq(schema.groupMembership.groupSlug, schema.group.slug),
         )
         .where(eq(schema.groupMembership.userId, userId));
-    if (memberships.some((m) => m.role === "leader" && isSubgroupType(m.type)))
+    if (
+        memberships.some(
+            (m) =>
+                m.role === "leader" &&
+                (m.slug === HS_GROUP_SLUG || isSubgroupType(m.type)),
+        )
+    )
         return;
 
     // Still holds an hs verv (e.g. AU title)?

--- a/apps/api/src/lib/group/index.ts
+++ b/apps/api/src/lib/group/index.ts
@@ -241,12 +241,26 @@ export async function demoteOtherLeaders(
 
     if (outgoing.length === 0) return;
 
+    const group = await getGroup(ctx, groupSlug);
+    if (!group) return;
+
     // Avgåtte undergruppeledere mister HS-plassen på samme måte som når de
     // settes ned manuelt eller meldes ut.
-    const group = await getGroup(ctx, groupSlug);
-    if (!group || !isSubgroupType(group.type)) return;
-    for (const { userId } of outgoing) {
-        await syncSubgroupLeaderOutOfHs(ctx, userId, groupSlug);
+    if (isSubgroupType(group.type)) {
+        for (const { userId } of outgoing) {
+            await syncSubgroupLeaderOutOfHs(ctx, userId, groupSlug);
+        }
+        return;
+    }
+
+    // HS er AU + undergruppelederne, ikke et sted man blir sittende: en
+    // avgått president har ingenting der å gjøre med mindre noe annet gir
+    // plassen (et AU-verv eller lederskapet i en undergruppe), akkurat som
+    // for undergruppelederne over.
+    if (group.slug === HS_GROUP_SLUG) {
+        for (const { userId } of outgoing) {
+            await pruneHsMembershipIfUnwarranted(ctx, userId);
+        }
     }
 }
 
@@ -403,6 +417,18 @@ export const HS_GROUP_SLUG = "hs";
  *  (Lepton rows are upper case), so compare case-insensitively. */
 export function isSubgroupType(type: string): boolean {
     return type.toLowerCase() === "subgroup";
+}
+
+/**
+ * True for groups whose next leader may be someone who is not a member yet.
+ *
+ * HS is the exception: presidenten velges på generalforsamlingen og sitter
+ * ikke i Hovedstyret før hun tar over, så lederen kan ikke plukkes blant HS
+ * sine egne medlemmer. Alle andre grupper velger lederen sin innenfra, og der
+ * er «ikke medlem» en feil verdt å stoppe på.
+ */
+export function allowsNonMemberLeader(group: { slug: string }): boolean {
+    return group.slug === HS_GROUP_SLUG;
 }
 
 /**

--- a/apps/api/src/routes/groups/members/add.ts
+++ b/apps/api/src/routes/groups/members/add.ts
@@ -95,9 +95,11 @@ export const addMemberRoute = route().post(
             });
         }
 
-        // Handing out leadership is an escalation — a subgroup leader also
-        // gets the leader role and a seat in HS — so it stays with
-        // "groups:manage". A group's own leader may add plain members only.
+        // "Legg til medlem" legger til medlemmer. En leder som vil gi fra seg
+        // vervet gjør det gjennom PATCH members/:userId, som er stedet
+        // reglene for overføring bor (bare til andre, og bare utenfor egen
+        // medlemsliste i HS). Å dele ut lederrollen herfra krever fortsatt
+        // "groups:manage".
         if (body.role === "leader" && c.get("isResourceOwner")) {
             throw new HTTPException(403, {
                 message:

--- a/apps/api/src/routes/groups/members/update.ts
+++ b/apps/api/src/routes/groups/members/update.ts
@@ -2,7 +2,13 @@ import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
-import { isDerivedGroupType, updateGroupMemberRole } from "~/lib/group";
+import {
+    addUserToGroup,
+    allowsNonMemberLeader,
+    isDerivedGroupType,
+    updateGroupMemberRole,
+} from "~/lib/group";
+import { isGroupLeader } from "~/lib/group/middleware";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -19,7 +25,7 @@ export const updateMemberRoleRoute = route().patch(
         summary: "Update member role",
         operationId: "updateGroupMemberRole",
         description:
-            "Update a member's role in a group. Requires 'groups:manage' permission.",
+            "Update a member's role in a group. Requires 'groups:manage' (globally or scoped to the group), or being the group's leader — a sitting leader may only hand the leadership over to someone else.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -29,13 +35,14 @@ export const updateMemberRoleRoute = route().patch(
         .notFound({ description: "Group, user, or membership not found" })
         .build(),
     requireAuth,
-    // Scoped like add/remove: a `groups:manage` grant for this group counts.
-    // Unlike those two there is no leader ownership — appointing the next
-    // leader is not the sitting leader's own call, matching how adding a
-    // member AS leader is refused further down in members/add.ts.
+    // Scoped like add/remove: a `groups:manage` grant for this group counts,
+    // and the sitting leader owns the handover of their own verv. What the
+    // leader may do through that ownership is narrowed in the handler: only
+    // appointing someone else as leader, never setting members down.
     requireAccess({
         permission: "groups:manage",
         scope: (c) => `group:${c.req.param("groupSlug")}`,
+        ownership: { param: "groupSlug", check: isGroupLeader },
     }),
     validator("json", updateMemberRoleSchema),
     async (c) => {
@@ -44,6 +51,26 @@ export const updateMemberRoleRoute = route().patch(
         const userId = c.req.param("userId");
         const ctx = c.get("ctx");
         const { db } = ctx;
+        // True only when the request got through on leadership alone; anyone
+        // holding "groups:manage" for the group lands here with `false`.
+        const asSittingLeader = c.get("isResourceOwner") === true;
+
+        if (asSittingLeader) {
+            // Overføring, ikke rosettdeling: lederen kan peke ut sin
+            // etterfølger, men ikke sette medlemmer opp og ned ellers — og
+            // ikke legge ned ledervervet uten å gi det videre.
+            if (body.role !== "leader") {
+                throw new HTTPException(403, {
+                    message:
+                        "Changing a member's role requires the 'groups:manage' permission",
+                });
+            }
+            if (userId === c.get("user")?.id) {
+                throw new HTTPException(400, {
+                    message: "You are already the leader of this group",
+                });
+            }
+        }
 
         // Validate group exists
         const group = await db
@@ -79,9 +106,35 @@ export const updateMemberRoleRoute = route().patch(
             .then((res) => res[0]);
 
         if (!membership) {
-            throw new HTTPException(404, {
-                message: `User "${userId}" is not a member of group "${groupSlug}"`,
-            });
+            // Presidenten er ikke medlem av HS før hun blir valgt, så der kan
+            // ledervervet gis til hvem som helst — medlemskapet opprettes som
+            // en del av overføringen. Alle andre grupper velger lederen sin
+            // blant sine egne medlemmer.
+            if (body.role !== "leader" || !allowsNonMemberLeader(group)) {
+                throw new HTTPException(404, {
+                    message: `User "${userId}" is not a member of group "${groupSlug}"`,
+                });
+            }
+
+            const incoming = await db
+                .select({ id: schema.user.id })
+                .from(schema.user)
+                .where(eq(schema.user.id, userId))
+                .limit(1)
+                .then((res) => res[0]);
+
+            if (!incoming) {
+                throw new HTTPException(404, {
+                    message: `User with ID "${userId}" not found`,
+                });
+            }
+
+            // Legger inn som leder direkte: helperen setter den sittende
+            // lederen ned og holder HS-synkingen i orden, akkurat som
+            // updateGroupMemberRole gjør nedenfor.
+            await addUserToGroup(ctx, userId, groupSlug, "leader");
+
+            return c.json({ message: "Member role updated successfully" }, 200);
         }
 
         // Goes through the helper rather than a bare UPDATE: it sets the

--- a/apps/api/src/routes/groups/positions/delete.ts
+++ b/apps/api/src/routes/groups/positions/delete.ts
@@ -1,6 +1,7 @@
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
+import { HS_GROUP_SLUG, pruneHsMembershipIfUnwarranted } from "~/lib/group";
 import { canManagePositions, getPosition } from "~/lib/group/positions";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -14,7 +15,7 @@ export const deletePositionRoute = route().delete(
         summary: "Delete a position",
         operationId: "deleteGroupPosition",
         description:
-            "Delete a position (verv). Holders lose the position's permissions. Deleting a global position requires 'roles:create'.",
+            "Delete a position (verv). Holders lose the position's permissions. Deleting an HS position also takes the holder's seat in HS unless something else warrants it. Deleting a global position requires 'roles:create'.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -45,9 +46,26 @@ export const deletePositionRoute = route().delete(
             });
         }
 
+        // Holderen leses før slettingen: holder-raden kaskaderer bort med
+        // vervet, og prunen må uansett kjøre etterpå — ellers ser den vervet
+        // den nettopp mistet som grunn til å bli sittende.
+        const holders = await db
+            .select({ userId: schema.groupPositionHolder.userId })
+            .from(schema.groupPositionHolder)
+            .where(eq(schema.groupPositionHolder.positionId, positionId));
+
         await db
             .delete(schema.groupPosition)
             .where(eq(schema.groupPosition.id, positionId));
+
+        // Legges vervet ned, forsvinner grunnen til å sitte i HS med det —
+        // med mindre noe annet gir plassen (lederskap i HS eller i en
+        // undergruppe, eller et annet HS-verv).
+        if (position.groupSlug === HS_GROUP_SLUG) {
+            for (const { userId } of holders) {
+                await pruneHsMembershipIfUnwarranted(ctx, userId);
+            }
+        }
 
         return c.json({ message: "Position deleted" });
     },

--- a/apps/api/src/routes/groups/positions/unassign.ts
+++ b/apps/api/src/routes/groups/positions/unassign.ts
@@ -1,6 +1,7 @@
 import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
+import { HS_GROUP_SLUG, pruneHsMembershipIfUnwarranted } from "~/lib/group";
 import { canAssignPosition, getPosition } from "~/lib/group/positions";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -66,6 +67,13 @@ export const unassignPositionRoute = route().delete(
                     eq(schema.groupPositionHolder.userId, targetUserId),
                 ),
             );
+
+        // HS er AU + undergruppelederne. Mister du AU-vervet ditt, mister du
+        // plassen med det — med mindre noe annet gir den (lederskapet i HS
+        // eller i en undergruppe, eller et annet HS-verv).
+        if (position.groupSlug === HS_GROUP_SLUG) {
+            await pruneHsMembershipIfUnwarranted(ctx, targetUserId);
+        }
 
         return c.json({ message: "Position removed from user" });
     },

--- a/apps/api/src/test/groups/members.test.ts
+++ b/apps/api/src/test/groups/members.test.ts
@@ -926,6 +926,247 @@ describe("group members", () => {
         );
     });
 
+    describe("leader hands the verv over", () => {
+        integrationTest(
+            "sitting leader can promote a member without groups:manage",
+            async ({ ctx }) => {
+                const leader = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(leader);
+
+                const group = await ctx.utils.createTestGroup();
+                const successor = await ctx.auth.api.createUser({
+                    body: {
+                        email: "successor@test.com",
+                        name: "Successor",
+                        password: "test123!",
+                    },
+                });
+
+                await ctx.db.insert(schema.groupMembership).values([
+                    {
+                        userId: leader.id,
+                        groupSlug: group.slug,
+                        role: "leader",
+                    },
+                    {
+                        userId: successor.user.id,
+                        groupSlug: group.slug,
+                        role: "member",
+                    },
+                ]);
+
+                const response = await client.api.groups[":groupSlug"].members[
+                    ":userId"
+                ].$patch({
+                    param: {
+                        groupSlug: group.slug,
+                        userId: successor.user.id,
+                    },
+                    json: { role: "leader" },
+                });
+
+                expect(response.status).toBe(200);
+
+                const memberships = await ctx.db.query.groupMembership.findMany(
+                    {
+                        where: eq(schema.groupMembership.groupSlug, group.slug),
+                    },
+                );
+                const roleByUser = new Map(
+                    memberships.map((m) => [m.userId, m.role]),
+                );
+                expect(roleByUser.get(successor.user.id)).toBe("leader");
+                expect(roleByUser.get(leader.id)).toBe("member");
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "sitting leader cannot set a member down",
+            async ({ ctx }) => {
+                const leader = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(leader);
+
+                const group = await ctx.utils.createTestGroup();
+                const member = await ctx.auth.api.createUser({
+                    body: {
+                        email: "plain-member@test.com",
+                        name: "Plain Member",
+                        password: "test123!",
+                    },
+                });
+
+                await ctx.db.insert(schema.groupMembership).values([
+                    {
+                        userId: leader.id,
+                        groupSlug: group.slug,
+                        role: "leader",
+                    },
+                    {
+                        userId: member.user.id,
+                        groupSlug: group.slug,
+                        role: "member",
+                    },
+                ]);
+
+                const response = await client.api.groups[":groupSlug"].members[
+                    ":userId"
+                ].$patch({
+                    param: { groupSlug: group.slug, userId: member.user.id },
+                    json: { role: "member" },
+                });
+
+                expect(response.status).toBe(403);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "a normal group's leader must be picked among its members",
+            async ({ ctx }) => {
+                const leader = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(leader);
+
+                const group = await ctx.utils.createTestGroup();
+                const outsider = await ctx.auth.api.createUser({
+                    body: {
+                        email: "outsider@test.com",
+                        name: "Outsider",
+                        password: "test123!",
+                    },
+                });
+
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: leader.id,
+                    groupSlug: group.slug,
+                    role: "leader",
+                });
+
+                const response = await client.api.groups[":groupSlug"].members[
+                    ":userId"
+                ].$patch({
+                    param: { groupSlug: group.slug, userId: outsider.user.id },
+                    json: { role: "leader" },
+                });
+
+                expect(response.status).toBe(404);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "HS leadership can go to someone who is not a member yet",
+            async ({ ctx }) => {
+                const president = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(president);
+
+                // Presidenten velges pa generalforsamlingen og sitter ikke i
+                // HS for hun tar over, sa medlemskapet opprettes underveis.
+                const hs = await ctx.utils.createTestGroup({
+                    slug: "hs",
+                    name: "Hovedstyret",
+                    type: "board",
+                });
+                const successor = await ctx.auth.api.createUser({
+                    body: {
+                        email: "next-president@test.com",
+                        name: "Next President",
+                        password: "test123!",
+                    },
+                });
+
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: president.id,
+                    groupSlug: hs.slug,
+                    role: "leader",
+                });
+
+                const response = await client.api.groups[":groupSlug"].members[
+                    ":userId"
+                ].$patch({
+                    param: { groupSlug: hs.slug, userId: successor.user.id },
+                    json: { role: "leader" },
+                });
+
+                expect(response.status).toBe(200);
+
+                const memberships = await ctx.db.query.groupMembership.findMany(
+                    {
+                        where: eq(schema.groupMembership.groupSlug, hs.slug),
+                    },
+                );
+                const roleByUser = new Map(
+                    memberships.map((m) => [m.userId, m.role]),
+                );
+                expect(roleByUser.get(successor.user.id)).toBe("leader");
+                // Den avgatte presidenten blir ikke staende igjen i HS: uten
+                // AU-verv eller undergruppelederskap er plassen ikke lenger
+                // hennes.
+                expect(roleByUser.has(president.id)).toBe(false);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "outgoing president keeps the HS seat when an AU verv warrants it",
+            async ({ ctx }) => {
+                const president = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(president);
+
+                const hs = await ctx.utils.createTestGroup({
+                    slug: "hs",
+                    name: "Hovedstyret",
+                    type: "board",
+                });
+                const successor = await ctx.auth.api.createUser({
+                    body: {
+                        email: "incoming-president@test.com",
+                        name: "Incoming President",
+                        password: "test123!",
+                    },
+                });
+
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: president.id,
+                    groupSlug: hs.slug,
+                    role: "leader",
+                });
+
+                // Finansministeren sitter i AU og blir vaerende i HS selv om
+                // hun gir fra seg ledervervet.
+                const [position] = await ctx.db
+                    .insert(schema.groupPosition)
+                    .values({ groupSlug: hs.slug, name: "Finansminister" })
+                    .returning();
+                await ctx.db.insert(schema.groupPositionHolder).values({
+                    positionId: position!.id,
+                    userId: president.id,
+                });
+
+                const response = await client.api.groups[":groupSlug"].members[
+                    ":userId"
+                ].$patch({
+                    param: { groupSlug: hs.slug, userId: successor.user.id },
+                    json: { role: "leader" },
+                });
+
+                expect(response.status).toBe(200);
+
+                const memberships = await ctx.db.query.groupMembership.findMany(
+                    {
+                        where: eq(schema.groupMembership.groupSlug, hs.slug),
+                    },
+                );
+                const roleByUser = new Map(
+                    memberships.map((m) => [m.userId, m.role]),
+                );
+                expect(roleByUser.get(successor.user.id)).toBe("leader");
+                expect(roleByUser.get(president.id)).toBe("member");
+            },
+            500_000,
+        );
+    });
+
     describe("former members (membership history)", () => {
         integrationTest(
             "records the stint when a member is removed",

--- a/apps/api/src/test/groups/positions.test.ts
+++ b/apps/api/src/test/groups/positions.test.ts
@@ -840,6 +840,47 @@ describe("group positions", () => {
         );
 
         integrationTest(
+            "deleting an HS verv takes its holder's seat with it",
+            async ({ ctx }) => {
+                const admin = await ctx.utils.createTestUser();
+                await ctx.utils.giveUserPermissions(admin, ["root"]);
+                await ctx.utils.createTestGroup(HS);
+                const client = await ctx.utils.clientForUser(admin);
+                const visepresident = await ctx.utils.createTestUser();
+
+                await addUserToGroup(ctx, visepresident.id, "hs", "member");
+                const [position] = await ctx.db
+                    .insert(schema.groupPosition)
+                    .values({ groupSlug: "hs", name: "Visepresident" })
+                    .returning();
+                await ctx.db.insert(schema.groupPositionHolder).values({
+                    positionId: position!.id,
+                    userId: visepresident.id,
+                });
+
+                // Vervet legges ned, ikke bare fratas.
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].positions[":positionId"].$delete({
+                    param: { groupSlug: "hs", positionId: position!.id },
+                });
+
+                expect(response.status).toBe(200);
+
+                const membership = await ctx.db.query.groupMembership.findFirst(
+                    {
+                        where: and(
+                            eq(schema.groupMembership.userId, visepresident.id),
+                            eq(schema.groupMembership.groupSlug, "hs"),
+                        ),
+                    },
+                );
+                expect(membership).toBeUndefined();
+            },
+            500_000,
+        );
+
+        integrationTest(
             "the sitting HS leader keeps the seat when a verv is taken away",
             async ({ ctx }) => {
                 const admin = await ctx.utils.createTestUser();

--- a/apps/api/src/test/groups/positions.test.ts
+++ b/apps/api/src/test/groups/positions.test.ts
@@ -740,6 +740,151 @@ describe("group positions", () => {
         );
     });
 
+    describe("AU verv follow the seat in HS", () => {
+        const HS = { slug: "hs", name: "Hovedstyret", type: "board" };
+
+        integrationTest(
+            "losing an AU verv takes the HS seat with it",
+            async ({ ctx }) => {
+                const admin = await ctx.utils.createTestUser();
+                await ctx.utils.giveUserPermissions(admin, ["root"]);
+                await ctx.utils.createTestGroup(HS);
+                const client = await ctx.utils.clientForUser(admin);
+                const finansminister = await ctx.utils.createTestUser();
+
+                await addUserToGroup(ctx, finansminister.id, "hs", "member");
+                const [position] = await ctx.db
+                    .insert(schema.groupPosition)
+                    .values({ groupSlug: "hs", name: "Finansminister" })
+                    .returning();
+                await ctx.db.insert(schema.groupPositionHolder).values({
+                    positionId: position!.id,
+                    userId: finansminister.id,
+                });
+
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].positions[":positionId"].holders[":userId"].$delete({
+                    param: {
+                        groupSlug: "hs",
+                        positionId: position!.id,
+                        userId: finansminister.id,
+                    },
+                });
+
+                expect(response.status).toBe(200);
+
+                const membership = await ctx.db.query.groupMembership.findFirst(
+                    {
+                        where: and(
+                            eq(
+                                schema.groupMembership.userId,
+                                finansminister.id,
+                            ),
+                            eq(schema.groupMembership.groupSlug, "hs"),
+                        ),
+                    },
+                );
+                expect(membership).toBeUndefined();
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "a subgroup leader keeps the HS seat when an AU verv is taken away",
+            async ({ ctx }) => {
+                const admin = await ctx.utils.createTestUser();
+                await ctx.utils.giveUserPermissions(admin, ["root"]);
+                await ctx.utils.createTestGroup(HS);
+                const client = await ctx.utils.clientForUser(admin);
+                const minister = await ctx.utils.createTestUser();
+                const subgroup = await ctx.utils.createTestGroup({
+                    type: "subgroup",
+                    name: "Undergruppen",
+                });
+
+                // Lederskapet i undergruppen tar hen inn i HS uansett.
+                await addUserToGroup(ctx, minister.id, subgroup.slug, "leader");
+                const [position] = await ctx.db
+                    .insert(schema.groupPosition)
+                    .values({ groupSlug: "hs", name: "Visepresident" })
+                    .returning();
+                await ctx.db.insert(schema.groupPositionHolder).values({
+                    positionId: position!.id,
+                    userId: minister.id,
+                });
+
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].positions[":positionId"].holders[":userId"].$delete({
+                    param: {
+                        groupSlug: "hs",
+                        positionId: position!.id,
+                        userId: minister.id,
+                    },
+                });
+
+                expect(response.status).toBe(200);
+
+                const membership = await ctx.db.query.groupMembership.findFirst(
+                    {
+                        where: and(
+                            eq(schema.groupMembership.userId, minister.id),
+                            eq(schema.groupMembership.groupSlug, "hs"),
+                        ),
+                    },
+                );
+                expect(membership).toBeDefined();
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "the sitting HS leader keeps the seat when a verv is taken away",
+            async ({ ctx }) => {
+                const admin = await ctx.utils.createTestUser();
+                await ctx.utils.giveUserPermissions(admin, ["root"]);
+                await ctx.utils.createTestGroup(HS);
+                const client = await ctx.utils.clientForUser(admin);
+                const president = await ctx.utils.createTestUser();
+
+                await addUserToGroup(ctx, president.id, "hs", "leader");
+                const [position] = await ctx.db
+                    .insert(schema.groupPosition)
+                    .values({ groupSlug: "hs", name: "President" })
+                    .returning();
+                await ctx.db.insert(schema.groupPositionHolder).values({
+                    positionId: position!.id,
+                    userId: president.id,
+                });
+
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].positions[":positionId"].holders[":userId"].$delete({
+                    param: {
+                        groupSlug: "hs",
+                        positionId: position!.id,
+                        userId: president.id,
+                    },
+                });
+
+                expect(response.status).toBe(200);
+
+                // Ledervervet i HS er sin egen grunn til a sitte der.
+                const membership = await ctx.db.query.groupMembership.findFirst(
+                    {
+                        where: and(
+                            eq(schema.groupMembership.userId, president.id),
+                            eq(schema.groupMembership.groupSlug, "hs"),
+                        ),
+                    },
+                );
+                expect(membership?.role).toBe("leader");
+            },
+            500_000,
+        );
+    });
+
     describe("leader permissions follow leadership", () => {
         integrationTest(
             "promoting and demoting moves the group's leaderPermissions",

--- a/apps/kvark/src/components/group-add-member-dialog.tsx
+++ b/apps/kvark/src/components/group-add-member-dialog.tsx
@@ -16,6 +16,17 @@ import type { UserSearchOption } from "#/components/user-search-combobox";
 import { UserSearchCombobox } from "#/components/user-search-combobox";
 
 export type GroupAddMemberDialogProps = {
+    /**
+     * Teksten i dialogen. Standard er «legg til medlem»; lederoverføringen i
+     * HS bruker samme søk og velger, men er en annen handling.
+     */
+    copy?: {
+        trigger: string;
+        title: string;
+        description: string;
+        submit: string;
+        submitting: string;
+    };
     /** Søketekst — eies av forelderen, som også henter treffene. */
     query: string;
     onQueryChange: (query: string) => void;
@@ -30,7 +41,17 @@ export type GroupAddMemberDialogProps = {
     onAdd: (userId: string) => Promise<void>;
 };
 
+const DEFAULT_COPY = {
+    trigger: "Legg til",
+    title: "Legg til medlem",
+    description:
+        "Brukeren vil motta en epost/varsel om at de er lagt til i gruppen.",
+    submit: "Legg til medlem",
+    submitting: "Legger til …",
+} as const;
+
 export function GroupAddMemberDialog({
+    copy = DEFAULT_COPY,
     query,
     onQueryChange,
     results,
@@ -61,17 +82,14 @@ export function GroupAddMemberDialog({
                 render={
                     <Button size="sm">
                         <Plus />
-                        Legg til
+                        {copy.trigger}
                     </Button>
                 }
             />
             <DialogContent className="max-w-md">
                 <DialogHeader>
-                    <DialogTitle>Legg til medlem</DialogTitle>
-                    <DialogDescription>
-                        Brukeren vil motta en epost/varsel om at de er lagt til
-                        i gruppen.
-                    </DialogDescription>
+                    <DialogTitle>{copy.title}</DialogTitle>
+                    <DialogDescription>{copy.description}</DialogDescription>
                 </DialogHeader>
                 <FieldGroup>
                     <Field>
@@ -110,7 +128,7 @@ export function GroupAddMemberDialog({
                             });
                         }}
                     >
-                        {isAdding ? "Legger til …" : "Legg til medlem"}
+                        {isAdding ? copy.submitting : copy.submit}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/apps/kvark/src/components/group-member-row.tsx
+++ b/apps/kvark/src/components/group-member-row.tsx
@@ -38,7 +38,10 @@ type GroupMemberRowProps = {
     member: Member;
     historic?: boolean;
     isLeader?: boolean;
-    /** Promoting to leader requires `groups:manage` — leadership alone is not enough. */
+    /**
+     * Gjør medlemmet til leder. Krever `groups:manage` for gruppen, eller at
+     * du er lederen som gir vervet fra deg.
+     */
     onPromote?: (member: Member) => void;
     onRemove?: (member: Member) => void;
 };
@@ -112,6 +115,9 @@ function MemberRowMenu({
     onRemove?: (member: Member) => void;
 }) {
     const [confirmRemove, setConfirmRemove] = useState(false);
+    // Overføringen setter den sittende lederen ned, og gjør du det på deg
+    // selv får du den ikke tilbake. Verdt et bekreftelsessteg.
+    const [confirmPromote, setConfirmPromote] = useState(false);
 
     return (
         <>
@@ -141,9 +147,11 @@ function MemberRowMenu({
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     {onPromote && !isLeader ? (
-                        <DropdownMenuItem onClick={() => onPromote(member)}>
+                        <DropdownMenuItem
+                            onClick={() => setConfirmPromote(true)}
+                        >
                             <ArrowUpCircle />
-                            Promoter til leder
+                            Gjør til leder
                         </DropdownMenuItem>
                     ) : null}
                     {onRemove ? (
@@ -157,6 +165,28 @@ function MemberRowMenu({
                     ) : null}
                 </DropdownMenuContent>
             </DropdownMenu>
+
+            <AlertDialog open={confirmPromote} onOpenChange={setConfirmPromote}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>
+                            Gjør {member.name} til leder?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Gruppen har én leder, så den sittende lederen trer
+                            av.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel variant="outline" size="default">
+                            Avbryt
+                        </AlertDialogCancel>
+                        <AlertDialogAction onClick={() => onPromote?.(member)}>
+                            Gjør til leder
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
 
             <AlertDialog open={confirmRemove} onOpenChange={setConfirmRemove}>
                 <AlertDialogContent>

--- a/apps/kvark/src/components/group-members-tab.tsx
+++ b/apps/kvark/src/components/group-members-tab.tsx
@@ -24,10 +24,16 @@ type GroupMembersTabProps = {
     formerMembers: Member[];
     /** Leder eller groups:manage for gruppen — kan legge til og fjerne medlemmer. */
     isAdmin: boolean;
-    /** Kun groups:manage — å utnevne en ny leder er ikke lederens eget kall. */
+    /** Leder eller groups:manage — lederen kan gi vervet videre selv. */
     canPromote: boolean;
     /** Søk og innsending for «Legg til medlem»; eies av ruten. */
     memberSearch: GroupAddMemberDialogProps;
+    /**
+     * Søk og innsending for «Overfør lederverv». Settes bare for grupper som
+     * kan hente lederen utenfra (HS) — ellers går overføringen gjennom
+     * medlemslista, og en egen søkedialog ville bare vært en omvei.
+     */
+    leaderTransfer?: GroupAddMemberDialogProps;
     onPromote: (member: Member) => void;
     onRemove: (member: Member) => void;
 };
@@ -39,6 +45,7 @@ export function GroupMembersTab({
     isAdmin,
     canPromote,
     memberSearch,
+    leaderTransfer,
     onPromote,
     onRemove,
 }: GroupMembersTabProps) {
@@ -53,9 +60,14 @@ export function GroupMembersTab({
                 }
             />
 
-            {leaders.length > 0 ? (
+            {leaders.length > 0 || leaderTransfer ? (
                 <div className="flex flex-col gap-2">
-                    <h3 className="text-lg">Leder</h3>
+                    <div className="flex items-center justify-between gap-2">
+                        <h3 className="text-lg">Leder</h3>
+                        {leaderTransfer ? (
+                            <GroupAddMemberDialog {...leaderTransfer} />
+                        ) : null}
+                    </div>
                     <ul className="flex flex-col gap-2">
                         {leaders.map((m) => (
                             <li key={m.id}>

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -34,6 +34,18 @@ export type Group = {
     finesAdminId?: string | null;
 };
 
+export const HS_GROUP_SLUG = "hs";
+
+/**
+ * Hvorvidt gruppa kan hente lederen sin utenfra. Presidenten sitter ikke i
+ * Hovedstyret før hun blir valgt, så der søker man blant alle brukere; andre
+ * grupper velger lederen blant sine egne medlemmer. Speiler
+ * `allowsNonMemberLeader` i API-et.
+ */
+export function allowsNonMemberLeader(slug: string): boolean {
+    return slug === HS_GROUP_SLUG;
+}
+
 export type Member = {
     id: string;
     username?: string;

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -82,6 +82,7 @@ import { GroupOmTab } from "#/components/group-om-tab";
 import { mapFormQuestions, toFormFieldsPayload } from "#/lib/form";
 import {
     type Form,
+    allowsNonMemberLeader,
     mapFine,
     mapFineUser,
     mapForm,
@@ -211,8 +212,8 @@ function GroupDetail() {
     const isLeader = useIsGroupLeaderOf(slug);
     const canManage = canEditGroup || isLeader;
     // Roster changes: `groups:manage` for this group, or being its leader.
-    // Adding someone AS leader still needs `groups:manage` — the dialog only
-    // adds plain members, and the API refuses the rest.
+    // Det samme gjelder å gi ledervervet videre — men «Legg til medlem»-veien
+    // legger fortsatt bare til vanlige medlemmer, slik API-et krever.
     const hasGroupsManage = useScopedPermission(
         "groups:manage",
         `group:${slug}`,
@@ -343,6 +344,26 @@ function GroupDetail() {
             ),
         [memberSearchResults, members],
     );
+    // Eget søk for lederoverføring i HS: presidenten er ikke medlem ennå, så
+    // her filtreres ingen bort — bare den som allerede er leder.
+    const canPickLeaderOutsideGroup = allowsNonMemberLeader(slug);
+    const [leaderQuery, setLeaderQuery] = useState("");
+    const [leaderError, setLeaderError] = useState<string | null>(null);
+    const debouncedLeaderQuery = useDebounced(leaderQuery);
+    const { data: leaderSearchResults, isFetching: isSearchingLeader } =
+        useQuery({
+            ...searchUsersQuery(debouncedLeaderQuery),
+            enabled:
+                canPickLeaderOutsideGroup && debouncedLeaderQuery.length >= 2,
+        });
+    const leaderCandidates = useMemo(
+        () =>
+            (leaderSearchResults ?? []).filter(
+                (user) => !leaders.some((m) => m.id === user.id),
+            ),
+        [leaderSearchResults, leaders],
+    );
+
     const group = useMemo(
         () => mapGroup(apiGroup, leaders[0]?.name),
         [apiGroup, leaders],
@@ -600,7 +621,48 @@ function GroupDetail() {
                             members={regularMembers}
                             formerMembers={formerMembers}
                             isAdmin={canManageMembers}
-                            canPromote={hasGroupsManage}
+                            canPromote={canManageMembers}
+                            leaderTransfer={
+                                canManageMembers && canPickLeaderOutsideGroup
+                                    ? {
+                                          copy: {
+                                              trigger: "Overfør",
+                                              title: "Overfør lederverv",
+                                              description:
+                                                  "Den nye lederen legges til i gruppen om hen ikke er medlem. Avtroppende leder mister plassen med mindre et verv gir den.",
+                                              submit: "Overfør lederverv",
+                                              submitting: "Overfører …",
+                                          },
+                                          query: leaderQuery,
+                                          onQueryChange: setLeaderQuery,
+                                          results: leaderCandidates,
+                                          isSearching: isSearchingLeader,
+                                          isAdding: updateMemberRole.isPending,
+                                          error: leaderError,
+                                          onAdd: async (userId) => {
+                                              setLeaderError(null);
+                                              try {
+                                                  await updateMemberRole.mutateAsync(
+                                                      {
+                                                          groupSlug: slug,
+                                                          userId,
+                                                          data: {
+                                                              role: "leader",
+                                                          },
+                                                      },
+                                                  );
+                                              } catch (error) {
+                                                  setLeaderError(
+                                                      await extractErrorMessage(
+                                                          error,
+                                                      ),
+                                                  );
+                                                  throw error;
+                                              }
+                                          },
+                                      }
+                                    : undefined
+                            }
                             memberSearch={{
                                 query: memberQuery,
                                 onQueryChange: setMemberQuery,

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1669,7 +1669,7 @@ export interface paths {
         head?: never;
         /**
          * Update member role
-         * @description Update a member's role in a group. Requires 'groups:manage' permission.
+         * @description Update a member's role in a group. Requires 'groups:manage' (globally or scoped to the group), or being the group's leader — a sitting leader may only hand the leadership over to someone else.
          */
         patch: operations["updateGroupMemberRole"];
         trace?: never;

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1710,7 +1710,7 @@ export interface paths {
         post?: never;
         /**
          * Delete a position
-         * @description Delete a position (verv). Holders lose the position's permissions. Deleting a global position requires 'roles:create'.
+         * @description Delete a position (verv). Holders lose the position's permissions. Deleting an HS position also takes the holder's seat in HS unless something else warrants it. Deleting a global position requires 'roles:create'.
          */
         delete: operations["deleteGroupPosition"];
         options?: never;


### PR DESCRIPTION
## Hvorfor

Å utnevne neste leder krevde `groups:manage`, så en avtroppende leder måtte be HS eller en admin om å gjøre selve overleveringen. Det er lederens eget verv å gi videre.

Samtidig var HS-plassene halvsynket: undergruppeledere ble lagt til og fjernet automatisk, mens en avtroppende president eller finansminister ble sittende igjen som vanlig medlem.

## Hva

**Overføring av lederverv** — `PATCH /groups/:slug/members/:userId`
- Lederen er nå `ownership` på ruta, men bare til overføring: rollen må være `leader`, den må gis til en annen (400 på seg selv), og å sette medlemmer ned krever fortsatt `groups:manage` (403).
- **HS er unntaket fra «velg blant medlemmene»**: presidenten velges på generalforsamlingen og sitter ikke i Hovedstyret før hun tar over, så der opprettes medlemskapet som del av overføringen (`allowsNonMemberLeader`). Andre grupper får 404 for en ikke-medlem, som før.
- `POST /members` er urørt: å legge til noen *som* leder krever fortsatt `groups:manage`, så overføringsreglene bor ett sted.

**HS-plassen følger grunnen til å sitte der.** Alle tre veiene ut prunes nå:
- Lederbytte i HS — avtroppende leder ut (`demoteOtherLeaders`), som for avgåtte undergruppeledere.
- Vervet fratas noen (`DELETE .../positions/:id/holders/:userId`) — dekker President, Visepresident og Finansminister.
- Vervet legges ned (`DELETE .../positions/:id`) — holderen leses før slettingen, siden holder-raden kaskaderer bort med vervet.

Plassen beholdes når noe annet gir den: lederskapet i HS, lederskapet i en undergruppe, eller et annet HS-verv. `pruneHsMembershipIfUnwarranted` teller nå også HS-lederskapet, ellers ville presidenten mistet plassen i det noen tok et verv fra henne.

**Kvark**
- «Gjør til leder» i medlemsmenyen er nå synlig for lederen, med bekreftelsesdialog.
- I HS i tillegg en «Overfør»-knapp ved Leder-overskriften, som søker blant alle brukere — ikke bare medlemmene.

## Verifisert

- `src/test/groups/`: 141/141, inkludert 9 nye — leder forfremmer uten `groups:manage`, 403 på nedsetting, 404 for ikke-medlem i vanlig gruppe, HS godtar ikke-medlem og fjerner avtroppende leder, avtroppende leder med AU-verv beholder plassen, tap av verv fjerner plassen, sletting av verv fjerner plassen, undergruppeleder og sittende HS-leder beholder den.
- `typecheck`, `lint`, `format`, `build` grønt.
- Kjørt mot lokal API i nettleseren: overføring av HS-ledervervet til en ikke-medlem (hen ble leder med nytt medlemskap, avtroppende ledere ut av HS), fjerning av Finansminister-vervet fra holderen i /admin/roller (ut av HS), og sletting av hele Finansminister-vervet (19 → 18 medlemmer). Testdataen er rullet tilbake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)