### PR TITLE
style(kvark): still 404-knappene side om side og gi sida mer tyngde

### DIFF
--- a/apps/kvark/src/components/route-not-found.tsx
+++ b/apps/kvark/src/components/route-not-found.tsx
@@ -25,18 +25,24 @@ type RouteNotFoundProps = {
  */
 export function RouteNotFound({ onBack, children }: RouteNotFoundProps) {
     return (
-        <Empty className="py-16">
-            <EmptyHeader>
-                <EmptyMedia variant="icon">
-                    <MapPinOffIcon />
+        <Empty className="min-h-[60vh] gap-6 py-24">
+            <EmptyHeader className="max-w-md gap-3">
+                <EmptyMedia variant="icon" className="size-12">
+                    <MapPinOffIcon className="size-6" />
                 </EmptyMedia>
                 <EmptyTitle>Fant ikke siden</EmptyTitle>
                 <EmptyDescription>
                     Lenken kan være gammel, eller adressen feilskrevet.
                 </EmptyDescription>
             </EmptyHeader>
-            <EmptyContent>
-                <Button onClick={onBack}>Gå tilbake</Button>
+            {/* Handlingene står side om side og deler bredden likt.
+             * `items-stretch` gir dem samme høyde uansett hvilken størrelse
+             * kalleren gir sekundærknappen, og `flex-1` på barna sparer
+             * kalleren for å måtte vite om bredden i det hele tatt. */}
+            <EmptyContent className="w-full max-w-md flex-row items-stretch justify-center gap-3 [&>*]:flex-1">
+                <Button size="lg" onClick={onBack}>
+                    Gå tilbake
+                </Button>
                 {children}
             </EmptyContent>
         </Empty>

--- a/apps/kvark/src/router.tsx
+++ b/apps/kvark/src/router.tsx
@@ -48,7 +48,7 @@ function DefaultRouteNotFound() {
                 else void router.navigate({ to: "/" });
             }}
         >
-            <Button variant="outline" render={<Link to="/" />}>
+            <Button size="lg" variant="outline" render={<Link to="/" />}>
                 Til forsida
             </Button>
         </RouteNotFound>


### PR DESCRIPTION
Oppfølging til #583.

## Problemet

Knappene på 404-sida lå under hverandre i `EmptyContent` sin `max-w-sm`-spalte med standard knappestørrelse. Resultatet var at sida dekket en liten flekk midt på skjermen, med mye tom plass rundt.

## Endringen

- Handlingene står side om side og deler bredden likt
- `items-stretch` gir dem samme høyde uansett hvilken størrelse kalleren gir sekundærknappen, og `flex-1` på barna sparer kalleren for å måtte vite om bredden — layouten eies av komponenten, ikke av `router.tsx`
- Begge knappene er `size="lg"`
- Blokka fyller `min-h-[60vh]` med større ikon og mer luft

Bare layout-utilities, i tråd med regel 2 i apps/kvark/CLAUDE.md — ingen farger, typografi eller dekorasjon lagt til i appen.

## Verifisering

Kjørt mot lokal app.

- **Desktop:** begge knappene måler 218x36 px med samme topp-posisjon — altså eksakt like og på linje
- **Mobil (375px):** knappene står fortsatt side om side, ingen horisontal overflyt
- `size="lg"` gir `h-9` mot standardens `h-8`, bekreftet i DOM-en
- «Gå tilbake» oppfører seg som før: direkte innlasting av en død lenke → forsida

`typecheck` (9/9), `build` (4/4), `lint` og `format` grønne, null funn i kvark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)