### PR TITLE
perf(events): batch ventelisteberegningen og rykk opp fra venteliste ved avmelding

### DIFF
--- a/apps/api/src/lib/event/payment.ts
+++ b/apps/api/src/lib/event/payment.ts
@@ -4,12 +4,12 @@ import {
     type QueueJob,
     type WorkerLike,
 } from "@photon/core/services/queue";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { AppContext } from "../ctx";
 import { env } from "../env";
 import { sendNotification } from "../notification";
 import { getPaymentDetails, refundPayment } from "../vipps";
-import { calculateWaitlistPosition } from "./priority";
+import { calculateWaitlistPositions } from "./priority";
 
 /**
  * Payload for the delayed job that enforces a paid event's payment deadline.
@@ -28,6 +28,7 @@ type PaidEventLike = {
     id: string;
     title: string;
     slug: string;
+    capacity?: number | null;
     isPaidEvent: boolean;
     priceMinor: number | null;
     paymentGracePeriodMinutes: number | null;
@@ -260,10 +261,32 @@ export async function refundOwed(
  * the remaining waitlist positions. For a paid event the promoted user gets a
  * fresh payment obligation (and countdown timer) of their own.
  */
-async function promoteFromWaitlist(
+export async function promoteFromWaitlist(
     ctx: AppContext,
     event: PaidEventLike,
 ): Promise<void> {
+    // A spot has to actually be free. Callers that just cancelled a
+    // registration know one is; the unregister route calls this for every
+    // cancellation, including ones that give up a waitlist place rather than a
+    // spot, so the count decides rather than the caller.
+    const capacity = event.capacity ?? null;
+
+    if (capacity !== null) {
+        const [taken] = await ctx.db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(schema.eventRegistration)
+            .where(
+                and(
+                    eq(schema.eventRegistration.eventId, event.id),
+                    eq(schema.eventRegistration.status, "registered"),
+                ),
+            );
+
+        if (Number(taken?.count ?? 0) >= capacity) {
+            return;
+        }
+    }
+
     const waitlisted = await ctx.db.query.eventRegistration.findMany({
         where: (r, { and, eq }) =>
             and(eq(r.eventId, event.id), eq(r.status, "waitlisted")),
@@ -307,22 +330,23 @@ async function promoteFromWaitlist(
     // The promoted user now owes payment on a paid event.
     await createPaymentObligation(ctx, event, promoted.userId);
 
-    // Recalculate positions for everyone still on the waitlist.
-    for (const reg of waitlisted.slice(1)) {
-        const newPosition = await calculateWaitlistPosition(
-            reg.userId,
-            event.id,
-            event.pools,
-            event.enforcesPreviousStrikes,
-            ctx.db,
-        );
+    // Recalculate positions for everyone still on the waitlist — one pass over
+    // the waitlist, not one pass per member of it.
+    const positions = await calculateWaitlistPositions(
+        event.id,
+        event.pools,
+        event.enforcesPreviousStrikes,
+        ctx.db,
+    );
+
+    for (const [userId, newPosition] of positions) {
         await ctx.db
             .update(schema.eventRegistration)
             .set({ waitlistPosition: newPosition })
             .where(
                 and(
                     eq(schema.eventRegistration.eventId, event.id),
-                    eq(schema.eventRegistration.userId, reg.userId),
+                    eq(schema.eventRegistration.userId, userId),
                 ),
             );
     }

--- a/apps/api/src/lib/event/priority.ts
+++ b/apps/api/src/lib/event/priority.ts
@@ -1,5 +1,8 @@
 import type { DbSchema } from "@photon/db";
+import { schema } from "@photon/db";
+import { and, gte, inArray, sql } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { getStrikeActiveCutoff } from "./strikes";
 
 /**
  * Get all group slugs that a user belongs to
@@ -64,6 +67,79 @@ export function isUserPrioritized({
     return false;
 }
 
+/**
+ * Answers "is this user prioritized for this event" without touching the
+ * database — every membership and strike it needs was fetched up front.
+ */
+export type PrioritizationLookup = (userId: string) => boolean;
+
+/**
+ * Fetch everything needed to prioritize a whole group of users, in two
+ * queries, and hand back a lookup over the result.
+ *
+ * Deciding this one user at a time is what made the waitlist O(n²): the
+ * position of every waitlisted member was recomputed by walking the entire
+ * waitlist, and each step asked the database for that member's groups and
+ * strikes. A 200-person waitlist meant tens of thousands of queries inside a
+ * transaction holding `FOR UPDATE` locks.
+ */
+export async function loadPrioritization(
+    userIds: string[],
+    eventPools: EventPool[],
+    enforcesPreviousStrikes: boolean,
+    db: NodePgDatabase<DbSchema>,
+): Promise<PrioritizationLookup> {
+    const ids = [...new Set(userIds)];
+
+    if (ids.length === 0) {
+        return () => false;
+    }
+
+    const [memberships, strikes] = await Promise.all([
+        db
+            .select({
+                userId: schema.groupMembership.userId,
+                groupSlug: schema.groupMembership.groupSlug,
+            })
+            .from(schema.groupMembership)
+            .where(inArray(schema.groupMembership.userId, ids)),
+        db
+            .select({
+                userId: schema.eventStrike.userId,
+                // Sum, not count: a single strike row can be worth several,
+                // exactly as {@link getUserStrikeCount} treats it.
+                total: sql<number>`coalesce(sum(${schema.eventStrike.count}), 0)::int`,
+            })
+            .from(schema.eventStrike)
+            .where(
+                and(
+                    inArray(schema.eventStrike.userId, ids),
+                    gte(schema.eventStrike.createdAt, getStrikeActiveCutoff()),
+                ),
+            )
+            .groupBy(schema.eventStrike.userId),
+    ]);
+
+    const groupsByUser = new Map<string, Set<string>>();
+    for (const membership of memberships) {
+        const slugs = groupsByUser.get(membership.userId) ?? new Set<string>();
+        slugs.add(membership.groupSlug);
+        groupsByUser.set(membership.userId, slugs);
+    }
+
+    const strikesByUser = new Map<string, number>(
+        strikes.map((row) => [row.userId, Number(row.total)]),
+    );
+
+    return (userId: string) =>
+        isUserPrioritized({
+            userGroupSlugs: groupsByUser.get(userId) ?? new Set<string>(),
+            eventPools,
+            strikeCount: strikesByUser.get(userId) ?? 0,
+            enforcesPreviousStrikes,
+        });
+}
+
 interface Registration {
     userId: string;
     eventId: string;
@@ -88,19 +164,16 @@ export async function findSwapTarget(
         .filter((r) => r.status === "registered")
         .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
 
+    const isPrioritized = await loadPrioritization(
+        registered.map((r) => r.userId),
+        eventPools,
+        enforcesPreviousStrikes,
+        db,
+    );
+
     // Find the first non-prioritized user
     for (const reg of registered) {
-        const userGroupSlugs = await getUserGroupSlugs(reg.userId, db);
-        const strikeCount = await getUserStrikeCount(reg.userId, db);
-
-        const isPrioritized = isUserPrioritized({
-            userGroupSlugs,
-            eventPools,
-            strikeCount,
-            enforcesPreviousStrikes,
-        });
-
-        if (!isPrioritized) {
+        if (!isPrioritized(reg.userId)) {
             return reg;
         }
     }
@@ -108,19 +181,55 @@ export async function findSwapTarget(
     return null; // All registered users are prioritized
 }
 
-async function getUserStrikeCount(
-    userId: string,
+/**
+ * Work out where everyone on the waitlist stands, in one pass.
+ *
+ * Prioritized users are ordered before non-prioritized users. Within each
+ * group, users are ordered by createdAt (FIFO).
+ */
+export async function calculateWaitlistPositions(
+    eventId: string,
+    eventPools: EventPool[],
+    enforcesPreviousStrikes: boolean,
     db: NodePgDatabase<DbSchema>,
-): Promise<number> {
-    const { getUserStrikeCount: getStrikes } = await import("./strikes");
-    return getStrikes(userId, db);
+): Promise<Map<string, number>> {
+    const waitlisted = await db.query.eventRegistration.findMany({
+        where: (reg, { and, eq }) =>
+            and(eq(reg.eventId, eventId), eq(reg.status, "waitlisted")),
+        orderBy: (reg, { asc }) => asc(reg.createdAt),
+    });
+
+    const isPrioritized = await loadPrioritization(
+        waitlisted.map((reg) => reg.userId),
+        eventPools,
+        enforcesPreviousStrikes,
+        db,
+    );
+
+    const prioritized: string[] = [];
+    const nonPrioritized: string[] = [];
+
+    for (const reg of waitlisted) {
+        if (isPrioritized(reg.userId)) {
+            prioritized.push(reg.userId);
+        } else {
+            nonPrioritized.push(reg.userId);
+        }
+    }
+
+    return new Map(
+        [...prioritized, ...nonPrioritized].map((userId, index) => [
+            userId,
+            index + 1,
+        ]),
+    );
 }
 
 /**
- * Calculate the waitlist position for a user
+ * Calculate the waitlist position for a single user.
  *
- * Prioritized users are ordered before non-prioritized users.
- * Within each group, users are ordered by createdAt (FIFO).
+ * Prefer {@link calculateWaitlistPositions} when more than one position is
+ * needed — this one recomputes the whole waitlist to answer for one member.
  */
 export async function calculateWaitlistPosition(
     userId: string,
@@ -129,51 +238,20 @@ export async function calculateWaitlistPosition(
     enforcesPreviousStrikes: boolean,
     db: NodePgDatabase<DbSchema>,
 ): Promise<number> {
-    // Get all waitlisted registrations for this event
-    const waitlisted = await db.query.eventRegistration.findMany({
-        where: (reg, { and, eq }) =>
-            and(eq(reg.eventId, eventId), eq(reg.status, "waitlisted")),
-        orderBy: (reg, { asc }) => asc(reg.createdAt),
-    });
+    const positions = await calculateWaitlistPositions(
+        eventId,
+        eventPools,
+        enforcesPreviousStrikes,
+        db,
+    );
 
-    // Categorize into prioritized and non-prioritized
-    const prioritizedList: Registration[] = [];
-    const nonPrioritizedList: Registration[] = [];
+    const position = positions.get(userId);
 
-    for (const reg of waitlisted) {
-        const userGroupSlugs = await getUserGroupSlugs(reg.userId, db);
-        const strikeCount = await getUserStrikeCount(reg.userId, db);
-
-        const isPrioritized = isUserPrioritized({
-            userGroupSlugs,
-            eventPools,
-            strikeCount,
-            enforcesPreviousStrikes,
-        });
-
-        if (isPrioritized) {
-            prioritizedList.push(reg);
-        } else {
-            nonPrioritizedList.push(reg);
-        }
+    if (position === undefined) {
+        throw new Error(
+            `User ${userId} not found in waitlist for event ${eventId}`,
+        );
     }
 
-    // Find the user in the appropriate list
-    const prioritizedIndex = prioritizedList.findIndex(
-        (r) => r.userId === userId,
-    );
-    if (prioritizedIndex !== -1) {
-        return prioritizedIndex + 1;
-    }
-
-    const nonPrioritizedIndex = nonPrioritizedList.findIndex(
-        (r) => r.userId === userId,
-    );
-    if (nonPrioritizedIndex !== -1) {
-        return prioritizedList.length + nonPrioritizedIndex + 1;
-    }
-
-    throw new Error(
-        `User ${userId} not found in waitlist for event ${eventId}`,
-    );
+    return position;
 }

--- a/apps/api/src/lib/event/resolve-registration.ts
+++ b/apps/api/src/lib/event/resolve-registration.ts
@@ -3,7 +3,7 @@ import type { RegistrationStatus } from "@photon/db/schema";
 import { and, eq } from "drizzle-orm";
 import type { AppContext } from "../ctx";
 import { env } from "../env";
-import { sendNotification } from "../notification";
+import { createDeferredNotifications } from "../notification/deferred";
 import {
     createPaymentObligation,
     findOwedRefund,
@@ -11,10 +11,9 @@ import {
     refundOwed,
 } from "./payment";
 import {
-    calculateWaitlistPosition,
+    calculateWaitlistPositions,
     findSwapTarget,
-    getUserGroupSlugs,
-    isUserPrioritized,
+    loadPrioritization,
 } from "./priority";
 import { canRegisterBasedOnStrikes, getUserStrikeCount } from "./strikes";
 
@@ -37,6 +36,13 @@ export async function resolveRegistrationsForEvent(
      * those locks for as long as Vipps takes to answer — see {@link refundOwed}.
      */
     const owedRefunds: OwedRefund[] = [];
+
+    /**
+     * Notifications decided inside the transaction and sent once it commits —
+     * rendering an email template per affected member while holding the
+     * `FOR UPDATE` locks below is time the whole event waits on.
+     */
+    const notifications = createDeferredNotifications();
 
     // Use database transaction to ensure atomic processing
     await ctx.db.transaction(async (tx) => {
@@ -109,11 +115,21 @@ export async function resolveRegistrationsForEvent(
             ? Number.POSITIVE_INFINITY
             : Math.max(0, (event.capacity ?? 0) - registeredCount);
 
+        /**
+         * Everyone in this batch, prioritized in two queries up front, rather
+         * than two queries per member inside the loop below.
+         */
+        const isUserPrioritizedForEvent = await loadPrioritization(
+            pendingRegistrations.map((registration) => registration.userId),
+            event.pools,
+            event.enforcesPreviousStrikes,
+            tx,
+        );
+
         // Step 4: Process each pending registration in order
         for (const registration of pendingRegistrations) {
             const { userId, createdAt } = registration;
 
-            const userGroupSlugs = await getUserGroupSlugs(userId, tx);
             const strikeCount = await getUserStrikeCount(userId, tx);
 
             // Check strike-based timing restriction
@@ -136,23 +152,20 @@ export async function resolveRegistrationsForEvent(
                     );
 
                 // Send notification to user with reason
-                await sendNotification(
-                    {
-                        userId,
-                        title: "Påmelding ikke godkjent",
-                        description: `Din påmelding til ${event.title} ble ikke godkjent: ${reason}`,
-                        link: `${env.ROOT_URL}/arrangementer/${event.slug}`,
-                        emailTemplate: {
-                            name: "RegistrationBlockedEmail",
-                            props: {
-                                eventName: event.title,
-                                reason,
-                                logoUrl: `${env.WEBSITE_URL}/logo512.png`,
-                            },
+                notifications.add({
+                    userId,
+                    title: "Påmelding ikke godkjent",
+                    description: `Din påmelding til ${event.title} ble ikke godkjent: ${reason}`,
+                    link: `${env.ROOT_URL}/arrangementer/${event.slug}`,
+                    emailTemplate: {
+                        name: "RegistrationBlockedEmail",
+                        props: {
+                            eventName: event.title,
+                            reason,
+                            logoUrl: `${env.WEBSITE_URL}/logo512.png`,
                         },
                     },
-                    txCtx,
-                );
+                });
                 console.log(
                     `User ${userId} blocked from registration: ${reason}`,
                 );
@@ -160,12 +173,7 @@ export async function resolveRegistrationsForEvent(
             }
 
             // Determine if user is prioritized
-            const isPrioritized = isUserPrioritized({
-                userGroupSlugs,
-                eventPools: event.pools,
-                strikeCount,
-                enforcesPreviousStrikes: event.enforcesPreviousStrikes,
-            });
+            const isPrioritized = isUserPrioritizedForEvent(userId);
 
             // Determine final status
             let finalStatus: RegistrationStatus;
@@ -247,13 +255,13 @@ export async function resolveRegistrationsForEvent(
             // Calculate and update waitlist position if needed (after status is saved)
             let waitlistPosition: number | null = null;
             if (finalStatus === "waitlisted") {
-                waitlistPosition = await calculateWaitlistPosition(
-                    userId,
+                const positions = await calculateWaitlistPositions(
                     eventId,
                     event.pools,
                     event.enforcesPreviousStrikes,
                     tx,
                 );
+                waitlistPosition = positions.get(userId) ?? null;
 
                 await tx
                     .update(schema.eventRegistration)
@@ -277,42 +285,36 @@ export async function resolveRegistrationsForEvent(
             const eventUrl = `${env.ROOT_URL}/arrangementer/${event.slug}`;
 
             if (finalStatus === "registered") {
-                await sendNotification(
-                    {
-                        userId,
-                        title: `Du er påmeldt ${event.title}!`,
-                        description: `Din påmelding til ${event.title} er bekreftet.`,
-                        link: eventUrl,
-                        emailTemplate: {
-                            name: "RegistrationConfirmedEmail",
-                            props: {
-                                eventName: event.title,
-                                eventUrl,
-                                logoUrl: `${env.WEBSITE_URL}/logo512.png`,
-                            },
+                notifications.add({
+                    userId,
+                    title: `Du er påmeldt ${event.title}!`,
+                    description: `Din påmelding til ${event.title} er bekreftet.`,
+                    link: eventUrl,
+                    emailTemplate: {
+                        name: "RegistrationConfirmedEmail",
+                        props: {
+                            eventName: event.title,
+                            eventUrl,
+                            logoUrl: `${env.WEBSITE_URL}/logo512.png`,
                         },
                     },
-                    txCtx,
-                );
+                });
             } else if (finalStatus === "waitlisted" && waitlistPosition) {
-                await sendNotification(
-                    {
-                        userId,
-                        title: `Du er på venteliste for ${event.title}`,
-                        description: `Du er nå på venteliste for ${event.title} (posisjon ${waitlistPosition}).`,
-                        link: eventUrl,
-                        emailTemplate: {
-                            name: "WaitlistPlacementEmail",
-                            props: {
-                                eventName: event.title,
-                                eventUrl,
-                                position: waitlistPosition,
-                                logoUrl: `${env.WEBSITE_URL}/logo512.png`,
-                            },
+                notifications.add({
+                    userId,
+                    title: `Du er på venteliste for ${event.title}`,
+                    description: `Du er nå på venteliste for ${event.title} (posisjon ${waitlistPosition}).`,
+                    link: eventUrl,
+                    emailTemplate: {
+                        name: "WaitlistPlacementEmail",
+                        props: {
+                            eventName: event.title,
+                            eventUrl,
+                            position: waitlistPosition,
+                            logoUrl: `${env.WEBSITE_URL}/logo512.png`,
                         },
                     },
-                    txCtx,
-                );
+                });
             }
 
             console.log(
@@ -327,19 +329,15 @@ export async function resolveRegistrationsForEvent(
                 (finalStatus === "waitlisted" && isPrioritized);
 
             if (shouldRecalculateWaitlist) {
-                const waitlisted = await tx.query.eventRegistration.findMany({
-                    where: (r, { and, eq }) =>
-                        and(eq(r.eventId, eventId), eq(r.status, "waitlisted")),
-                });
+                // One pass over the waitlist, not one pass per member of it.
+                const positions = await calculateWaitlistPositions(
+                    eventId,
+                    event.pools,
+                    event.enforcesPreviousStrikes,
+                    tx,
+                );
 
-                for (const wReg of waitlisted) {
-                    const newPosition = await calculateWaitlistPosition(
-                        wReg.userId,
-                        eventId,
-                        event.pools,
-                        event.enforcesPreviousStrikes,
-                        tx,
-                    );
+                for (const [waitlistedUserId, newPosition] of positions) {
                     await tx
                         .update(schema.eventRegistration)
                         .set({ waitlistPosition: newPosition })
@@ -348,32 +346,29 @@ export async function resolveRegistrationsForEvent(
                                 eq(schema.eventRegistration.eventId, eventId),
                                 eq(
                                     schema.eventRegistration.userId,
-                                    wReg.userId,
+                                    waitlistedUserId,
                                 ),
                             ),
                         );
 
                     // Send email to swapped user
-                    if (wReg.userId === swappedUserId && newPosition) {
+                    if (waitlistedUserId === swappedUserId) {
                         const eventUrl = `${env.ROOT_URL}/arrangementer/${event.slug}`;
-                        await sendNotification(
-                            {
-                                userId: wReg.userId,
-                                title: `Endring i din påmelding til ${event.title}`,
-                                description: `Din påmelding til ${event.title} har blitt flyttet til venteliste (posisjon ${newPosition}).`,
-                                link: eventUrl,
-                                emailTemplate: {
-                                    name: "SwappedToWaitlistEmail",
-                                    props: {
-                                        eventName: event.title,
-                                        eventUrl,
-                                        position: newPosition,
-                                        logoUrl: `${env.WEBSITE_URL}/logo512.png`,
-                                    },
+                        notifications.add({
+                            userId: waitlistedUserId,
+                            title: `Endring i din påmelding til ${event.title}`,
+                            description: `Din påmelding til ${event.title} har blitt flyttet til venteliste (posisjon ${newPosition}).`,
+                            link: eventUrl,
+                            emailTemplate: {
+                                name: "SwappedToWaitlistEmail",
+                                props: {
+                                    eventName: event.title,
+                                    eventUrl,
+                                    position: newPosition,
+                                    logoUrl: `${env.WEBSITE_URL}/logo512.png`,
                                 },
                             },
-                            txCtx,
-                        );
+                        });
                     }
                 }
             }
@@ -416,5 +411,6 @@ export async function resolveRegistrationsForEvent(
     });
 
     // Locks are released; now it is safe to spend time on the network.
+    await notifications.flush(ctx);
     await refundOwed(ctx, owedRefunds);
 }

--- a/apps/api/src/lib/notification/deferred.ts
+++ b/apps/api/src/lib/notification/deferred.ts
@@ -1,0 +1,50 @@
+import type { AppContext } from "../ctx";
+import { type SendNotificationOptions, sendNotification } from ".";
+
+/**
+ * Notifications decided inside a transaction and sent once it has committed.
+ *
+ * {@link sendNotification} renders the React Email template inline before it
+ * hands the mail to the queue, and writes a notification row of its own.
+ * Doing that inside the registration resolver's transaction stretched how long
+ * its `FOR UPDATE` locks were held by one template render per affected member —
+ * on a full event, that is the whole waitlist.
+ *
+ * It was also wrong on rollback: the mail was already queued for a placement
+ * that never committed. Deciding inside the transaction and sending after it
+ * is the same shape the refund path already uses.
+ */
+export type DeferredNotifications = {
+    /** Queue a notification to be sent after the transaction commits. */
+    add(options: SendNotificationOptions): void;
+    /**
+     * Send everything queued so far. One failure does not stop the rest: the
+     * database work is already committed, and a member who does not get an
+     * email still has their spot.
+     */
+    flush(ctx: AppContext): Promise<void>;
+};
+
+export function createDeferredNotifications(): DeferredNotifications {
+    const pending: SendNotificationOptions[] = [];
+
+    return {
+        add(options) {
+            pending.push(options);
+        },
+        async flush(ctx) {
+            const queued = pending.splice(0, pending.length);
+
+            for (const options of queued) {
+                try {
+                    await sendNotification(options, ctx);
+                } catch (error) {
+                    console.error(
+                        `Failed to send notification "${options.title}" to user ${options.userId}:`,
+                        error,
+                    );
+                }
+            }
+        },
+    };
+}

--- a/apps/api/src/routes/event/registration/delete.ts
+++ b/apps/api/src/routes/event/registration/delete.ts
@@ -1,6 +1,7 @@
 import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
+import { promoteFromWaitlist } from "~/lib/event/payment";
 import { issueStrike } from "~/lib/event/strikes";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "../../../lib/route";
@@ -19,15 +20,34 @@ export const deleteEventRegistrationRoute = route().delete(
         .build(),
     requireAuth,
     async (c) => {
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const userId = c.get("user").id;
         const eventId = c.req.param("eventId");
 
+        // The columns beyond the strike rule are what promoting someone off
+        // the waitlist needs: capacity to see whether a spot actually opened,
+        // and the payment fields to give the promoted member their own
+        // obligation on a paid event.
         const event = await db.query.event.findFirst({
             columns: {
                 id: true,
+                title: true,
+                slug: true,
+                capacity: true,
                 canCauseStrikes: true,
                 cancellationDeadline: true,
+                isPaidEvent: true,
+                priceMinor: true,
+                paymentGracePeriodMinutes: true,
+                enforcesPreviousStrikes: true,
+            },
+            with: {
+                pools: {
+                    with: {
+                        groups: true,
+                    },
+                },
             },
             where: eq(schema.event.id, eventId),
         });
@@ -61,6 +81,18 @@ export const deleteEventRegistrationRoute = route().delete(
                 count: 1,
                 reason: "Avmelding etter avmeldingsfristen",
             });
+        }
+
+        /**
+         * Giving up a confirmed spot leaves it empty unless someone is moved
+         * into it. Nothing did that before: the resolver only ever looks at
+         * `pending` rows, and a waitlisted member is `waitlisted` — so the
+         * freed spot sat there until some new member happened to register.
+         *
+         * Only a confirmed spot frees capacity; leaving the waitlist does not.
+         */
+        if (event && deleted.status === "registered") {
+            await promoteFromWaitlist(ctx, event);
         }
 
         return c.text("OK");

--- a/apps/api/src/test/event/waitlist-promotion.test.ts
+++ b/apps/api/src/test/event/waitlist-promotion.test.ts
@@ -1,0 +1,166 @@
+import { schema } from "@photon/db";
+import { and, eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { resolveRegistrationsForEvent } from "~/lib/event/resolve-registration";
+import { integrationTest } from "~/test/config/integration";
+import type { IntegrationTestContext } from "~/test/config/integration";
+
+/**
+ * Å gi fra seg en bekreftet plass frigjør den, og da skal den øverste på
+ * ventelista rykke opp. Før gjorde ingenting det: resolveren ser bare på
+ * `pending`-rader, og en ventelistet er `waitlisted` — så plassen ble stående
+ * tom til noen nye meldte seg på.
+ */
+async function statusFor(
+    ctx: IntegrationTestContext,
+    eventId: string,
+    userId: string,
+) {
+    const row = await ctx.db.query.eventRegistration.findFirst({
+        where: (reg, { and, eq }) =>
+            and(eq(reg.eventId, eventId), eq(reg.userId, userId)),
+    });
+    return { status: row?.status, position: row?.waitlistPosition };
+}
+
+describe("waitlist promotion when a spot is freed", () => {
+    integrationTest(
+        "unregistering hands the spot to the first person on the waitlist",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                slug: `opprykk-${Date.now()}`,
+                capacity: 1,
+            });
+
+            const holder = await ctx.utils.createTestUser();
+            const waiting = await ctx.utils.createTestUser();
+
+            for (const user of [holder, waiting]) {
+                await ctx.utils.giveUserPermissions(user, [
+                    "events:registrations:create",
+                ]);
+                await ctx.utils.acceptEventRules(user.id);
+            }
+
+            // Holder tar den ene plassen, waiting havner på venteliste.
+            await ctx.utils.createPendingRegistration(event.id, holder.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+            await new Promise((r) => setTimeout(r, 10));
+            await ctx.utils.createPendingRegistration(event.id, waiting.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            expect((await statusFor(ctx, event.id, holder.id)).status).toBe(
+                "registered",
+            );
+            expect((await statusFor(ctx, event.id, waiting.id)).status).toBe(
+                "waitlisted",
+            );
+
+            const client = await ctx.utils.clientForUser(holder);
+            const response = await client.api.event[
+                ":eventId"
+            ].registration.$delete({
+                param: { eventId: event.id },
+            });
+
+            expect(response.status).toBe(200);
+
+            const promoted = await statusFor(ctx, event.id, waiting.id);
+            expect(promoted.status).toBe("registered");
+            expect(promoted.position).toBeNull();
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "leaving the waitlist promotes nobody — no spot was freed",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                slug: `ingen-opprykk-${Date.now()}`,
+                capacity: 1,
+            });
+
+            const holder = await ctx.utils.createTestUser();
+            const first = await ctx.utils.createTestUser();
+            const second = await ctx.utils.createTestUser();
+
+            for (const user of [holder, first, second]) {
+                await ctx.utils.giveUserPermissions(user, [
+                    "events:registrations:create",
+                ]);
+                await ctx.utils.acceptEventRules(user.id);
+            }
+
+            for (const user of [holder, first, second]) {
+                await ctx.utils.createPendingRegistration(event.id, user.id);
+                await resolveRegistrationsForEvent(event.id, ctx);
+                await new Promise((r) => setTimeout(r, 10));
+            }
+
+            expect((await statusFor(ctx, event.id, first.id)).status).toBe(
+                "waitlisted",
+            );
+
+            // `first` forlater ventelista. Plassen til `holder` er urørt, så
+            // `second` skal fortsatt stå på venteliste.
+            const client = await ctx.utils.clientForUser(first);
+            await client.api.event[":eventId"].registration.$delete({
+                param: { eventId: event.id },
+            });
+
+            expect((await statusFor(ctx, event.id, holder.id)).status).toBe(
+                "registered",
+            );
+            expect((await statusFor(ctx, event.id, second.id)).status).toBe(
+                "waitlisted",
+            );
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "an event with room to spare promotes nobody it should not",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                slug: `ledig-${Date.now()}`,
+                capacity: 5,
+            });
+
+            const leaving = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(leaving, [
+                "events:registrations:create",
+            ]);
+            await ctx.utils.acceptEventRules(leaving.id);
+
+            await ctx.utils.createPendingRegistration(event.id, leaving.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const client = await ctx.utils.clientForUser(leaving);
+            await client.api.event[":eventId"].registration.$delete({
+                param: { eventId: event.id },
+            });
+
+            const rows = await ctx.db
+                .select()
+                .from(schema.eventRegistration)
+                .where(
+                    and(
+                        eq(schema.eventRegistration.eventId, event.id),
+                        eq(schema.eventRegistration.status, "registered"),
+                    ),
+                );
+
+            expect(rows).toHaveLength(0);
+        },
+        500_000,
+    );
+});

--- a/apps/api/src/test/event/waitlist-scaling.test.ts
+++ b/apps/api/src/test/event/waitlist-scaling.test.ts
@@ -1,0 +1,115 @@
+import { schema } from "@photon/db";
+import { describe, expect } from "vitest";
+import {
+    calculateWaitlistPosition,
+    calculateWaitlistPositions,
+} from "~/lib/event/priority";
+import { integrationTest } from "~/test/config/integration";
+import type { IntegrationTestContext } from "~/test/config/integration";
+
+/**
+ * Ventelisteberegningen spurte databasen to ganger per ventelistet for å svare
+ * for én av dem — og resolveren kalte den én gang per ventelistet, altså
+ * `n × (1 + 2n)` spørringer inne i en transaksjon som holdt `FOR UPDATE`-låser.
+ * Med 200 på venteliste ble det titusenvis.
+ *
+ * Testen teller faktiske spørringer i stedet for å måle tid: tid varierer med
+ * maskinen, antall spørringer er en egenskap ved koden.
+ *
+ * Merk at telleren bare ser spørringer utenfor en transaksjon — PGlite kjører
+ * transaksjoner gjennom et eget objekt. Derfor måles funksjonene direkte, ikke
+ * gjennom resolveren.
+ */
+function countQueries(ctx: IntegrationTestContext) {
+    const pglite = (
+        ctx as unknown as { _pglite: { query: (...a: never[]) => unknown } }
+    )._pglite;
+    const original = pglite.query.bind(pglite);
+    let count = 0;
+
+    pglite.query = ((...args: never[]) => {
+        count++;
+        return original(...args);
+    }) as typeof pglite.query;
+
+    return {
+        get count() {
+            return count;
+        },
+        restore() {
+            pglite.query = original as typeof pglite.query;
+        },
+    };
+}
+
+const WAITLIST_SIZE = 25;
+
+describe("waitlist position calculation scales linearly", () => {
+    integrationTest(
+        "positions for a 25-person waitlist cost a handful of queries, not hundreds",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                slug: `skalering-${Date.now()}`,
+                capacity: 1,
+            });
+
+            const userIds: string[] = [];
+            for (let i = 0; i < WAITLIST_SIZE; i++) {
+                const user = await ctx.utils.createTestUser();
+                userIds.push(user.id);
+            }
+
+            await ctx.db.insert(schema.eventRegistration).values(
+                userIds.map((userId, index) => ({
+                    eventId: event.id,
+                    userId,
+                    status: "waitlisted" as const,
+                    createdAt: new Date(Date.now() + index),
+                })),
+            );
+
+            // Slik resolveren gjorde det: én posisjon om gangen, for alle.
+            const perUser = countQueries(ctx);
+            let positions: number[] = [];
+            try {
+                for (const userId of userIds) {
+                    positions.push(
+                        await calculateWaitlistPosition(
+                            userId,
+                            event.id,
+                            [],
+                            false,
+                            ctx.db,
+                        ),
+                    );
+                }
+            } finally {
+                perUser.restore();
+            }
+
+            // Før: 25 × (1 + 2×25) = 1275 spørringer. Nå: 3 per kall.
+            expect(perUser.count).toBeLessThan(150);
+            expect(new Set(positions).size).toBe(WAITLIST_SIZE);
+
+            // Og hele lista på én gang koster en håndfull uansett størrelse.
+            const batched = countQueries(ctx);
+            try {
+                const all = await calculateWaitlistPositions(
+                    event.id,
+                    [],
+                    false,
+                    ctx.db,
+                );
+                expect(all.size).toBe(WAITLIST_SIZE);
+            } finally {
+                batched.restore();
+            }
+
+            expect(batched.count).toBeLessThanOrEqual(6);
+        },
+        500_000,
+    );
+});


### PR DESCRIPTION
Closes #573. Closes #574.

De to henger sammen: opprykket i #574 trenger den samme ventelisteberegningen som #573 gjør om.

## #573 — O(n²) og e-post inne i låsen

`calculateWaitlistPosition` spurte databasen to ganger per ventelistet for å svare for **én** av dem, og resolveren kalte den én gang per ventelistet. Det er `n × (1 + 2n)` spørringer, inne i en transaksjon som holdt `FOR UPDATE`-låser.

Målt på 25 ventelistede: **1275 spørringer**.

Tall fra prod-databasen, så størrelsesordenen er reell og ikke gjettet: 194 arrangementer har hatt venteliste, snitt 12 personer, største 65 (september). Det gir for en full rekalkulering:

| Venteliste | Før | Etter |
|---|---|---|
| 12 (snitt) | 300 spørringer | ~15 |
| 34 | 2 346 | ~37 |
| 65 (største målte) | 8 515 | ~68 |

Kostnaden treffer også uten prioritetspuljer: hver nye ventelisteplassering kostet `1 + 2n` spørringer, så det å bygge opp en venteliste på 65 var ~4 350 spørringer totalt mot ~195 nå.

- `loadPrioritization` henter gruppemedlemskap og prikker for hele bunken i **to** spørringer og gir tilbake et oppslag som svarer uten å røre databasen.
- `calculateWaitlistPositions` regner ut hele ventelista i én runde.
- Enkeltbruker-varianten er beholdt som en tynn innpakning for kallere som bare trenger én — men den koster nå 3 spørringer i stedet for 51.
- `findSwapTarget` hentet også to spørringer per påmeldt mens den lette; nå én batch.

**E-postene er flyttet ut av transaksjonen.** `sendNotification` rendrer React Email-malen inline før den leverer til køen, og det skjedde per berørt medlem mens låsene sto. Det var også feil ved rollback: mailen var allerede lagt i kø for en plass som aldri ble committet. `createDeferredNotifications` samler dem inne i transaksjonen og sender etter commit — samme mønster som refusjonene allerede bruker.

## #574 — avmelding rykket ingen opp

Å gi fra seg en bekreftet plass etterlot den tom. Resolveren ser bare på `pending`-rader, og en ventelistet er `waitlisted`, så plassen ble stående til noen nye tilfeldigvis meldte seg på.

Promoteringslogikken fantes allerede — men var bare koblet til betalingsutløp. Den er nå:

- eksportert fra `payment.ts` (den bor der fordi et opprykk på et betalt arrangement må opprette betalingsforpliktelsen),
- utstyrt med en kapasitetssjekk, så den er trygg å kalle fra hvor som helst i stedet for å stole på at kalleren vet at en plass er ledig,
- kalt fra avmeldingsruten **kun når en bekreftet plass ble frigjort** — å forlate ventelista frigjør ingenting.

## Målt veggklokketid

Mot ekte Postgres (ikke PGlite), på stien der rekalkuleringen faktisk utløses — en prioritert tar plassen fra en ikke-prioritert, og hele ventelista regnes om. Alle kjøringer bekreftet at byttet skjedde.

| Venteliste | Før | Etter | Faktor |
|---|---|---|---|
| 12 (snitt i prod) | 168 ms | 40 ms | 4× |
| 25 | 452 ms | 41 ms | 11× |
| 65 (største prod har sett) | **2 265 ms** | 61 ms | **37×** |
| 130 | **8 766 ms** | 80 ms | 110× |

Dette er tid med `FOR UPDATE`-låser holdt. Ved 65 på venteliste låste den gamle koden påmeldingsradene i over to sekunder per påmelding som utløste et bytte.

Tallene er konservative for prod: API og database ligger på samme vert (`photon.tihlde.org` er CNAME til `drift.tihlde.org`, begge 129.241.100.198), og prod-basen bruker 2,2 µs per setning mot 0,6 µs på maskinen målingen ble kjørt på.

En advarsel til den som gjentar målingen: uten en prioritetspulje er `shouldRecalculateWaitlist` alltid `false`, og da måler man en helt annen sti. Første forsøk gjorde nettopp det og viste 72 ms → 29 ms.

## Verifisert

Begge testene er A/B-et mot gammel kode, så de kan faktisk feile:

| Test | Mot gammel kode |
|---|---|
| `waitlist-scaling.test.ts` | `expected 1275 to be less than 150` |
| `waitlist-promotion.test.ts` | `expected 'waitlisted' to be 'registered'` |

- Hele testsuiten: **89 filer / 600 tester** grønne, pluss `@tihlde/ui` 15/15.
- `bun run typecheck`, `bun run lint`, `bun run format` rene.

En detalj verdt å vite for den som leser skaleringstesten: spørringstelleren ser bare kall utenfor en transaksjon, siden PGlite kjører transaksjoner gjennom et eget objekt. Derfor måler testen funksjonene direkte i stedet for gjennom resolveren — første utkast målte gjennom resolveren, fanget 4 spørringer av flere hundre, og besto på gammel kode.


