### PR TITLE
refactor(kvark): slå sammen leder- og medlemslista på gruppesiden

### DIFF
--- a/apps/kvark/src/components/group-members-tab.tsx
+++ b/apps/kvark/src/components/group-members-tab.tsx
@@ -54,48 +54,40 @@ export function GroupMembersTab({
     return (
         <div className="flex flex-col gap-6">
             <GroupPageHeader
-                title="Medlemmer"
+                title={`Medlemmer (${leaders.length + members.length})`}
                 action={
-                    isAdmin ? <GroupAddMemberDialog {...memberSearch} /> : null
-                }
-            />
-
-            {leaders.length > 0 || leaderTransfer ? (
-                <div className="flex flex-col gap-2">
-                    <div className="flex items-center justify-between gap-2">
-                        <h3 className="text-lg">Leder</h3>
+                    <div className="flex flex-wrap items-center gap-2">
                         {leaderTransfer ? (
                             <GroupAddMemberDialog {...leaderTransfer} />
                         ) : null}
+                        {isAdmin ? (
+                            <GroupAddMemberDialog {...memberSearch} />
+                        ) : null}
                     </div>
-                    <ul className="flex flex-col gap-2">
-                        {leaders.map((m) => (
-                            <li key={m.id}>
-                                <GroupMemberRow
-                                    member={m}
-                                    isLeader
-                                    onRemove={isAdmin ? onRemove : undefined}
-                                />
-                            </li>
-                        ))}
-                    </ul>
-                </div>
-            ) : null}
+                }
+            />
 
-            <div className="flex flex-col gap-2">
-                <h3 className="text-lg">Medlemmer ({members.length})</h3>
-                <ul className="flex flex-col gap-2">
-                    {members.map((m) => (
-                        <li key={m.id}>
-                            <GroupMemberRow
-                                member={m}
-                                onPromote={canPromote ? onPromote : undefined}
-                                onRemove={isAdmin ? onRemove : undefined}
-                            />
-                        </li>
-                    ))}
-                </ul>
-            </div>
+            {/* Lederen ligger øverst i samme liste som resten — badgen skiller den ut. */}
+            <ul className="flex flex-col gap-2">
+                {leaders.map((m) => (
+                    <li key={m.id}>
+                        <GroupMemberRow
+                            member={m}
+                            isLeader
+                            onRemove={isAdmin ? onRemove : undefined}
+                        />
+                    </li>
+                ))}
+                {members.map((m) => (
+                    <li key={m.id}>
+                        <GroupMemberRow
+                            member={m}
+                            onPromote={canPromote ? onPromote : undefined}
+                            onRemove={isAdmin ? onRemove : undefined}
+                        />
+                    </li>
+                ))}
+            </ul>
 
             {formerMembers.length > 0 ? (
                 <Collapsible open={showFormer} onOpenChange={setShowFormer}>


### PR DESCRIPTION
Fjerner «Leder»- og «Medlemmer (n)»-overskriftene. Antallet står nå bare i topp-headingen, og lederen ligger øverst i den vanlige lista med badgen som skille. «Overfør» flyttes opp ved siden av «Legg til».