### PR TITLE
fix(events): vis kapasitet, fullt arrangement og ventelistetall

### DIFF
--- a/apps/api/src/routes/event/get.ts
+++ b/apps/api/src/routes/event/get.ts
@@ -83,19 +83,30 @@ export const getRoute = route().get(
         }
 
         // How many are going is public; who they are is not. The roster
-        // endpoint is members-only, so the count lives here instead — it is
-        // the same set of statuses that endpoint counts by default.
-        const registeredCount = await db.$count(
-            schema.eventRegistration,
-            and(
-                eq(schema.eventRegistration.eventId, event.id),
-                inArray(schema.eventRegistration.status, [
-                    "registered",
-                    "attended",
-                    "no_show",
-                ]),
+        // endpoint is members-only, so the counts live here instead — the
+        // registered one covers the same set of statuses that endpoint counts
+        // by default. The waitlist length belongs next to it: on a full event
+        // it is what tells a member whether queueing up is worth it.
+        const [registeredCount, waitlistCount] = await Promise.all([
+            db.$count(
+                schema.eventRegistration,
+                and(
+                    eq(schema.eventRegistration.eventId, event.id),
+                    inArray(schema.eventRegistration.status, [
+                        "registered",
+                        "attended",
+                        "no_show",
+                    ]),
+                ),
             ),
-        );
+            db.$count(
+                schema.eventRegistration,
+                and(
+                    eq(schema.eventRegistration.eventId, event.id),
+                    eq(schema.eventRegistration.status, "waitlisted"),
+                ),
+            ),
+        ]);
 
         let registration: z.infer<typeof eventDetailSchema>["registration"] =
             null;
@@ -194,6 +205,7 @@ export const getRoute = route().get(
             capacity: event.capacity,
             canCauseStrikes: event.canCauseStrikes,
             registeredCount,
+            waitlistCount,
             image: event.imageUrl,
             imageAlt: event.imageAlt,
             createdById: event.createdByUserId,

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -561,6 +561,10 @@ export const eventDetailSchema = Schema(
             description:
                 "Number of people signed up (registered, attended or no-show). Public, unlike the roster itself, so the open event page can show how many are going without naming them.",
         }),
+        waitlistCount: z.number().int().meta({
+            description:
+                "Number of people on the waitlist. Public for the same reason as registeredCount: how long the queue is tells a member whether signing up is worth it, without naming anyone in it.",
+        }),
         image: z
             .url()
             .nullable()

--- a/apps/api/src/test/event/waitlist-count.test.ts
+++ b/apps/api/src/test/event/waitlist-count.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect } from "vitest";
+import { resolveRegistrationsForEvent } from "~/lib/event/resolve-registration";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * Køen bak et fullt arrangement er offentlig av samme grunn som antall
+ * påmeldte: hvor lang den er avgjør om det er verdt å melde seg på i det hele
+ * tatt. Hvem som står i den er den fortsatt ikke.
+ */
+describe("event detail reports the waitlist length", () => {
+    integrationTest(
+        "waitlistCount counts the queue, registeredCount only the spots",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                slug: `venteliste-${Date.now()}`,
+                capacity: 1,
+            });
+
+            const first = await ctx.utils.createTestUser();
+            const second = await ctx.utils.createTestUser();
+
+            for (const user of [first, second]) {
+                await ctx.utils.giveUserPermissions(user, [
+                    "events:registrations:create",
+                ]);
+                await ctx.utils.acceptEventRules(user.id);
+                const client = await ctx.utils.clientForUser(user);
+                const response = await client.api.event[
+                    ":eventId"
+                ].registration.$post({
+                    param: { eventId: event.id },
+                    json: {},
+                });
+                expect(response.status).toBe(200);
+            }
+
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const client = await ctx.utils.clientForUser(first);
+            const detailResponse = await client.api.event[":eventId"].$get({
+                param: { eventId: event.id },
+            });
+            expect(detailResponse.status).toBe(200);
+            const detail = await detailResponse.json();
+
+            expect(detail).toMatchObject({
+                capacity: 1,
+                registeredCount: 1,
+                waitlistCount: 1,
+            });
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "an event with room to spare has an empty waitlist",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                slug: `ledig-${Date.now()}`,
+                capacity: 10,
+            });
+
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(user, [
+                "events:registrations:create",
+            ]);
+            await ctx.utils.acceptEventRules(user.id);
+            const client = await ctx.utils.clientForUser(user);
+
+            const response = await client.api.event[
+                ":eventId"
+            ].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+            expect(response.status).toBe(200);
+
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const detailResponse = await client.api.event[":eventId"].$get({
+                param: { eventId: event.id },
+            });
+            expect(detailResponse.status).toBe(200);
+            const detail = await detailResponse.json();
+
+            expect(detail).toMatchObject({
+                registeredCount: 1,
+                waitlistCount: 0,
+            });
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -235,19 +235,28 @@ function getStateRendering(
                 message: "Påmelding er stengt",
             };
 
+        // Fullt stopper aldri en påmelding: det finnes alltid en venteliste, og
+        // plassen går videre til den som står først når noen melder seg av.
         case "full":
             return {
                 icon: AlertCircle,
                 message: "Arrangementet er fullt",
+                secondary:
+                    props.waitlistCount > 0
+                        ? `${props.waitlistCount} står på venteliste.`
+                        : "Meld deg på ventelista, så får du plassen om noen melder seg av.",
                 // Ventelista går gjennom samme påmelding, så den er stengt av
                 // samme grunn — knappen ville bare gitt en avvisning.
                 actions: blockedByEventRules ? null : (
                     <Button
                         variant="outline"
                         className="w-full"
-                        onClick={props.onJoinWaitlist}
+                        disabled={props.isSubmitting}
+                        onClick={() => props.onJoinWaitlist?.()}
                     >
-                        Sett meg på venteliste
+                        {props.isSubmitting
+                            ? "Setter deg på ventelista …"
+                            : "Sett meg på venteliste"}
                     </Button>
                 ),
             };

--- a/apps/kvark/src/components/profile-upcoming-events.tsx
+++ b/apps/kvark/src/components/profile-upcoming-events.tsx
@@ -26,16 +26,17 @@ export type ProfileUpcomingEvent = {
 };
 
 /**
- * Ventelisteplassen og uavklarte påmeldinger merkes, siden de betyr noe annet
- * enn en sikret plass. En vanlig påmelding får ikke merke — det er normalen.
+ * Hva påmeldingen faktisk er verdt: en sikret plass, en ventelisteplass med
+ * nummer, eller en påmelding som ennå ikke er avgjort. Uten merket måtte
+ * medlemmet åpne hvert arrangement for å finne ut om de har plass.
  */
-function statusLabel(event: ProfileUpcomingEvent): string | null {
+function statusLabel(event: ProfileUpcomingEvent): string {
     if (event.status === "pending") return "Behandles";
     if (event.status === "waitlisted")
         return event.waitlistPosition !== null
             ? `Venteliste #${event.waitlistPosition}`
             : "Venteliste";
-    return null;
+    return "Du har plass";
 }
 
 /** Påmeldingene som ikke er over ennå, som arrangementskort. */
@@ -78,27 +79,24 @@ export function ProfileUpcomingEvents({
 
     return (
         <ul className="flex flex-col gap-3">
-            {events.map((event) => {
-                const label = statusLabel(event);
-                return (
-                    <li key={event.eventId}>
-                        <EventCard
-                            slug={event.slug}
-                            title={event.title}
-                            startsAt={formatEventDateTime(event.startTime)}
-                            location={event.location ?? ""}
-                            organizer={event.organizer ?? ""}
-                            imageUrl={event.image || undefined}
-                            imageAlt={event.imageAlt || undefined}
-                            badge={
-                                label ? (
-                                    <Badge variant="secondary">{label}</Badge>
-                                ) : null
-                            }
-                        />
-                    </li>
-                );
-            })}
+            {events.map((event) => (
+                <li key={event.eventId}>
+                    <EventCard
+                        slug={event.slug}
+                        title={event.title}
+                        startsAt={formatEventDateTime(event.startTime)}
+                        location={event.location ?? ""}
+                        organizer={event.organizer ?? ""}
+                        imageUrl={event.image || undefined}
+                        imageAlt={event.imageAlt || undefined}
+                        badge={
+                            <Badge variant="secondary">
+                                {statusLabel(event)}
+                            </Badge>
+                        }
+                    />
+                </li>
+            ))}
         </ul>
     );
 }

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -56,6 +56,10 @@ type RegistrationStateInput = {
     registrationEnd?: string | null;
     /** When the event itself ends. */
     endTime?: string | null;
+    /** Maksgrensen for antall plasser. Null means "no limit". */
+    capacity?: number | null;
+    /** How many already hold a spot — compared against `capacity`. */
+    registeredCount?: number;
 };
 
 /**
@@ -76,6 +80,8 @@ export function deriveRegistrationState(
         registrationStart,
         registrationEnd,
         endTime,
+        capacity,
+        registeredCount,
     }: RegistrationStateInput,
     now: Date = new Date(),
 ): EventRegistrationState {
@@ -102,6 +108,14 @@ export function deriveRegistrationState(
             }
             if (registrationStart && new Date(registrationStart) > now) {
                 return "not-open";
+            }
+            // Sist av alle grensene: at plassene er tatt betyr ingenting så
+            // lenge påmeldingen er stengt eller ikke åpnet ennå — da er det
+            // det som skal stå. Uten dette sto det «Meld deg på» på et fullt
+            // arrangement, og medlemmet oppdaget først etterpå at de havnet
+            // på venteliste.
+            if (capacity != null && (registeredCount ?? 0) >= capacity) {
+                return "full";
             }
             return "open";
     }

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -147,6 +147,8 @@ function EventDetailPage() {
         registrationStart: event.registrationStart,
         registrationEnd: event.registrationEnd,
         endTime: event.endTime,
+        capacity: event.capacity,
+        registeredCount: event.registeredCount,
     });
     // Feil fra på- eller avmelding. Uten dette så knappen ut til å ikke gjøre
     // noe når API-et avviste forsøket.
@@ -384,12 +386,15 @@ function EventDetailPage() {
                                 ? toEventDeadline(event.registrationEnd)
                                 : undefined
                         }
-                        capacity={null}
+                        capacity={event.capacity}
                         registeredCount={registeredCount}
-                        waitlistCount={0}
+                        waitlistCount={event.waitlistCount}
                         isAdmin={isAdmin}
                         price={price}
                         onRegister={handleRegister}
+                        // Ventelista er samme påmelding: serveren avgjør om
+                        // det ble plass eller kø.
+                        onJoinWaitlist={handleRegister}
                         onUnregister={handleUnregister}
                         isSubmitting={
                             registerMutation.isPending ||

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3848,6 +3848,8 @@ export interface components {
             canCauseStrikes: boolean;
             /** @description Number of people signed up (registered, attended or no-show). Public, unlike the roster itself, so the open event page can show how many are going without naming them. */
             registeredCount: number;
+            /** @description Number of people on the waitlist. Public for the same reason as registeredCount: how long the queue is tells a member whether signing up is worth it, without naming anyone in it. */
+            waitlistCount: number;
             /** @description Event image URL (nullable) */
             image: string | null;
             /** @description Alt text for the event image (nullable) */

--- a/packages/ui/src/components/ui/progress.tsx
+++ b/packages/ui/src/components/ui/progress.tsx
@@ -2,6 +2,21 @@ import { Progress as ProgressPrimitive } from "@base-ui/react/progress";
 
 import { cn } from "#/lib/utils";
 
+/**
+ * Prosenten som leses opp, formatert likt på server og klient.
+ *
+ * Uten dette formaterer Base UI den med `Intl.NumberFormat` og standardlokalet
+ * på hver side: serveren skriver «40%», nettleseren «40 %» (med hardt
+ * mellomrom), og React kastet en hydration-feil på `aria-valuetext` for hver
+ * framdriftslinje på sida.
+ */
+function progressAriaValueText(
+    _formattedValue: string | null,
+    value: number | null,
+) {
+    return value === null ? "" : `${value} %`;
+}
+
 function Progress({
     className,
     children,
@@ -11,6 +26,7 @@ function Progress({
     return (
         <ProgressPrimitive.Root
             value={value}
+            getAriaValueText={progressAriaValueText}
             data-slot="progress"
             className={cn("flex flex-wrap gap-3", className)}
             {...props}


### PR DESCRIPTION
## Hva var galt

Påmeldingskortet hadde kapasiteten hardkodet til `null`, så det sto `0/∞ påmeldte` uansett hvilken maksgrense arrangøren hadde satt. API-et har returnert `capacity` hele tiden, og admin-skjemaet lagret den — kortet spurte bare aldri etter den.

## Hva som er fikset

**Kapasiteten vises.** `capacity={null}` → `capacity={event.capacity}`. Et arrangement med 12 plasser og 2 påmeldte sier nå `2/12 påmeldte` med framdriftslinje.

**Fullt arrangement sier at det er fullt.** `deriveRegistrationState` returnerte aldri `"full"` — tilstanden fantes i kortet, men var uoppnåelig, så et fullt arrangement viste en innbydende «Meld deg på» og medlemmet oppdaget først etterpå at de havnet på venteliste. Kapasiteten sjekkes **sist**, etter stengt/ikke-åpnet, så et fullt arrangement som er stengt fortsatt sier «stengt». `onJoinWaitlist` var heller ikke koblet til noe — knappen i den tilstanden gjorde ingenting. Den går nå til samme påmelding, siden serveren avgjør plass vs. kø.

**Ventelistetall.** Var hardkodet til 0. `GET /api/event/:eventId` returnerer nå `waitlistCount`, offentlig av samme grunn som `registeredCount`: på et fullt arrangement er det det som forteller om det er verdt å melde seg på. Vises både i statuslinja (`· 4 venteliste`) og under «Arrangementet er fullt» (`4 står på venteliste.`). De to tellingene kjører i parallell, ikke etter hverandre.

**Fullt stopper aldri en påmelding.** `allowWaitlist` håndheves ikke noe sted i backend — `create.ts` utleder den fra `requiresSigningUp`, og resolveren kø-legger alle uansett. Det finnes ingen situasjon der et arrangement skal avvise en påmelding fordi det er fullt, så kortet leser ikke flagget.

**Profilen.** En kommende påmelding sier nå alltid hva den er verdt: `Du har plass`, `Venteliste #3` eller `Behandles`. Ventelisteplassen var der før; en sikret plass sa ingenting. `EventCard` på `/arrangementer` er urørt.

**Bonus:** `Progress` i `@tihlde/ui` kastet en hydration-feil på `aria-valuetext` (server «40%», nettleser «40 %» — ulikt standardlokale). Den lå der før, men bare på en admin-side; nå ville den truffet hver arrangementsside med kapasitet. Egen commit, ingen synlig endring.

## Verifisering

Lokal API mot dev-basen, ikke bare typecheck:

- Fullt arrangement (kapasitet 12, 12 påmeldte, 4 i kø): `12/12 påmeldte · 4 venteliste`, «Arrangementet er fullt», «4 står på venteliste.», knapp `Sett meg på venteliste`.
- Samme arrangement med `allow_waitlist = false` i basen: knappen kommer opp uansett — flagget kan ikke stenge noen ute.
- Fullt uten kø (12/12, 0 på venteliste): «Meld deg på ventelista, så får du plassen om noen melder seg av.»
- Kapasitet hevet til 20: `12/20 påmeldte`, tilbake til `Meld deg på`.
- Uten kapasitet: fortsatt `0/∞ påmeldte`, ingen framdriftslinje.
- Konsollen er ren på fersk sideinnlasting.

Nye API-tester i `waitlist-count.test.ts`: `waitlistCount` teller køen mens `registeredCount` bare teller plassene, og er 0 når det er ledig. Hele `src/test/event`: **135 tester grønne**. `bun run typecheck`, `bun run build` og `bun run lint` er grønne.

**Ikke verifisert i nettleser:** profilkortet — det krever innlogging. Endringen er typesjekket og bygget, og `status: "registered"` kommer allerede fra `/api/event/my-upcoming`.

## Til oppfølging

`allowWaitlist` er nå et dødt felt: det ligger i DB-kolonnen, i create/update-skjemaene med validering, i svarene og i SDK-typene, men ingen leser det og ingen kan sette det meningsfullt. Å rydde det bort er en brytende API-endring for klienter som leser det i dag (KontRes m.fl.) og hører i en egen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)