### PR TITLE
fix(kvark): fjern «Botsystem»-overskriften i rediger gruppe

### DIFF
--- a/apps/kvark/src/components/group-edit-dialog.tsx
+++ b/apps/kvark/src/components/group-edit-dialog.tsx
@@ -254,7 +254,6 @@ export function GroupEditDialog({
 
                         <Separator />
 
-                        <h3 className="text-sm font-medium">Botsystem</h3>
                         <Field orientation="horizontal">
                             <FieldLabel htmlFor="fines-activated">
                                 Botsystem på


### PR DESCRIPTION
## Hva

Fjerner `<h3>Botsystem</h3>` i «Rediger gruppen»-dialogen. Feltene rett under sier det samme selv — «Botsystem på» og «Botsystem: praktiske detaljer» — så overskriften gjentok bare ordet. Skillelinja over seksjonen står igjen.

Overskriften var også den eneste plassen i denne filen som brukte typografi-utilities (`text-sm font-medium`) direkte i kvark, noe `apps/kvark/CLAUDE.md` uansett ikke tillater.

## Verifisert

- `bun run typecheck` (9/9), `bun run lint`, `bun run format` — rene.
- Åpnet dialogen lokalt som innlogget admin på `/grupper/2017`: «Botsystem på»-bryteren følger nå rett etter skillelinja, uten overskriften.