### PR TITLE
fix(forms): la spørsmål endres når skjemaet har svar

### DIFF
--- a/apps/api/src/lib/form/exceptions.ts
+++ b/apps/api/src/lib/form/exceptions.ts
@@ -9,14 +9,17 @@ export class DuplicateSubmissionException extends HTTPException {
 }
 
 /**
- * Rewriting the questions deletes the answers that belong to them, so a group
- * form is frozen from the first submission.
+ * Et gruppeskjema med svar kan fortsatt redigeres — det er bare endringene som
+ * ville tatt svar med seg som stoppes, og meldingen sier hvilke. Se
+ * `findDestructiveFieldChanges`.
  */
 export class FormHasSubmissionsException extends HTTPException {
-    constructor() {
+    constructor(problems: string[] = []) {
         super(409, {
             message:
-                "Spørsmålene kan ikke endres etter at noen har svart på skjemaet",
+                problems.length > 0
+                    ? `Endringen ville slettet svar som allerede er sendt inn: ${problems.join("; ")}`
+                    : "Spørsmålene kan ikke endres etter at noen har svart på skjemaet",
         });
     }
 }

--- a/apps/api/src/lib/form/service.ts
+++ b/apps/api/src/lib/form/service.ts
@@ -220,6 +220,130 @@ export async function createFieldsAndOptions(
 }
 
 /**
+ * Endringene i `fields` som ville tatt svar med seg, beskrevet på norsk.
+ *
+ * Å skrive om spørsmålene er ikke destruktivt i seg selv: `updateFieldsAndOptions`
+ * kjenner igjen spørsmål og alternativer på id, så tittel, rekkefølge og
+ * «påkrevd» kan endres uten at noe forsvinner. Det som tar svar med seg er å
+ * fjerne noe noen har svart på:
+ *
+ * - Fjernes et spørsmål, blir `answer.field_id` satt til null, og svaret hører
+ *   ikke lenger til noe spørsmål.
+ * - Fjernes et alternativ, kaskaderer det til `answer_option` — selve valget
+ *   forsvinner.
+ * - Byttes typen på et spørsmål, sletter oppdateringen alternativene som ikke
+ *   passer den nye typen, med de samme følgene.
+ *
+ * Spørsmål og alternativer ingen har svart på kan fjernes fritt. Tom liste
+ * betyr at oppdateringen er trygg.
+ */
+export async function findDestructiveFieldChanges(
+    db: Database,
+    formId: string,
+    fields: UpdateFieldInput[],
+): Promise<string[]> {
+    const existingFields = await db.query.formField.findMany({
+        where: eq(schema.formField.formId, formId),
+        with: { options: true },
+    });
+
+    if (existingFields.length === 0) return [];
+
+    const answeredFieldIds = new Set(
+        (
+            await db
+                .selectDistinct({ fieldId: schema.formAnswer.fieldId })
+                .from(schema.formAnswer)
+                .where(
+                    inArray(
+                        schema.formAnswer.fieldId,
+                        existingFields.map((field) => field.id),
+                    ),
+                )
+        )
+            .map((row) => row.fieldId)
+            .filter((id): id is string => id !== null),
+    );
+
+    const existingOptionIds = existingFields.flatMap((field) =>
+        field.options.map((option) => option.id),
+    );
+
+    const answeredOptionIds = new Set(
+        existingOptionIds.length === 0
+            ? []
+            : (
+                  await db
+                      .selectDistinct({
+                          optionId: schema.formAnswerOption.optionId,
+                      })
+                      .from(schema.formAnswerOption)
+                      .where(
+                          inArray(
+                              schema.formAnswerOption.optionId,
+                              existingOptionIds,
+                          ),
+                      )
+              ).map((row) => row.optionId),
+    );
+
+    // Bare id-er som faktisk hører til dette skjemaet teller som «beholdt».
+    // En id fra et annet skjema oppretter et nytt spørsmål her, den flytter
+    // ikke det andre — se `updateFieldsAndOptions`.
+    const ownFieldIds = new Set(existingFields.map((field) => field.id));
+    const keptFields = new Map(
+        fields
+            .filter((field) => field.id && ownFieldIds.has(field.id))
+            .map((field) => [field.id as string, field]),
+    );
+
+    const problems: string[] = [];
+
+    for (const existing of existingFields) {
+        const kept = keptFields.get(existing.id);
+
+        if (!kept) {
+            if (answeredFieldIds.has(existing.id)) {
+                problems.push(
+                    `spørsmålet «${existing.title}» er fjernet, og noen har svart på det`,
+                );
+            }
+            continue;
+        }
+
+        if (kept.type !== existing.type && answeredFieldIds.has(existing.id)) {
+            problems.push(
+                `spørsmålet «${existing.title}» har byttet type, og noen har svart på det`,
+            );
+            // Typebyttet sletter alternativene uansett hvilke som er med i
+            // lista, så det er ingen grunn til å telle dem opp i tillegg.
+            continue;
+        }
+
+        // Uten `options` i payloaden sletter oppdateringen alle alternativene
+        // til spørsmålet, akkurat som en tom liste ville gjort.
+        const keptOptionIds = new Set(
+            (kept.options ?? [])
+                .map((option) => option.id)
+                .filter((id): id is string => id !== undefined),
+        );
+
+        for (const option of existing.options) {
+            if (
+                !keptOptionIds.has(option.id) &&
+                answeredOptionIds.has(option.id)
+            ) {
+                problems.push(
+                    `alternativet «${option.title}» i «${existing.title}» er fjernet, og noen har valgt det`,
+                );
+            }
+        }
+    }
+
+    return problems;
+}
+
+/**
  * Update fields and options for a form
  * - Fields/options with id: update
  * - Fields/options without id: create
@@ -237,6 +361,8 @@ export async function updateFieldsAndOptions(
             options: true,
         },
     });
+
+    const existingFieldIds = new Set(existingFields.map((f) => f.id));
 
     const updatedFieldIds = fields
         .filter((f) => f.id)
@@ -257,7 +383,10 @@ export async function updateFieldsAndOptions(
 
     // Update or create fields
     for (const fieldData of fields) {
-        if (fieldData.id) {
+        // En id som ikke hører til dette skjemaet behandles som et nytt
+        // spørsmål: ellers ville en payload kunne skrive om spørsmålene i et
+        // annet skjema, som den som sender den ikke nødvendigvis eier.
+        if (fieldData.id && existingFieldIds.has(fieldData.id)) {
             // Update existing field
             await db
                 .update(schema.formField)
@@ -296,9 +425,16 @@ export async function updateFieldsAndOptions(
                     );
                 }
 
+                const existingOptionIds = new Set(
+                    existingOptions.map((o) => o.id),
+                );
+
                 // Update or create options
                 for (const optionData of fieldData.options) {
-                    if (optionData.id) {
+                    // Som for spørsmålene: en id som ikke hører til dette
+                    // spørsmålet blir et nytt alternativ, ikke en skriving inn
+                    // i et annet skjema.
+                    if (optionData.id && existingOptionIds.has(optionData.id)) {
                         await db
                             .update(schema.formOption)
                             .set({

--- a/apps/api/src/routes/form/update.ts
+++ b/apps/api/src/routes/form/update.ts
@@ -6,6 +6,7 @@ import { HTTPException } from "hono/http-exception";
 import { FormHasSubmissionsException } from "~/lib/form/exceptions";
 import {
     canManageForm,
+    findDestructiveFieldChanges,
     resolveScheduledOpenState,
     updateFieldsAndOptions,
 } from "~/lib/form/service";
@@ -80,15 +81,18 @@ export const updateRoute = route().patch(
             where: eq(schema.formGroupForm.formId, formId),
         });
 
-        // Rewriting the questions deletes the answers hanging off them. Event
-        // forms are left alone here — organisers may edit a survey while
-        // registrations are open, and re-submitting replaces the old answer.
+        // Spørsmålene kan endres selv om skjemaet har svar — det er bare det å
+        // fjerne noe noen har svart på som stoppes. Event forms are left alone
+        // here — organisers may edit a survey while registrations are open, and
+        // re-submitting replaces the old answer.
         if (body.fields && groupForm) {
-            const answered = await db.query.formSubmission.findFirst({
-                where: eq(schema.formSubmission.formId, formId),
-            });
-            if (answered) {
-                throw new FormHasSubmissionsException();
+            const problems = await findDestructiveFieldChanges(
+                db,
+                formId,
+                body.fields,
+            );
+            if (problems.length > 0) {
+                throw new FormHasSubmissionsException(problems);
             }
         }
 

--- a/apps/api/src/test/form/answered-questions.test.ts
+++ b/apps/api/src/test/form/answered-questions.test.ts
@@ -1,0 +1,352 @@
+import { schema } from "@photon/db";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * Et gruppeskjema med svar er ikke frosset. Det som stoppes er endringene som
+ * ville tatt svar med seg — å fjerne et besvart spørsmål eller alternativ, og
+ * å bytte type på et besvart spørsmål. Resten, inkludert å stenge skjemaet,
+ * skal gå gjennom med svarene i behold.
+ */
+describe("Editing a group form that has answers", () => {
+    integrationTest(
+        "Closing the form and renaming questions keeps the submissions",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            const member = await ctx.utils.createTestUser();
+
+            await ctx.utils.setupGroups();
+            await ctx.db.insert(schema.groupMembership).values([
+                { userId: leader.id, groupSlug: "index", role: "leader" },
+                { userId: member.id, groupSlug: "index", role: "member" },
+            ]);
+
+            const leaderClient = await ctx.utils.clientForUser(leader);
+            const memberClient = await ctx.utils.clientForUser(member);
+
+            const createResponse = await leaderClient.api.groups[
+                ":slug"
+            ].forms.$post({
+                param: { slug: "index" },
+                json: {
+                    title: "Påmelding",
+                    template: false,
+                    group: "index",
+                    can_submit_multiple: false,
+                    is_open_for_submissions: true,
+                    only_for_group_members: false,
+                    fields: [
+                        {
+                            title: "Hva heter du?",
+                            type: "text_answer",
+                            required: true,
+                            order: 0,
+                        },
+                        {
+                            title: "Allergier?",
+                            type: "single_select",
+                            required: false,
+                            order: 1,
+                            options: [
+                                { title: "Ingen", order: 0 },
+                                { title: "Nøtter", order: 1 },
+                            ],
+                        },
+                    ],
+                },
+            });
+            expect(createResponse.status).toBe(201);
+            const form = await createResponse.json();
+            const textField = form.fields?.[0]!;
+            const selectField = form.fields?.[1]!;
+
+            const submitResponse = await memberClient.api.forms[
+                ":formId"
+            ].submissions.$post({
+                param: { formId: form.id! },
+                json: {
+                    answers: [
+                        {
+                            field: { id: textField.id },
+                            answer_text: "Kari",
+                        },
+                        {
+                            field: { id: selectField.id },
+                            selected_options: [
+                                { id: selectField.options?.[1]?.id! },
+                            ],
+                        },
+                    ],
+                },
+            });
+            expect(submitResponse.status).toBe(201);
+
+            // Å stenge skjemaet er ikke en endring av spørsmålene, og går
+            // gjennom selv om spørsmålene sendes med uendret.
+            const closeResponse = await leaderClient.api.forms[":id"].$patch({
+                param: { id: form.id! },
+                json: {
+                    is_open_for_submissions: false,
+                    fields: [
+                        {
+                            id: textField.id,
+                            title: "Hva heter du?",
+                            type: "text_answer",
+                            required: true,
+                            order: 0,
+                        },
+                        {
+                            id: selectField.id,
+                            title: "Allergier?",
+                            type: "single_select",
+                            required: false,
+                            order: 1,
+                            options: [
+                                {
+                                    id: selectField.options?.[0]?.id!,
+                                    title: "Ingen",
+                                    order: 0,
+                                },
+                                {
+                                    id: selectField.options?.[1]?.id!,
+                                    title: "Nøtter",
+                                    order: 1,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            });
+            expect(closeResponse.status).toBe(200);
+            expect((await closeResponse.json()).is_open_for_submissions).toBe(
+                false,
+            );
+
+            // Skrivefeil kan rettes, rekkefølgen endres, og nye spørsmål og
+            // alternativer legges til.
+            const editResponse = await leaderClient.api.forms[":id"].$patch({
+                param: { id: form.id! },
+                json: {
+                    fields: [
+                        {
+                            id: selectField.id,
+                            title: "Har du allergier?",
+                            type: "single_select",
+                            required: true,
+                            order: 0,
+                            options: [
+                                {
+                                    id: selectField.options?.[0]?.id!,
+                                    title: "Ingen allergier",
+                                    order: 0,
+                                },
+                                {
+                                    id: selectField.options?.[1]?.id!,
+                                    title: "Nøtter",
+                                    order: 1,
+                                },
+                                { title: "Melk", order: 2 },
+                            ],
+                        },
+                        {
+                            id: textField.id,
+                            title: "Navn",
+                            type: "text_answer",
+                            required: true,
+                            order: 1,
+                        },
+                        {
+                            title: "Kommentar",
+                            type: "text_answer",
+                            required: false,
+                            order: 2,
+                        },
+                    ],
+                },
+            });
+            expect(editResponse.status).toBe(200);
+            const edited = await editResponse.json();
+            expect(edited.fields?.map((f) => f.title)).toEqual([
+                "Har du allergier?",
+                "Navn",
+                "Kommentar",
+            ]);
+
+            // Svaret står igjen, med teksten og alternativet det ble sendt inn
+            // med — spørsmålene beholdt id-ene sine.
+            const submissionsResponse = await leaderClient.api.forms[
+                ":formId"
+            ].submissions.$get({ param: { formId: form.id! } });
+            expect(submissionsResponse.status).toBe(200);
+            const submissions = await submissionsResponse.json();
+            expect(submissions).toHaveLength(1);
+            const answers = submissions[0]?.answers ?? [];
+            expect(answers).toHaveLength(2);
+            expect(
+                answers.find((a) => a.field_id === textField.id)?.answer_text,
+            ).toBe("Kari");
+            expect(
+                answers.find((a) => a.field_id === selectField.id)
+                    ?.selected_options?.[0]?.title,
+            ).toBe("Nøtter");
+        },
+    );
+
+    integrationTest(
+        "Removing an answered question, option, or changing its type is rejected",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            const member = await ctx.utils.createTestUser();
+
+            await ctx.utils.setupGroups();
+            await ctx.db.insert(schema.groupMembership).values([
+                { userId: leader.id, groupSlug: "index", role: "leader" },
+                { userId: member.id, groupSlug: "index", role: "member" },
+            ]);
+
+            const leaderClient = await ctx.utils.clientForUser(leader);
+            const memberClient = await ctx.utils.clientForUser(member);
+
+            const createResponse = await leaderClient.api.groups[
+                ":slug"
+            ].forms.$post({
+                param: { slug: "index" },
+                json: {
+                    title: "Påmelding",
+                    template: false,
+                    group: "index",
+                    can_submit_multiple: false,
+                    is_open_for_submissions: true,
+                    only_for_group_members: false,
+                    fields: [
+                        {
+                            title: "Allergier?",
+                            type: "single_select",
+                            required: false,
+                            order: 0,
+                            options: [
+                                { title: "Ingen", order: 0 },
+                                { title: "Nøtter", order: 1 },
+                            ],
+                        },
+                        {
+                            title: "Ubesvart spørsmål",
+                            type: "text_answer",
+                            required: false,
+                            order: 1,
+                        },
+                    ],
+                },
+            });
+            expect(createResponse.status).toBe(201);
+            const form = await createResponse.json();
+            const selectField = form.fields?.[0]!;
+            const unansweredField = form.fields?.[1]!;
+            const chosenOption = selectField.options?.[1]!;
+
+            const submitResponse = await memberClient.api.forms[
+                ":formId"
+            ].submissions.$post({
+                param: { formId: form.id! },
+                json: {
+                    answers: [
+                        {
+                            field: { id: selectField.id },
+                            selected_options: [{ id: chosenOption.id }],
+                        },
+                    ],
+                },
+            });
+            expect(submitResponse.status).toBe(201);
+
+            const keepSelectField = {
+                id: selectField.id,
+                title: "Allergier?",
+                type: "single_select" as const,
+                required: false,
+                order: 0,
+                options: [
+                    {
+                        id: selectField.options?.[0]?.id!,
+                        title: "Ingen",
+                        order: 0,
+                    },
+                    { id: chosenOption.id, title: "Nøtter", order: 1 },
+                ],
+            };
+
+            // Spørsmålet noen har svart på er fjernet.
+            const removeField = await leaderClient.api.forms[":id"].$patch({
+                param: { id: form.id! },
+                json: { fields: [] },
+            });
+            expect(removeField.status).toBe(409);
+
+            // Alternativet noen har valgt er fjernet.
+            const removeOption = await leaderClient.api.forms[":id"].$patch({
+                param: { id: form.id! },
+                json: {
+                    fields: [
+                        {
+                            ...keepSelectField,
+                            options: [
+                                {
+                                    id: selectField.options?.[0]?.id!,
+                                    title: "Ingen",
+                                    order: 0,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            });
+            expect(removeOption.status).toBe(409);
+
+            // Typen på et besvart spørsmål er byttet.
+            const changeType = await leaderClient.api.forms[":id"].$patch({
+                param: { id: form.id! },
+                json: {
+                    fields: [
+                        {
+                            id: selectField.id,
+                            title: "Allergier?",
+                            type: "text_answer",
+                            required: false,
+                            order: 0,
+                        },
+                    ],
+                },
+            });
+            expect(changeType.status).toBe(409);
+
+            // Ingen av avvisningene skrev noe: spørsmålene og svaret står som
+            // før.
+            const detail = await leaderClient.api.forms[":id"].$get({
+                param: { id: form.id! },
+            });
+            expect((await detail.json()).fields).toHaveLength(2);
+
+            // Et spørsmål ingen har svart på kan fortsatt fjernes.
+            const removeUnanswered = await leaderClient.api.forms[":id"].$patch(
+                {
+                    param: { id: form.id! },
+                    json: { fields: [keepSelectField] },
+                },
+            );
+            expect(removeUnanswered.status).toBe(200);
+            const remaining = await removeUnanswered.json();
+            expect(remaining.fields).toHaveLength(1);
+            expect(remaining.fields?.[0]?.id).toBe(selectField.id);
+            expect(unansweredField.id).not.toBe(selectField.id);
+
+            const submissionsResponse = await leaderClient.api.forms[
+                ":formId"
+            ].submissions.$get({ param: { formId: form.id! } });
+            const submissions = await submissionsResponse.json();
+            expect(submissions).toHaveLength(1);
+            expect(
+                submissions[0]?.answers?.[0]?.selected_options?.[0]?.title,
+            ).toBe("Nøtter");
+        },
+    );
+});

--- a/apps/kvark/src/components/group-form-edit-dialog.tsx
+++ b/apps/kvark/src/components/group-form-edit-dialog.tsx
@@ -37,11 +37,7 @@ export type GroupFormEditValues = {
     onlyForMembers: boolean;
     /** Tom streng betyr «ingen varsling». */
     emailReceiver: string;
-    /**
-     * Utelatt når skjemaet allerede har svar. Da skal spørsmålene ikke sendes
-     * med i det hele tatt — API-et sletter svarene til spørsmål som forsvinner.
-     */
-    questions?: FormQuestionValues[];
+    questions: FormQuestionValues[];
 };
 
 const QUESTION_TYPES: { value: FormQuestionType; label: string }[] = [
@@ -207,11 +203,8 @@ type EditFormProps = {
 function useEditForm({
     form,
     questions,
-    answerCount,
     onSubmit,
-}: Pick<EditFormProps, "form" | "questions" | "answerCount" | "onSubmit">) {
-    const questionsLocked = answerCount > 0;
-
+}: Pick<EditFormProps, "form" | "questions" | "onSubmit">) {
     return useAppForm({
         defaultValues: {
             title: form.title,
@@ -233,7 +226,7 @@ function useEditForm({
                 canSubmitMultiple: value.canSubmitMultiple,
                 onlyForMembers: value.onlyForMembers,
                 emailReceiver: value.emailReceiver.trim(),
-                ...(questionsLocked ? {} : { questions: value.questions }),
+                questions: value.questions,
             });
         },
     });
@@ -253,7 +246,7 @@ function EditForm({
     isDeleting,
     deleteError,
 }: EditFormProps) {
-    const editForm = useEditForm({ form, questions, answerCount, onSubmit });
+    const editForm = useEditForm({ form, questions, onSubmit });
 
     return (
         <form {...formHandlers(editForm)} className="flex flex-col gap-6">
@@ -387,16 +380,20 @@ function EditForm({
             {answerCount > 0 ? (
                 <Alert>
                     <LockIcon />
-                    <AlertTitle>Spørsmålene er låst</AlertTitle>
-                    <AlertDescription>
+                    <AlertTitle>
                         Skjemaet har {answerCount}{" "}
-                        {answerCount === 1 ? "svar" : "svar"}. Å endre
-                        spørsmålene nå ville slettet svarene som hører til dem.
+                        {answerCount === 1 ? "svar" : "svar"}
+                    </AlertTitle>
+                    <AlertDescription>
+                        Du kan endre tekst, rekkefølge og «påkrevd», og legge
+                        til nye spørsmål og alternativer. Spørsmålene som
+                        allerede er besvart kan ikke fjernes eller bytte type —
+                        da ville svarene på dem forsvunnet.
                     </AlertDescription>
                 </Alert>
-            ) : (
-                <QuestionsEditor editForm={editForm} />
-            )}
+            ) : null}
+
+            <QuestionsEditor editForm={editForm} hasAnswers={answerCount > 0} />
 
             <DialogFooter>
                 {onRequestDelete ? (
@@ -435,8 +432,21 @@ function EditForm({
 /**
  * Spørsmålene redigeres som en liste: rekkefølgen i listen blir rekkefølgen i
  * skjemaet, og `order` settes av den som lagrer.
+ *
+ * `hasAnswers` sperrer det som ville tatt svar med seg. Sperringen gjelder alt
+ * som er lagret fra før, mens spørsmål og alternativer man legger til i denne
+ * runden kan fjernes igjen — ingen har rukket å svare på dem. API-et er
+ * finere kornet og slipper gjennom et lagret spørsmål ingen har svart på, men
+ * dialogen vet ikke hvilke det er, og velger heller å ikke friste med en
+ * knapp som kan gi 409.
  */
-function QuestionsEditor({ editForm }: { editForm: EditFormApi }) {
+function QuestionsEditor({
+    editForm,
+    hasAnswers,
+}: {
+    editForm: EditFormApi;
+    hasAnswers: boolean;
+}) {
     return (
         <editForm.Field name="questions" mode="array">
             {(questionList) => (
@@ -469,13 +479,14 @@ function QuestionsEditor({ editForm }: { editForm: EditFormApi }) {
                         </p>
                     ) : null}
 
-                    {questionList.state.value.map((_, index) => (
+                    {questionList.state.value.map((question, index) => (
                         <QuestionRow
                             // Indeksen er nøkkelen: et nytt spørsmål har ingen
                             // stabil id før det er lagret.
                             key={index}
                             editForm={editForm}
                             index={index}
+                            locked={hasAnswers && question.id !== undefined}
                             onRemove={() => questionList.removeValue(index)}
                         />
                     ))}
@@ -488,10 +499,13 @@ function QuestionsEditor({ editForm }: { editForm: EditFormApi }) {
 function QuestionRow({
     editForm,
     index,
+    locked,
     onRemove,
 }: {
     editForm: EditFormApi;
     index: number;
+    /** Spørsmålet er besvart: det kan endres, men ikke fjernes eller byttes. */
+    locked: boolean;
     onRemove: () => void;
 }) {
     return (
@@ -507,16 +521,18 @@ function QuestionRow({
                             </field.Field>
                         )}
                     </editForm.AppField>
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        aria-label={`Slett spørsmål ${index + 1}`}
-                        className="mt-6"
-                        onClick={onRemove}
-                    >
-                        <TrashIcon />
-                    </Button>
+                    {locked ? null : (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            aria-label={`Slett spørsmål ${index + 1}`}
+                            className="mt-6"
+                            onClick={onRemove}
+                        >
+                            <TrashIcon />
+                        </Button>
+                    )}
                 </div>
 
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
@@ -524,7 +540,15 @@ function QuestionRow({
                         {(field) => (
                             <field.Field className="flex-1">
                                 <field.Label>Type</field.Label>
-                                <field.Select options={QUESTION_TYPES} />
+                                <field.Select
+                                    options={QUESTION_TYPES}
+                                    disabled={locked}
+                                />
+                                {locked ? (
+                                    <field.Description>
+                                        Låst fordi spørsmålet er besvart
+                                    </field.Description>
+                                ) : null}
                                 <field.Error />
                             </field.Field>
                         )}
@@ -546,7 +570,11 @@ function QuestionRow({
                 >
                     {(type) =>
                         type === "text_answer" || type === undefined ? null : (
-                            <OptionsEditor editForm={editForm} index={index} />
+                            <OptionsEditor
+                                editForm={editForm}
+                                index={index}
+                                lockSaved={locked}
+                            />
                         )
                     }
                 </editForm.Subscribe>
@@ -558,15 +586,18 @@ function QuestionRow({
 function OptionsEditor({
     editForm,
     index,
+    lockSaved,
 }: {
     editForm: EditFormApi;
     index: number;
+    /** Alternativer som allerede er lagret kan ikke fjernes; nye kan. */
+    lockSaved: boolean;
 }) {
     return (
         <editForm.Field name={`questions[${index}].options`} mode="array">
             {(optionList) => (
                 <div className="flex flex-col gap-2">
-                    {optionList.state.value.map((_, optionIndex) => (
+                    {optionList.state.value.map((option, optionIndex) => (
                         <div key={optionIndex} className="flex items-end gap-2">
                             <editForm.AppField
                                 name={`questions[${index}].options[${optionIndex}].title`}
@@ -581,17 +612,19 @@ function OptionsEditor({
                                     </field.Field>
                                 )}
                             </editForm.AppField>
-                            <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                aria-label={`Slett alternativ ${optionIndex + 1}`}
-                                onClick={() =>
-                                    optionList.removeValue(optionIndex)
-                                }
-                            >
-                                <TrashIcon />
-                            </Button>
+                            {lockSaved && option.id !== undefined ? null : (
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    aria-label={`Slett alternativ ${optionIndex + 1}`}
+                                    onClick={() =>
+                                        optionList.removeValue(optionIndex)
+                                    }
+                                >
+                                    <TrashIcon />
+                                </Button>
+                            )}
                         </div>
                     ))}
                     {optionList.state.value.length === 0 ? (

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -548,9 +548,10 @@ function GroupDetail() {
     }
 
     /**
-     * Spørsmålene sendes bare når dialogen faktisk lot noen endre dem:
-     * `updateFieldsAndOptions` sletter spørsmål som mangler i lista, og med
-     * dem svarene som hører til.
+     * Spørsmålene sendes alltid med, id-ene inkludert: `updateFieldsAndOptions`
+     * kjenner igjen spørsmål og alternativer på id og lar svarene stå. API-et
+     * avviser bare endringene som ville tatt svar med seg — se
+     * `findDestructiveFieldChanges`.
      */
     async function handleSaveForm(values: GroupFormEditValues) {
         if (!editingForm) return;
@@ -568,9 +569,7 @@ function GroupDetail() {
                     can_submit_multiple: values.canSubmitMultiple,
                     only_for_group_members: values.onlyForMembers,
                     email_receiver_on_submit: values.emailReceiver || null,
-                    ...(values.questions
-                        ? { fields: toFormFieldsPayload(values.questions) }
-                        : {}),
+                    fields: toFormFieldsPayload(values.questions),
                 },
             });
             setEditingForm(null);


### PR DESCRIPTION
## Problem

Et gruppeskjema med minst ett svar var helt frosset. Enhver `PATCH` med `fields` ga 409, og redigeringsdialogen erstattet hele spørsmålseditoren med «Spørsmålene er låst — å endre spørsmålene nå ville slettet svarene som hører til dem». Det gjorde det umulig å rette en skrivefeil eller legge til et spørsmål, og det så ut som om selv det å stenge skjemaet kunne ta svarene med seg.

Det er strengere enn nødvendig: `updateFieldsAndOptions` kjenner igjen spørsmål og alternativer på id, så tittel, rekkefølge og «påkrevd» kan endres uten at noe forsvinner.

## Løsning

`findDestructiveFieldChanges` avviser bare endringene som faktisk sletter svar:

- et besvart spørsmål er fjernet fra lista (`answer.field_id` ville blitt null)
- et valgt alternativ er fjernet (kaskaderer til `answer_option`)
- et besvart spørsmål bytter type (alternativene slettes uansett)

Alt annet går gjennom — stenging, tittel, beskrivelse, rekkefølge, «påkrevd», nye spørsmål og alternativer, og fjerning av spørsmål/alternativer ingen har svart på. 409-meldingen navngir spørsmålet eller alternativet i stedet for å si at alt er låst.

Dialogen viser derfor spørsmålene også når skjemaet har svar. Lagrede spørsmål mister slettknappen og får låst typevelger («Låst fordi spørsmålet er besvart»), lagrede alternativer mister slettknappen; nye er fritt redigerbare. Frontend er litt strengere enn API-et — den vet ikke hvilke lagrede spørsmål som faktisk er besvart, og velger å ikke friste med en knapp som kan gi 409.

## Sidefunn

`updateFieldsAndOptions` oppdaterte spørsmål og alternativer på id alene, uten å sjekke at de hørte til skjemaet som ble oppdatert — en payload med en id fra et annet skjema skrev inn i det. Slike id-er behandles nå som nye.

## Verifisert

- Ny integrasjonstest `answered-questions.test.ts`: stenging + omdøping + omrokering beholder innsending og svar; fjerning/typebytte gir 409 uten å skrive noe; ubesvart spørsmål kan fortsatt fjernes. Alle 9 form-tester passerer.
- `bun run typecheck` grønt, lint og format rent.
- I nettleseren mot lokal dev-DB: åpnet et skjema med 64 svar som gruppeleder, rettet tittelen på ett spørsmål og lagret. Feltet beholdt id-en, og 64 innsendinger / 320 svar sto urørt etterpå.

🤖 Generated with [Claude Code](https://claude.com/claude-code)