### PR TITLE
fix(kvark): fjern treffteller og match kortavstand på annonser

### DIFF
--- a/apps/kvark/src/routes/_app/annonser.index.tsx
+++ b/apps/kvark/src/routes/_app/annonser.index.tsx
@@ -84,12 +84,7 @@ function JobsPage() {
                 </aside>
 
                 <section className="flex min-w-0 flex-col gap-3">
-                    <p className="text-sm text-muted-foreground">
-                        {data.totalCount} stillinger funnet
-                    </p>
-                    <Stagger
-                        render={<ul className="flex flex-col gap-4 sm:gap-1" />}
-                    >
+                    <Stagger render={<ul className="flex flex-col gap-3" />}>
                         {jobs.map((job) => (
                             <li key={job.id}>
                                 <JobCard


### PR DESCRIPTION
## Hva

- Fjerner teksten `X stillinger funnet` over stillingslisten på `/annonser`.
- Setter samme avstand mellom annonsekortene som mellom arrangementskortene: `flex flex-col gap-4 sm:gap-1` → `flex flex-col gap-3`, identisk med lista i `arrangementer.index.tsx`.

## Verifisering

- Sjekket i dev-preview: teksten er borte, og `<ul>`-en for annonser regner nå ut `row-gap: 12px` med klassen `flex flex-col gap-3` — samme som arrangementslista.
- `typecheck` grønn, `format --check` ren, ingen nye lint-advarsler.

Merk: lokal dev-DB har bare én stillingsannonse, så avstanden mellom flere kort er ikke synlig i previewen — likheten er bekreftet via identisk klasse/utregnet gap. Arrangementssida lot seg ikke rendre lokalt (DB-skjemafeil mot delt lokal API, urelatert til denne endringen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)