### PR TITLE
fix(kvark): sett punktum på intervjuteksten på opptakssiden

### DIFF
--- a/apps/kvark/src/routes/_app/opptak.tsx
+++ b/apps/kvark/src/routes/_app/opptak.tsx
@@ -111,7 +111,7 @@ function AdmissionsPage() {
                     </h2>
                     <p className="mx-auto max-w-lg text-muted-foreground">
                         Det er separate intervjuer for hvert verv du har søkt
-                        på, dersom du blir tatt opp til intervju
+                        på, dersom du blir tatt opp til intervju.
                     </p>
                 </div>
 


### PR DESCRIPTION
Setningen mistet punktumet da teksten ble skrevet om i #567.

```diff
-på, dersom du blir tatt opp til intervju
+på, dersom du blir tatt opp til intervju.
```

Verifisert i nettleseren på `/opptak`: avsnittet rendrer nå «Det er separate intervjuer for hvert verv du har søkt på, dersom du blir tatt opp til intervju.»

🤖 Generated with [Claude Code](https://claude.com/claude-code)