### PR TITLE
fix(groups): la gruppeledere søke opp brukere de kan legge til

### DIFF
--- a/apps/api/src/routes/user/search.ts
+++ b/apps/api/src/routes/user/search.ts
@@ -1,10 +1,14 @@
+import { hasPermission, hasScopedPermission } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
 import { ilike, or } from "drizzle-orm";
+import { createMiddleware } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
 import { validator } from "hono-openapi";
 import z from "zod";
+import type { AppContext } from "~/lib/ctx";
+import { isGroupLeader } from "~/lib/group/middleware";
 import { Schema, describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { requireAccess } from "~/middleware/access";
 import { requireAuth } from "~/middleware/auth";
 
 export const userSearchResultSchema = Schema(
@@ -19,6 +23,52 @@ export const userSearchResultSchema = Schema(
     ),
 );
 
+/**
+ * Søket brukes til to ting: å tildele roller/verv (admin), og å finne noen som
+ * skal legges til i en gruppe. Tilgangen speiler handlingen søket tjener — en
+ * undergruppeleder har lov til å legge til medlemmer i sin egen gruppe, og må
+ * derfor kunne søke opp folk når `groupSlug` peker på den gruppen. Uten
+ * `groupSlug` er det fortsatt bare `users:view`/`roles:assign` som gjelder, så
+ * hele brukerregisteret ikke blir åpent for enhver leder.
+ */
+const requireUserSearchAccess = createMiddleware<{
+    Variables: {
+        user: { id: string } | null;
+        ctx: AppContext;
+    };
+}>(async (c, next) => {
+    const user = c.get("user");
+    if (!user) {
+        throw new HTTPException(401, { message: "Authentication required" });
+    }
+    const ctx = c.get("ctx");
+
+    if (await hasPermission(ctx, user.id, ["users:view", "roles:assign"])) {
+        await next();
+        return;
+    }
+
+    const groupSlug = c.req.query("groupSlug");
+    if (groupSlug) {
+        const canManageGroup =
+            (await hasScopedPermission(
+                ctx,
+                user.id,
+                "groups:manage",
+                `group:${groupSlug}`,
+            )) || (await isGroupLeader(ctx, groupSlug, user.id));
+        if (canManageGroup) {
+            await next();
+            return;
+        }
+    }
+
+    throw new HTTPException(403, {
+        message:
+            "Forbidden - requires permission: users:view or roles:assign, or the right to manage the given group",
+    });
+});
+
 export const searchUsersRoute = route().get(
     "/search",
     describeRoute({
@@ -26,17 +76,20 @@ export const searchUsersRoute = route().get(
         summary: "Search users",
         operationId: "searchUsers",
         description:
-            "Search users by name or username (case-insensitive substring). Used by admin UIs to assign roles and positions. Requires 'users:view' or 'roles:assign'.",
+            "Search users by name or username (case-insensitive substring). Used by admin UIs to assign roles and positions. Requires 'users:view' or 'roles:assign' — or, when 'groupSlug' is given, the right to manage that group's roster ('groups:manage' scoped to it, or being its leader).",
     })
         .schemaResponse({
             statusCode: 200,
             schema: userSearchResultSchema,
             description: "Matching users",
         })
-        .forbidden({ description: "Requires users:view or roles:assign" })
+        .forbidden({
+            description:
+                "Requires users:view or roles:assign, or the right to manage the given group",
+        })
         .build(),
     requireAuth,
-    requireAccess({ permission: ["users:view", "roles:assign"] }),
+    requireUserSearchAccess,
     validator(
         "query",
         z.object({
@@ -45,6 +98,10 @@ export const searchUsersRoute = route().get(
                 .min(2)
                 .max(100)
                 .meta({ description: "Search term (name or username)" }),
+            groupSlug: z.string().optional().meta({
+                description:
+                    "Group the search is for. Lets that group's leader (or anyone with 'groups:manage' for it) search users in order to add members.",
+            }),
         }),
     ),
     async (c) => {

--- a/apps/api/src/test/user-search.test.ts
+++ b/apps/api/src/test/user-search.test.ts
@@ -1,3 +1,4 @@
+import { schema } from "@photon/db";
 import { describe, expect } from "vitest";
 import { integrationTest } from "~/test/config/integration";
 
@@ -43,6 +44,56 @@ describe("user search", () => {
                 query: { q: "søketest" },
             });
             expect(forbidden.status).toBe(403);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "lets a group leader search for their own group, but not otherwise",
+        async ({ ctx }) => {
+            // Lederen har lov til å legge til medlemmer, men har ingen av de
+            // globale tilgangene søket krevde — uten `groupSlug` ser et 403 ut
+            // som at personen ikke finnes.
+            const group = await ctx.utils.createTestGroup({ slug: "plask" });
+            const otherGroup = await ctx.utils.createTestGroup({
+                slug: "annen-gruppe",
+            });
+            const leader = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.groupMembership).values({
+                groupSlug: group.slug,
+                userId: leader.id,
+                role: "leader",
+            });
+            const client = await ctx.utils.clientForUser(leader);
+
+            const target = await ctx.auth.api.createUser({
+                body: {
+                    email: "plaskmedlem@test.com",
+                    name: "Torkil Plasketest",
+                    password: "test123!",
+                    data: { username: "torkilplask" },
+                },
+            });
+
+            const forOwnGroup = await client.api.user.search.$get({
+                query: { q: "plasketest", groupSlug: group.slug },
+            });
+            expect(forOwnGroup.status).toBe(200);
+            expect(
+                (await forOwnGroup.json()).some((u) => u.id === target.user.id),
+            ).toBe(true);
+
+            // En annen gruppe er ikke lederens bord.
+            const forOtherGroup = await client.api.user.search.$get({
+                query: { q: "plasketest", groupSlug: otherGroup.slug },
+            });
+            expect(forOtherGroup.status).toBe(403);
+
+            // Og uten gruppe gjelder fortsatt users:view/roles:assign.
+            const withoutGroup = await client.api.user.search.$get({
+                query: { q: "plasketest" },
+            });
+            expect(withoutGroup.status).toBe(403);
         },
         500_000,
     );

--- a/apps/kvark/src/api/queries/roles.ts
+++ b/apps/kvark/src/api/queries/roles.ts
@@ -11,12 +11,17 @@ const RoleQueryKeys = {
 
 // -- User search (for assigning roles/positions by name, not ID) --
 
-export const searchUsersQuery = (q: string) =>
+/**
+ * `groupSlug` sendes med når søket skjer på vegne av en gruppe. Da slipper
+ * gruppens leder gjennom uten `users:view` — ellers ville et søk hen har lov
+ * til å handle på (legge til medlem) svart 403 og sett ut som «ingen treff».
+ */
+export const searchUsersQuery = (q: string, groupSlug?: string) =>
     queryOptions({
-        queryKey: [...RoleQueryKeys.userSearch, q],
+        queryKey: [...RoleQueryKeys.userSearch, q, groupSlug ?? null],
         queryFn: () =>
             apiClient.get("/api/user/search", {
-                searchParams: { q },
+                searchParams: groupSlug ? { q, groupSlug } : { q },
             }),
         staleTime: 30_000,
     });

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -99,6 +99,12 @@ import { errorStatus } from "#/lib/utils";
 /** Module-level so the permission lookup keeps a stable identity. */
 const EVENT_CREATE_PERMISSIONS = ["events:create", "events:manage"] as const;
 
+/**
+ * Et feilet søk skal ikke se ut som at ingen matcher — da leter man videre
+ * etter en person som aldri ville dukket opp.
+ */
+const SEARCH_FAILED_MESSAGE = "Søket feilet. Prøv igjen.";
+
 const searchSchema = z.object({
     tab: z
         .enum([
@@ -333,11 +339,17 @@ function GroupDetail() {
     // avledet gruppe"), men den må hentes ut av responsen asynkront.
     const [addMemberError, setAddMemberError] = useState<string | null>(null);
     const debouncedMemberQuery = useDebounced(memberQuery);
-    const { data: memberSearchResults, isFetching: isSearchingMembers } =
-        useQuery({
-            ...searchUsersQuery(debouncedMemberQuery),
-            enabled: debouncedMemberQuery.length >= 2,
-        });
+    const {
+        data: memberSearchResults,
+        isFetching: isSearchingMembers,
+        error: memberSearchFailure,
+    } = useQuery({
+        // Gruppen sendes med så lederen selv kan søke: uten den svarer API-et
+        // 403 for alle uten `users:view`, og en tom liste ser ut som at
+        // personen ikke finnes.
+        ...searchUsersQuery(debouncedMemberQuery, slug),
+        enabled: debouncedMemberQuery.length >= 2,
+    });
     // Den som allerede er med skal ikke kunne legges til på nytt — API-et
     // svarer 400, og det er en dårligere forklaring enn å utelate treffet.
     const addableUsers = useMemo(
@@ -353,12 +365,14 @@ function GroupDetail() {
     const [leaderQuery, setLeaderQuery] = useState("");
     const [leaderError, setLeaderError] = useState<string | null>(null);
     const debouncedLeaderQuery = useDebounced(leaderQuery);
-    const { data: leaderSearchResults, isFetching: isSearchingLeader } =
-        useQuery({
-            ...searchUsersQuery(debouncedLeaderQuery),
-            enabled:
-                canPickLeaderOutsideGroup && debouncedLeaderQuery.length >= 2,
-        });
+    const {
+        data: leaderSearchResults,
+        isFetching: isSearchingLeader,
+        error: leaderSearchFailure,
+    } = useQuery({
+        ...searchUsersQuery(debouncedLeaderQuery, slug),
+        enabled: canPickLeaderOutsideGroup && debouncedLeaderQuery.length >= 2,
+    });
     const leaderCandidates = useMemo(
         () =>
             (leaderSearchResults ?? []).filter(
@@ -671,7 +685,11 @@ function GroupDetail() {
                                           results: leaderCandidates,
                                           isSearching: isSearchingLeader,
                                           isAdding: updateMemberRole.isPending,
-                                          error: leaderError,
+                                          error:
+                                              leaderError ??
+                                              (leaderSearchFailure
+                                                  ? SEARCH_FAILED_MESSAGE
+                                                  : null),
                                           onAdd: async (userId) => {
                                               setLeaderError(null);
                                               try {
@@ -702,7 +720,11 @@ function GroupDetail() {
                                 results: addableUsers,
                                 isSearching: isSearchingMembers,
                                 isAdding: addMember.isPending,
-                                error: addMemberError,
+                                error:
+                                    addMemberError ??
+                                    (memberSearchFailure
+                                        ? SEARCH_FAILED_MESSAGE
+                                        : null),
                                 onAdd: async (userId) => {
                                     setAddMemberError(null);
                                     try {

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2679,7 +2679,7 @@ export interface paths {
         };
         /**
          * Search users
-         * @description Search users by name or username (case-insensitive substring). Used by admin UIs to assign roles and positions. Requires 'users:view' or 'roles:assign'.
+         * @description Search users by name or username (case-insensitive substring). Used by admin UIs to assign roles and positions. Requires 'users:view' or 'roles:assign' — or, when 'groupSlug' is given, the right to manage that group's roster ('groups:manage' scoped to it, or being its leader).
          */
         get: operations["searchUsers"];
         put?: never;
@@ -14306,6 +14306,8 @@ export interface operations {
             query: {
                 /** @description Search term (name or username) */
                 q: string;
+                /** @description Group the search is for. Lets that group's leader (or anyone with 'groups:manage' for it) search users in order to add members. */
+                groupSlug?: string;
             };
             header?: never;
             path?: never;

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,11 @@
     "ui": "tui",
     "tasks": {
         "dev": {
-            "dependsOn": ["^build", "@photon/docker#dev:up", "@photon/db#db:push"],
+            "dependsOn": [
+                "^build",
+                "@photon/docker#dev:up",
+                "@photon/db#db:push"
+            ],
             "persistent": true
         },
         "@photon/web#dev": {


### PR DESCRIPTION
## Problem

Lederen for TIHLDE Plask fikk ikke opp personen de søkte etter i «Legg til medlem». En root/admin fikk opp samme person.

Årsaken er at søket var strengere enn handlingen det tjener:

- `/api/user/search` krevde **globalt** `users:view` eller `roles:assign`
- `POST /groups/:slug/members` holder med `groups:manage` scopet til gruppen, **eller** å være gruppens leder

En undergruppeleder har altså lov til å legge til medlemmet, men ikke til å finne det. `users:view`/`roles:assign` deles bare ut til root/admin og HS-vervene President/Visepresident/Finansminister.

Frontenden gjorde feilen usynlig: `useQuery` leste bare `data`, så 403-en ble svelget, lista ble tom, og comboboxen viste «Ingen treff» — som om personen ikke fantes.

## Endring

**Backend** — `/api/user/search` tar en valgfri `groupSlug`:

- `users:view` eller `roles:assign` globalt → som før
- ellers, med `groupSlug`: `groups:manage` scopet til gruppen, eller å være dens leder

Uten `groupSlug` er endepunktet like lukket som før, så hele brukerregisteret blir ikke åpent for enhver leder.

**Frontend** — gruppesiden sender med sin egen slug (både «legg til medlem» og lederoverføring), og viser en feilmelding i dialogen i stedet for at et feilet søk ser ut som null treff.

SDK-typene er regenerert.

## Verifisering

- Ny integrasjonstest: leder av `plask` får 200 med `groupSlug=plask`, 403 med en annen gruppes slug, og 403 uten `groupSlug`. Begge testene i fila er grønne.
- `bun run typecheck` (9/9), `bun run lint` (exit 0), `bun run format` grønt.

`turbo.json` ligger i diffen fordi fila var uformatert fra før og formatteringen retter den — si fra om den heller skal ut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)