### PR TITLE
fix(build): la sharp bli en ekte modul, ikke inlinet i bundelen

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "bun --watch src/index.ts",
-        "build": "bun build src/index.ts src/migrate.ts --outdir dist --target bun --sourcemap",
+        "build": "bun build src/index.ts src/migrate.ts --outdir dist --target bun --sourcemap --external sharp",
         "start": "bun dist/index.js",
         "test": "vitest run",
         "test:watch": "vitest",

--- a/apps/api/src/lib/asset/image.ts
+++ b/apps/api/src/lib/asset/image.ts
@@ -20,6 +20,13 @@ let sharpModule: typeof Sharp | null | undefined;
  * Optimization is a nice-to-have; serving the site is not. Resolving it lazily
  * confines the blast radius to uploads, which already fall back to storing the
  * original whenever re-encoding fails.
+ *
+ * Lazy is not enough on its own: `bun build` inlines this import unless sharp is
+ * marked external, and inlined sharp resolves its own platform package
+ * (`@img/sharp-*`) from the bundle's directory, where it does not exist. That is
+ * why the API's build script passes `--external sharp` — without it this catch
+ * fires on every upload and images are stored unoptimized, silently. It did
+ * exactly that in production from late July until 2026-08-14.
  */
 async function loadSharp(logger?: LoggerType): Promise<typeof Sharp | null> {
     if (sharpModule !== undefined) {


### PR DESCRIPTION
Oppfølging til #536. Den fiksen stoppet krasjloopen, men fikk ikke `sharp` til å virke — det gjør denne.

## Hva som var galt

Bildeoptimalisering i prod har vært av siden slutten av juli. Hver opplasting og hver variant-forespørsel logget `sharp could not be loaded; uploads will be stored without optimization` (level 50) og lagret originalen i stedet. Ingen merket det, fordi [image.ts](apps/api/src/lib/asset/image.ts) fanger feilen og siden fungerer uansett — bare med tyngre bilder.

`bun build` inliner `sharp` i `dist/index.js`. Den inlinede koden laster den native pakken sin (`@img/sharp-linux-x64`) med en require på kjøretid, og den løses fra bundelens katalog og oppover — der `@img` aldri ligger. Den late importen i `image.ts` hjalp ikke: bundleren inliner en `await import()` like godt som en statisk import.

`--external sharp` lar importen stå som en ekte modulreferanse. På kjøretid løses den fra `apps/api/node_modules/sharp`, som er en symlink inn i `.bun`-lageret, der `@img` ligger som søsken. Det er stien #536 gjorde tilgjengelig ved å kopiere `apps/api/node_modules` inn i imaget — denne PR-en tar den faktisk i bruk.

## Verifisering

Jeg testet feil sti i #536: `await import("sharp")` fra en fil i `apps/api/dist/` går utenom bundelen og passerer selv når bundelen feiler. Denne gangen er testen end-to-end mot det faktiske imaget — en asset i MinIO, en rad i basen, og så `GET /api/assets/<key>?w=320`, som er ruta som kaller `resizeImage`:

| Image | Svar | sharp-feil i logg |
|---|---|---|
| `release-5` (uten flagget) | 200 `image/png`, 137 212 B — original, uoptimalisert | 1 |
| Denne buildet | 200 `image/webp`, 1 148 B — re-enkodet av sharp | 0 |

Begge mot ferske nøkler. Varianter caches i S3, så en gjenbrukt nøkkel gir falsk grønt — det gikk jeg på én gang underveis.

Bundelen inneholder heller ikke lenger sharps binærnavn (`grep -c sharp-linux-x64`: 2 → 0), og de to `import("sharp")` står igjen som ekte referanser.

`bun run typecheck` grønn (9/9), `oxfmt --check` grønn, ingen nye lint-varsler.

## Merk

Dette er tredje gang sharp tar ned eller degraderer prod — kommentaren i `image.ts` viser til en tilsvarende hendelse 29. juli. De tre lagene er nå på plass: lat import (fra før), `apps/api/node_modules` i imaget (#536), og ekstern modul (denne).

🤖 Generated with [Claude Code](https://claude.com/claude-code)