### PR TITLE
fix(forms): bredere skjemadialoger og lesbare svarkolonner

### DIFF
--- a/apps/kvark/src/components/form-submissions-table.tsx
+++ b/apps/kvark/src/components/form-submissions-table.tsx
@@ -38,7 +38,13 @@ export function FormSubmissionsTable({
                     <TableHead>Navn</TableHead>
                     <TableHead>Sendt inn</TableHead>
                     {questions.map((question) => (
-                        <TableHead key={question.id} className="max-w-xs">
+                        // `whitespace-normal` som i cellene under: uten den
+                        // står overskriften på én linje uansett `max-w`, og et
+                        // langt spørsmål legger seg oppå nabokolonnen.
+                        <TableHead
+                            key={question.id}
+                            className="max-w-xs whitespace-normal"
+                        >
                             {question.title}
                         </TableHead>
                     ))}

--- a/apps/kvark/src/components/group-form-edit-dialog.tsx
+++ b/apps/kvark/src/components/group-form-edit-dialog.tsx
@@ -3,6 +3,7 @@ import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent } from "@tihlde/ui/ui/card";
 import {
     Dialog,
+    DialogBody,
     DialogContent,
     DialogDescription,
     DialogFooter,
@@ -127,7 +128,9 @@ export function GroupFormEditDialog({
                 if (!o) onClose();
             }}
         >
-            <DialogContent className="sm:max-w-lg">
+            {/* Bredt: spørsmålstekstene er ofte lange setninger, og på en smal
+            dialog ser man bare en flik av det man skriver. */}
+            <DialogContent className="sm:max-w-3xl">
                 <DialogHeader>
                     <DialogTitle>Rediger spørreskjema</DialogTitle>
                     <DialogDescription>
@@ -249,151 +252,176 @@ function EditForm({
     const editForm = useEditForm({ form, questions, onSubmit });
 
     return (
-        <form {...formHandlers(editForm)} className="flex flex-col gap-6">
-            {error ? (
-                <Alert variant="destructive">
-                    <TriangleAlert />
-                    <AlertTitle>Klarte ikke å lagre skjemaet</AlertTitle>
-                    <AlertDescription>{error}</AlertDescription>
-                </Alert>
-            ) : null}
+        // DialogBody låser tittel og knapperad mens spørsmålene scroller. Uten
+        // den scroller hele dialogen, og med et opptaksskjema på ti spørsmål
+        // er «Lagre» langt under skjermkanten. Knapperaden står utenfor
+        // <form>: SubmitButton kaller handleSubmit selv når den ikke hører til
+        // et form-element.
+        <>
+            <DialogBody>
+                <form
+                    {...formHandlers(editForm)}
+                    className="flex flex-col gap-6"
+                >
+                    {error ? (
+                        <Alert variant="destructive">
+                            <TriangleAlert />
+                            <AlertTitle>
+                                Klarte ikke å lagre skjemaet
+                            </AlertTitle>
+                            <AlertDescription>{error}</AlertDescription>
+                        </Alert>
+                    ) : null}
 
-            {deleteError ? (
-                <Alert variant="destructive">
-                    <TriangleAlert />
-                    <AlertTitle>Klarte ikke å slette skjemaet</AlertTitle>
-                    <AlertDescription>{deleteError}</AlertDescription>
-                </Alert>
-            ) : null}
+                    {deleteError ? (
+                        <Alert variant="destructive">
+                            <TriangleAlert />
+                            <AlertTitle>
+                                Klarte ikke å slette skjemaet
+                            </AlertTitle>
+                            <AlertDescription>{deleteError}</AlertDescription>
+                        </Alert>
+                    ) : null}
 
-            <FieldGroup>
-                <editForm.AppField name="title">
-                    {(field) => (
-                        <field.Field required>
-                            <field.Label>Tittel</field.Label>
-                            <field.Input placeholder="Skriv her..." />
-                            <field.Error />
-                        </field.Field>
-                    )}
-                </editForm.AppField>
-                <editForm.AppField name="description">
-                    {(field) => (
-                        <field.Field>
-                            <field.Label>Beskrivelse</field.Label>
-                            <field.Markdown placeholder="Skriv her..." />
-                            <field.Description>
-                                Vises over spørsmålene
-                            </field.Description>
-                            <field.Error />
-                        </field.Field>
-                    )}
-                </editForm.AppField>
-                {/* Stenger man skjemaet, følger åpningstidspunktet med: ellers
+                    <FieldGroup>
+                        <editForm.AppField name="title">
+                            {(field) => (
+                                <field.Field required>
+                                    <field.Label>Tittel</field.Label>
+                                    <field.Input placeholder="Skriv her..." />
+                                    <field.Error />
+                                </field.Field>
+                            )}
+                        </editForm.AppField>
+                        <editForm.AppField name="description">
+                            {(field) => (
+                                <field.Field>
+                                    <field.Label>Beskrivelse</field.Label>
+                                    <field.Markdown placeholder="Skriv her..." />
+                                    <field.Description>
+                                        Vises over spørsmålene
+                                    </field.Description>
+                                    <field.Error />
+                                </field.Field>
+                            )}
+                        </editForm.AppField>
+                        {/* Stenger man skjemaet, følger åpningstidspunktet med: ellers
                     ville skjemaet man nettopp stengte åpnet seg selv igjen. */}
-                <editForm.AppField
-                    name="isOpen"
-                    listeners={{
-                        onChange: ({ value }) => {
-                            if (!value) editForm.setFieldValue("opensAt", null);
-                        },
-                    }}
-                >
-                    {(field) => (
-                        <field.Field orientation="horizontal">
-                            <FieldContent>
-                                <field.Label>Åpent for svar</field.Label>
-                                <field.Description>
-                                    Skjemaet kan bare svares på og deles når det
-                                    er åpent
-                                </field.Description>
-                            </FieldContent>
-                            <field.Switch />
-                        </field.Field>
-                    )}
-                </editForm.AppField>
-                {/* Og setter man et tidspunkt, er det fordi skjemaet skal åpne
+                        <editForm.AppField
+                            name="isOpen"
+                            listeners={{
+                                onChange: ({ value }) => {
+                                    if (!value)
+                                        editForm.setFieldValue("opensAt", null);
+                                },
+                            }}
+                        >
+                            {(field) => (
+                                <field.Field orientation="horizontal">
+                                    <FieldContent>
+                                        <field.Label>
+                                            Åpent for svar
+                                        </field.Label>
+                                        <field.Description>
+                                            Skjemaet kan bare svares på og deles
+                                            når det er åpent
+                                        </field.Description>
+                                    </FieldContent>
+                                    <field.Switch />
+                                </field.Field>
+                            )}
+                        </editForm.AppField>
+                        {/* Og setter man et tidspunkt, er det fordi skjemaet skal åpne
                     da — bryteren følger etter. */}
-                <editForm.AppField
-                    name="opensAt"
-                    listeners={{
-                        onChange: ({ value }) => {
-                            if (value) editForm.setFieldValue("isOpen", true);
-                        },
-                    }}
-                >
-                    {(field) => (
-                        <field.Field>
-                            <field.Label>Åpner</field.Label>
-                            <field.DateTimePicker />
-                            <field.Description>
-                                Valgfritt. Med et tidspunkt er skjemaet stengt
-                                til da, og åpner seg selv når tiden kommer.
-                            </field.Description>
-                            <field.Error />
-                        </field.Field>
-                    )}
-                </editForm.AppField>
-                <editForm.AppField name="canSubmitMultiple">
-                    {(field) => (
-                        <field.Field orientation="horizontal">
-                            <FieldContent>
-                                <field.Label>
-                                    Tillat flere svar fra samme person
-                                </field.Label>
-                            </FieldContent>
-                            <field.Switch />
-                        </field.Field>
-                    )}
-                </editForm.AppField>
-                <editForm.AppField name="onlyForMembers">
-                    {(field) => (
-                        <field.Field orientation="horizontal">
-                            <FieldContent>
-                                <field.Label>
-                                    Bare for medlemmer av gruppen
-                                </field.Label>
-                            </FieldContent>
-                            <field.Switch />
-                        </field.Field>
-                    )}
-                </editForm.AppField>
-                <editForm.AppField name="emailReceiver">
-                    {(field) => (
-                        <field.Field>
-                            <field.Label>Varsle på e-post</field.Label>
-                            <field.Input
-                                type="email"
-                                placeholder="navn@tihlde.org"
-                            />
-                            <field.Description>
-                                Får en e-post for hvert svar. La stå tom for
-                                ingen varsling.
-                            </field.Description>
-                            <field.Error />
-                        </field.Field>
-                    )}
-                </editForm.AppField>
-            </FieldGroup>
+                        <editForm.AppField
+                            name="opensAt"
+                            listeners={{
+                                onChange: ({ value }) => {
+                                    if (value)
+                                        editForm.setFieldValue("isOpen", true);
+                                },
+                            }}
+                        >
+                            {(field) => (
+                                <field.Field>
+                                    <field.Label>Åpner</field.Label>
+                                    <field.DateTimePicker />
+                                    <field.Description>
+                                        Valgfritt. Med et tidspunkt er skjemaet
+                                        stengt til da, og åpner seg selv når
+                                        tiden kommer.
+                                    </field.Description>
+                                    <field.Error />
+                                </field.Field>
+                            )}
+                        </editForm.AppField>
+                        <editForm.AppField name="canSubmitMultiple">
+                            {(field) => (
+                                <field.Field orientation="horizontal">
+                                    <FieldContent>
+                                        <field.Label>
+                                            Tillat flere svar fra samme person
+                                        </field.Label>
+                                    </FieldContent>
+                                    <field.Switch />
+                                </field.Field>
+                            )}
+                        </editForm.AppField>
+                        <editForm.AppField name="onlyForMembers">
+                            {(field) => (
+                                <field.Field orientation="horizontal">
+                                    <FieldContent>
+                                        <field.Label>
+                                            Bare for medlemmer av gruppen
+                                        </field.Label>
+                                    </FieldContent>
+                                    <field.Switch />
+                                </field.Field>
+                            )}
+                        </editForm.AppField>
+                        <editForm.AppField name="emailReceiver">
+                            {(field) => (
+                                <field.Field>
+                                    <field.Label>Varsle på e-post</field.Label>
+                                    <field.Input
+                                        type="email"
+                                        placeholder="navn@tihlde.org"
+                                    />
+                                    <field.Description>
+                                        Får en e-post for hvert svar. La stå tom
+                                        for ingen varsling.
+                                    </field.Description>
+                                    <field.Error />
+                                </field.Field>
+                            )}
+                        </editForm.AppField>
+                    </FieldGroup>
 
-            <Separator />
+                    <Separator />
 
-            {answerCount > 0 ? (
-                <Alert>
-                    <LockIcon />
-                    <AlertTitle>
-                        Skjemaet har {answerCount}{" "}
-                        {answerCount === 1 ? "svar" : "svar"}
-                    </AlertTitle>
-                    <AlertDescription>
-                        Du kan endre tekst, rekkefølge og «påkrevd», og legge
-                        til nye spørsmål og alternativer. Spørsmålene som
-                        allerede er besvart kan ikke fjernes eller bytte type —
-                        da ville svarene på dem forsvunnet.
-                    </AlertDescription>
-                </Alert>
-            ) : null}
+                    {answerCount > 0 ? (
+                        <Alert>
+                            <LockIcon />
+                            <AlertTitle>
+                                Skjemaet har {answerCount}{" "}
+                                {answerCount === 1 ? "svar" : "svar"}
+                            </AlertTitle>
+                            <AlertDescription>
+                                Du kan endre tekst, rekkefølge og «påkrevd», og
+                                legge til nye spørsmål og alternativer.
+                                Spørsmålene som allerede er besvart kan ikke
+                                fjernes eller bytte type — da ville svarene på
+                                dem forsvunnet.
+                            </AlertDescription>
+                        </Alert>
+                    ) : null}
 
-            <QuestionsEditor editForm={editForm} hasAnswers={answerCount > 0} />
+                    <QuestionsEditor
+                        editForm={editForm}
+                        hasAnswers={answerCount > 0}
+                    />
+                </form>
+            </DialogBody>
 
             <DialogFooter>
                 {onRequestDelete ? (
@@ -425,7 +453,7 @@ function EditForm({
                     </editForm.SubmitButton>
                 </editForm.AppForm>
             </DialogFooter>
-        </form>
+        </>
     );
 }
 

--- a/apps/kvark/src/components/new-form-dialog.tsx
+++ b/apps/kvark/src/components/new-form-dialog.tsx
@@ -154,7 +154,9 @@ export function NewFormDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="sm:max-w-lg">
+            {/* Bredt: spørsmålstekstene er ofte lange setninger, og på en smal
+            dialog ser man bare en flik av det man skriver. */}
+            <DialogContent className="sm:max-w-3xl">
                 <DialogHeader>
                     <DialogTitle>{title}</DialogTitle>
                     <DialogDescription>{description}</DialogDescription>


### PR DESCRIPTION
Opptak til verv starter i natt, så jeg gikk gjennom hele spørreskjema-løpet lokalt — fra opprettelse og redigering til søkerens innsending og admins svarvisning.

## Endringer

**Bredere dialoger.** Både «Nytt spørreskjema» og «Rediger spørreskjema» var `sm:max-w-lg`. Opptaksspørsmål er lange setninger, og man så bare en flik av det man skrev. Begge er nå `sm:max-w-3xl`.

**Låst header/knapperad i redigeringsdialogen.** Den manglet `DialogBody`, så hele dialogen scrollet — på et skjema med mange spørsmål havnet «Lagre» langt under skjermkanten. Nå scroller bare innholdet. Knapperaden står utenfor `<form>`; `SubmitButton` kaller `handleSubmit` selv når den ikke hører til et form-element.

**Bugfiks: overlappende kolonneoverskrifter i svar-tabellen.** `whitespace-normal` var satt på datacellene, men ikke på overskriftene. Et langt spørsmål la seg derfor oppå nabokolonnen og gjorde begge uleselige. Målt før fiksen: celle 396px bred, innhold 616px, `nowrap` + `overflow: visible`. Dette ville truffet opptaket direkte i morgen.

## Verifisert lokalt

Mot lokal API + Kvark, som leder i Index:

- Opprette skjema med fritekst- og flervalgsspørsmål
- Påkrevd-validering blokkerer innsending for søker
- Sende inn svar (flervalg)
- Se svar, statistikk-fanen, og last ned CSV (200 `text/csv`, riktige kolonner)
- Redigere skjema som har svar — besvarte spørsmål låses mot sletting og typebytte
- Slette skjema, med advarsel om at svarene forsvinner
- `/opptak` finner skjemaet og viser «Søk nå»

9/9 API-tester i `src/test/form`, typecheck, lint, format og `bun run build` (4/4) er grønne.

## Verdt å vite (ikke endret her)

`/opptak` finner søknadsskjemaet ved å lete etter tittel som inneholder `"opptak"` (`opptak.tsx:206`). Heter skjemaet f.eks. «Søknad til Drift 2026», dukker det ikke opp på opptakssiden. Gruppene bør få beskjed om navnekonvensjonen.

Åpningstidspunkt er trygt: åpningen regnes ut ved lesing (`!opensAt || opensAt <= now`), ikke av en cron-jobb, så et skjema satt til 00:00 åpner seg selv presis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)