### PR TITLE
fix(kvark): presiser intervjutekst på opptakssiden

### DIFF
--- a/apps/kvark/src/routes/_app/opptak.tsx
+++ b/apps/kvark/src/routes/_app/opptak.tsx
@@ -110,8 +110,8 @@ function AdmissionsPage() {
                         Det er mange verv å velge mellom!
                     </h2>
                     <p className="mx-auto max-w-lg text-muted-foreground">
-                        Du vil bli kalt inn til intervju etter søknadsfristen,
-                        for alle verv du har søkt på.
+                        Det er separate intervjuer for hvert verv du har søkt
+                        på, dersom du blir tatt opp til intervju
                     </p>
                 </div>
 


### PR DESCRIPTION
Endrer teksten på opptakssiden fra

> Du vil bli kalt inn til intervju etter søknadsfristen, for alle verv du har søkt på.

til

> Det er separate intervjuer for hvert verv du har søkt på, dersom du blir tatt opp til intervju

Ren tekstendring i `apps/kvark/src/routes/_app/opptak.tsx`. `oxfmt --check` er grønn. Siden ligger bak Feide-innlogging, så den er ikke verifisert visuelt lokalt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)