### PR TITLE
perf(auth): 7 → 3 spørringer per get-session

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -733,30 +733,43 @@ export function createAuth(options: CreateAuthOptions) {
             customSession(async ({ user, session }) => {
                 const db = options.services.db;
 
-                const [settings, permissions, groups, row] = await Promise.all([
-                    db.query.userSettings.findFirst({
-                        where: (s, { eq }) => eq(s.userId, user.id),
-                        with: { allergies: { columns: { allergySlug: true } } },
+                /**
+                 * Three round-trips, and they were seven until we measured
+                 * what this costs: every `get-session` runs this callback,
+                 * cookie cache or not, because `customSession` only caches the
+                 * session Better Auth itself reads. All of it stays live —
+                 * caching the result would open exactly the stale-permission
+                 * window the RBAC rollout depends on not existing (#354).
+                 *
+                 * `approvalStatus` rides along with the settings because it is
+                 * ours, not part of Better Auth's user model: the session
+                 * `user` handed to this callback carries only the columns it
+                 * knows. The frontend needs it to tell a member from someone
+                 * still waiting for an admin. Rooted at `user` rather than at
+                 * the settings row, since not every account has settings.
+                 */
+                const [row, permissions, groups] = await Promise.all([
+                    db.query.user.findFirst({
+                        where: (u, { eq }) => eq(u.id, user.id),
+                        columns: { approvalStatus: true },
+                        with: {
+                            settings: {
+                                with: {
+                                    allergies: {
+                                        columns: { allergySlug: true },
+                                    },
+                                },
+                            },
+                        },
                     }),
                     getUserPermissions({ db }, user.id),
                     db.query.groupMembership.findMany({
                         where: (gm, { eq }) => eq(gm.userId, user.id),
                         with: { group: true },
                     }),
-                    /**
-                     * Read separately because `approvalStatus` is ours, not
-                     * part of Better Auth's user model — the session `user` it
-                     * hands this callback carries only the columns it knows.
-                     * The frontend needs it to tell a member from someone still
-                     * waiting for an admin, and every request already has the
-                     * session in hand, so this is the cheapest place to answer
-                     * it once.
-                     */
-                    db.query.user.findFirst({
-                        where: (u, { eq }) => eq(u.id, user.id),
-                        columns: { approvalStatus: true },
-                    }),
                 ]);
+
+                const settings = row?.settings;
 
                 return {
                     user: {

--- a/packages/auth/src/rbac/permissions/checker.ts
+++ b/packages/auth/src/rbac/permissions/checker.ts
@@ -5,8 +5,9 @@
  * both globally and within specific scopes.
  */
 
-import { eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { unionAll } from "drizzle-orm/pg-core";
 import {
     group,
     groupMembership,
@@ -31,60 +32,60 @@ type DbCtx = { db: NodePgDatabase<DbSchema> };
 // =============================================================================
 
 /**
- * Get all permissions for a user from their roles.
- * Returns raw array with potential duplicates.
+ * Every way a user can hold a permission, as one query.
+ *
+ * The six branches were four separate round-trips until we measured what
+ * `get-session` actually costs: seven queries per call, each holding its own
+ * pool connection, four of them from here. The work itself is sub-millisecond
+ * and every branch is index-covered — it was the round-trips that added up, so
+ * they are now one.
+ *
+ * Each branch yields `(permissions, scope)` and nothing else, so the caller
+ * formats them all the same way. `scope` is {@link GLOBAL_SCOPE} for the
+ * unscoped sources, which {@link formatPermission} passes through untouched —
+ * a role permission that already carries its own `@scope` therefore survives
+ * verbatim, exactly as when this returned the raw column.
+ *
+ * The scope literal is cast explicitly: as a bare parameter Postgres cannot
+ * infer its type inside a UNION and refuses the query.
  */
-async function getPermissionsFromRoles(
-    ctx: DbCtx,
-    userId: string,
-): Promise<string[]> {
+function permissionRows(ctx: DbCtx, userId: string) {
     const db = ctx.db;
-    const rows = await db
-        .select({ permissions: role.permissions })
+    const globalScope = sql<string>`cast(${GLOBAL_SCOPE} as text)`;
+
+    /** Roles: the permission strings are stored ready-formatted. */
+    const fromRoles = db
+        .select({
+            permissions: role.permissions,
+            scope: globalScope.as("scope"),
+        })
         .from(userRole)
         .innerJoin(role, eq(userRole.roleId, role.id))
         .where(eq(userRole.userId, userId));
 
-    return rows.flatMap((r) => r.permissions ?? []);
-}
-
-/**
- * Get all direct permissions for a user (not from roles).
- * Returns array of permission strings in format "permission" or "permission@scope".
- */
-async function getDirectPermissions(
-    ctx: DbCtx,
-    userId: string,
-): Promise<string[]> {
-    const db = ctx.db;
-    const rows = await db
+    /** Direct grants: one permission per row, with its own scope. */
+    const fromDirect = db
         .select({
-            permission: userPermission.permission,
+            permissions: sql<
+                string[]
+            >`array[${userPermission.permission}]::text[]`.as("permissions"),
             scope: userPermission.scope,
         })
         .from(userPermission)
         .where(eq(userPermission.userId, userId));
 
-    return rows.map((r) => formatPermission(r.permission, r.scope));
-}
-
-/**
- * Get all permissions a user receives from group positions (verv/titler).
- *
- * Positions with scope "group" grant their permissions scoped to the
- * position's group ("permission@group:<slug>"); positions with scope
- * "global" grant them globally.
- */
-async function getPermissionsFromPositions(
-    ctx: DbCtx,
-    userId: string,
-): Promise<string[]> {
-    const db = ctx.db;
-    const rows = await db
+    /**
+     * Verv (titler): positions with scope "group" grant their permissions
+     * scoped to the position's group; positions with scope "global" grant
+     * them globally.
+     */
+    const fromPositions = db
         .select({
             permissions: groupPosition.permissions,
-            scope: groupPosition.scope,
-            groupSlug: groupPosition.groupSlug,
+            scope: sql<string>`case
+                when ${groupPosition.scope} = 'global' then cast(${GLOBAL_SCOPE} as text)
+                else 'group:' || ${groupPosition.groupSlug}
+            end`.as("scope"),
         })
         .from(groupPositionHolder)
         .innerJoin(
@@ -93,76 +94,78 @@ async function getPermissionsFromPositions(
         )
         .where(eq(groupPositionHolder.userId, userId));
 
-    return rows.flatMap((row) =>
-        (row.permissions ?? []).map((p) =>
-            row.scope === "global"
-                ? p
-                : formatPermission(p, `group:${row.groupSlug}`),
-        ),
-    );
-}
-
-/**
- * Get all permissions a user receives from BELONGING to a group.
- *
- * Three lists come off the group row, all read live from the membership so a
- * grant cannot outlive the job — leave the group, or step down as leader, and
- * it is gone on the next check:
- *
- * - `memberPermissions` — held by every member, scoped to the group
- *   ("permission@group:<slug>"), so nothing reaches another group's resources.
- * - `memberGlobalPermissions` — held by every member, org-wide. This is what
- *   lets all of Index administer TIHLDE; it replaced the auto-assigned `admin`
- *   and `hs` RBAC roles, which did the same thing invisibly.
- * - `leaderPermissions` — held by the leader only, scoped to the group. The
- *   leader is a member too, so these stack on top of the member lists.
- */
-async function getPermissionsFromGroups(
-    ctx: DbCtx,
-    userId: string,
-): Promise<string[]> {
-    const db = ctx.db;
-    const rows = await db
+    /**
+     * Held by every member, scoped to the group, so nothing reaches another
+     * group's resources.
+     */
+    const fromMembership = db
         .select({
-            memberPermissions: group.memberPermissions,
-            memberGlobalPermissions: group.memberGlobalPermissions,
-            leaderPermissions: group.leaderPermissions,
-            membershipRole: groupMembership.role,
-            groupSlug: group.slug,
+            permissions: group.memberPermissions,
+            scope: sql<string>`'group:' || ${group.slug}`.as("scope"),
         })
         .from(groupMembership)
         .innerJoin(group, eq(groupMembership.groupSlug, group.slug))
         .where(eq(groupMembership.userId, userId));
 
-    return rows.flatMap((row) => {
-        const scoped = [
-            ...(row.memberPermissions ?? []),
-            ...(row.membershipRole === "leader"
-                ? (row.leaderPermissions ?? [])
-                : []),
-        ].map((p) => formatPermission(p, `group:${row.groupSlug}`));
+    /**
+     * Held by the leader only, scoped to the group. The leader is a member
+     * too, so these stack on top of the member lists.
+     */
+    const fromLeadership = db
+        .select({
+            permissions: group.leaderPermissions,
+            scope: sql<string>`'group:' || ${group.slug}`.as("scope"),
+        })
+        .from(groupMembership)
+        .innerJoin(group, eq(groupMembership.groupSlug, group.slug))
+        .where(
+            and(
+                eq(groupMembership.userId, userId),
+                eq(groupMembership.role, "leader"),
+            ),
+        );
 
-        return [...scoped, ...(row.memberGlobalPermissions ?? [])];
-    });
+    /**
+     * Held by every member, org-wide. This is what lets all of Index
+     * administer TIHLDE; it replaced the auto-assigned `admin` and `hs` RBAC
+     * roles, which did the same thing invisibly.
+     */
+    const fromMembershipGlobal = db
+        .select({
+            permissions: group.memberGlobalPermissions,
+            scope: globalScope.as("scope"),
+        })
+        .from(groupMembership)
+        .innerJoin(group, eq(groupMembership.groupSlug, group.slug))
+        .where(eq(groupMembership.userId, userId));
+
+    return unionAll(
+        fromRoles,
+        fromDirect,
+        fromPositions,
+        fromMembership,
+        fromLeadership,
+        fromMembershipGlobal,
+    );
 }
 
 /**
  * Get all permissions for a user (roles + direct grants + verv + groups).
  * Returns raw array with potential duplicates.
+ *
+ * Everything a group grants is read live from the membership, so a grant
+ * cannot outlive the job: leave the group, or step down as leader, and it is
+ * gone on the next check.
  */
 export async function getUserPermissions(
     ctx: DbCtx,
     userId: string,
 ): Promise<string[]> {
-    const [rolePerms, directPerms, positionPerms, groupPerms] =
-        await Promise.all([
-            getPermissionsFromRoles(ctx, userId),
-            getDirectPermissions(ctx, userId),
-            getPermissionsFromPositions(ctx, userId),
-            getPermissionsFromGroups(ctx, userId),
-        ]);
+    const rows = await permissionRows(ctx, userId);
 
-    return [...rolePerms, ...directPerms, ...positionPerms, ...groupPerms];
+    return rows.flatMap((row) =>
+        (row.permissions ?? []).map((p) => formatPermission(p, row.scope)),
+    );
 }
 
 /**

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -8,6 +8,8 @@ import {
     pgTableCreator,
 } from "drizzle-orm/pg-core";
 
+import { userSettings } from "./user";
+
 const pgTable = pgTableCreator((name) => `auth_${name}`);
 
 /**
@@ -237,13 +239,29 @@ export const oauthConsent = pgTable(
     ],
 );
 
-export const userRelations = relations(user, ({ many }) => ({
+export const userRelations = relations(user, ({ one, many }) => ({
     sessions: many(session),
     accounts: many(account),
     oauthClients: many(oauthClient),
     oauthRefreshTokens: many(oauthRefreshToken),
     oauthAccessTokens: many(oauthAccessToken),
     oauthConsents: many(oauthConsent),
+    /**
+     * Declared from this side, not from `userSettings`, so a user with no
+     * settings row still answers: three accounts in production have none, and
+     * `approvalStatus` — read alongside the settings on every `get-session` —
+     * would silently read as "approved" for them if the query started at the
+     * settings table.
+     *
+     * `userSettings` is imported lazily through the relations callback, which
+     * is what keeps this from being a module cycle: `user.ts` imports `user`
+     * from here at load, and this only touches `userSettings` when the
+     * relational schema is built.
+     */
+    settings: one(userSettings, {
+        fields: [user.id],
+        references: [userSettings.userId],
+    }),
 }));
 
 export const sessionRelations = relations(session, ({ one, many }) => ({

--- a/packages/sdk/src/generated/session-types.ts
+++ b/packages/sdk/src/generated/session-types.ts
@@ -11,10 +11,10 @@ export type ExtendedSession = {
             createdAt: Date;
             updatedAt: Date;
             userId: string;
-            gender: "other" | "male" | "female";
-            imageUrl: string | null;
+            gender: "male" | "female" | "other";
             allowsPhotosByDefault: boolean;
             acceptsEventRules: boolean;
+            imageUrl: string | null;
             bioDescription: string | null;
             githubUrl: string | null;
             linkedinUrl: string | null;


### PR DESCRIPTION
Følger opp målingene i #354. Konklusjonen der er at caching av session-enrichment ikke er verdt det — men målingene avdekket at det var **sju** spørringer per `get-session`, ikke tre som issuen antok, og at `session.cookieCache` ikke sparer noen av dem.

`customSession` definerer sitt eget `/get-session`, kaller Better Auths `getSession()` og kjører deretter alltid callbacken. Cookie-cache-treffet kortslutter bare det indre kallet — og siden sessions ligger i `secondaryStorage` (Redis), var det indre kallet aldri en DB-spørring.

Denne PR-en tar 7 → 3 uten å røre friskheten på noe.

## Endringer

**`getUserPermissions`: fire spørringer → én.** Seks `UNION ALL`-grener (roller, direkte grants, verv, gruppemedlemskap, gruppeledelse, gruppens globale liste). Hver gren gir `(permissions, scope)` og ingenting mer, så kalleren formaterer alle likt gjennom `formatPermission`. En rolle-permission som allerede bærer sin egen `@scope` overlever ordrett, som før. Scope-literalen castes eksplisitt — som naken parameter klarer ikke Postgres å utlede typen inne i en UNION.

**`approvalStatus` leses sammen med settings.** Rotet i `user`, ikke i settings-raden: tre kontoer i prod har ingen settings-rad, og en spørring som startet der ville lest dem som «godkjent». Krever en `settings`-relasjon på `user`, deklarert i `auth.ts` — `userSettings` importeres lazy gjennom relations-callbacken, så det blir ingen modulsyklus.

Ingen migrasjon. Ingen caching: alt leses fortsatt live, så vinduet med utdaterte rettigheter som RBAC-utrullingen er avhengig av at ikke finnes, oppstår ikke.

## Verifisering

- **Spørringstelling:** `log_statement=all`, 10 kall → 3,0 spørringer per `get-session` (var 7).
- **Ekvivalens:** gammel og ny `getUserPermissions` kjørt mot alle 1757 brukere i en prod-stor dev-DB (6575 medlemskap). 5227 permission-strenger, **0 avvik**.
- **Settings-løse brukere:** de tre kontoene uten settings-rad returnerer fortsatt riktig `approvalStatus` og `settings: null`.
- **Tester:** 218 grønne (`src/test/auth`, `groups`, `rbac`, `user-approval`, `user-allergies`).
- **Sesjonsformen uendret:** settings 14 felter inkl. allergier, permissions, groups, `approvalStatus`/`isPendingApproval` — sjekket mot et ekte `get-session`-svar.
- `typecheck`, `lint`, `build` grønne. Diffen i `packages/sdk/src/generated/session-types.ts` er kun feltrekkefølge fra codegen.

Kostnaden var uansett aldri stor — 1,0 ms serielt, ~1300 enrichments/s i benchen mot en prod-topp på 3,4/s. Dette er å fjerne fire round-trips som ikke gjorde noe nyttig, ikke en ytelsesfiks for et problem brukerne merker.

Lukker ikke #354 — den bør lukkes med «målt, ikke verdt det» når dette har landet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
