### PR TITLE
fix(kvark): sentrer heroen i synlig flate på mobil

### DIFF
--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -209,14 +209,20 @@ function EventsSkeleton() {
 }
 
 function Hero() {
+    // The hero fills exactly the space the first screen actually offers, so its
+    // content lands on the optical centre on every device instead of drifting
+    // low: 100svh (stable while mobile browser chrome hides and shows) minus
+    // the 3.5rem header, and below lg also the fixed bottom bar with its
+    // safe-area inset. The padding is the floor for short viewports, where the
+    // content is taller than the space available.
     return (
-        <div className="relative">
+        <div className="relative flex min-h-[calc(100svh_-_3.5rem_-_4rem_-_env(safe-area-inset-bottom))] flex-col justify-center lg:min-h-[calc(100svh_-_3.5rem)]">
             <HeroSectionBackground className="h-full text-primary -z-50" />
             {/* Logo, blurb and actions are the section's three direct children,
              * so Stagger walks them in that reading order on its own. */}
             <Stagger
                 render={
-                    <section className="container mx-auto flex w-full flex-col items-center gap-6 px-4 py-50 text-center" />
+                    <section className="container mx-auto flex w-full flex-col items-center gap-6 px-4 py-16 text-center" />
                 }
             >
                 <div


### PR DESCRIPTION
## Problem

Heroen på forsiden lå litt for lavt på mobil. Den hadde fast `py-50` (200 px topp/bunn) og ble dermed sentrert i seg selv — ikke i det området skjermen faktisk gir. På mobil spiser headeren (56 px) toppen og den faste bunnmenyen (64 px + safe-area) dekker bunnen, så innholdet havnet ~50 px under optisk senter.

## Løsning

Heroen får minstehøyde lik den frie flaten — `100svh` minus header, og under `lg` også bunnmenyen med `env(safe-area-inset-bottom)` — og sentrerer innholdet med flex. `svh` gjør at den ikke hopper når nettleserlinja på mobil skjuler/viser seg. `py-16` står igjen som gulv på lave skjermer.

## Verifisert

Målt med `getBoundingClientRect` i preview, ikke øyemål:

| Viewport | Innholdssenter | Senter i fri flate |
| --- | --- | --- |
| 375×812 (mobil) | 402 px | 403 px |
| 1280×800 (desktop, ingen bunnmeny) | 428 px | 428 px |

På 320×480 vokser heroen til 412 px og innholdet stopper på 404 px — godt klar av bunnmenyen, ingen overlapp.

`oxfmt` og `oxlint` er rene for fila. `typecheck` gir 3 feil, alle i `packages/core` (`@photon/email` ikke bygd i worktreen) — ingen i kvark-koden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)