### PR TITLE
fix(docker): la sharp finne binæren sin, og ikke la den velte oppstarten

### DIFF
--- a/apps/api/src/lib/contract/pdf.ts
+++ b/apps/api/src/lib/contract/pdf.ts
@@ -13,7 +13,6 @@
 
 import type { SignaturePlacement } from "@photon/db/schema";
 import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
-import sharp from "sharp";
 
 export type StampContractInput = {
     /** The original, unsigned contract PDF. */
@@ -58,9 +57,19 @@ function formatDateTime(date: Date): string {
  *
  * Falls back to the original bytes if the image cannot be trimmed — a
  * misaligned signature beats a failed signing.
+ *
+ * `sharp` is imported here rather than at the top of the file on purpose. It
+ * loads a native binary, and a top-level import makes that load part of booting
+ * the API: this module hangs off the contract routes, so a `sharp` that cannot
+ * load takes down every endpoint, not just signing. That is exactly what
+ * happened on 14 August 2026 — the whole API crash-looped on boot for 18
+ * minutes because the release image could not resolve sharp's platform package.
+ * Imported here, the same failure lands in the catch below and costs us a
+ * slightly misaligned signature.
  */
 async function trimSignature(png: Uint8Array): Promise<Uint8Array> {
     try {
+        const { default: sharp } = await import("sharp");
         const trimmed = await sharp(Buffer.from(png))
             .trim({
                 background: { r: 0, g: 0, b: 0, alpha: 0 },

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -32,15 +32,28 @@ RUN bun run build --filter=@photon/api
 # Final image
 FROM oven/bun:1-slim AS release
 WORKDIR /usr/src/app
-COPY --from=build /usr/src/app/apps/api/dist ./dist
-# Migration SQL, applied by dist/migrate.js on boot — the deploy pipeline only
-# ships a new image and never migrates, so the app has to do it itself.
+# The bundle keeps its build-time path (apps/api/dist), so a package it has to
+# resolve at runtime is found the same way it was during the build. `bun build`
+# inlines JavaScript dependencies, but a package with a native binary — sharp —
+# still requires its platform package (`@img/sharp-linux-x64`) at runtime, and
+# that require resolves from the bundle's own directory upwards. Copied to
+# /usr/src/app/dist it would only ever reach the root node_modules, which holds
+# the repo's dev tooling and none of the API's dependencies. That is what took
+# the API down on 14 August 2026.
+COPY --from=build /usr/src/app/apps/api/dist ./apps/api/dist
+# Migration SQL, applied by migrate.js on boot — the deploy pipeline only ships
+# a new image and never migrates, so the app has to do it itself. Stays at the
+# working directory because migrate.js looks for "./drizzle" relative to cwd.
 COPY --from=build /usr/src/app/packages/db/drizzle ./drizzle
+# Both halves of the install are needed, at their original paths: the API's own
+# dependencies live in apps/api/node_modules as symlinks into the .bun store at
+# the root, so copying either one alone leaves dangling links.
 COPY --from=install /usr/src/app/node_modules ./node_modules
+COPY --from=install /usr/src/app/apps/api/node_modules ./apps/api/node_modules
 
 USER bun
 EXPOSE 4000/tcp
 # Migrate before serving. `&&` aborts the boot when a migration fails instead of
 # starting the API against a schema it no longer matches.
-ENTRYPOINT ["sh", "-c", "bun run ./dist/migrate.js && bun run ./dist/index.js"]
+ENTRYPOINT ["sh", "-c", "bun run ./apps/api/dist/migrate.js && bun run ./apps/api/dist/index.js"]
 


### PR DESCRIPTION
Retter nedetiden i dag, 14. august, kl. 18:04–18:22. API-et krasjet i loop i 18 minutter og nginx svarte 502 på alle ruter. Prod kjører nå release-1 etter rollback; denne PR-en er det som må til før release-2-innholdet kan slippes på nytt.

## Hva som skjedde

`import sharp` lå på toppnivå i `apps/api/src/lib/contract/pdf.ts`, som henger på kontrakt-rutene. Modulen ble derfor lastet mens appen startet — ikke først når noen signerte. `sharp` klarte ikke laste, importen kastet, prosessen døde med exit 1, og Docker startet den på nytt i loop. Prod-loggen viser samme stack hvert tredje sekund: `sharp.mjs:171 → pdf.ts:16 → sign.ts:6`.

## De to feilene

**Imaget fant aldri sharp.** `bun build` inliner JavaScript, men `sharp` laster den native pakken sin (`@img/sharp-linux-x64`) med en require på kjøretid, og den løses fra bundelens egen katalog og oppover. Bundelen lå på `/usr/src/app/dist`, som bare når rot-`node_modules` — der ligger repoets verktøy (turbo, oxlint, typescript) og ingen av API-ets avhengigheter. Pakkene lå i imaget hele tiden, bare på et sted ingenting slo opp i. Bundelen beholder nå byggestien sin, `apps/api/dist`, og `apps/api/node_modules` blir med. Begge halvdelene av installasjonen må kopieres på sine opprinnelige stier, siden API-ets avhengigheter er symlinker inn i `.bun`-lageret i roten.

**Importen kunne velte hele API-et.** `sharp` lastes nå inne i `trimSignature`. `try/catch`-en der har alltid hatt riktig oppførsel — «en skjev signatur slår en feilet signering» — men fikk aldri sjansen når importen lå på toppnivå. Nå koster en sharp-feil en signatur som ikke er beskåret, i stedet for hele API-et.

## Hvorfor CI var grønn

Ingenting importerer `sharp` under bygg eller typecheck, og testene kjører ikke i det ferdige runtime-imaget. Feilen fantes bare når imaget faktisk ble startet — som første gang skjedde i prod.

## Verifisering

Bygget `linux/amd64`-imaget lokalt og kjørte det mot en base gjenskapt fra prod-skjemaet:

- `sharp` laster og beskjærer fra bundelens katalog: `libvips 8.18.3`, trim ga 106 bytes. Samme test mot `photon:2026-08-14.release-2` gir `Cannot find package 'sharp'`.
- Full oppstart: migreringene kjører, cronene starter, serveren svarer 200 på `/openapi` og `/api/event`.
- `bun run typecheck` grønn (9/9), `oxfmt --check` grønn, ingen nye lint-varsler.

## Etter merge

Release-2-innholdet (registrerings-indeksene og kontrakt-fiksen) er fortsatt ute av prod. Slipp en ny release på denne når den er merget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)