### PR TITLE
perf(events): avgjør påmelding med én gang i stedet for å vente på cron

### DIFF
--- a/apps/api/src/lib/event/resolve-queue.ts
+++ b/apps/api/src/lib/event/resolve-queue.ts
@@ -1,0 +1,76 @@
+import {
+    REGISTRATION_QUEUE_NAME,
+    type QueueJob,
+    type WorkerLike,
+} from "@photon/core/services/queue";
+import type { AppContext } from "../ctx";
+import { resolveRegistrationsForEvent } from "./resolve-registration";
+
+export type RegistrationResolveJobData = {
+    eventId: string;
+};
+
+/**
+ * Ask for an event's pending registrations to be resolved now, instead of
+ * waiting for the next tick of the cron in `lib/jobs.ts`.
+ *
+ * A member who presses "Meld deg på" would otherwise sit on "Behandler
+ * påmeldingen din …" for whatever was left of the 5-second tick — 2.5 seconds
+ * on average, for work that takes milliseconds.
+ *
+ * The queue, rather than a floating promise in the request handler, for two
+ * reasons. The request must not hold a database connection while queueing
+ * behind the resolver's `FOR UPDATE` lock — a stampede of blocked requests is
+ * what exhausts the pool. And background work that outlives the request has
+ * nothing to keep it in check: in the test suite it kept issuing queries into
+ * a database that had already been torn down, and spun until the run was
+ * killed. A job has an owner, a retry, and a worker whose lifetime is the
+ * process's.
+ *
+ * Enqueueing is best-effort on purpose. If Redis is unreachable the
+ * registration must still stand — the cron picks it up within five seconds,
+ * which is exactly where we were before.
+ */
+export async function enqueueRegistrationResolve(
+    eventId: string,
+    ctx: AppContext,
+): Promise<void> {
+    try {
+        await ctx.queue
+            .getQueue<RegistrationResolveJobData>(REGISTRATION_QUEUE_NAME)
+            .add("resolve-registrations", { eventId });
+    } catch (error) {
+        console.error(
+            `Could not enqueue registration resolve for event ${eventId}, leaving it to the cron:`,
+            error,
+        );
+    }
+}
+
+/**
+ * Runs the resolver for whatever {@link enqueueRegistrationResolve} asked for.
+ *
+ * Jobs are processed one at a time, so the registrations that pile in when
+ * sign-up opens are resolved in a couple of passes over the whole batch rather
+ * than one transaction per member all queueing on the same lock. A pass for an
+ * event with nothing pending costs a single indexed lookup, so duplicate jobs
+ * are cheap and need no deduplication.
+ */
+export function startRegistrationResolveWorker(ctx: AppContext): WorkerLike {
+    const worker = ctx.queue.createWorker<RegistrationResolveJobData, void>(
+        REGISTRATION_QUEUE_NAME,
+        async (job: QueueJob<RegistrationResolveJobData>) => {
+            await resolveRegistrationsForEvent(job.data.eventId, ctx);
+        },
+    );
+
+    worker.on("failed", (job, err) => {
+        console.error(`❌ Registration resolve job ${job?.id} failed:`, err);
+    });
+
+    worker.on("error", (err) => {
+        console.error("Registration resolve worker error:", err);
+    });
+
+    return worker;
+}

--- a/apps/api/src/lib/jobs.ts
+++ b/apps/api/src/lib/jobs.ts
@@ -4,12 +4,21 @@ import { startAssetCleanupCron } from "./asset/worker";
 import type { AppContext } from "./ctx";
 import { processNoShowStrikesForEndedEvents } from "./event/no-show";
 import { startPaymentTimerWorker } from "./event/payment";
-import { resolveRegistrationsForEvent } from "./event/resolve-registration";
+import {
+    enqueueRegistrationResolve,
+    startRegistrationResolveWorker,
+} from "./event/resolve-queue";
 import { startPushNotificationWorker } from "./notification/push";
 
 /**
  * Start cron job to resolve pending event registrations
- * Runs every 5 seconds to process pending registrations from database
+ *
+ * Registrations are queued for resolution the moment they are created — see
+ * {@link enqueueRegistrationResolve}. This sweep is the safety net for the
+ * rows that missed out: an enqueue that failed because Redis was unreachable,
+ * an instance that died between the insert and the job, or a row written by
+ * something other than the registration route. It runs every 5 seconds and
+ * normally finds nothing.
  */
 function startRegistrationResolverCron(ctx: AppContext): void {
     // Run every 5 seconds
@@ -29,14 +38,16 @@ function startRegistrationResolverCron(ctx: AppContext): void {
                 eventsWithPending.map((reg) => reg.eventId),
             );
 
-            // Resolve registrations for each event that has pending registrations
+            // Hand each event to the same worker the registration route uses,
+            // so a sweep never opens a second transaction alongside a pass
+            // that is already running.
             if (eventIds.size > 0) {
                 console.log(
                     `🔄 Processing pending registrations for ${eventIds.size} event(s)`,
                 );
 
                 for (const eventId of eventIds) {
-                    await resolveRegistrationsForEvent(eventId, ctx);
+                    await enqueueRegistrationResolve(eventId, ctx);
                 }
             }
         } catch (error) {
@@ -73,6 +84,9 @@ export function startBackgroundJobs(ctx: AppContext): void {
 
     // Start payment-deadline countdown worker
     startPaymentTimerWorker(ctx);
+
+    // Start the worker that resolves pending registrations
+    startRegistrationResolveWorker(ctx);
 
     // Start push notification worker
     startPushNotificationWorker(ctx);

--- a/apps/api/src/routes/event/registration/create.ts
+++ b/apps/api/src/routes/event/registration/create.ts
@@ -10,6 +10,7 @@ import {
     getUserGroupSlugs,
     isUserPrioritized,
 } from "../../../lib/event/priority";
+import { enqueueRegistrationResolve } from "../../../lib/event/resolve-queue";
 import { getUserStrikeCount } from "../../../lib/event/strikes";
 import { getUnansweredEvaluations } from "../../../lib/form/evaluation";
 import { route } from "../../../lib/route";
@@ -53,20 +54,49 @@ export const registerToEventRoute = route().post(
         const now = new Date();
         const eventId = c.req.param("eventId");
         const userId = c.get("user").id;
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const body = c.req.valid("json");
 
-        const event = await db.query.event.findFirst({
-            where: (event, { eq }) => eq(event.id, eventId),
-            with: {
-                pools: {
-                    with: {
-                        groups: true,
+        /**
+         * Hver av disse ser på noe helt forskjellig, og en påmelding som går
+         * gjennom trenger svar fra alle sammen. Kjørt etter hverandre var
+         * knappen fem tur-retur til databasen om å bli ferdig — her venter
+         * den bare på den tregeste. Sjekkene under gjøres fortsatt i samme
+         * rekkefølge, så medlemmet får samme feilmelding som før.
+         */
+        const [
+            event,
+            hasAcceptedRules,
+            unanswered,
+            existingRegistration,
+            userSettings,
+        ] = await Promise.all([
+            db.query.event.findFirst({
+                where: (event, { eq }) => eq(event.id, eventId),
+                with: {
+                    pools: {
+                        with: {
+                            groups: true,
+                        },
                     },
+                    restrictedToInstitute: true,
                 },
-                restrictedToInstitute: true,
-            },
-        });
+            }),
+            hasAcceptedEventRules(userId, ctx),
+            getUnansweredEvaluations(ctx, userId),
+            db.query.eventRegistration.findFirst({
+                where: (reg, { and, eq }) =>
+                    and(eq(reg.eventId, eventId), eq(reg.userId, userId)),
+            }),
+            // Bare nødvendig når kallet ikke sier noe om bildesamtykke selv.
+            body.allowPhoto === undefined
+                ? db.query.userSettings.findFirst({
+                      where: (settings, { eq }) => eq(settings.userId, userId),
+                      columns: { allowsPhotosByDefault: true },
+                  })
+                : undefined,
+        ]);
 
         if (!event) {
             throw new HTTPException(404, { message: "Event not found" });
@@ -81,7 +111,7 @@ export const registerToEventRoute = route().post(
         // Checked before every event-specific rule so the message a member
         // gets is the one thing they can act on. The frontend shows the same
         // block ahead of time — hitting it here means they went around it.
-        if (!(await hasAcceptedEventRules(userId, c.get("ctx")))) {
+        if (!hasAcceptedRules) {
             throw new HTTPException(403, {
                 message:
                     "You must accept the event rules before registering for events",
@@ -97,8 +127,6 @@ export const registerToEventRoute = route().post(
          * The events are named in the message: "you have unanswered
          * evaluations" is useless if you cannot tell which.
          */
-        const unanswered = await getUnansweredEvaluations(c.get("ctx"), userId);
-
         if (unanswered.length > 0) {
             const titles = unanswered.map((e) => e.eventTitle).join(", ");
             throw new HTTPException(403, {
@@ -129,8 +157,10 @@ export const registerToEventRoute = route().post(
         // Events with onlyAllowPrioritized reject non-prioritized users
         // outright at sign-up time, instead of waitlisting them.
         if (event.onlyAllowPrioritized) {
-            const userGroupSlugs = await getUserGroupSlugs(userId, db);
-            const strikeCount = await getUserStrikeCount(userId, db);
+            const [userGroupSlugs, strikeCount] = await Promise.all([
+                getUserGroupSlugs(userId, db),
+                getUserStrikeCount(userId, db),
+            ]);
 
             const isPrioritized = isUserPrioritized({
                 userGroupSlugs,
@@ -148,13 +178,6 @@ export const registerToEventRoute = route().post(
         }
 
         // Check if user is already registered
-        const existingRegistration = await db.query.eventRegistration.findFirst(
-            {
-                where: (reg, { and, eq }) =>
-                    and(eq(reg.eventId, eventId), eq(reg.userId, userId)),
-            },
-        );
-
         if (existingRegistration) {
             throw new HTTPException(409, {
                 message: "User is already registered for this event",
@@ -165,14 +188,7 @@ export const registerToEventRoute = route().post(
         // eksplisitt felt i kallet er kontoinnstillingen fasit; brukere uten
         // innstillinger (ikke onboardet) faller tilbake på kolonnedefaulten.
         const allowPhoto =
-            body.allowPhoto ??
-            (
-                await db.query.userSettings.findFirst({
-                    where: (settings, { eq }) => eq(settings.userId, userId),
-                    columns: { allowsPhotosByDefault: true },
-                })
-            )?.allowsPhotosByDefault ??
-            true;
+            body.allowPhoto ?? userSettings?.allowsPhotosByDefault ?? true;
 
         // Create pending registration in database
         await db.insert(schema.eventRegistration).values({
@@ -181,6 +197,16 @@ export const registerToEventRoute = route().post(
             status: "pending",
             allowPhoto,
         });
+
+        /**
+         * Be om at plassen avgjøres med én gang, i stedet for å vente på
+         * neste cron-tikk. Svaret her sier fortsatt «pending» — resolveren
+         * kjører i en jobb, nettopp for at requesten ikke skal holde på en
+         * databasetilkobling mens den står i kø bak låsen — men klienten
+         * finner den avklarte statusen på første poll i stedet for etter opp
+         * til fem sekunder.
+         */
+        await enqueueRegistrationResolve(eventId, ctx);
 
         return c.json({
             eventId,

--- a/apps/api/src/test/event/registration-immediate-resolve.test.ts
+++ b/apps/api/src/test/event/registration-immediate-resolve.test.ts
@@ -1,0 +1,120 @@
+import { REGISTRATION_QUEUE_NAME } from "@photon/core/services/queue";
+import { describe, expect } from "vitest";
+import type { RegistrationResolveJobData } from "~/lib/event/resolve-queue";
+import { resolveRegistrationsForEvent } from "~/lib/event/resolve-registration";
+import { integrationTest } from "~/test/config/integration";
+import type { IntegrationTestContext } from "~/test/config/integration";
+
+/**
+ * Påmeldingen legges inn som «pending» og avgjøres av resolveren. Før ventet
+ * den på at cron-en skulle plukke den opp, i opptil fem sekunder; nå ber ruten
+ * om en resolver-runde selv. Jobbene kjøres ikke av seg selv i testene — det
+ * er `startBackgroundJobs` som starter workeren — så testene her sjekker at
+ * ruten legger inn jobben, og kjører resolveren selv der utfallet er poenget.
+ */
+async function queuedResolveJobs(ctx: IntegrationTestContext) {
+    const jobs = await ctx.queue
+        .getQueue<RegistrationResolveJobData>(REGISTRATION_QUEUE_NAME)
+        .getJobs();
+    return jobs.map((job) => job.data.eventId);
+}
+
+describe("registration is queued for resolution without waiting for the cron", () => {
+    integrationTest(
+        "registering asks for the event to be resolved right away",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                slug: `straks-${Date.now()}`,
+                capacity: 10,
+            });
+
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(user, [
+                "events:registrations:create",
+            ]);
+            await ctx.utils.acceptEventRules(user.id);
+            const client = await ctx.utils.clientForUser(user);
+
+            const response = await client.api.event[
+                ":eventId"
+            ].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            expect(response.status).toBe(200);
+            expect(await queuedResolveJobs(ctx)).toEqual([event.id]);
+
+            // Ruten svarer før plassen er avgjort, så raden er «pending» til
+            // workeren har kjørt.
+            const queued = await ctx.db.query.eventRegistration.findFirst({
+                where: (reg, { and, eq }) =>
+                    and(eq(reg.eventId, event.id), eq(reg.userId, user.id)),
+            });
+            expect(queued?.status).toBe("pending");
+
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const resolved = await ctx.db.query.eventRegistration.findFirst({
+                where: (reg, { and, eq }) =>
+                    and(eq(reg.eventId, event.id), eq(reg.userId, user.id)),
+            });
+            expect(resolved?.status).toBe("registered");
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "back-to-back registrations for the last spot keep FIFO order",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                slug: `siste-plass-${Date.now()}`,
+                capacity: 1,
+            });
+
+            const first = await ctx.utils.createTestUser();
+            const second = await ctx.utils.createTestUser();
+
+            for (const user of [first, second]) {
+                await ctx.utils.giveUserPermissions(user, [
+                    "events:registrations:create",
+                ]);
+                await ctx.utils.acceptEventRules(user.id);
+            }
+
+            for (const user of [first, second]) {
+                const client = await ctx.utils.clientForUser(user);
+                const response = await client.api.event[
+                    ":eventId"
+                ].registration.$post({
+                    param: { eventId: event.id },
+                    json: {},
+                });
+                expect(response.status).toBe(200);
+            }
+
+            // Én jobb per påmelding. En runde uten noe å gjøre koster ett
+            // indeksert oppslag, så duplikatene er billige og trenger ingen
+            // deduplisering.
+            expect(await queuedResolveJobs(ctx)).toEqual([event.id, event.id]);
+
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const rows = await ctx.db.query.eventRegistration.findMany({
+                where: (reg, { eq }) => eq(reg.eventId, event.id),
+            });
+            const status = (userId: string) =>
+                rows.find((row) => row.userId === userId)?.status;
+
+            expect(status(first.id)).toBe("registered");
+            expect(status(second.id)).toBe("waitlisted");
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -108,6 +108,23 @@ export function deriveRegistrationState(
 }
 
 /**
+ * Hvor lenge vi venter før vi spør igjen om en påmelding som står som
+ * «pending», gitt hvor lenge den har stått slik.
+ *
+ * Serveren avgjør plassen med én gang påmeldingen er lagret, så svaret ligger
+ * som regel klart et titalls millisekunder etter at knappen ga fra seg
+ * kontrollen. Første spørring kommer derfor raskt. Blir den likevel stående —
+ * et fullt arrangement med lang venteliste tar lengre tid å avgjøre — trapper
+ * vi ned, så en treg avklaring ikke blir til titalls spørringer i minuttet fra
+ * hver eneste som venter.
+ */
+export function registrationPollInterval(pendingForMs: number): number {
+    if (pendingForMs < 3_000) return 300;
+    if (pendingForMs < 15_000) return 1_000;
+    return 3_000;
+}
+
+/**
  * Oversett en feil fra påmeldings-endepunktet til noe et medlem forstår.
  *
  * API-meldingene er engelske og skrevet for utviklere. De vanligste årsakene

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
     useInfiniteQuery,
@@ -57,6 +58,7 @@ import {
     formatEventPrice,
     formatEventTime,
     registrationErrorMessage,
+    registrationPollInterval,
 } from "#/lib/event";
 
 export const Route = createFileRoute("/_app/arrangementer/$slug")({
@@ -69,13 +71,24 @@ function EventDetailPage() {
     const { slug } = Route.useParams();
     const navigate = useNavigate();
 
-    // En fersk påmelding ligger som «pending» til cron-en på serveren har
-    // avgjort plass eller venteliste. Vi poller til den er avklart, ellers
-    // ville brukeren blitt stående i behandling til de lastet siden på nytt.
+    // En fersk påmelding ligger som «pending» til serveren har avgjort plass
+    // eller venteliste. Vi poller til den er avklart, ellers ville brukeren
+    // blitt stående i behandling til de lastet siden på nytt. Intervallet
+    // trappes ned med hvor lenge den har stått — se
+    // `registrationPollInterval`.
+    const pendingSinceRef = useRef<number | null>(null);
     const { data: event } = useSuspenseQuery({
         ...getEventByIdQuery(slug),
-        refetchInterval: (query) =>
-            query.state.data?.registration?.status === "pending" ? 2000 : false,
+        refetchInterval: (query) => {
+            if (query.state.data?.registration?.status !== "pending") {
+                pendingSinceRef.current = null;
+                return false;
+            }
+            pendingSinceRef.current ??= Date.now();
+            return registrationPollInterval(
+                Date.now() - pendingSinceRef.current,
+            );
+        },
         // Pollingen står ellers stille når fanen ikke er i forgrunnen, og en
         // bruker som bytter fane mens vi behandler ville kommet tilbake til
         // «Behandler påmeldingen din …» som aldri gikk videre.

--- a/packages/core/src/services/queue/base.ts
+++ b/packages/core/src/services/queue/base.ts
@@ -6,6 +6,8 @@ export const PAYMENT_QUEUE_NAME = "payment" satisfies QueueName;
 
 export const PUSH_QUEUE_NAME = "push" satisfies QueueName;
 
+export const REGISTRATION_QUEUE_NAME = "registration" satisfies QueueName;
+
 /** Options accepted when enqueueing a job. */
 export interface QueueAddOptions {
     /** Delay in milliseconds before the job becomes available to a worker. */

--- a/packages/core/src/services/queue/index.ts
+++ b/packages/core/src/services/queue/index.ts
@@ -3,6 +3,7 @@ export {
     EMAIL_SEND_RATE_MS,
     PAYMENT_QUEUE_NAME,
     PUSH_QUEUE_NAME,
+    REGISTRATION_QUEUE_NAME,
     type QueueAddOptions,
     type QueueJob,
     type QueueJobState,


### PR DESCRIPTION
Closes #562.

## Hva som gjorde knappen treg

Ventetiden var strukturell, ikke en treg spørring:

1. `POST /api/event/{id}/registration` la inn raden som `pending` og svarte.
2. En cron plukket opp `pending`-rader **hvert 5. sekund**.
3. Siden spurte om arrangementet **hvert 2. sekund** så lenge status var `pending`.

«Behandler påmeldingen din …» varte dermed i typisk ~3,5 sekunder, og opptil ~7 — for arbeid som tar millisekunder. Køen med `pending`-rader finnes for å gi rettferdig FIFO når alle melder seg på samtidig, og den rettferdigheten er beholdt.

## Hva som er endret

**Ruten ber om avklaring med én gang.** Påmeldingen legges på `registration`-køen — navnet fantes allerede i `QueueName`, men var ubrukt — og en worker kjører resolveren.

Køen, og ikke et løst løfte i request-handleren, av to grunner:

- Requesten skal ikke holde på en databasetilkobling mens den står i kø bak resolverens `FOR UPDATE`-lås. En storm av blokkerte requester er det som tømmer poolen.
- Bakgrunnsarbeid som overlever requesten har ingenting som holder det i sjakk. Første forsøk var et løst løfte, og i testene fortsatte det å sende spørringer inn i en database som allerede var revet ned — kjøringen spant på 100 % CPU til den ble drept. En jobb har en eier, et forsøk til, og en worker som lever like lenge som prosessen.

Jobbene kjøres én om gangen, så påmeldingene som strømmer inn når påmeldingen åpner avgjøres i noen få runder over hele bunken — samme batching som cron-en ga oss, uten ventetiden. En runde for et arrangement uten noe å gjøre koster ett indeksert oppslag, så duplikatjobber er billige og trenger ingen deduplisering.

Innleggingen er **best-effort**: er Redis nede, står påmeldingen fortsatt, og cron-en tar den innen fem sekunder — nøyaktig der vi var før. Cron-en blir stående som sikkerhetsnett.

**Forhåndssjekkene i ruten kjører parallelt.** Fem tur-retur til databasen etter hverandre ble til ett `Promise.all`. Sjekkene gjøres i samme rekkefølge etterpå, så medlemmet får nøyaktig samme feilmelding som før.

**Frontenden spør raskere først.** Første poll etter 300 ms i stedet for 2 sekunder, med nedtrapping til 1 og 3 sekunder hvis avklaringen faktisk drar ut — så et fullt arrangement med lang venteliste ikke gir titalls spørringer i minuttet fra hver eneste som venter.

## Verifisert

- **Ende til ende i nettleseren mot lokal dev-stack**, målt på DOM-endringer fra klikk til «Du har plass på arrangementet!»: **393 ms, 22 ms, 70 ms** over tre påmeldinger. Spredningen er et kappløp: mutasjonen invaliderer arrangementet med én gang, og lander den refetchen etter at resolveren har committet, er kortet oppdatert umiddelbart (22/70 ms). Ellers venter klienten på første poll, og da er 300 ms taket (393 ms). Til sammenligning: ~3,5 sekunder i snitt før, og opptil ~7.
- **Køhoppet** — enqueue til worker — er **1,3 ms** (median av 10 mot dev-Redis), så køen er ikke det som avgjør tallene over.
- **Hele testsuiten:** 86 filer / 593 tester grønne, pluss `@tihlde/ui` 15/15.
- Ny test `registration-immediate-resolve.test.ts` dekker at ruten legger inn jobben, at raden står som `pending` til workeren har kjørt, og at to påmeldinger til siste plass fortsatt gir `registered` + `waitlisted` i FIFO-rekkefølge.
- `bun run typecheck`, `bun run lint` og `bun run format` er rene.

## Ikke i dette PR-et

To ting jeg fant mens jeg leste, som ligger igjen som egne issues:

- **#573** — resolveren gjør O(n²) spørringer i ventelisteberegningen og rendrer e-post inne i `FOR UPDATE`-transaksjonen. Dette er den gjenstående trege stien på fulle arrangementer, og dette PR-et gjør den mer synlig siden ingenting lenger skjuler den.
- **#574** — avmelding fra et fullt arrangement rykker ingen opp fra ventelista. Plassen blir stående tom til noen nye melder seg på.

