### PR TITLE
feat(arrangement): la betalte deltakere selge billetten sin videre

### DIFF
--- a/apps/api/src/routes/event/get.ts
+++ b/apps/api/src/routes/event/get.ts
@@ -121,6 +121,22 @@ export const getRoute = route().get(
             });
 
             if (dbRegistration) {
+                // Om betalingen er gjennomført avgjør om medlemmet får
+                // tilbudet om å selge billetten sin videre. Bare paid-events
+                // har rader i betalingstabellen, så gratisarrangementer
+                // slipper spørringen.
+                const payment = event.isPaidEvent
+                    ? await db.query.eventPayment.findFirst({
+                          columns: { id: true },
+                          where: (payment, { eq, and }) =>
+                              and(
+                                  eq(payment.eventId, event.id),
+                                  eq(payment.userId, user.id),
+                                  eq(payment.status, "paid"),
+                              ),
+                      })
+                    : undefined;
+
                 registration = {
                     attendedAt:
                         dbRegistration.attendedAt?.toISOString() ?? null,
@@ -128,6 +144,7 @@ export const getRoute = route().get(
                     status: dbRegistration.status,
                     updatedAt: dbRegistration.updatedAt.toISOString(),
                     waitlistPosition: dbRegistration.waitlistPosition,
+                    hasPaid: payment !== undefined,
                 };
             }
         }

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -671,6 +671,10 @@ export const eventDetailSchema = Schema(
                     description:
                         "When the user was registered as an attendee by TIHLDE for this event. Is null if not attended.",
                 }),
+                hasPaid: z.boolean().meta({
+                    description:
+                        "Whether the user has a completed payment for this event. Always false on free events.",
+                }),
             })
             .nullable()
             .meta({

--- a/apps/api/src/test/event/registration-has-paid.test.ts
+++ b/apps/api/src/test/event/registration-has-paid.test.ts
@@ -1,0 +1,107 @@
+import { schema } from "@photon/db";
+import { and, eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+// `hasPaid` is what decides whether the event page offers the member the
+// ticket-resale link, so it must stay false until the payment is actually
+// completed.
+describe("event detail registration.hasPaid", () => {
+    integrationTest(
+        "is false while the payment for a paid event is still pending",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                isPaidEvent: true,
+                priceMinor: 10000,
+                paymentGracePeriodMinutes: 30,
+            });
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, user.id);
+            await ctx.db.insert(schema.eventPayment).values({
+                eventId: event.id,
+                userId: user.id,
+                amountMinor: 10000,
+                status: "pending",
+            });
+
+            const client = await ctx.utils.clientForUser(user);
+            const response = await client.api.event[":eventId"].$get({
+                param: { eventId: event.id },
+            });
+            expect(response.status).toBe(200);
+            const body = await response.json();
+            // 404-svaret er en streng, så smalne typen inn før feltet leses.
+            if (typeof body === "string") throw new Error(body);
+            expect(body.registration?.hasPaid).toBe(false);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "is true once the payment is completed",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                isPaidEvent: true,
+                priceMinor: 10000,
+                paymentGracePeriodMinutes: 30,
+            });
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, user.id);
+            await ctx.db.insert(schema.eventPayment).values({
+                eventId: event.id,
+                userId: user.id,
+                amountMinor: 10000,
+                status: "paid",
+            });
+
+            const client = await ctx.utils.clientForUser(user);
+            const response = await client.api.event[":eventId"].$get({
+                param: { eventId: event.id },
+            });
+            expect(response.status).toBe(200);
+            const body = await response.json();
+            // 404-svaret er en streng, så smalne typen inn før feltet leses.
+            if (typeof body === "string") throw new Error(body);
+            expect(body.registration?.hasPaid).toBe(true);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "is false on a free event, where no payment exists",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({});
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, user.id);
+
+            const client = await ctx.utils.clientForUser(user);
+            const response = await client.api.event[":eventId"].$get({
+                param: { eventId: event.id },
+            });
+            expect(response.status).toBe(200);
+            const body = await response.json();
+            // 404-svaret er en streng, så smalne typen inn før feltet leses.
+            if (typeof body === "string") throw new Error(body);
+            expect(body.registration?.hasPaid).toBe(false);
+
+            // Guard against the free-event path accidentally creating one.
+            const payments = await ctx.db.query.eventPayment.findMany({
+                where: and(
+                    eq(schema.eventPayment.eventId, event.id),
+                    eq(schema.eventPayment.userId, user.id),
+                ),
+            });
+            expect(payments).toHaveLength(0);
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -15,6 +15,7 @@ import {
     Lock,
     QrCode,
     Tag,
+    Ticket,
     Users,
     type LucideIcon,
 } from "lucide-react";
@@ -45,6 +46,12 @@ type EventRegistrationCardProps = {
     onPay?: () => void;
     qrSlot?: ReactNode;
     headerSlot?: ReactNode;
+    /**
+     * Lenka til Facebook-gruppa for billettsalg. Settes bare når medlemmet har
+     * betalt for plassen sin, så tilbudet om å selge billetten videre kun
+     * dukker opp for dem som faktisk har en billett å selge.
+     */
+    ticketResaleUrl?: string;
     /**
      * Satt når medlemmet ikke har godkjent arrangementsreglene. Da vises
      * `eventRulesSlot` i stedet for påmeldingsknappen — også før påmeldingen
@@ -179,6 +186,22 @@ function getStateRendering(
                                 Påmeldingsbevis
                             </Button>
                         )}
+                        {props.ticketResaleUrl ? (
+                            <Button
+                                variant="outline"
+                                className="w-full"
+                                render={
+                                    <a
+                                        href={props.ticketResaleUrl}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    />
+                                }
+                            >
+                                <Ticket />
+                                Selg billetten din
+                            </Button>
+                        ) : null}
                         <Button
                             variant="destructive"
                             className="w-full"

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -180,6 +180,14 @@ export function registrationErrorMessage(error: unknown): string {
 }
 
 /**
+ * Facebook-gruppa der medlemmer kjøper og selger billetter til betalte
+ * arrangementer. Samme gruppe som den gamle nettsida lenket til, så alle som
+ * allerede er medlem der finner igjen det de er vant til.
+ */
+export const TICKET_RESALE_GROUP_URL =
+    "https://www.facebook.com/groups/598608738731749/";
+
+/**
  * Build a price label from the API event's paid-event fields.
  * `priceMinor` is stored in minor units (øre).
  */

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -59,6 +59,7 @@ import {
     formatEventTime,
     registrationErrorMessage,
     registrationPollInterval,
+    TICKET_RESALE_GROUP_URL,
 } from "#/lib/event";
 
 export const Route = createFileRoute("/_app/arrangementer/$slug")({
@@ -417,6 +418,14 @@ function EventDetailPage() {
                         }
                         waitlistPosition={
                             event.registration?.waitlistPosition ?? undefined
+                        }
+                        // Har man betalt for plassen sin, er billetten noe man
+                        // kan bli sittende igjen med. Da tilbyr vi samme utvei
+                        // som før: legg den ut i Facebook-gruppa.
+                        ticketResaleUrl={
+                            event.registration?.hasPaid
+                                ? TICKET_RESALE_GROUP_URL
+                                : undefined
                         }
                         headerSlot={
                             canSeeRegistrants ? (

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3939,6 +3939,8 @@ export interface components {
                 waitlistPosition: number | null;
                 /** @description When the user was registered as an attendee by TIHLDE for this event. Is null if not attended. */
                 attendedAt: string | null;
+                /** @description Whether the user has a completed payment for this event. Always false on free events. */
+                hasPaid: boolean;
             } | null;
         };
         EventRegistration: {


### PR DESCRIPTION
## Hva

På betalte arrangementer får medlemmer som har plass **og** har betalt nå en knapp «Selg billetten din» i påmeldingskortet. Den går til den samme Facebook-gruppa for billettsalg som den gamle nettsida (Kvark/Lepton) lenket til, så folk som allerede er medlem der finner igjen det de er vant til.

## Hvordan

- **API**: `GET /api/event/:eventId` legger ved `registration.hasPaid` — sann bare når det finnes en `paid`-rad i `event_payment` for brukeren på arrangementet. Gratisarrangementer slipper spørringen og får alltid `false`.
- **Kvark**: `EventRegistrationCard` har fått en `ticketResaleUrl`-prop som vises i «Du har plass»-tilstanden. Arrangementssiden setter den kun når `registration.hasPaid` er sann. URL-en ligger som konstant i `lib/event.ts`.

## Verifisert

- 3 nye integrasjonstester (`registration-has-paid.test.ts`): betalt → `true`, pending → `false`, gratis → `false` og ingen betalingsrad opprettes.
- I nettleseren mot lokal API + dev-DB: med betalt påmelding rendres lenka som en ekte `<a>` med riktig href, `target="_blank"` og `rel="noreferrer"`. Settes betalingen til `pending`, forsvinner den mens resten av kortet står uendret. Ingen console-feil.
- `bun run typecheck`, `lint` og `format` er grønne.

## Ikke med

Lepton hadde også motsatt variant — «Sjekk om noen selger billett her» for de som ikke har plass på et fullt arrangement. Den er bevisst holdt utenfor her; si fra om den også ønskes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)