### PR TITLE
feat(kvark): skjul spørreskjema for utloggede og la redaktører slette dem

### DIFF
--- a/apps/kvark/src/api/queries/forms.ts
+++ b/apps/kvark/src/api/queries/forms.ts
@@ -127,6 +127,12 @@ export const deleteFormMutation = mutationOptions({
             queryKey: [...FormQueryKeys.listInfinite],
             exact: false,
         });
+        // Gruppeskjemaene ligger under gruppas egen nøkkel, så uten denne blir
+        // et slettet skjema stående i lista på gruppesiden.
+        ctx.client.invalidateQueries({
+            queryKey: [...GroupQueryKeys.forms],
+            exact: false,
+        });
     },
 });
 

--- a/apps/kvark/src/components/group-form-edit-dialog.tsx
+++ b/apps/kvark/src/components/group-form-edit-dialog.tsx
@@ -19,8 +19,10 @@ import { Separator } from "@tihlde/ui/ui/separator";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import { Spinner } from "@tihlde/ui/ui/spinner";
 import { LockIcon, PlusIcon, TrashIcon, TriangleAlert } from "lucide-react";
+import { useState } from "react";
 import { z } from "zod";
 
+import { ConfirmDeleteDialog } from "#/components/confirm-delete-dialog";
 import { formHandlers, useAppForm } from "#/hooks/form";
 import type { FormQuestionType, FormQuestionValues } from "#/lib/form";
 import type { Form } from "#/lib/group";
@@ -98,6 +100,13 @@ type GroupFormEditDialogProps = {
     onSubmit: (values: GroupFormEditValues) => void;
     isSubmitting: boolean;
     error: string | null;
+    /**
+     * Å slette hører til den samme tilgangen som å redigere. Utelatt når den
+     * som ser på ikke har den.
+     */
+    onDelete?: () => void;
+    isDeleting?: boolean;
+    deleteError?: string | null;
 };
 
 export function GroupFormEditDialog({
@@ -109,7 +118,12 @@ export function GroupFormEditDialog({
     onSubmit,
     isSubmitting,
     error,
+    onDelete,
+    isDeleting = false,
+    deleteError = null,
 }: GroupFormEditDialogProps) {
+    const [confirmDelete, setConfirmDelete] = useState(false);
+
     return (
         <Dialog
             open={open}
@@ -136,6 +150,11 @@ export function GroupFormEditDialog({
                         onSubmit={onSubmit}
                         isSubmitting={isSubmitting}
                         error={error}
+                        onRequestDelete={
+                            onDelete ? () => setConfirmDelete(true) : undefined
+                        }
+                        isDeleting={isDeleting}
+                        deleteError={deleteError}
                     />
                 ) : (
                     <div className="flex flex-col gap-3">
@@ -144,6 +163,25 @@ export function GroupFormEditDialog({
                         <Skeleton className="h-9 w-full" />
                     </div>
                 )}
+
+                {form && onDelete ? (
+                    <ConfirmDeleteDialog
+                        open={confirmDelete}
+                        onOpenChange={setConfirmDelete}
+                        title={`Slette «${form.title}»?`}
+                        description={
+                            answerCount > 0
+                                ? `Skjemaet og de ${answerCount} svarene som er sendt inn forsvinner for godt.`
+                                : "Skjemaet forsvinner for godt, og lenken til det slutter å virke."
+                        }
+                        confirmLabel="Slett skjema"
+                        isPending={isDeleting}
+                        onConfirm={() => {
+                            setConfirmDelete(false);
+                            onDelete();
+                        }}
+                    />
+                ) : null}
             </DialogContent>
         </Dialog>
     );
@@ -157,6 +195,9 @@ type EditFormProps = {
     onSubmit: (values: GroupFormEditValues) => void;
     isSubmitting: boolean;
     error: string | null;
+    onRequestDelete?: () => void;
+    isDeleting: boolean;
+    deleteError: string | null;
 };
 
 /**
@@ -208,6 +249,9 @@ function EditForm({
     onSubmit,
     isSubmitting,
     error,
+    onRequestDelete,
+    isDeleting,
+    deleteError,
 }: EditFormProps) {
     const editForm = useEditForm({ form, questions, answerCount, onSubmit });
 
@@ -218,6 +262,14 @@ function EditForm({
                     <TriangleAlert />
                     <AlertTitle>Klarte ikke å lagre skjemaet</AlertTitle>
                     <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            ) : null}
+
+            {deleteError ? (
+                <Alert variant="destructive">
+                    <TriangleAlert />
+                    <AlertTitle>Klarte ikke å slette skjemaet</AlertTitle>
+                    <AlertDescription>{deleteError}</AlertDescription>
                 </Alert>
             ) : null}
 
@@ -347,12 +399,24 @@ function EditForm({
             )}
 
             <DialogFooter>
+                {onRequestDelete ? (
+                    <Button
+                        type="button"
+                        variant="destructive"
+                        className="sm:mr-auto"
+                        disabled={isSubmitting || isDeleting}
+                        onClick={onRequestDelete}
+                    >
+                        <TrashIcon />
+                        Slett skjema
+                    </Button>
+                ) : null}
                 <Button type="button" variant="outline" onClick={onClose}>
                     Avbryt
                 </Button>
                 <editForm.AppForm>
                     <editForm.SubmitButton
-                        disabled={isSubmitting}
+                        disabled={isSubmitting || isDeleting}
                         loading={
                             <>
                                 <Spinner />

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -21,6 +21,7 @@ import { authQueryOptions } from "#/api/auth";
 import { searchUsersQuery } from "#/api/queries/roles";
 import { useImageUploader } from "#/api/queries/assets";
 import {
+    deleteFormMutation,
     getFormByIdQuery,
     getFormSubmissionsQuery,
     updateFormMutation,
@@ -175,6 +176,7 @@ function GroupDetail() {
     const [formError, setFormError] = useState<string | null>(null);
     const [editingForm, setEditingForm] = useState<Form | null>(null);
     const [editFormError, setEditFormError] = useState<string | null>(null);
+    const [deleteFormError, setDeleteFormError] = useState<string | null>(null);
 
     function setActive(tab: GroupNavKey) {
         navigate({ search: (prev) => ({ ...prev, tab }) });
@@ -201,6 +203,7 @@ function GroupDetail() {
     const updateLaw = useMutation(updateLawMutation);
     const deleteLaw = useMutation(deleteLawMutation);
     const updateForm = useMutation(updateFormMutation);
+    const deleteForm = useMutation(deleteFormMutation);
 
     // The scope is known here, so these mirror the API exactly: a grant for
     // this group counts, a grant for another group does not.
@@ -284,9 +287,10 @@ function GroupDetail() {
         ...getGroupFineStatisticsQuery(slug),
         enabled: canViewFines,
     });
+    const isLoggedIn = Boolean(session);
     const { data: apiForms } = useQuery({
         ...getGroupFormsQuery(slug),
-        enabled: Boolean(session),
+        enabled: isLoggedIn,
     });
     const { data: apiLaws } = useQuery({
         ...getGroupLawsQuery(slug),
@@ -413,12 +417,17 @@ function GroupDetail() {
 
     const navItems = useMemo(
         () =>
-            GROUP_NAV_ITEMS.filter((item) =>
-                item.key === "boter" || item.key === "lovverk"
-                    ? canViewFines
-                    : true,
-            ),
-        [canViewFines],
+            GROUP_NAV_ITEMS.filter((item) => {
+                if (item.key === "boter" || item.key === "lovverk") {
+                    return canViewFines;
+                }
+                // Spørreskjemaene ligger bak innlogging i API-et, så en
+                // utlogget besøkende skal ikke se fanen i det hele tatt — den
+                // ville uansett bare stått tom.
+                if (item.key === "sporreskjema") return isLoggedIn;
+                return true;
+            }),
+        [canViewFines, isLoggedIn],
     );
     // ?tab=boter kan stå i URL-en fra før rettighetene ble sjekket, så en fane
     // som ikke lenger finnes faller tilbake til «Om».
@@ -515,7 +524,27 @@ function GroupDetail() {
 
     function handleEditForm(form: Form | null) {
         setEditFormError(null);
+        setDeleteFormError(null);
         setEditingForm(form);
+    }
+
+    /**
+     * Sletting følger den samme tilgangen som redigering, og tar med seg
+     * svarene: API-et kaskaderer til spørsmål, alternativer og innsendinger.
+     */
+    async function handleDeleteForm() {
+        if (!editingForm) return;
+        setDeleteFormError(null);
+        try {
+            await deleteForm.mutateAsync({ formId: editingForm.id });
+            setEditingForm(null);
+        } catch (error) {
+            setDeleteFormError(
+                error instanceof Error
+                    ? error.message
+                    : "Ukjent feil da skjemaet skulle slettes",
+            );
+        }
     }
 
     /**
@@ -873,6 +902,9 @@ function GroupDetail() {
                 onSubmit={handleSaveForm}
                 isSubmitting={updateForm.isPending}
                 error={editFormError}
+                onDelete={canManageForms ? handleDeleteForm : undefined}
+                isDeleting={deleteForm.isPending}
+                deleteError={deleteFormError}
             />
         </>
     );


### PR DESCRIPTION
## Hva

To ting på gruppesidenes spørreskjema:

**1. Spørreskjema krever innlogging**

API-et krevde allerede innlogging (`requireAuth` på `GET /api/forms/:id` og `GET /api/groups/:slug/forms`), og `/sporreskjema/$id` redirigerer til login. Lekkasjen var fanen på gruppesiden: «Spørreskjema» ble vist til alle, bare med tom liste. Den filtreres nå bort uten sesjon, på samme måte som Bøter og Lovverk — og `?tab=sporreskjema` faller tilbake til «Om».

**2. Sletting for de som kan redigere**

`DELETE /api/forms/:id` fantes allerede, men var ikke koblet opp i grensesnittet. Den som kan redigere et skjema kan nå også slette det, fra redigeringsdialogen og bak en bekreftelse som sier hvor mange svar som forsvinner med det. Sletting invaliderer også gruppas egen skjemaliste, ellers ble skjemaet stående igjen i lista.

## Endringer

- `apps/kvark/src/routes/_app/grupper.$slug.tsx` — skjuler fanen uten sesjon, kobler opp `deleteFormMutation`
- `apps/kvark/src/components/group-form-edit-dialog.tsx` — «Slett skjema» i footeren, `ConfirmDeleteDialog`, egen feilmelding
- `apps/kvark/src/api/queries/forms.ts` — sletting invaliderer `GroupQueryKeys.forms`

## Verifisering

- Utlogget SSR-forespørsel mot `/grupper/index?tab=sporreskjema` viser Om, Medlemmer og Arrangementer — ingen «Spørreskjema» (heller ikke Bøter/Lovverk).
- Slettet et testskjema på Index via dialogen mot lokal API: `DELETE … → 200`, oppfølgende `GET` gir 404, og raden forsvant fra lista uten refresh.
- `typecheck`, `build`, `lint` og `format` er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)