### PR TITLE
fix(kvark): la ikke ett feilende API-kall velte hele sida, og gi 404 en vei tilbake

### DIFF
--- a/apps/kvark/src/components/route-error.tsx
+++ b/apps/kvark/src/components/route-error.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@tihlde/ui/ui/button";
+import {
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from "@tihlde/ui/ui/empty";
+import { TriangleAlertIcon } from "lucide-react";
+
+type RouteErrorProps = {
+    /**
+     * Teknisk feilmelding. Send den bare inn i utvikling — den sier ingenting
+     * til folk som bare skulle lese sida.
+     */
+    detail?: string;
+    onRetry: () => void;
+};
+
+/**
+ * Vist når en rute ikke fikk lastet dataene sine, i stedet for TanStack
+ * Routers innebygde «Something went wrong!» — som er uoversatt, ustylet og
+ * ikke gir noen vei videre.
+ */
+export function RouteError({ detail, onRetry }: RouteErrorProps) {
+    return (
+        <Empty className="py-16">
+            <EmptyHeader>
+                <EmptyMedia variant="icon">
+                    <TriangleAlertIcon />
+                </EmptyMedia>
+                <EmptyTitle>Vi fikk ikke lastet siden</EmptyTitle>
+                <EmptyDescription>
+                    Som regel går det over av seg selv. Prøv igjen.
+                </EmptyDescription>
+                {detail ? <EmptyDescription>{detail}</EmptyDescription> : null}
+            </EmptyHeader>
+            <Button onClick={onRetry}>Prøv igjen</Button>
+        </Empty>
+    );
+}

--- a/apps/kvark/src/components/route-not-found.tsx
+++ b/apps/kvark/src/components/route-not-found.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@tihlde/ui/ui/button";
+import {
+    Empty,
+    EmptyContent,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from "@tihlde/ui/ui/empty";
+import { MapPinOffIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+type RouteNotFoundProps = {
+    onBack: () => void;
+    /**
+     * Sekundærhandlingen. Sendes inn av kalleren fordi den kjenner rutene —
+     * denne komponenten skal bare vise dem.
+     */
+    children?: ReactNode;
+};
+
+/**
+ * Vist når adressen ikke finnes. Erstatter TanStack Routers innebygde
+ * `<p>Not Found</p>`, som er uoversatt, ustylet og lar folk stå fast.
+ */
+export function RouteNotFound({ onBack, children }: RouteNotFoundProps) {
+    return (
+        <Empty className="py-16">
+            <EmptyHeader>
+                <EmptyMedia variant="icon">
+                    <MapPinOffIcon />
+                </EmptyMedia>
+                <EmptyTitle>Fant ikke siden</EmptyTitle>
+                <EmptyDescription>
+                    Lenken kan være gammel, eller adressen feilskrevet.
+                </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+                <Button onClick={onBack}>Gå tilbake</Button>
+                {children}
+            </EmptyContent>
+        </Empty>
+    );
+}

--- a/apps/kvark/src/components/section-error.tsx
+++ b/apps/kvark/src/components/section-error.tsx
@@ -1,0 +1,21 @@
+import { Empty, EmptyDescription, EmptyHeader } from "@tihlde/ui/ui/empty";
+
+type SectionErrorProps = {
+    /** Hva som ikke lot seg laste, sett fra leseren. */
+    message: string;
+};
+
+/**
+ * Vist i stedet for en enkelt seksjon som ikke fikk hentet dataene sine.
+ * Motstykket til [RouteError](./route-error.tsx): den tar hele sida, denne
+ * lar resten av sida stå og innrømmer bare at én bit mangler.
+ */
+export function SectionError({ message }: SectionErrorProps) {
+    return (
+        <Empty>
+            <EmptyHeader>
+                <EmptyDescription>{message}</EmptyDescription>
+            </EmptyHeader>
+        </Empty>
+    );
+}

--- a/apps/kvark/src/routeTree.gen.ts
+++ b/apps/kvark/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AuthRouteImport } from './routes/_auth'
 import { Route as DevRouteImport } from './routes/_dev'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as AppIndexRouteImport } from './routes/_app/index'
+import { Route as AppSplatRouteImport } from './routes/_app/$'
 import { Route as AppKokebokRouteImport } from './routes/_app/kokebok'
 import { Route as AppKontraktRouteImport } from './routes/_app/kontrakt'
 import { Route as AppNyStudentRouteImport } from './routes/_app/ny-student'
@@ -104,6 +105,11 @@ const AdminRoute = AdminRouteImport.update({
 const AppIndexRoute = AppIndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppSplatRoute = AppSplatRouteImport.update({
+  id: '/$',
+  path: '/$',
   getParentRoute: () => AppRoute,
 } as any)
 const AppKokebokRoute = AppKokebokRouteImport.update({
@@ -460,6 +466,7 @@ const AppSporreskjemaIdSvarRoute = AppSporreskjemaIdSvarRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof AppIndexRoute
   '/admin': typeof AdminRouteWithChildren
+  '/$': typeof AppSplatRoute
   '/kokebok': typeof AppKokebokRouteWithChildren
   '/kontrakt': typeof AppKontraktRoute
   '/ny-student': typeof AppNyStudentRoute
@@ -531,6 +538,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof AppIndexRoute
+  '/$': typeof AppSplatRoute
   '/kokebok': typeof AppKokebokRouteWithChildren
   '/kontrakt': typeof AppKontraktRoute
   '/ny-student': typeof AppNyStudentRoute
@@ -605,6 +613,7 @@ export interface FileRoutesById {
   '/_auth': typeof AuthRouteWithChildren
   '/_dev': typeof DevRouteWithChildren
   '/admin': typeof AdminRouteWithChildren
+  '/_app/$': typeof AppSplatRoute
   '/_app/kokebok': typeof AppKokebokRouteWithChildren
   '/_app/kontrakt': typeof AppKontraktRoute
   '/_app/ny-student': typeof AppNyStudentRoute
@@ -681,6 +690,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/admin'
+    | '/$'
     | '/kokebok'
     | '/kontrakt'
     | '/ny-student'
@@ -752,6 +762,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/$'
     | '/kokebok'
     | '/kontrakt'
     | '/ny-student'
@@ -825,6 +836,7 @@ export interface FileRouteTypes {
     | '/_auth'
     | '/_dev'
     | '/admin'
+    | '/_app/$'
     | '/_app/kokebok'
     | '/_app/kontrakt'
     | '/_app/ny-student'
@@ -939,6 +951,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof AppIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/$': {
+      id: '/_app/$'
+      path: '/$'
+      fullPath: '/$'
+      preLoaderRoute: typeof AppSplatRouteImport
       parentRoute: typeof AppRoute
     }
     '/_app/kokebok': {
@@ -1520,6 +1539,7 @@ const AppProfilIdRouteWithChildren = AppProfilIdRoute._addFileChildren(
 )
 
 interface AppRouteChildren {
+  AppSplatRoute: typeof AppSplatRoute
   AppKokebokRoute: typeof AppKokebokRouteWithChildren
   AppKontraktRoute: typeof AppKontraktRoute
   AppNyStudentRoute: typeof AppNyStudentRoute
@@ -1552,6 +1572,7 @@ interface AppRouteChildren {
 }
 
 const AppRouteChildren: AppRouteChildren = {
+  AppSplatRoute: AppSplatRoute,
   AppKokebokRoute: AppKokebokRouteWithChildren,
   AppKontraktRoute: AppKontraktRoute,
   AppNyStudentRoute: AppNyStudentRoute,

--- a/apps/kvark/src/router.tsx
+++ b/apps/kvark/src/router.tsx
@@ -1,8 +1,32 @@
-import { createRouter as createTanStackRouter } from "@tanstack/react-router";
+import {
+    type ErrorComponentProps,
+    createRouter as createTanStackRouter,
+    useRouter,
+} from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import * as TanstackQuery from "#/integrations/tanstack-query";
+import { RouteError } from "#/components/route-error";
+
+/**
+ * Feilgrensa for alle ruter som ikke har sin egen `errorComponent` — altså
+ * alle. Uten den faller de tilbake på TanStack Routers innebygde boks, og ett
+ * feilende API-kall i en loader bytter hele sida ut med en engelsk
+ * debug-melding. Det traff folk under nettverksbruddet 16. august 2026.
+ */
+function DefaultRouteError({ error }: ErrorComponentProps) {
+    const router = useRouter();
+
+    return (
+        <RouteError
+            // `invalidate` kjører loaderen på nytt og nullstiller feilgrensa
+            // selv, så knappen trenger ikke røre `reset`.
+            onRetry={() => void router.invalidate()}
+            detail={import.meta.env.DEV ? error.message : undefined}
+        />
+    );
+}
 
 export function getRouter() {
     const queryContext = TanstackQuery.getContext();
@@ -13,6 +37,7 @@ export function getRouter() {
         scrollRestoration: true,
         defaultPreload: "intent",
         defaultPreloadStaleTime: 0,
+        defaultErrorComponent: DefaultRouteError,
         Wrap({ children }) {
             return (
                 <TanstackQuery.Provider {...queryContext}>

--- a/apps/kvark/src/router.tsx
+++ b/apps/kvark/src/router.tsx
@@ -1,13 +1,16 @@
 import {
     type ErrorComponentProps,
+    Link,
     createRouter as createTanStackRouter,
     useRouter,
 } from "@tanstack/react-router";
+import { Button } from "@tihlde/ui/ui/button";
 import { routeTree } from "./routeTree.gen";
 
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import * as TanstackQuery from "#/integrations/tanstack-query";
 import { RouteError } from "#/components/route-error";
+import { RouteNotFound } from "#/components/route-not-found";
 
 /**
  * Feilgrensa for alle ruter som ikke har sin egen `errorComponent` — altså
@@ -28,6 +31,30 @@ function DefaultRouteError({ error }: ErrorComponentProps) {
     );
 }
 
+/**
+ * Vist for adresser som ikke finnes. Uten den er svaret TanStack Routers
+ * `<p>Not Found</p>` — naken engelsk tekst uten vei videre.
+ */
+function DefaultRouteNotFound() {
+    const router = useRouter();
+
+    return (
+        <RouteNotFound
+            // Kom du rett hit — fra en gammel lenke, et bokmerke eller en
+            // feilskrevet adresse — finnes det ingen historikk å gå tilbake
+            // til. Da sender vi til forsida i stedet for å gjøre ingenting.
+            onBack={() => {
+                if (router.history.canGoBack()) router.history.back();
+                else void router.navigate({ to: "/" });
+            }}
+        >
+            <Button variant="outline" render={<Link to="/" />}>
+                Til forsida
+            </Button>
+        </RouteNotFound>
+    );
+}
+
 export function getRouter() {
     const queryContext = TanstackQuery.getContext();
 
@@ -38,6 +65,7 @@ export function getRouter() {
         defaultPreload: "intent",
         defaultPreloadStaleTime: 0,
         defaultErrorComponent: DefaultRouteError,
+        defaultNotFoundComponent: DefaultRouteNotFound,
         Wrap({ children }) {
             return (
                 <TanstackQuery.Provider {...queryContext}>

--- a/apps/kvark/src/routes/_app/$.tsx
+++ b/apps/kvark/src/routes/_app/$.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+
+/**
+ * Fanger adresser som ikke treffer noen rute. Uten den havner 404-en på
+ * rot-ruta, utenfor `_app`, og da vises den naken uten header og footer —
+ * altså uten noen av lenkene folk trenger for å komme seg videre.
+ *
+ * Selve visningen er routerens `defaultNotFoundComponent`, så den er lik her
+ * som for `notFound()` kastet fra en loader.
+ */
+export const Route = createFileRoute("/_app/$")({
+    loader: () => {
+        throw notFound();
+    },
+});

--- a/apps/kvark/src/routes/_app/bedrift.index.tsx
+++ b/apps/kvark/src/routes/_app/bedrift.index.tsx
@@ -1,4 +1,4 @@
-import { Link, createFileRoute } from "@tanstack/react-router";
+import { CatchBoundary, Link, createFileRoute } from "@tanstack/react-router";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { Button } from "@tihlde/ui/ui/button";
@@ -17,6 +17,7 @@ import { CompanyContactForm } from "#/components/company-contact-form";
 import { CompanyOfferCard } from "#/components/company-offer-card";
 import { HeroSectionBackground } from "#/components/hero-section";
 import { JobCard } from "#/components/job-card";
+import { SectionError } from "#/components/section-error";
 import { StudyProgrammeCard } from "#/components/study-programme-card";
 import {
     COMPANY_EVENT_TYPES,
@@ -35,10 +36,10 @@ const EVENT_TYPE_OPTIONS = COMPANY_EVENT_TYPES.map((type) => ({
 
 export const Route = createFileRoute("/_app/bedrift/")({
     component: CompanyLandingPage,
-    loader: ({ context }) =>
-        context.queryClient.ensureQueryData(
-            getJobsQuery(0, {}, JOB_PREVIEW_COUNT),
-        ),
+    // Sida er i hovedsak fast innhold og et kontaktskjema som ikke henter
+    // noe. Stillingene er den eneste biten som spør API-et, og de får hente
+    // seg selv bak sin egen Suspense- og feilgrense — et nede endepunkt skal
+    // ikke ta med seg kontaktskjemaet, som er grunnen til at sida finnes.
 });
 
 function CompanyLandingPage() {
@@ -91,9 +92,16 @@ function CompanyLandingPage() {
                         de beste kandidatene!
                     </p>
                 </div>
-                <Suspense fallback={<JobPreviewSkeleton />}>
-                    <JobPreview />
-                </Suspense>
+                <CatchBoundary
+                    getResetKey={() => "jobs"}
+                    errorComponent={() => (
+                        <SectionError message="Vi fikk ikke lastet stillingene." />
+                    )}
+                >
+                    <Suspense fallback={<JobPreviewSkeleton />}>
+                        <JobPreview />
+                    </Suspense>
+                </CatchBoundary>
             </section>
 
             <section className="container mx-auto flex max-w-5xl flex-col gap-4 px-4 py-16">

--- a/apps/kvark/src/routes/_app/index.tsx
+++ b/apps/kvark/src/routes/_app/index.tsx
@@ -1,5 +1,10 @@
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { Link, type LinkProps, createFileRoute } from "@tanstack/react-router";
+import {
+    CatchBoundary,
+    Link,
+    type LinkProps,
+    createFileRoute,
+} from "@tanstack/react-router";
 import { Button } from "@tihlde/ui/ui/button";
 import { EventCalendar } from "@tihlde/ui/complex/event-calendar";
 import { Reveal, Stagger } from "@tihlde/ui/ui/motion";
@@ -16,6 +21,7 @@ import { getVisibleBannersQuery } from "#/api/queries/banners";
 import { EventCard } from "#/components/event-card";
 import { InfoBanner } from "#/components/info-banner";
 import { NewsCard } from "#/components/news-card";
+import { SectionError } from "#/components/section-error";
 import { TihldeLogo } from "#/components/icons/tihlde";
 import { HeroSectionBackground } from "#/components/hero-section";
 import { formatEventDateTime } from "#/lib/event";
@@ -36,13 +42,11 @@ const latestNewsQuery = () => getNewsQuery(0, {}, NEWS_PREVIEW_COUNT);
 
 export const Route = createFileRoute("/_app/")({
     component: Home,
-    loader: async ({ context }) => {
-        await Promise.all([
-            context.queryClient.ensureQueryData(upcomingEventsQuery()),
-            context.queryClient.ensureQueryData(getVisibleBannersQuery()),
-            context.queryClient.ensureQueryData(latestNewsQuery()),
-        ]);
-    },
+    // Bare arrangementene blokkerer — de er grunnen til at forsida finnes.
+    // Bannere og nyheter henter seg selv bak hver sin Suspense- og feilgrense,
+    // så et feilende kall der koster oss den seksjonen og ikke hele sida.
+    loader: ({ context }) =>
+        context.queryClient.ensureQueryData(upcomingEventsQuery()),
 });
 
 function Home() {
@@ -57,10 +61,16 @@ function Home() {
 
     return (
         <>
-            {/* Preloaded in the route loader, so the fallback never flashes. */}
-            <Suspense fallback={null}>
-                <BannersSection />
-            </Suspense>
+            {/* Bannere er beskjeder vi av og til har. Både mens de lastes og
+             * hvis de feiler er riktig svar det samme: ingenting. */}
+            <CatchBoundary
+                getResetKey={() => "banners"}
+                errorComponent={() => null}
+            >
+                <Suspense fallback={null}>
+                    <BannersSection />
+                </Suspense>
+            </CatchBoundary>
 
             <Hero />
 
@@ -84,9 +94,14 @@ function Home() {
                     actionTo="/admin/nyheter"
                     actionSearch={{ ny: true }}
                 />
-                <Suspense fallback={<NewsSkeleton />}>
-                    <NewsSection />
-                </Suspense>
+                <CatchBoundary
+                    getResetKey={() => "news"}
+                    errorComponent={NewsUnavailable}
+                >
+                    <Suspense fallback={<NewsSkeleton />}>
+                        <NewsSection />
+                    </Suspense>
+                </CatchBoundary>
             </section>
         </>
     );
@@ -183,6 +198,11 @@ function NewsSection() {
             ))}
         </Stagger>
     );
+}
+
+/** Nyhetene er ikke verdt en feilside — vi sier fra og lar resten stå. */
+function NewsUnavailable() {
+    return <SectionError message="Vi fikk ikke lastet nyhetene." />;
 }
 
 function NewsSkeleton() {

--- a/apps/kvark/src/routes/_app/ny-student.tsx
+++ b/apps/kvark/src/routes/_app/ny-student.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { Link, createFileRoute } from "@tanstack/react-router";
+import { CatchBoundary, Link, createFileRoute } from "@tanstack/react-router";
 import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent } from "@tihlde/ui/ui/card";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
@@ -185,9 +185,16 @@ function NewStudentPage() {
                 </Suspense>
             </section>
 
-            <Suspense fallback={null}>
-                <LatestToddelSection />
-            </Suspense>
+            {/* Seksjonen skjuler seg selv når det ikke er noe å vise, så en
+             * feil skal føre til det samme — ikke til at hele sida ryker. */}
+            <CatchBoundary
+                getResetKey={() => "toddel"}
+                errorComponent={() => null}
+            >
+                <Suspense fallback={null}>
+                    <LatestToddelSection />
+                </Suspense>
+            </CatchBoundary>
 
             <section className="container mx-auto flex max-w-5xl flex-col gap-8 px-4 py-16">
                 <h2 className="text-center text-2xl md:text-4xl">

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -103,8 +103,16 @@ export const Route = createFileRoute("/admin/arrangementer/$eventId")({
         const event = await context.queryClient.ensureQueryData(
             getEventByIdQuery(params.eventId),
         );
-        void context.queryClient.ensureQueryData(getGroupsQuery(0));
-        void context.queryClient.ensureQueryData(getInstitutesQuery());
+        // Varmer cachen til detaljfanen uten å blokkere. Feiler de, tar
+        // `DetailsTab` det med sin egen Suspense-grense — men løftet må
+        // fanges her, ellers står vi igjen med en ubehandlet avvisning som
+        // kan felle SSR-prosessen.
+        void context.queryClient
+            .ensureQueryData(getGroupsQuery(0))
+            .catch(() => {});
+        void context.queryClient
+            .ensureQueryData(getInstitutesQuery())
+            .catch(() => {});
         return { breadcrumbs: event.title };
     },
 });

--- a/apps/kvark/src/routes/admin/index.tsx
+++ b/apps/kvark/src/routes/admin/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { CatchBoundary, createFileRoute, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { nb } from "date-fns/locale";
@@ -26,31 +26,20 @@ import { getEventsQuery } from "#/api/queries/events";
 import { getGroupsQuery } from "#/api/queries/groups";
 import { getJobsQuery } from "#/api/queries/jobs";
 import { getNewsQuery } from "#/api/queries/news";
-import { authClient, sessionHasPermissionInAnyScope } from "#/api/auth";
+import { SectionError } from "#/components/section-error";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 import { ADMIN_SECTION_PERMISSIONS } from "#/lib/admin-sections";
 
 export const Route = createFileRoute("/admin/")({
     component: DashboardPage,
-    loader: async ({ context }) => {
-        // Only prefetch what the viewer may read. `/api/contracts` answers 403
-        // without `contracts:view`, and prefetching it unconditionally took
-        // the whole dashboard down with an error for everyone else.
-        const auth = await authClient();
-        const mayRead = (permission: string | readonly string[]) =>
-            sessionHasPermissionInAnyScope(auth?.permissions, permission);
-
-        await Promise.all([
-            context.queryClient.ensureQueryData(getEventsQuery(0)),
-            context.queryClient.ensureQueryData(getNewsQuery(0)),
-            context.queryClient.ensureQueryData(getJobsQuery(0)),
-            context.queryClient.ensureQueryData(getGroupsQuery(0)),
-            ...(mayRead(ADMIN_SECTION_PERMISSIONS.opptak)
-                ? [context.queryClient.ensureQueryData(getContractListQuery())]
-                : []),
-        ]);
-        return { breadcrumbs: "Dashboard" };
-    },
+    // Dashbordet er en samling uavhengige widgeter, og ingen av dem er sida.
+    // Derfor blokkerer loaderen ikke på noe: hver widget henter selv bak sin
+    // egen Suspense- og feilgrense, så ett feilende endepunkt koster oss den
+    // ene widgeten. Tidligere prefetchet loaderen alt under ett `Promise.all`,
+    // og da tok `/api/contracts` med seg hele dashbordet for alle uten
+    // `contracts:view` — se `ContractsStatCard`, som fortsatt er skilt ut for
+    // at den spørringen ikke skal kjøre for andre i det hele tatt.
+    loader: () => ({ breadcrumbs: "Dashboard" }),
 });
 
 function DashboardPage() {
@@ -78,21 +67,57 @@ function DashboardPage() {
                 }
             />
 
-            <Suspense fallback={<StatsSkeleton />}>
-                <StatsGrid />
-            </Suspense>
+            <CatchBoundary
+                getResetKey={() => "stats"}
+                errorComponent={() => (
+                    <SectionError message="Vi fikk ikke lastet tallene." />
+                )}
+            >
+                <Suspense fallback={<StatsSkeleton />}>
+                    <StatsGrid />
+                </Suspense>
+            </CatchBoundary>
 
             <QuickActions />
 
             <div className="grid gap-6 lg:grid-cols-2">
-                <Suspense fallback={<ListCardSkeleton />}>
-                    <RecentEvents />
-                </Suspense>
-                <Suspense fallback={<ListCardSkeleton />}>
-                    <RecentNews />
-                </Suspense>
+                <CatchBoundary
+                    getResetKey={() => "recent-events"}
+                    errorComponent={() => (
+                        <CardError title="Siste arrangementer" />
+                    )}
+                >
+                    <Suspense fallback={<ListCardSkeleton />}>
+                        <RecentEvents />
+                    </Suspense>
+                </CatchBoundary>
+                <CatchBoundary
+                    getResetKey={() => "recent-news"}
+                    errorComponent={() => <CardError title="Siste nyheter" />}
+                >
+                    <Suspense fallback={<ListCardSkeleton />}>
+                        <RecentNews />
+                    </Suspense>
+                </CatchBoundary>
             </div>
         </Stagger>
+    );
+}
+
+/**
+ * Feilet innhold i et av korta i rutenettet. Kortet beholder tittelen og
+ * plassen sin, så resten av dashbordet ikke hopper.
+ */
+function CardError({ title }: { title: string }) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>{title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <SectionError message="Vi fikk ikke lastet dette." />
+            </CardContent>
+        </Card>
     );
 }
 


### PR DESCRIPTION
## Bakgrunn

16. august ca. 17:15 fikk Evine «Something went wrong!» på forsida. Teksten er ikke vår — det er TanStack Routers innebygde feilkomponent, som vises når en rute kaster og ingen `errorComponent` er definert. Ingen rute i Kvark definerte en.

Selve utløseren var et nettverksbrudd mot API-et og utenfor vår kontroll. Det som er vårt, er at et kort brudd byttet ut hele forsida med en ustylet engelsk debug-boks uten vei videre.

## Hva som var galt

Loaderen på forsida ventet på tre uavhengige kall under ett `Promise.all`. Ett feilende kall — også banneret, som er det minst kritiske på sida — avviste hele loaderen og sendte ruta til feilgrensa.

En gjennomgang av alle 45 ruter med loader fant det samme mønsteret tre steder til:

| Rute | Konsekvens av ett nede endepunkt |
|---|---|
| `_app/index` | Bannere eller nyheter tok forsida |
| `admin/index` | Ett av fem kall tok hele dashbordet |
| `_app/bedrift.index` | `/api/jobs` tok kontaktskjemaet, sidas konverteringspunkt |
| `_app/ny-student` | `/api/toddel` tok landingssida for nye studenter |

De 40 rutene med én `ensureQueryData` er riktige som de er — der *er* spørringen sida.

I tillegg hadde `admin/arrangementer/$eventId` to `void ensureQueryData(...)` uten `.catch`. Feiler de, står vi igjen med en ubehandlet løfteavvisning, som i SSR kan felle prosessen.

## Hva som er gjort

**Commit 1 — feilgrenser.** `defaultErrorComponent` på routeren: norsk tekst, TIHLDE-design, «Prøv igjen» som kaller `router.invalidate()`. Loaderne blokkerer nå bare på det sida faktisk er, og de supplerende seksjonene har fått hver sin `CatchBoundary`.

Det holdt ikke å fjerne dem fra loaderen alene: `useSuspenseQuery` kaster forbi `<Suspense>`, så uten feilgrense ville feilen bare truffet rute-grensa litt senere i stedet.

**Commit 2 — 404.** Døde lenker svarte med `<p>Not Found</p>`, rendret utenfor app-skallet. Nå: «Fant ikke siden» med «Gå tilbake» som primærhandling og «Til forsida» som sekundær. Kommer du rett inn fra en gammel lenke finnes ingen historikk, og knappen sender til forsida i stedet for å gjøre ingenting. Splat-ruta `_app/$` sørger for at 404-en vises med header og footer.

## Verifisering

Kjørt mot lokal app med ekte API.

- API nede → forsida viser den nye boksen med skallet intakt; «Prøv igjen» hentet inn hele sida uten reload etter at API-et kom opp
- Nyhetskallet tvunget til å feile på dashbordet → tallene og nyhetskortet degraderte hver for seg, mens «Siste arrangementer», hurtighandlinger og header sto urørt
- API utilgjengelig → `/bedrift` svarer **200 med sida intakt**, mens `/` og `/ny-student` gir 500 fordi de faktisk ikke kan vise noe. Nøyaktig forskjellen endringen skulle lage
- 404: «Gå tilbake» etter klient-navigasjon → forrige side; etter direkte innlasting → forsida, fortsatt på domenet
- Splat-ruta skygger ingenting: 14 ekte ruter fra `/` til `/admin` treffer sin egen rute, mens `/admin/tull` og `/dyp/sti/som/ikke/finnes` svarer 404 med den nye sida

`typecheck` (9/9), `build` (4/4), `lint` og `format` grønne, null nye funn i kvark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)