### PR TITLE
fix(kvark): fanene flyter ikke lenger ut av siden på mobil

### DIFF
--- a/apps/kvark/src/components/detail-layout.tsx
+++ b/apps/kvark/src/components/detail-layout.tsx
@@ -1,3 +1,4 @@
+import { ScrollFade } from "@tihlde/ui/ui/scroll-fade";
 import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 import type { ReactNode } from "react";
 
@@ -75,10 +76,10 @@ export function DetailLayoutNav<K extends string>({
     const flatItems = sections.flat();
 
     return (
-        // overflow-y-hidden er ikke overflødig: per CSS-spec beregnes den andre
-        // aksen til `auto` når én akse settes, så `overflow-x-auto` alene gjør
-        // fanene til en vertikal scrollcontainer og lar dem rubberband-e på iOS.
-        <nav className="-mx-4 min-w-0 overflow-x-auto overflow-y-hidden px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        // Scrollboksen følger innholdsbredden (ingen full-bleed), så fanene
+        // holder seg i linje med resten av siden. ScrollFade toner dem ut i den
+        // kanten det finnes mer å scrolle til, i stedet for et hardt kutt.
+        <ScrollFade render={<nav />}>
             <Tabs
                 value={active}
                 onValueChange={(value) => onSelect(value as K)}
@@ -96,7 +97,7 @@ export function DetailLayoutNav<K extends string>({
                     ))}
                 </TabsList>
             </Tabs>
-        </nav>
+        </ScrollFade>
     );
 }
 

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -10,6 +10,7 @@ import {
 } from "@tanstack/react-router";
 import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Button } from "@tihlde/ui/ui/button";
+import { ScrollFade } from "@tihlde/ui/ui/scroll-fade";
 import { Separator } from "@tihlde/ui/ui/separator";
 import {
     CalendarDays,
@@ -308,9 +309,10 @@ function ProfileNav({
     return (
         <>
             {/* Mobile: horizontal scroll */}
-            {/* overflow-y-hidden: se DetailLayoutNav — én akse satt gjør den
-                andre til `auto`, og fanene blir vertikalt scrollbare. */}
-            <nav className="-mx-4 min-w-0 overflow-x-auto overflow-y-hidden px-4 [scrollbar-width:none] md:hidden [&::-webkit-scrollbar]:hidden">
+            {/* Ingen full-bleed her: scrollboksen følger innholdsbredden, så
+                fanene holder seg i linje med resten av siden, og ScrollFade
+                toner dem ut i kanten det finnes mer å scrolle til. */}
+            <ScrollFade render={<nav />} className="md:hidden">
                 <ul className="flex w-max gap-2">
                     {flatItems.map((item) => (
                         <li key={item.label} className="shrink-0">
@@ -332,7 +334,7 @@ function ProfileNav({
                         </li>
                     ) : null}
                 </ul>
-            </nav>
+            </ScrollFade>
 
             {/* Desktop: vertical sidebar */}
             <aside className="hidden md:block">

--- a/packages/ui/src/components/ui/scroll-fade.tsx
+++ b/packages/ui/src/components/ui/scroll-fade.tsx
@@ -1,0 +1,81 @@
+import { useRender } from "@base-ui/react/use-render";
+import {
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    type ComponentProps,
+} from "react";
+
+import { cn } from "#/lib/utils";
+
+/** Hvor lang uttoningen er i hver kant. */
+const FADE_LENGTH = "1.5rem";
+
+function edgeMask(fadeStart: boolean, fadeEnd: boolean) {
+    // Uten uttoning i en kant legges stoppene på 0 % / 100 %, altså en maske
+    // som ikke skjuler noe. Da kan gradienten stå på hele tiden i stedet for å
+    // slås av og på, og kantene kan tones inn og ut.
+    const start = fadeStart ? FADE_LENGTH : "0px";
+    const end = fadeEnd ? FADE_LENGTH : "0px";
+    return `linear-gradient(to right, transparent 0, #000 ${start}, #000 calc(100% - ${end}), transparent 100%)`;
+}
+
+type ScrollFadeProps = ComponentProps<"div"> & {
+    render?: useRender.RenderProp;
+};
+
+/**
+ * Vannrett scrollcontainer som toner ut innholdet i kantene der det finnes mer
+ * å scrolle til. Uttoningen ligger bare på den siden som faktisk har skjult
+ * innhold, slik at en liste som får plass ser helt vanlig ut.
+ */
+function ScrollFade({ className, render, ...props }: ScrollFadeProps) {
+    const ref = useRef<HTMLDivElement>(null);
+    const [edges, setEdges] = useState({ start: false, end: false });
+
+    const sync = useCallback(() => {
+        const el = ref.current;
+        if (!el) return;
+        const max = el.scrollWidth - el.clientWidth;
+        // Subpiksel-avrunding gjør at scrollLeft sjelden treffer 0 eller max
+        // helt presist, så kantene regnes som nådd innenfor én piksel.
+        const offset = Math.abs(el.scrollLeft);
+        setEdges({ start: offset > 1, end: offset < max - 1 });
+    }, []);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+        sync();
+        // Innholdet kan endre bredde uten at containeren gjør det (faner som
+        // dukker opp, fonter som lastes), så begge observeres.
+        const observer = new ResizeObserver(sync);
+        observer.observe(el);
+        for (const child of el.children) observer.observe(child);
+        return () => observer.disconnect();
+    }, [sync]);
+
+    const mask = edgeMask(edges.start, edges.end);
+
+    return useRender({
+        render: render ?? <div />,
+        props: {
+            ref,
+            "data-slot": "scroll-fade",
+            onScroll: sync,
+            className: cn(
+                // overflow-y-hidden er ikke overflødig: per CSS-spec beregnes
+                // den andre aksen til `auto` når én akse settes, så
+                // `overflow-x-auto` alene gjør boksen til en vertikal
+                // scrollcontainer og lar innholdet rubberband-e på iOS.
+                "min-w-0 overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+                className,
+            ),
+            style: { maskImage: mask, WebkitMaskImage: mask },
+            ...props,
+        },
+    });
+}
+
+export { ScrollFade };


### PR DESCRIPTION
Closes #402.

## Problem

Meldt inn fra mobil: fane-raden på profilsiden scroller sidelengs, men fanene «flyr av siden» — de fortsetter helt ut til skjermkanten i stedet for å følge resten av innholdet.

Årsaken var full-bleed på scrollboksen (`-mx-4 ... px-4`), som gjorde den bredere enn innholdet. Samme mønster lå i `DetailLayoutNav`, altså på gruppe- og søknadssidene.

## Løsning

- Scrollboksen følger nå innholdsbredden, så fanene holder seg i linje med resten av siden.
- Ny `ScrollFade` i `@tihlde/ui` toner innholdet ut (1.5rem) i den kanten det faktisk finnes mer å scrolle til, i stedet for et hardt kutt ved paddingen. Får fanene plass, ser raden helt vanlig ut.
- Maskeringen ligger i UI-pakken siden det er visuell polish; komponenten følger `render`-mønsteret fra `Card` så den kan rendres som `<nav>`.

## Verifisert

Preview på `/grupper/hs`:

- 375 px, uscrollet: skarp venstre kant, uttoning til høyre.
- Midt i scrollen: uttoning i begge kanter.
- 1280 px, alle faner får plass: ingen uttoning i noen kant.
- Resize desktop → mobil uten reload gir uttoning tilbake (`ResizeObserver` treffer).
- Ingen horisontal scroll på siden (`body.scrollWidth` = `innerWidth`).

Profilsiden krever innlogging og er ikke sjekket i nettleser — den bruker samme komponent.

`typecheck` (ui + kvark), `lint` og `format` er rene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
