### PR TITLE
feat: vis kommende påmeldinger på profilen

### DIFF
--- a/apps/api/src/routes/event/index.ts
+++ b/apps/api/src/routes/event/index.ts
@@ -14,6 +14,7 @@ import { refundEventPaymentRoute } from "./payment/refund";
 import { paymentWebhookRoute } from "./payment/webhook";
 import { setAttendanceRoute } from "./registration/attendance";
 import { getMyEventHistoryRoute } from "./registration/history";
+import { getMyUpcomingEventsRoute } from "./registration/upcoming";
 import { registerToEventRoute } from "./registration/create";
 import { deleteEventRegistrationRoute } from "./registration/delete";
 import { getAllRegistrationsForEventsRoute } from "./registration/list";
@@ -27,6 +28,7 @@ export const eventRoutes = route()
     .route("/", listStrikesRoute)
     // Static path, so it has to beat "/:eventId" to the punch as well
     .route("/", getMyEventHistoryRoute)
+    .route("/", getMyUpcomingEventsRoute)
     .route("/", createStrikeRoute)
     .route("/", deleteStrikeRoute)
 

--- a/apps/api/src/routes/event/registration/upcoming.ts
+++ b/apps/api/src/routes/event/registration/upcoming.ts
@@ -41,6 +41,10 @@ export const getMyUpcomingEventsRoute = route().get(
                 startTime: schema.event.start,
                 endTime: schema.event.end,
                 categorySlug: schema.event.categorySlug,
+                location: schema.event.location,
+                image: schema.event.imageUrl,
+                imageAlt: schema.event.imageAlt,
+                organizer: schema.group.name,
                 status: schema.eventRegistration.status,
                 waitlistPosition: schema.eventRegistration.waitlistPosition,
             })
@@ -48,6 +52,12 @@ export const getMyUpcomingEventsRoute = route().get(
             .innerJoin(
                 schema.event,
                 eq(schema.eventRegistration.eventId, schema.event.id),
+            )
+            // Left join: an event without an organizing group still belongs in
+            // the list, it just has no badge.
+            .leftJoin(
+                schema.group,
+                eq(schema.event.organizerGroupSlug, schema.group.slug),
             )
             .where(
                 and(
@@ -70,6 +80,10 @@ export const getMyUpcomingEventsRoute = route().get(
                 startTime: row.startTime.toISOString(),
                 endTime: row.endTime.toISOString(),
                 categorySlug: row.categorySlug,
+                location: row.location,
+                image: row.image,
+                imageAlt: row.imageAlt,
+                organizer: row.organizer,
                 status: row.status as "registered" | "waitlisted" | "pending",
                 waitlistPosition: row.waitlistPosition,
             }),

--- a/apps/api/src/routes/event/registration/upcoming.ts
+++ b/apps/api/src/routes/event/registration/upcoming.ts
@@ -1,0 +1,80 @@
+import { schema } from "@photon/db";
+import { and, asc, eq, gte, inArray } from "drizzle-orm";
+import type z from "zod";
+import { describeRoute } from "~/lib/openapi";
+import { route } from "~/lib/route";
+import { requireAuth } from "~/middleware/auth";
+import { myUpcomingEventsSchema } from "../schema";
+
+/**
+ * Everything the caller is signed up for that has not happened yet — the
+ * counterpart to `/my-registrations`, which stops at events that are over.
+ * Waitlisted and pending registrations are included: from the member's side
+ * those are still something they signed up for and need to keep an eye on.
+ * Nothing filters on category, so activities show up alongside the rest.
+ */
+export const getMyUpcomingEventsRoute = route().get(
+    "/my-upcoming-registrations",
+    describeRoute({
+        tags: ["events"],
+        summary: "Get my upcoming event registrations",
+        operationId: "getMyUpcomingEvents",
+        description:
+            "Retrieve the events you are registered, waitlisted or pending for that have not ended yet, soonest first.",
+    })
+        .schemaResponse({
+            statusCode: 200,
+            schema: myUpcomingEventsSchema,
+            description: "OK",
+        })
+        .build(),
+    requireAuth,
+    async (c) => {
+        const { db } = c.get("ctx");
+        const userId = c.get("user").id;
+
+        const rows = await db
+            .select({
+                eventId: schema.event.id,
+                title: schema.event.title,
+                slug: schema.event.slug,
+                startTime: schema.event.start,
+                endTime: schema.event.end,
+                categorySlug: schema.event.categorySlug,
+                status: schema.eventRegistration.status,
+                waitlistPosition: schema.eventRegistration.waitlistPosition,
+            })
+            .from(schema.eventRegistration)
+            .innerJoin(
+                schema.event,
+                eq(schema.eventRegistration.eventId, schema.event.id),
+            )
+            .where(
+                and(
+                    eq(schema.eventRegistration.userId, userId),
+                    inArray(schema.eventRegistration.status, [
+                        "registered",
+                        "waitlisted",
+                        "pending",
+                    ]),
+                    gte(schema.event.end, new Date()),
+                ),
+            )
+            .orderBy(asc(schema.event.start));
+
+        const response: z.infer<typeof myUpcomingEventsSchema> = rows.map(
+            (row) => ({
+                eventId: row.eventId,
+                title: row.title,
+                slug: row.slug,
+                startTime: row.startTime.toISOString(),
+                endTime: row.endTime.toISOString(),
+                categorySlug: row.categorySlug,
+                status: row.status as "registered" | "waitlisted" | "pending",
+                waitlistPosition: row.waitlistPosition,
+            }),
+        );
+
+        return c.json(response, 200);
+    },
+);

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -780,6 +780,37 @@ export const favoriteEventsSchema = Schema(
     ),
 );
 
+/**
+ * The registrations that still lie ahead. No category filter: activities are
+ * ordinary events with the `aktivitet` category, so they belong here too.
+ */
+export const myUpcomingEventsSchema = Schema(
+    "MyUpcomingEvents",
+    z.array(
+        z.object({
+            eventId: z.string().meta({ description: "Event ID" }),
+            title: z.string().meta({ description: "Event title" }),
+            slug: z.string().meta({ description: "Event slug" }),
+            startTime: z.iso.datetime().meta({
+                description: "When the event starts (ISO 8601)",
+            }),
+            endTime: z.iso.datetime().meta({
+                description: "When the event ends (ISO 8601)",
+            }),
+            categorySlug: z
+                .string()
+                .meta({ description: "Slug of the event's category" }),
+            status: z.enum(["registered", "waitlisted", "pending"]).meta({
+                description: "Your registration status for the event",
+            }),
+            waitlistPosition: z.number().nullable().meta({
+                description:
+                    "Your place in the waitlist, or null if you have a spot",
+            }),
+        }),
+    ),
+);
+
 export const myEventHistorySchema = Schema(
     "MyEventHistory",
     z.object({

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -800,6 +800,22 @@ export const myUpcomingEventsSchema = Schema(
             categorySlug: z
                 .string()
                 .meta({ description: "Slug of the event's category" }),
+            location: z
+                .string()
+                .nullable()
+                .meta({ description: "Where the event takes place" }),
+            image: z
+                .string()
+                .nullable()
+                .meta({ description: "Cover image URL" }),
+            imageAlt: z
+                .string()
+                .nullable()
+                .meta({ description: "Alt text for the cover image" }),
+            organizer: z
+                .string()
+                .nullable()
+                .meta({ description: "Name of the organizing group" }),
             status: z.enum(["registered", "waitlisted", "pending"]).meta({
                 description: "Your registration status for the event",
             }),

--- a/apps/api/src/test/event/my-upcoming.test.ts
+++ b/apps/api/src/test/event/my-upcoming.test.ts
@@ -1,0 +1,84 @@
+import { schema } from "@photon/db";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+describe("my upcoming registrations", () => {
+    integrationTest(
+        "returns every upcoming registration, activities included, and leaves out past ones",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const now = Date.now();
+
+            const bedpres = await ctx.utils.createTestEvent({
+                title: "Bedpres",
+                slug: `bedpres-${now}`,
+                categorySlug: "bedpres",
+                start: new Date(now + 2 * DAY),
+                end: new Date(now + 2 * DAY + 2 * HOUR),
+            });
+            const activity = await ctx.utils.createTestEvent({
+                title: "Aktivitet",
+                slug: `aktivitet-${now}`,
+                categorySlug: "aktivitet",
+                start: new Date(now + DAY),
+                end: new Date(now + DAY + 2 * HOUR),
+            });
+            const waitlisted = await ctx.utils.createTestEvent({
+                title: "Fullt arrangement",
+                slug: `fullt-${now}`,
+                categorySlug: "sosialt",
+                start: new Date(now + 3 * DAY),
+                end: new Date(now + 3 * DAY + 2 * HOUR),
+            });
+            const past = await ctx.utils.createTestEvent({
+                title: "Ferdig arrangement",
+                slug: `ferdig-${now}`,
+                categorySlug: "sosialt",
+                start: new Date(now - 2 * DAY),
+                end: new Date(now - 2 * DAY + 2 * HOUR),
+            });
+
+            const user = await ctx.utils.createTestUser();
+            const other = await ctx.utils.createTestUser();
+
+            await ctx.db.insert(schema.eventRegistration).values([
+                { eventId: bedpres.id, userId: user.id, status: "registered" },
+                { eventId: activity.id, userId: user.id, status: "registered" },
+                {
+                    eventId: waitlisted.id,
+                    userId: user.id,
+                    status: "waitlisted",
+                    waitlistPosition: 3,
+                },
+                { eventId: past.id, userId: user.id, status: "attended" },
+                { eventId: bedpres.id, userId: other.id, status: "registered" },
+            ]);
+
+            const client = await ctx.utils.clientForUser(user);
+            const response =
+                await client.api.event["my-upcoming-registrations"].$get();
+
+            expect(response.status).toBe(200);
+            const body = await response.json();
+
+            // Soonest first, and the activity is in the list rather than
+            // filtered out with the other categories.
+            expect(body.map((e) => e.slug)).toEqual([
+                activity.slug,
+                bedpres.slug,
+                waitlisted.slug,
+            ]);
+            expect(body.map((e) => e.categorySlug)).toContain("aktivitet");
+
+            const waitlistRow = body.find((e) => e.slug === waitlisted.slug);
+            expect(waitlistRow?.status).toBe("waitlisted");
+            expect(waitlistRow?.waitlistPosition).toBe(3);
+        },
+        500_000,
+    );
+});

--- a/apps/api/src/test/event/my-upcoming.test.ts
+++ b/apps/api/src/test/event/my-upcoming.test.ts
@@ -27,6 +27,10 @@ describe("my upcoming registrations", () => {
                 categorySlug: "aktivitet",
                 start: new Date(now + DAY),
                 end: new Date(now + DAY + 2 * HOUR),
+                location: "Klatresenteret",
+                imageUrl: "https://example.com/klatring.jpg",
+                imageAlt: "Klatrevegg",
+                organizerGroupSlug: "basket",
             });
             const waitlisted = await ctx.utils.createTestEvent({
                 title: "Fullt arrangement",
@@ -74,6 +78,13 @@ describe("my upcoming registrations", () => {
                 waitlisted.slug,
             ]);
             expect(body.map((e) => e.categorySlug)).toContain("aktivitet");
+
+            // Kortet trenger bilde, sted og arrangør, ikke bare tittel og tid.
+            const activityRow = body.find((e) => e.slug === activity.slug);
+            expect(activityRow?.location).toBe("Klatresenteret");
+            expect(activityRow?.image).toBe("https://example.com/klatring.jpg");
+            expect(activityRow?.imageAlt).toBe("Klatrevegg");
+            expect(activityRow?.organizer).toBe("TIHLDE Basket");
 
             const waitlistRow = body.find((e) => e.slug === waitlisted.slug);
             expect(waitlistRow?.status).toBe("waitlisted");

--- a/apps/kvark/src/api/queries/events.ts
+++ b/apps/kvark/src/api/queries/events.ts
@@ -24,6 +24,7 @@ const EventQueryKeys = {
     payments: ["events", "payments"] as const,
     forms: ["events", "forms"] as const,
     strikes: ["events", "strikes"] as const,
+    myUpcoming: ["events", "my-upcoming"] as const,
     myHistory: ["events", "my-history"] as const,
     myHistoryInfinite: ["events", "my-history-infinite"] as const,
 } as const;
@@ -168,6 +169,17 @@ export const getFavoriteEventsQuery = () =>
     });
 
 /**
+ * Alt du er påmeldt som ikke er over ennå — «Kommende» på profilen. Ventelisten
+ * og uavklarte påmeldinger er med, og ingenting filtreres på kategori, så
+ * aktiviteter havner i samme liste som resten.
+ */
+export const getMyUpcomingEventsQuery = () =>
+    queryOptions({
+        queryKey: [...EventQueryKeys.myUpcoming],
+        queryFn: () => apiClient.get("/api/event/my-upcoming-registrations"),
+    });
+
+/**
  * Arrangementene du faktisk har vært på — brukes i «Tidligere» på profilen.
  * Avlyste og ubetalte påmeldinger og alt som ikke er over ennå er filtrert
  * bort server-side.
@@ -293,6 +305,11 @@ export const registerForEventMutation = mutationOptions({
             queryKey: [...EventQueryKeys.registrations, vars.eventId],
             exact: false,
         });
+        // «Kommende» på profilen er en liste over egne påmeldinger, så den er
+        // utdatert i det man melder seg på eller av.
+        ctx.client.invalidateQueries({
+            queryKey: [...EventQueryKeys.myUpcoming],
+        });
         invalidateEventDetails(ctx.client);
     },
 });
@@ -306,6 +323,11 @@ export const unregisterFromEventMutation = mutationOptions({
         ctx.client.invalidateQueries({
             queryKey: [...EventQueryKeys.registrations, vars.eventId],
             exact: false,
+        });
+        // «Kommende» på profilen er en liste over egne påmeldinger, så den er
+        // utdatert i det man melder seg på eller av.
+        ctx.client.invalidateQueries({
+            queryKey: [...EventQueryKeys.myUpcoming],
         });
         invalidateEventDetails(ctx.client);
     },

--- a/apps/kvark/src/components/event-card.tsx
+++ b/apps/kvark/src/components/event-card.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { CalendarDays, MapPin, UsersRound } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { ListCard } from "#/components/list-card";
 
@@ -14,6 +15,8 @@ export type EventCardProps = {
     imageAlt?: string;
     capacity?: number | null;
     registeredCount?: number;
+    /** Status ved siden av tittelen, f.eks. ventelisteplassen din. */
+    badge?: ReactNode;
 };
 
 export function EventCard({
@@ -26,6 +29,7 @@ export function EventCard({
     imageAlt,
     capacity,
     registeredCount,
+    badge,
 }: EventCardProps) {
     const meta = [
         { icon: CalendarDays, text: startsAt },
@@ -50,6 +54,7 @@ export function EventCard({
             imageUrl={imageUrl}
             imageAlt={imageAlt}
             imageBadge={organizer}
+            titleBadge={badge}
             meta={meta}
         />
     );

--- a/apps/kvark/src/components/list-card.tsx
+++ b/apps/kvark/src/components/list-card.tsx
@@ -18,6 +18,8 @@ type ListCardProps = {
     imageUrl?: string;
     imageAlt?: string;
     imageBadge?: ReactNode;
+    /** Status ved siden av tittelen, f.eks. ventelisteplassen din. */
+    titleBadge?: ReactNode;
     meta: ListCardMetaRow[];
 };
 
@@ -27,6 +29,7 @@ export function ListCard({
     imageUrl,
     imageAlt,
     imageBadge,
+    titleBadge,
     meta,
 }: ListCardProps) {
     return useRender({
@@ -73,9 +76,14 @@ export function ListCard({
                          * long title set the row's max-content width and push
                          * the list wider than the viewport.
                          */}
-                        <h3 className="line-clamp-1 text-lg sm:text-xl">
-                            {title}
-                        </h3>
+                        <div className="flex items-start justify-between gap-2">
+                            <h3 className="line-clamp-1 text-lg sm:text-xl">
+                                {title}
+                            </h3>
+                            {titleBadge ? (
+                                <div className="shrink-0">{titleBadge}</div>
+                            ) : null}
+                        </div>
                         <div className="flex flex-col gap-1 text-sm text-muted-foreground">
                             {meta.map((row, i) => (
                                 // `min-w-0`: uten den setter et langt stedsnavn

--- a/apps/kvark/src/components/profile-upcoming-events.tsx
+++ b/apps/kvark/src/components/profile-upcoming-events.tsx
@@ -1,6 +1,4 @@
-import { Link } from "@tanstack/react-router";
 import { Badge } from "@tihlde/ui/ui/badge";
-import { Card } from "@tihlde/ui/ui/card";
 import {
     Empty,
     EmptyDescription,
@@ -11,6 +9,7 @@ import {
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import { CalendarDays } from "lucide-react";
 
+import { EventCard } from "#/components/event-card";
 import { formatEventDateTime } from "#/lib/event";
 
 export type ProfileUpcomingEvent = {
@@ -18,13 +17,17 @@ export type ProfileUpcomingEvent = {
     title: string;
     slug: string;
     startTime: string;
+    location: string | null;
+    image: string | null;
+    imageAlt: string | null;
+    organizer: string | null;
     status: "registered" | "waitlisted" | "pending";
     waitlistPosition: number | null;
 };
 
 /**
- * Påmeldingene som ikke er over ennå. Ventelisteplassen og uavklarte
- * påmeldinger merkes, siden de betyr noe annet enn en sikret plass.
+ * Ventelisteplassen og uavklarte påmeldinger merkes, siden de betyr noe annet
+ * enn en sikret plass. En vanlig påmelding får ikke merke — det er normalen.
  */
 function statusLabel(event: ProfileUpcomingEvent): string | null {
     if (event.status === "pending") return "Behandles";
@@ -35,6 +38,7 @@ function statusLabel(event: ProfileUpcomingEvent): string | null {
     return null;
 }
 
+/** Påmeldingene som ikke er over ennå, som arrangementskort. */
 export function ProfileUpcomingEvents({
     events,
     isPending,
@@ -47,7 +51,8 @@ export function ProfileUpcomingEvents({
             <ul className="flex flex-col gap-3">
                 {[0, 1].map((i) => (
                     <li key={i}>
-                        <Skeleton className="h-16 w-full" />
+                        {/* Speiler kortet: bilde i 21/9 på mobil, rad på sm+. */}
+                        <Skeleton className="h-48 w-full sm:h-28" />
                     </li>
                 ))}
             </ul>
@@ -77,28 +82,20 @@ export function ProfileUpcomingEvents({
                 const label = statusLabel(event);
                 return (
                     <li key={event.eventId}>
-                        <Card
-                            size="sm"
-                            className="flex-row items-center gap-3 px-3"
-                            render={
-                                <Link
-                                    to="/arrangementer/$slug"
-                                    params={{ slug: event.slug }}
-                                />
+                        <EventCard
+                            slug={event.slug}
+                            title={event.title}
+                            startsAt={formatEventDateTime(event.startTime)}
+                            location={event.location ?? ""}
+                            organizer={event.organizer ?? ""}
+                            imageUrl={event.image || undefined}
+                            imageAlt={event.imageAlt || undefined}
+                            badge={
+                                label ? (
+                                    <Badge variant="secondary">{label}</Badge>
+                                ) : null
                             }
-                        >
-                            <div className="flex min-w-0 flex-1 flex-col">
-                                <span className="truncate font-medium">
-                                    {event.title}
-                                </span>
-                                <span className="truncate text-sm text-muted-foreground">
-                                    {formatEventDateTime(event.startTime)}
-                                </span>
-                            </div>
-                            {label ? (
-                                <Badge variant="secondary">{label}</Badge>
-                            ) : null}
-                        </Card>
+                        />
                     </li>
                 );
             })}

--- a/apps/kvark/src/components/profile-upcoming-events.tsx
+++ b/apps/kvark/src/components/profile-upcoming-events.tsx
@@ -1,0 +1,107 @@
+import { Link } from "@tanstack/react-router";
+import { Badge } from "@tihlde/ui/ui/badge";
+import { Card } from "@tihlde/ui/ui/card";
+import {
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from "@tihlde/ui/ui/empty";
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+import { CalendarDays } from "lucide-react";
+
+import { formatEventDateTime } from "#/lib/event";
+
+export type ProfileUpcomingEvent = {
+    eventId: string;
+    title: string;
+    slug: string;
+    startTime: string;
+    status: "registered" | "waitlisted" | "pending";
+    waitlistPosition: number | null;
+};
+
+/**
+ * Påmeldingene som ikke er over ennå. Ventelisteplassen og uavklarte
+ * påmeldinger merkes, siden de betyr noe annet enn en sikret plass.
+ */
+function statusLabel(event: ProfileUpcomingEvent): string | null {
+    if (event.status === "pending") return "Behandles";
+    if (event.status === "waitlisted")
+        return event.waitlistPosition !== null
+            ? `Venteliste #${event.waitlistPosition}`
+            : "Venteliste";
+    return null;
+}
+
+export function ProfileUpcomingEvents({
+    events,
+    isPending,
+}: {
+    events: ProfileUpcomingEvent[];
+    isPending: boolean;
+}) {
+    if (isPending) {
+        return (
+            <ul className="flex flex-col gap-3">
+                {[0, 1].map((i) => (
+                    <li key={i}>
+                        <Skeleton className="h-16 w-full" />
+                    </li>
+                ))}
+            </ul>
+        );
+    }
+
+    if (events.length === 0) {
+        return (
+            <Empty>
+                <EmptyHeader>
+                    <EmptyMedia variant="icon">
+                        <CalendarDays />
+                    </EmptyMedia>
+                    <EmptyTitle>Ingen kommende arrangementer</EmptyTitle>
+                    <EmptyDescription>
+                        Påmeldingene dine vises her når du melder deg på et
+                        arrangement.
+                    </EmptyDescription>
+                </EmptyHeader>
+            </Empty>
+        );
+    }
+
+    return (
+        <ul className="flex flex-col gap-3">
+            {events.map((event) => {
+                const label = statusLabel(event);
+                return (
+                    <li key={event.eventId}>
+                        <Card
+                            size="sm"
+                            className="flex-row items-center gap-3 px-3"
+                            render={
+                                <Link
+                                    to="/arrangementer/$slug"
+                                    params={{ slug: event.slug }}
+                                />
+                            }
+                        >
+                            <div className="flex min-w-0 flex-1 flex-col">
+                                <span className="truncate font-medium">
+                                    {event.title}
+                                </span>
+                                <span className="truncate text-sm text-muted-foreground">
+                                    {formatEventDateTime(event.startTime)}
+                                </span>
+                            </div>
+                            {label ? (
+                                <Badge variant="secondary">{label}</Badge>
+                            ) : null}
+                        </Card>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}

--- a/apps/kvark/src/routes/_app/profil/$id/arrangementer.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/arrangementer.tsx
@@ -2,6 +2,7 @@ import { requireOwnProfile } from "#/api/auth";
 import {
     getFavoriteEventsQuery,
     getMyEventHistoryInfiniteQuery,
+    getMyUpcomingEventsQuery,
 } from "#/api/queries/events";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
@@ -18,6 +19,7 @@ import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import { CalendarDays, Star } from "lucide-react";
 
 import { LoadMoreButton } from "#/components/load-more-button";
+import { ProfileUpcomingEvents } from "#/components/profile-upcoming-events";
 import { formatEventDate } from "#/lib/event";
 
 export const Route = createFileRoute("/_app/profil/$id/arrangementer")({
@@ -28,6 +30,9 @@ export const Route = createFileRoute("/_app/profil/$id/arrangementer")({
 
 function RouteComponent() {
     const { data: favorites, isPending } = useQuery(getFavoriteEventsQuery());
+    const { data: upcoming, isPending: isUpcomingPending } = useQuery(
+        getMyUpcomingEventsQuery(),
+    );
 
     // Favoritter er en huskeliste over noe som skal skje. Et arrangement som
     // er over hører ikke hjemme der — det står allerede under «Tidligere».
@@ -38,6 +43,14 @@ function RouteComponent() {
 
     return (
         <div className="flex flex-col gap-6">
+            <section className="flex flex-col gap-3">
+                <h3>Kommende</h3>
+                <ProfileUpcomingEvents
+                    events={upcoming ?? []}
+                    isPending={isUpcomingPending}
+                />
+            </section>
+
             <section className="flex flex-col gap-3">
                 <h3>Favoritter</h3>
                 {isPending ? (

--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -3,11 +3,13 @@ import {
     getActiveContractQuery,
     getMySignatureQuery,
 } from "#/api/queries/contracts";
+import { getMyUpcomingEventsQuery } from "#/api/queries/events";
 import { getUnreadNotificationCountQuery } from "#/api/queries/notifications";
 import { getUserProfileQuery } from "#/api/queries/user";
 import { ProfileLinksSection } from "#/components/profile-links-section";
 import { ProfileMembershipChips } from "#/components/profile-membership-chips";
 import { ProfileOverviewHeader } from "#/components/profile-overview-header";
+import { ProfileUpcomingEvents } from "#/components/profile-upcoming-events";
 import type { ProfileLink } from "#/components/profile-header";
 import { isPrivateGroupType } from "#/lib/group";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
@@ -22,7 +24,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from "@tihlde/ui/ui/empty";
-import { CalendarDays, FileSignature, ListTodo } from "lucide-react";
+import { FileSignature, ListTodo } from "lucide-react";
 
 export const Route = createFileRoute("/_app/profil/$id/")({
     component: RouteComponent,
@@ -48,6 +50,12 @@ function RouteComponent() {
     // Kontraktbanneret gjelder bare egen profil, så begge kallene hoppes over
     // på andres. Begge nøklene deles med /kontrakt, så signeringen der
     // invaliderer banneret her uten et ekstra kall.
+    // Egne påmeldinger, så listen hentes bare på egen profil.
+    const { data: upcomingEvents, isPending: isUpcomingPending } = useQuery({
+        ...getMyUpcomingEventsQuery(),
+        enabled: isOwnProfile,
+    });
+
     const { data: activeContract } = useQuery({
         ...getActiveContractQuery(),
         enabled: isOwnProfile,
@@ -140,20 +148,10 @@ function RouteComponent() {
                 <>
                     <div className="flex flex-col gap-3">
                         <h3>KOMMENDE</h3>
-                        <Empty>
-                            <EmptyHeader>
-                                <EmptyMedia variant="icon">
-                                    <CalendarDays />
-                                </EmptyMedia>
-                                <EmptyTitle>
-                                    Ingen kommende arrangementer
-                                </EmptyTitle>
-                                <EmptyDescription>
-                                    Påmeldingene dine vises her når du melder
-                                    deg på et arrangement.
-                                </EmptyDescription>
-                            </EmptyHeader>
-                        </Empty>
+                        <ProfileUpcomingEvents
+                            events={upcomingEvents ?? []}
+                            isPending={isUpcomingPending}
+                        />
                     </div>
 
                     <div className="flex flex-col gap-3">

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -642,6 +642,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/event/my-upcoming-registrations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get my upcoming event registrations
+         * @description Retrieve the events you are registered, waitlisted or pending for that have not ended yet, soonest first.
+         */
+        get: operations["getMyUpcomingEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/event/strikes/{strikeId}": {
         parameters: {
             query?: never;
@@ -3389,6 +3409,33 @@ export interface components {
                 status: "registered" | "attended" | "no_show";
             }[];
         };
+        MyUpcomingEvents: {
+            /** @description Event ID */
+            eventId: string;
+            /** @description Event title */
+            title: string;
+            /** @description Event slug */
+            slug: string;
+            /**
+             * Format: date-time
+             * @description When the event starts (ISO 8601)
+             */
+            startTime: string;
+            /**
+             * Format: date-time
+             * @description When the event ends (ISO 8601)
+             */
+            endTime: string;
+            /** @description Slug of the event's category */
+            categorySlug: string;
+            /**
+             * @description Your registration status for the event
+             * @enum {string}
+             */
+            status: "registered" | "waitlisted" | "pending";
+            /** @description Your place in the waitlist, or null if you have a spot */
+            waitlistPosition: number | null;
+        }[];
         CreateStrike: {
             /** @description User ID who receives the strike */
             userId: string;
@@ -7620,6 +7667,44 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MyEventHistory"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+        };
+    };
+    getMyUpcomingEvents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MyUpcomingEvents"];
                 };
             };
             /** @description Authentication required */

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3428,6 +3428,14 @@ export interface components {
             endTime: string;
             /** @description Slug of the event's category */
             categorySlug: string;
+            /** @description Where the event takes place */
+            location: string | null;
+            /** @description Cover image URL */
+            image: string | null;
+            /** @description Alt text for the cover image */
+            imageAlt: string | null;
+            /** @description Name of the organizing group */
+            organizer: string | null;
             /**
              * @description Your registration status for the event
              * @enum {string}

--- a/packages/sdk/src/generated/schemas.ts
+++ b/packages/sdk/src/generated/schemas.ts
@@ -153,6 +153,7 @@ export type MotetidSyncCalendarResponse = Schemas["MotetidSyncCalendarResponse"]
 export type MyEventHistory = Schemas["MyEventHistory"];
 export type MyGroup = Schemas["MyGroup"];
 export type MyGroupList = Schemas["MyGroupList"];
+export type MyUpcomingEvents = Schemas["MyUpcomingEvents"];
 export type NewsArticle = Schemas["NewsArticle"];
 export type NewsList = Schemas["NewsList"];
 export type NewsListItem = Schemas["NewsListItem"];


### PR DESCRIPTION
## Hva

«KOMMENDE» på profilsiden var en hardkodet tom-tilstand — den hentet aldri noe, så man fikk «Ingen kommende arrangementer» uansett hvor mange man var påmeldt. Nå viser den faktiske påmeldinger, aktiviteter inkludert.

- **Nytt endepunkt** `GET /api/event/my-upcoming-registrations` (`apps/api/src/routes/event/registration/upcoming.ts`): alle påmeldinger der arrangementet ikke er over ennå, nærmeste først. Ingen kategorifiltrering, så aktiviteter (kategori `aktivitet`) kommer med på lik linje med bedpres, sosialt og fadderuka. Statusene `registered`, `waitlisted` og `pending` er med — venteliste og uavklart påmelding er fortsatt noe man har meldt seg på, de merkes i lista i stedet for å skjules.
- **Frontend**: ny dum komponent `profile-upcoming-events.tsx` med skeleton, badge «Venteliste #N» / «Behandles», og den gamle tom-teksten når man faktisk ikke er påmeldt noe. Lista hentes bare på egen profil, og påmelding/avmelding invaliderer den.
- `/my-registrations` (Tidligere) er urørt og dekker fortsatt bare historikken.
- SDK-typene er regenerert (`packages/sdk/src/generated/*`).

## Verifisert

- Ny integrasjonstest `apps/api/src/test/event/my-upcoming.test.ts` passerer: rekkefølge, at aktiviteten er med, at et avsluttet arrangement er ute, og at ventelisteplassen følger med.
- `bun run typecheck`, `bun run lint`, `bun run format` og `bun run build` er grønne.
- Kjørt lokalt i nettleser mot dev-DB med tre påmeldinger (en aktivitet, en bedpres, en ventelisteplass) — alle tre vises under KOMMENDE med riktig dato og «Venteliste #2»-merket. Testdataene er ryddet bort etterpå.

## Til reviewer

Verdt en mening: `pending` vises som «Behandles». Statusen er kortvarig (påmeldingsresolveren kjører hvert 5. sekund), men å skjule den ville gjort at et arrangement man nettopp meldte seg på forsvant fra lista i noen sekunder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)