### PR TITLE
feat(arrangement): la admin sette prioriterte grupper på arrangementer

### DIFF
--- a/apps/kvark/src/components/event-form.tsx
+++ b/apps/kvark/src/components/event-form.tsx
@@ -1,6 +1,11 @@
 import { RichEditor } from "@tihlde/ui/complex/markdown";
 import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
+import {
+    PriorityPoolEditor,
+    type PoolGroup,
+    type PriorityPool,
+} from "#/components/priority-pool-editor";
 import { Checkbox } from "@tihlde/ui/ui/checkbox";
 import { DateTimePicker } from "@tihlde/ui/ui/date-time-picker";
 import {
@@ -61,12 +66,25 @@ export type EventFormValues = {
     price: string;
     image: File | null;
     imageAlt: string;
+    /**
+     * Prioriteringspooler. Alle gruppene i én pool må stemme samtidig, og det
+     * holder å treffe én av poolene — se `PriorityPoolEditor`.
+     */
+    priorityPools: PriorityPool[];
+    /** Avvis alle utenfor en pool i stedet for å sette dem på venteliste. */
+    onlyAllowPrioritized: boolean;
 };
 
 type EventFormProps = {
     values: EventFormValues;
     onChange: (patch: Partial<EventFormValues>) => void;
     groups: Array<{ slug: string; name: string }>;
+    /**
+     * Alle grupper i TIHLDE, til prioriteringspoolene. `groups` over er
+     * filtrert til dem brukeren kan arrangere for, og duger derfor ikke —
+     * en pool peker typisk på kull og studier arrangøren ikke er medlem av.
+     */
+    poolGroups: PoolGroup[];
     institutes: Array<{ slug: string; shortName: string; name: string }>;
     /** Medlemmene i den valgte arrangørgruppen — kandidatene til kontaktperson. */
     contactPersonCandidates: Array<{ id: string; name: string }>;
@@ -92,6 +110,7 @@ export function EventForm({
     values,
     onChange,
     groups,
+    poolGroups,
     institutes,
     contactPersonCandidates,
     addressSuggestions,
@@ -553,6 +572,22 @@ export function EventForm({
                     </FieldGroup>
                 </CardContent>
             </Card>
+
+            {/*
+             * Bare relevant når arrangementet har påmelding i det hele tatt —
+             * prioritering uten påmelding er ingenting å prioritere.
+             */}
+            {values.requiresSigningUp ? (
+                <PriorityPoolEditor
+                    pools={values.priorityPools}
+                    groups={poolGroups}
+                    onChange={(priorityPools) => onChange({ priorityPools })}
+                    onlyAllowPrioritized={values.onlyAllowPrioritized}
+                    onOnlyAllowPrioritizedChange={(onlyAllowPrioritized) =>
+                        onChange({ onlyAllowPrioritized })
+                    }
+                />
+            ) : null}
 
             <Card>
                 <CardHeader>

--- a/apps/kvark/src/components/priority-pool-editor.tsx
+++ b/apps/kvark/src/components/priority-pool-editor.tsx
@@ -1,0 +1,287 @@
+import {
+    Combobox,
+    ComboboxChip,
+    ComboboxChips,
+    ComboboxChipsInput,
+    ComboboxCollection,
+    ComboboxContent,
+    ComboboxEmpty,
+    ComboboxItem,
+    ComboboxList,
+    ComboboxValue,
+    useComboboxAnchor,
+} from "@tihlde/ui/ui/combobox";
+import { Button } from "@tihlde/ui/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@tihlde/ui/ui/card";
+import { Label } from "@tihlde/ui/ui/label";
+import { Switch } from "@tihlde/ui/ui/switch";
+import { Plus, Trash2 } from "lucide-react";
+
+import { computeClassYear } from "#/lib/utils";
+
+/** Det minste en pool-velger trenger for å sende en slug videre. */
+export type PoolGroup = {
+    slug: string;
+    name: string;
+    /** `STUDYYEAR`, `STUDY`, `COMMITTEE` … Vises som undertekst i lista. */
+    type: string;
+};
+
+/** En pool er en liste med gruppe-slugs. Rekkefølgen på poolene er uten betydning. */
+export type PriorityPool = { groups: string[] };
+
+type PriorityPoolEditorProps = {
+    pools: PriorityPool[];
+    /** Alle grupper i TIHLDE — ikke bare de brukeren kan arrangere for. */
+    groups: PoolGroup[];
+    onChange: (pools: PriorityPool[]) => void;
+    onlyAllowPrioritized: boolean;
+    onOnlyAllowPrioritizedChange: (next: boolean) => void;
+};
+
+/**
+ * «Kull» og «1. klasse i år» på samme rad.
+ *
+ * Kriteriet som lagres er kull-gruppa — opptaksåret — og det er med vilje:
+ * ekte klassetrinn som kriterium hører hjemme i #581, der det utledes ved
+ * oppslag i stedet for å fryses ned i arrangementet. Men opptaksår er ikke
+ * det arrangøren tenker i. «1. og 4. klasse har prioritet» har fire år på rad
+ * blitt kodet som «i år minus tre», regnet i hodet, og bommet minst like ofte
+ * som det traff.
+ *
+ * Så vi sier begge deler: verdien er kullet, og hva kullet betyr akkurat nå.
+ * Klassetrinnet vises bare når det er innenfor et studieløp — 2017-kullet er
+ * ikke «10. klasse», det er alumni, og da er året det eneste meningsfulle.
+ */
+function cohortDetail(name: string, now = new Date()): string | null {
+    const startYear = Number.parseInt(name, 10);
+    if (!Number.isFinite(startYear)) return null;
+
+    const classYear = computeClassYear(startYear, now);
+    // 5 er lengste studieløp (master); over det studerer man ikke lenger.
+    if (classYear < 1 || classYear > 5) return null;
+
+    return `${classYear}. klasse i år`;
+}
+
+/**
+ * Norske etiketter for gruppetypene, så lista kan skille «2026» (kull) fra et
+ * studie med samme navn. Typene ligger i databasen som fritekst i store
+ * bokstaver, arvet fra Lepton.
+ */
+const TYPE_LABELS: Record<string, string> = {
+    STUDYYEAR: "Kull",
+    STUDY: "Studie",
+    COMMITTEE: "Komité",
+    BOARD: "Styre",
+    SUBGROUP: "Undergruppe",
+    INTERESTGROUP: "Interessegruppe",
+    SPORTSTEAM: "Idrettslag",
+    TIHLDE: "TIHLDE",
+    PRIVATE: "Privat",
+};
+
+/**
+ * Redigerer prioriteringspoolene på et arrangement.
+ *
+ * Poolene fantes i databasen og i API-et hele tiden, men begge adminsidene
+ * sendte `priorityPools: null`, så feltet var uåpnelig fra nettsiden. Ingen
+ * pool var laget i Photon siden Lepton-importen — alle 258 kom derfra — og
+ * arrangementer opprettet etter det sto uten prioritering uten at noe sa fra.
+ *
+ * Semantikken er verdt å lese før du endrer noe her: **alle gruppene i én pool
+ * må stemme samtidig, mens det holder å treffe én av poolene.** «1. klasse
+ * eller 4. klasse» er derfor to pooler, mens «førsteklassinger på data» er én
+ * pool med to grupper. Se `isUserPrioritized` i API-et.
+ *
+ * Merk at koden og grensesnittet bruker ulike ord med hensikt. API-et og typene
+ * her sier «pool» og «grupper», fordi det er det feltene heter. Brukeren ser
+ * «prioritert gruppe» og «kriterie», fordi «pool» ikke betyr noe for en
+ * arrangør — og fordi «gruppe» i den forstand er nettopp det poolen beskriver:
+ * de som skal prioriteres. Endrer du ordene ett sted, gjør det begge.
+ */
+export function PriorityPoolEditor({
+    pools,
+    groups,
+    onChange,
+    onlyAllowPrioritized,
+    onOnlyAllowPrioritizedChange,
+}: PriorityPoolEditorProps) {
+    const bySlug = new Map(groups.map((g) => [g.slug, g]));
+
+    function updatePool(index: number, next: string[]) {
+        onChange(pools.map((p, i) => (i === index ? { groups: next } : p)));
+    }
+
+    function removePool(index: number) {
+        const next = pools.filter((_, i) => i !== index);
+        onChange(next);
+        // Kravet i API-et: «bare prioriterte» kan ikke stå igjen uten pooler.
+        // Å la den henge ville gitt en 400 ved lagring, uten at feltet som
+        // forårsaket den er synlig lenger.
+        if (next.length === 0) onOnlyAllowPrioritizedChange(false);
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Prioritert påmelding</CardTitle>
+                <CardDescription>
+                    Alle prioriterte grupper er likestilte. Legg til flere
+                    kriterier i samme gruppe for å oppnå strengere krav.
+                    «Førsteklassinger på data» blir én gruppe med kriteriene
+                    «Dataingeniør» og «1. klasse».
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+                {pools.length === 0 ? (
+                    <CardDescription>
+                        Ingen prioriterte grupper. Alle som kan melde seg på
+                        stiller likt.
+                    </CardDescription>
+                ) : (
+                    pools.map((pool, index) => (
+                        <div
+                            // Poolene har ingen id, og innholdet kan være tomt
+                            // mens det redigeres, så posisjonen er det eneste
+                            // stabile å nøkle på.
+                            key={index}
+                            className="flex flex-col gap-2"
+                        >
+                            <div className="flex items-center justify-between gap-2">
+                                <Label>Prioritert gruppe {index + 1}</Label>
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => removePool(index)}
+                                    aria-label={`Fjern prioritert gruppe ${index + 1}`}
+                                >
+                                    <Trash2 />
+                                </Button>
+                            </div>
+                            <GroupPicker
+                                groups={groups}
+                                value={pool.groups
+                                    .map((slug) => bySlug.get(slug))
+                                    .filter((g): g is PoolGroup => Boolean(g))}
+                                onValueChange={(next) =>
+                                    updatePool(
+                                        index,
+                                        next.map((g) => g.slug),
+                                    )
+                                }
+                            />
+                        </div>
+                    ))
+                )}
+
+                <div>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => onChange([...pools, { groups: [] }])}
+                    >
+                        <Plus />
+                        Legg til prioritert gruppe
+                    </Button>
+                </div>
+
+                <Label className="flex items-start gap-3">
+                    <Switch
+                        checked={onlyAllowPrioritized}
+                        disabled={pools.length === 0}
+                        onCheckedChange={onOnlyAllowPrioritizedChange}
+                    />
+                    <span className="flex flex-col gap-1">
+                        <span>Bare prioriterte kan melde seg på</span>
+                        <CardDescription>
+                            Uten denne havner alle andre på venteliste i stedet
+                            for å bli avvist. Krever minst én prioritert gruppe.
+                        </CardDescription>
+                    </span>
+                </Label>
+            </CardContent>
+        </Card>
+    );
+}
+
+function GroupPicker({
+    groups,
+    value,
+    onValueChange,
+}: {
+    groups: PoolGroup[];
+    value: PoolGroup[];
+    onValueChange: (next: PoolGroup[]) => void;
+}) {
+    const anchor = useComboboxAnchor();
+    return (
+        <Combobox
+            items={groups}
+            multiple
+            value={value}
+            onValueChange={onValueChange}
+            itemToStringLabel={(item: PoolGroup) => item.name}
+            itemToStringValue={(item: PoolGroup) => item.slug}
+            isItemEqualToValue={(a: PoolGroup, b: PoolGroup) =>
+                a.slug === b.slug
+            }
+        >
+            <ComboboxChips ref={anchor}>
+                <ComboboxValue>
+                    {(selected: PoolGroup[]) => (
+                        <>
+                            {selected.map((group) => {
+                                const detail = cohortDetail(group.name);
+                                return (
+                                    <ComboboxChip key={group.slug}>
+                                        {detail
+                                            ? `${group.name} (${detail.replace(" i år", "")})`
+                                            : group.name}
+                                    </ComboboxChip>
+                                );
+                            })}
+                            <ComboboxChipsInput placeholder="Legg til kriterie" />
+                        </>
+                    )}
+                </ComboboxValue>
+            </ComboboxChips>
+            <ComboboxContent anchor={anchor}>
+                <ComboboxList>
+                    <ComboboxEmpty>Ingen treff</ComboboxEmpty>
+                    <ComboboxCollection>
+                        {(item: PoolGroup) => (
+                            <ComboboxItem key={item.slug} value={item}>
+                                <span className="flex flex-col">
+                                    <span>{item.name}</span>
+                                    {/*
+                                     * Uten typen er «2026» (kull) umulig å
+                                     * skille fra et studie som heter det samme.
+                                     */}
+                                    <CardDescription>
+                                        {[
+                                            TYPE_LABELS[
+                                                item.type.toUpperCase()
+                                            ] ?? item.type,
+                                            cohortDetail(item.name),
+                                        ]
+                                            .filter(Boolean)
+                                            .join(" · ")}
+                                    </CardDescription>
+                                </span>
+                            </ComboboxItem>
+                        )}
+                    </ComboboxCollection>
+                </ComboboxList>
+            </ComboboxContent>
+        </Combobox>
+    );
+}

--- a/apps/kvark/src/components/priority-pool-editor.tsx
+++ b/apps/kvark/src/components/priority-pool-editor.tsx
@@ -36,6 +36,19 @@ export type PoolGroup = {
 /** En pool er en liste med gruppe-slugs. Rekkefølgen på poolene er uten betydning. */
 export type PriorityPool = { groups: string[] };
 
+/**
+ * Poolene slik de skal lagres: tomme kastes.
+ *
+ * En pool uten grupper matcher ingen (`isUserPrioritized` krever
+ * `length > 0`), så lagret ville den bare vært en rad som ser ut som en regel
+ * uten å være det — og sammen med «bare prioriterte» ville den stengt
+ * arrangementet for alle. En nettopp lagt til gruppe brukeren ikke rakk å
+ * fylle ut er en mellomtilstand i skjemaet, ikke noe å skrive til databasen.
+ */
+export function poolsForSubmit(pools: PriorityPool[]): PriorityPool[] {
+    return pools.filter((pool) => pool.groups.length > 0);
+}
+
 type PriorityPoolEditorProps = {
     pools: PriorityPool[];
     /** Alle grupper i TIHLDE — ikke bare de brukeren kan arrangere for. */
@@ -115,8 +128,28 @@ export function PriorityPoolEditor({
 }: PriorityPoolEditorProps) {
     const bySlug = new Map(groups.map((g) => [g.slug, g]));
 
+    /**
+     * En gruppe uten kriterier stenger alle ute i stedet for å slippe noen inn.
+     *
+     * `isUserPrioritized` krever `poolGroupSlugs.length > 0`, så en tom pool
+     * matcher ingen — og API-ets validering ser bare at det *finnes* en pool,
+     * ikke at den har innhold. «Bare prioriterte» + én tom gruppe passerer
+     * altså validering og gjør arrangementet umulig å melde seg på.
+     *
+     * Bryteren følger derfor gruppene som faktisk har kriterier, ikke antallet
+     * rader i skjemaet. En nettopp lagt til gruppe er en mellomtilstand, ikke
+     * et valg.
+     */
+    const effectivePools = pools.filter((p) => p.groups.length > 0);
+
     function updatePool(index: number, next: string[]) {
-        onChange(pools.map((p, i) => (i === index ? { groups: next } : p)));
+        const updated = pools.map((p, i) =>
+            i === index ? { groups: next } : p,
+        );
+        onChange(updated);
+        if (!updated.some((p) => p.groups.length > 0)) {
+            onOnlyAllowPrioritizedChange(false);
+        }
     }
 
     function removePool(index: number) {
@@ -125,7 +158,9 @@ export function PriorityPoolEditor({
         // Kravet i API-et: «bare prioriterte» kan ikke stå igjen uten pooler.
         // Å la den henge ville gitt en 400 ved lagring, uten at feltet som
         // forårsaket den er synlig lenger.
-        if (next.length === 0) onOnlyAllowPrioritizedChange(false);
+        if (!next.some((p) => p.groups.length > 0)) {
+            onOnlyAllowPrioritizedChange(false);
+        }
     }
 
     return (
@@ -197,14 +232,15 @@ export function PriorityPoolEditor({
                 <Label className="flex items-start gap-3">
                     <Switch
                         checked={onlyAllowPrioritized}
-                        disabled={pools.length === 0}
+                        disabled={effectivePools.length === 0}
                         onCheckedChange={onOnlyAllowPrioritizedChange}
                     />
                     <span className="flex flex-col gap-1">
                         <span>Bare prioriterte kan melde seg på</span>
                         <CardDescription>
                             Uten denne havner alle andre på venteliste i stedet
-                            for å bli avvist. Krever minst én prioritert gruppe.
+                            for å bli avvist. Krever minst én prioritert gruppe
+                            med et kriterium.
                         </CardDescription>
                     </span>
                 </Label>

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -65,6 +65,7 @@ import { AdminStatCard } from "#/components/admin-stat-card";
 import { ConfirmDeleteDialog } from "#/components/confirm-delete-dialog";
 import type { EventFormValues } from "#/components/event-form";
 import { ALL_INSTITUTES, EventForm } from "#/components/event-form";
+import { poolsForSubmit } from "#/components/priority-pool-editor";
 import type { NewFormValues } from "#/components/new-form-dialog";
 import { NewFormDialog } from "#/components/new-form-dialog";
 import {
@@ -375,7 +376,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
             isRegistrationClosed: event.closed,
             requiresSigningUp: values.requiresSigningUp,
             allowWaitlist: values.requiresSigningUp,
-            priorityPools: values.priorityPools,
+            priorityPools: poolsForSubmit(values.priorityPools),
             onlyAllowPrioritized: values.onlyAllowPrioritized,
             canCauseStrikes: values.canCauseStrikes,
             enforcesPreviousStrikes: values.canCauseStrikes,

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -218,6 +218,12 @@ function valuesFromEvent(event: Event): EventFormValues {
         typeof event.locationLng === "number";
 
     return {
+        // Arrangementet leverer poolene med hele gruppeobjekter; skjemaet
+        // jobber på slugs, som er det API-et tar imot igjen.
+        priorityPools: (event.priorityPools ?? []).map((pool) => ({
+            groups: pool.groups.map((g) => g.slug),
+        })),
+        onlyAllowPrioritized: event.onlyAllowPrioritized,
         title: event.title,
         description: event.description,
         categorySlug: event.category.slug,
@@ -369,8 +375,8 @@ function DetailsTab({ eventId }: { eventId: string }) {
             isRegistrationClosed: event.closed,
             requiresSigningUp: values.requiresSigningUp,
             allowWaitlist: values.requiresSigningUp,
-            priorityPools: null,
-            onlyAllowPrioritized: event.onlyAllowPrioritized,
+            priorityPools: values.priorityPools,
+            onlyAllowPrioritized: values.onlyAllowPrioritized,
             canCauseStrikes: values.canCauseStrikes,
             enforcesPreviousStrikes: values.canCauseStrikes,
             isPaidEvent: values.isPaidEvent,
@@ -415,6 +421,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
                 values={values}
                 onChange={handleChange}
                 groups={groups}
+                poolGroups={allGroups}
                 institutes={institutes}
                 contactPersonCandidates={contactPersonCandidates}
                 existingImageUrl={event.image}

--- a/apps/kvark/src/routes/admin/arrangementer.ny.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.ny.tsx
@@ -18,6 +18,7 @@ import { AdminNoAccess } from "#/components/admin-no-access";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import type { EventFormValues } from "#/components/event-form";
 import { ALL_INSTITUTES, EventForm } from "#/components/event-form";
+import { poolsForSubmit } from "#/components/priority-pool-editor";
 import {
     useAnyScopePermission,
     useCanActForGroup,
@@ -214,7 +215,7 @@ function NewEventPage() {
                     isRegistrationClosed: false,
                     requiresSigningUp: values.requiresSigningUp,
                     allowWaitlist: values.requiresSigningUp,
-                    priorityPools: values.priorityPools,
+                    priorityPools: poolsForSubmit(values.priorityPools),
                     onlyAllowPrioritized: values.onlyAllowPrioritized,
                     canCauseStrikes: values.canCauseStrikes,
                     enforcesPreviousStrikes: values.canCauseStrikes,

--- a/apps/kvark/src/routes/admin/arrangementer.ny.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.ny.tsx
@@ -64,6 +64,8 @@ function eventDateDefaults() {
 }
 
 const emptyValues: EventFormValues = {
+    priorityPools: [],
+    onlyAllowPrioritized: false,
     title: "",
     description: "",
     categorySlug: "",
@@ -212,8 +214,8 @@ function NewEventPage() {
                     isRegistrationClosed: false,
                     requiresSigningUp: values.requiresSigningUp,
                     allowWaitlist: values.requiresSigningUp,
-                    priorityPools: null,
-                    onlyAllowPrioritized: false,
+                    priorityPools: values.priorityPools,
+                    onlyAllowPrioritized: values.onlyAllowPrioritized,
                     canCauseStrikes: values.canCauseStrikes,
                     enforcesPreviousStrikes: values.canCauseStrikes,
                     isPaidEvent: values.isPaidEvent,
@@ -267,6 +269,7 @@ function NewEventPage() {
                 values={values}
                 onChange={handleChange}
                 groups={groups}
+                poolGroups={allGroups}
                 institutes={institutes}
                 contactPersonCandidates={contactPersonCandidates}
                 addressSuggestions={addressSuggestions ?? []}


### PR DESCRIPTION
Gjør det mulig å sette prioriterte grupper på et arrangement fra adminpanelet.

Del av #581.

## Hullet

Poolene har ligget i databasen og i API-et hele tiden — `create.ts` og `update.ts` håndterer `priorityPools` fullt ut — men begge adminsidene sendte `priorityPools: null` hardkodet, og `update.ts` behandler `null` som «rør ikke poolene». Feltet var dermed uåpnelig fra nettsiden.

Konsekvensen er målbar i prod:

| | |
|---|---|
| Prioriteringspooler totalt | 258 |
| **Laget i Photon etter migreringen** | **0** |
| Nyeste arrangement med pool | 5. juni 2026 |

Alle 258 kom fra Lepton-importen. **Alt som er opprettet etter 22. juli står uten prioritering** — inkludert Immatrikuleringsball 2026, der påmeldingen åpner 21. august. Det var ikke en forglemmelse fra FadderKom; de har ikke hatt noen måte å gjøre det på.

## Løsningen

En `PriorityPoolEditor` i den delte `EventForm`, så både «nytt arrangement» og «rediger» får den. Vises bare når arrangementet har påmelding.

API-et er uendret — det støttet dette hele tiden.

### Ord som ikke er de samme i kode og UI

Koden sier «pool» og «grupper», fordi det er det API-feltene heter. Brukeren ser **«prioritert gruppe»** og **«kriterie»**, fordi «pool» ikke betyr noe for en arrangør — og fordi en prioritert gruppe er nettopp det poolen beskriver: de som skal prioriteres, definert av ett eller flere kriterier. Bruddet er dokumentert i komponenten.

### Semantikken står i kortet

«Alle prioriterte grupper er likestilte. Legg til flere kriterier i samme gruppe for å oppnå strengere krav.»

Det er AND innad i en pool og OR på tvers, som er den delen som er lett å ta feil av. «1. klasse eller 4. klasse» blir to prioriterte grupper; «førsteklassinger på data» blir én gruppe med to kriterier.

### Kull vises med hva de betyr i år

Kriteriet som lagres er kull-gruppa — opptaksåret. Men opptaksår er ikke det arrangøren tenker i, og «i år minus tre» har blitt regnet i hodet på fire immeball på rad, med fire ulike resultater:

| Ball | Pooler |
|---|---|
| H22 | `hs`, `2022` |
| 2023 | `2023`, `hs`, `2020` |
| 2024 | `2024`, `hs`, `2021`, `forvaltningsgruppen` |
| 2025 | `hs`, `2022 + digital-samhandling`, `2025` |

Så velgeren sier begge deler: **`2023` → «Kull · 4. klasse i år»**. Klassetrinnet vises bare når det er innenfor et studieløp (1–5); kull 2021 og eldre får bare «Kull», siden «6. klasse» ville vært tull. Chippen viser det samme etter valg, så et lagret arrangement kan leses uten hoderegning neste år.

Dette er bevisst en *etikett*, ikke et nytt kriterium. Ekte klassetrinn som kriterium — der betydningen ikke drifter mellom år — hører hjemme i #581, der det utledes ved oppslag i `getUserGroupSlugs` i stedet for å fryses ned i arrangementet.

### Detaljer verdt å vite

- Velgeren bruker en egen `poolGroups`-prop, ikke `groups`. Sistnevnte er filtrert til gruppene brukeren kan arrangere for, mens et kriterium typisk peker på kull og studier arrangøren ikke er medlem av.
- Gruppetypen vises under navnet. Uten den er «2026» som kull umulig å skille fra et studie med samme navn.
- «Bare prioriterte kan melde seg på» slås av når siste gruppe fjernes. API-et avviser kombinasjonen, og en bryter som gir 400 uten at feltet den gjelder er synlig lenger, er ikke til å feilsøke.

## Testing

Verifisert lokalt gjennom hele kjeden, ikke bare at det rendrer: la til gruppe → søkte opp kriterium → valgte det → lagret → **fant raden i `event_priority_pool_group`** → lastet siden på nytt og så at kriteriet kom tilbake i skjemaet. Så vidt vi vet den første prioriteringspoolen som er laget i Photon.

613 API-tester grønne, typecheck på 9 pakker, lint 0 feil, format rent, build grønn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
