### PR TITLE
perf(db): hold databaseforbindelser varme

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -31,6 +31,25 @@ export type DbTimeouts = {
      * into a site-wide outage.
      */
     connectionTimeoutMs?: number;
+    /**
+     * How long an unused connection is kept before the pool closes it, and how
+     * many are kept regardless.
+     *
+     * `pg` closes idle connections after 10 seconds and keeps none, which on a
+     * site with our traffic means the pool is empty most of the time and a
+     * request that arrives after a quiet moment has to open its connections
+     * from scratch. That is not free: every one costs a TCP handshake, a
+     * backend process, and a SCRAM authentication whose whole purpose is to be
+     * slow to compute.
+     *
+     * It shows in the logs. `get-session` fires eight queries at once, and its
+     * server-side time runs 6 ms at best against a p50 of 43 ms — and it is
+     * *faster* while images are streaming, because the traffic keeps
+     * connections alive. Cheap queries, expensive connections.
+     */
+    idleTimeoutMs?: number;
+    /** Connections kept open even when idle. */
+    minConnections?: number;
 };
 
 /**
@@ -42,6 +61,8 @@ export const REQUEST_TIMEOUTS = {
     statementTimeoutMs: 15_000,
     idleInTransactionTimeoutMs: 30_000,
     connectionTimeoutMs: 5_000,
+    idleTimeoutMs: 60_000,
+    minConnections: 4,
 } as const satisfies DbTimeouts;
 
 /**
@@ -69,6 +90,10 @@ export const DISABLED_TIMEOUTS = {
     statementTimeoutMs: 0,
     idleInTransactionTimeoutMs: 0,
     connectionTimeoutMs: 0,
+    // A one-off script runs its queries and leaves. Holding connections open
+    // for it would only delay the exit.
+    idleTimeoutMs: 10_000,
+    minConnections: 0,
 } as const satisfies DbTimeouts;
 
 function buildOptions(timeouts: DbTimeouts): string {
@@ -228,8 +253,11 @@ export function createDb(config: {
     }
 
     if (connectionString) {
-        const { connectionTimeoutMs = REQUEST_TIMEOUTS.connectionTimeoutMs } =
-            timeouts;
+        const {
+            connectionTimeoutMs = REQUEST_TIMEOUTS.connectionTimeoutMs,
+            idleTimeoutMs = REQUEST_TIMEOUTS.idleTimeoutMs,
+            minConnections = REQUEST_TIMEOUTS.minConnections,
+        } = timeouts;
 
         return drizzle({
             client: watchSaturation(
@@ -238,6 +266,8 @@ export function createDb(config: {
                         connectionString,
                         options: buildOptions(timeouts),
                         connectionTimeoutMillis: connectionTimeoutMs,
+                        idleTimeoutMillis: idleTimeoutMs,
+                        min: minConnections,
                         max: POOL_MAX,
                     }),
                 ),


### PR DESCRIPTION
## Hva jeg lette etter, og hva jeg fant

`get-session` kalles på nesten hver sidelast og brukte 43 ms i median. Jeg antok at rettighetsoppslagene var tunge — de er fire parallelle spørringer mot RBAC-tabellene.

Det stemte ikke. Målt med `EXPLAIN ANALYZE` på prod, alle åtte spørringene ruta gjør:

```
session-oppslag           0,126 ms
bruker + approvalStatus   0,129 ms
innstillinger             0,122 ms
roller -> rettigheter     0,183 ms
direkte rettigheter       0,057 ms
verv -> rettigheter       0,071 ms
grupper                   0,392 ms
                          -------
                          1,08 ms
```

**Databasen står for 1,08 ms av 43.** Tabellene er små (0–1 919 rader) og alle allerede indeksert.

## Hvor tiden faktisk går

`pg` lukker ledige forbindelser etter 10 sekunder og holder ingen (`idleTimeoutMillis: 10000`, `min: 0`). På et nettsted med vår trafikk står poolen tom mesteparten av tiden. Prod bekrefter det — målt hvert femte sekund mens siden var i bruk:

```
21:14:00   2 forbindelser
21:14:05   2 forbindelser
21:14:10   2 forbindelser
...
```

To, hvorav én var min egen måleforbindelse. Photon holdt altså **én**, med en pool på 25.

Hver kalde forespørsel må da åpne sine forbindelser fra bunnen: TCP-håndtrykk, ny backend-prosess i Postgres, og en SCRAM-autentisering som er designet for å være tung å regne ut. `get-session` fyrer åtte spørringer parallelt, så den betaler for åtte oppkoblinger samtidig.

**Det forklarer et funn som ellers er uforståelig.** Jeg sjekket om bildelasting stjal tid fra andre ruter, og fant det motsatte:

```
get-session når ingen bilder lastes samtidig:   p50 84 ms
get-session når bilder lastes samtidig:         p50 37 ms
```

Den er raskere når det er travelt, fordi trafikken holder forbindelsene i live. Og laveste måling er 6 ms, mot p50 på 43 — akkurat det man ser når arbeidet er billig og oppkoblingen er dyr.

## Endringen

Poolen holder fire forbindelser åpne og lar ledige leve i 60 sekunder. Fire er nok til at `get-session` slipper å koble opp fra bunnen, og lite nok til at budsjettet på 100 forbindelser — delt med de andre tjenestene på verten — ikke merker det.

Migrasjoner og engangsskript beholder dagens oppførsel via `DISABLED_TIMEOUTS`: de kjører ferdig og går, og skal ikke vente på at en pool tømmer seg.

## Målt gevinst

Med den ekte `createDb`-koden, åtte parallelle spørringer etter 12 sekunders pause:

```
som i dag (idle 10s, min 0):     19,1 ms
ny standard (idle 60s, min 4):    6,9 ms
```

Det er mot lokal Postgres, som autentiserer raskere og ikke har last. Prod-effekten er trolig større, men den kan jeg først måle etter deploy — `get-session` sin p50 er tallet å følge med på.

`typecheck`, `build` og `test` (569 tester, 80 filer) er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)