### PR TITLE
feat(kvark): egen bedpres-fane i arrangementsoversikten

### DIFF
--- a/apps/kvark/src/lib/event-categories.ts
+++ b/apps/kvark/src/lib/event-categories.ts
@@ -20,6 +20,14 @@ export const ACTIVITY_CATEGORIES: EventCategoryOption[] = [
     { value: "aktivitet", label: "Aktivitet" },
 ];
 
+/**
+ * Bedpres har sin egen fane i oversikten. Kategorien ligger også i
+ * `EVENT_CATEGORIES` slik at bedpresser fortsatt dukker opp under
+ * «Arrangementer» — fanen er en snarvei, ikke et eget kategorirom.
+ */
+export const BEDPRES_CATEGORIES: EventCategoryOption[] =
+    EVENT_CATEGORIES.filter((category) => category.value === "bedpres");
+
 /** Alt som kan velges i skjemaet — begge fanene i oversikten. */
 export const ALL_EVENT_CATEGORIES: EventCategoryOption[] = [
     ...EVENT_CATEGORIES,

--- a/apps/kvark/src/routes/_app/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.index.tsx
@@ -21,7 +21,11 @@ import { PageHeader } from "#/components/page-header";
 import { useDebouncedValue } from "#/hooks/use-debounced-value";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 import { formatEventDateTime } from "#/lib/event";
-import { ACTIVITY_CATEGORIES, EVENT_CATEGORIES } from "#/lib/event-categories";
+import {
+    ACTIVITY_CATEGORIES,
+    BEDPRES_CATEGORIES,
+    EVENT_CATEGORIES,
+} from "#/lib/event-categories";
 
 const SEARCH_DEBOUNCE_MS = 300;
 
@@ -30,7 +34,7 @@ const EVENT_CREATE_PERMISSIONS = ["events:create", "events:manage"] as const;
 
 const ALL_CATEGORIES = { value: "all", label: "Alle kategorier" };
 
-type EventTab = "arrangementer" | "aktiviteter";
+type EventTab = "arrangementer" | "aktiviteter" | "bedpres";
 
 const TABS: { value: EventTab; label: string; categories: Category[] }[] = [
     {
@@ -43,6 +47,11 @@ const TABS: { value: EventTab; label: string; categories: Category[] }[] = [
         label: "Aktiviteter",
         categories: ACTIVITY_CATEGORIES,
     },
+    {
+        value: "bedpres",
+        label: "Bedpres",
+        categories: BEDPRES_CATEGORIES,
+    },
 ];
 
 // Slugs a tab covers when no single category is picked. The events tab also
@@ -54,6 +63,7 @@ const TAB_SLUGS: Record<EventTab, string[]> = {
         "uncategorized",
     ],
     aktiviteter: ACTIVITY_CATEGORIES.map((category) => category.value),
+    bedpres: BEDPRES_CATEGORIES.map((category) => category.value),
 };
 
 const toEventListFilters = (


### PR DESCRIPTION
## Hva

Ny fane «Bedpres» på `/arrangementer`, plassert rett etter «Aktiviteter». Den viser kun arrangementer i bedpres-kategorien.

Bedpres ligger fortsatt under «Arrangementer» også — fanen er en snarvei, ikke et eget kategorirom.

## Endringer

- `apps/kvark/src/lib/event-categories.ts` — ny `BEDPRES_CATEGORIES`, avledet fra `EVENT_CATEGORIES` så slugen ikke dupliseres.
- `apps/kvark/src/routes/_app/arrangementer.index.tsx` — `bedpres` lagt til i `EventTab`, `TABS` og `TAB_SLUGS`.

## Verifisert

- `bun run typecheck` rent, `oxfmt`/`oxlint` uten nye funn.
- Lokal preview: klikk på fanen gir `GET /api/event?page=0&pageSize=25&expired=false&category=bedpres` → 200 med 6 treff, ingen konsollfeil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)