### PR TITLE
feat(kvark): legg til Varsling-lenke i hovednav

### DIFF
--- a/apps/kvark/src/components/site-bottom-bar.tsx
+++ b/apps/kvark/src/components/site-bottom-bar.tsx
@@ -13,7 +13,12 @@ import {
     DrawerTitle,
     DrawerTrigger,
 } from "@tihlde/ui/ui/drawer";
-import { BriefcaseBusiness, Calendar, Menu } from "lucide-react";
+import {
+    BriefcaseBusiness,
+    Calendar,
+    Menu,
+    SquareArrowOutUpRight,
+} from "lucide-react";
 import { useState } from "react";
 
 import { TihldeLogo } from "./icons/tihlde";
@@ -148,10 +153,11 @@ function MenuLink({
                 href={link.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="py-2"
+                className="flex items-center gap-1 py-2"
                 onClick={onNavigate}
             >
                 {link.label}
+                <SquareArrowOutUpRight className="size-3.5" aria-hidden />
             </a>
         );
     }

--- a/apps/kvark/src/components/site-header.tsx
+++ b/apps/kvark/src/components/site-header.tsx
@@ -8,7 +8,7 @@ import {
     NavigationMenuList,
     NavigationMenuTrigger,
 } from "@tihlde/ui/ui/navigation-menu";
-import { ExternalLinkIcon, User } from "lucide-react";
+import { SquareArrowOutUpRight, User } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { ThemeSwitcher } from "./theme-switcher";
@@ -92,7 +92,7 @@ export function SiteHeader({ navItems, user, actions }: SiteHeaderProps) {
                                                             ) : null}
                                                             {sub.kind ===
                                                             "external" ? (
-                                                                <ExternalLinkIcon
+                                                                <SquareArrowOutUpRight
                                                                     className="absolute top-0 right-0 size-4"
                                                                     aria-hidden
                                                                 />
@@ -109,7 +109,15 @@ export function SiteHeader({ navItems, user, actions }: SiteHeaderProps) {
                                     <NavigationMenuLink
                                         render={renderLink(item)}
                                     >
-                                        {item.label}
+                                        <span className="flex items-center gap-1">
+                                            {item.label}
+                                            {item.kind === "external" ? (
+                                                <SquareArrowOutUpRight
+                                                    className="size-3.5"
+                                                    aria-hidden
+                                                />
+                                            ) : null}
+                                        </span>
                                     </NavigationMenuLink>
                                 </NavigationMenuItem>
                             ),

--- a/apps/kvark/src/components/site-nav-items.ts
+++ b/apps/kvark/src/components/site-nav-items.ts
@@ -81,6 +81,11 @@ export function useSiteNavItems(
                     href: "https://wiki.tihlde.org",
                 },
                 {
+                    kind: "external",
+                    label: "Varsling",
+                    href: "https://forms.gle/UE85Da8et8VJc7XWA",
+                },
+                {
                     kind: "internal",
                     label: "Stillinger",
                     link: linkOptions({ to: "/annonser" }),


### PR DESCRIPTION
## Hva

Legger til en ekstern nav-lenke «Varsling» som peker til varslingsskjemaet: https://forms.gle/UE85Da8et8VJc7XWA

Lenken ligger på toppnivå i hovednavet, mellom «Wiki» og «Stillinger».

## Ikon

Alle eksterne nav-lenker markeres nå med `SquareArrowOutUpRight` (firkant med pil skrått ut opp til høyre):
- Toppnivå-lenker i headeren (Wiki, Varsling) fikk ikonet inline etter teksten.
- Dropdown-elementene byttet fra `ExternalLinkIcon` til samme ikon for konsistens.
- Eksterne lenker i mobilmenyen fikk samme ikon.

## Verifisering

- `tsc --noEmit` i `apps/kvark` — grønt
- oxfmt + oxlint kjørt
- Sjekket i dev-preview: begge eksterne toppnivå-lenker rendrer ikonet, og «Varsling» peker på riktig URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)