### PR TITLE
refactor(kvark): fjern varsel-pillen fra profiloversikten

### DIFF
--- a/apps/kvark/src/components/profile-overview-header.tsx
+++ b/apps/kvark/src/components/profile-overview-header.tsx
@@ -1,17 +1,12 @@
-import { Badge } from "@tihlde/ui/ui/badge";
-import { Bell } from "lucide-react";
-
 type ProfileOverviewHeaderProps = {
     name: string;
-    /** Velkomsthilsen og varsler gir bare mening på ens egen profil. */
+    /** Velkomsthilsen gir bare mening på ens egen profil. */
     isOwnProfile?: boolean;
-    notifications?: number;
 };
 
 export function ProfileOverviewHeader({
     name,
     isOwnProfile = true,
-    notifications = 0,
 }: ProfileOverviewHeaderProps) {
     const firstName = name.split(" ")[0] ?? name;
 
@@ -25,14 +20,6 @@ export function ProfileOverviewHeader({
                     </p>
                 ) : null}
             </div>
-            {isOwnProfile ? (
-                <Badge variant="outline" className="gap-1.5">
-                    <Bell />
-                    {notifications === 1
-                        ? "1 nytt varsel"
-                        : `${notifications} nye varsler`}
-                </Badge>
-            ) : null}
         </div>
     );
 }

--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -4,7 +4,6 @@ import {
     getMySignatureQuery,
 } from "#/api/queries/contracts";
 import { getMyUpcomingEventsQuery } from "#/api/queries/events";
-import { getUnreadNotificationCountQuery } from "#/api/queries/notifications";
 import { getUserProfileQuery } from "#/api/queries/user";
 import { ProfileLinksSection } from "#/components/profile-links-section";
 import { ProfileMembershipChips } from "#/components/profile-membership-chips";
@@ -38,14 +37,6 @@ function RouteComponent() {
     const { data: profile } = useSuspenseQuery(getUserProfileQuery(id));
     const { data: session } = useQuery(authQueryOptions);
     const isOwnProfile = session?.user.id === profile.id;
-
-    // Varselmerket vises bare på egen profil, så andres profiler skal heller
-    // ikke koste et kall til det innloggede-scopede endepunktet. Den som venter
-    // på godkjenning får 403 på det kallet, så det hoppes over.
-    const { data: unreadNotifications } = useQuery({
-        ...getUnreadNotificationCountQuery(),
-        enabled: isOwnProfile && session?.user?.isPendingApproval !== true,
-    });
 
     // Kontraktbanneret gjelder bare egen profil, så begge kallene hoppes over
     // på andres. Begge nøklene deles med /kontrakt, så signeringen der
@@ -106,7 +97,6 @@ function RouteComponent() {
             <ProfileOverviewHeader
                 name={profile.name}
                 isOwnProfile={isOwnProfile}
-                notifications={unreadNotifications}
             />
             {profile.bio ? (
                 <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Hva

Fjerner pillen «0 nye varsler» øverst på Oversikt-fanen på profilsiden.

- `ProfileOverviewHeader`: badgen (`Badge` + `Bell`) og `notifications`-propen er borte.
- `/_app/profil/$id/`: `useQuery` mot `getUnreadNotificationCountQuery` var kun der for å mate pillen, så den ryker med. Ett API-kall mindre per visning av egen profil.

Overskriften viser nå bare «Oversikt» + «Velkommen tilbake, {fornavn}» på egen profil.

## Verifisert

- `bun run typecheck` (kvark) — rent
- `bun run lint` / `bun run format` — ingen nye funn på de endrede filene
- Dev-server: hentet den transformerte modulen fra Vite og bekreftet at badgen ikke lenger rendres; ingen bygg- eller serverfeil

Ikke verifisert visuelt i nettleser: worktreen mangler `apps/kvark/.env`, så frontend peker mot prod-API og blokkeres av CORS → redirect til innlogging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)