### PR TITLE
feat(arrangement): la enkeltpersoner være prioritert på arrangementer

### DIFF
--- a/apps/api/src/lib/event/payment.ts
+++ b/apps/api/src/lib/event/payment.ts
@@ -34,6 +34,7 @@ type PaidEventLike = {
     paymentGracePeriodMinutes: number | null;
     enforcesPreviousStrikes: boolean;
     pools: Array<{ groups: Array<{ groupSlug: string }> }>;
+    priorityUsers: Array<{ userId: string }>;
 };
 
 function eventUrl(slug: string): string {
@@ -334,7 +335,7 @@ export async function promoteFromWaitlist(
     // the waitlist, not one pass per member of it.
     const positions = await calculateWaitlistPositions(
         event.id,
-        event.pools,
+        event,
         event.enforcesPreviousStrikes,
         ctx.db,
     );
@@ -423,6 +424,7 @@ export async function handlePaymentExpiration(
                         groups: true,
                     },
                 },
+                priorityUsers: true,
             },
         });
 

--- a/apps/api/src/lib/event/priority.ts
+++ b/apps/api/src/lib/event/priority.ts
@@ -2,7 +2,47 @@ import type { DbSchema } from "@photon/db";
 import { schema } from "@photon/db";
 import { and, gte, inArray, sql } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { HTTPException } from "hono/http-exception";
 import { getStrikeActiveCutoff } from "./strikes";
+
+/**
+ * De unike id-ene i lista over navngitte prioriterte, etter at det er
+ * kontrollert at brukerne finnes.
+ *
+ * Uten sjekken slår en id som ikke finnes ut som en fremmednøkkelfeil midt i
+ * transaksjonen — 500, med spørringen i svaret. Det er ikke et teoretisk
+ * tilfelle: arrangøren søker opp noen, brukeren slettes, og lagringen skjer
+ * etterpå. Samme mønster som kontaktpersonen valideres med.
+ *
+ * Duplikater fjernes her, ikke i rutene: den sammensatte primærnøkkelen ville
+ * ellers avvist hele arrangementet fordi noen sto to ganger i lista.
+ */
+export async function resolvePriorityUserIds(
+    userIds: string[],
+    db: NodePgDatabase<DbSchema>,
+): Promise<string[]> {
+    const ids = [...new Set(userIds)];
+
+    if (ids.length === 0) {
+        return [];
+    }
+
+    const found = await db
+        .select({ id: schema.user.id })
+        .from(schema.user)
+        .where(inArray(schema.user.id, ids));
+
+    const foundIds = new Set(found.map((row) => row.id));
+    const missing = ids.filter((id) => !foundIds.has(id));
+
+    if (missing.length > 0) {
+        throw new HTTPException(400, {
+            message: `User with ID "${missing[0]}" does not exist`,
+        });
+    }
+
+    return ids;
+}
 
 /**
  * Get all group slugs that a user belongs to
@@ -25,33 +65,63 @@ interface EventPool {
     groups: Array<{ groupSlug: string }>;
 }
 
+/**
+ * The two ways an event grants priority, in the shape the loaded event row
+ * already has: pools of groups, and named individuals.
+ *
+ * Passed as one object rather than two parameters so a caller cannot load the
+ * event without its `priorityUsers` and still typecheck — forgetting it would
+ * silently drop everyone the organizer named by hand.
+ */
+export interface EventPriorityRules {
+    pools: EventPool[];
+    priorityUsers: Array<{ userId: string }>;
+}
+
 interface IsUserPrioritizedParams {
     userGroupSlugs: Set<string>;
-    eventPools: EventPool[];
+    event: EventPriorityRules;
     strikeCount: number;
     enforcesPreviousStrikes: boolean;
+    /**
+     * Whether the event names this user directly. Kept as a flag rather than
+     * a user id so the group-based path stays free of identity: this function
+     * never learns who it is reasoning about.
+     */
+    isNamedIndividually: boolean;
 }
 
 /**
  * Determine if a user is prioritized for an event
  *
  * A user is prioritized if they:
+ * - Are named individually on the event, OR
  * - Belong to ALL groups in AT LEAST ONE priority pool
- * - Have fewer than 3 strikes (if enforcesPreviousStrikes is true)
+ * - and have fewer than 3 strikes (if enforcesPreviousStrikes is true)
+ *
+ * The strike rule applies to named individuals too. Being singled out says
+ * the organizer wants you ahead of the queue, not that prikkene dine er
+ * strøket — and an event that enforces strikes would otherwise have a way to
+ * quietly not enforce them.
  */
 export function isUserPrioritized({
     userGroupSlugs,
-    eventPools,
+    event,
     strikeCount,
     enforcesPreviousStrikes,
+    isNamedIndividually,
 }: IsUserPrioritizedParams): boolean {
     // Users with 3+ strikes cannot be prioritized
     if (enforcesPreviousStrikes && strikeCount >= 3) {
         return false;
     }
 
+    if (isNamedIndividually) {
+        return true;
+    }
+
     // Check if user matches any priority pool
-    for (const pool of eventPools) {
+    for (const pool of event.pools) {
         const poolGroupSlugs = pool.groups.map((g) => g.groupSlug);
 
         // User must belong to ALL groups in the pool
@@ -85,7 +155,7 @@ export type PrioritizationLookup = (userId: string) => boolean;
  */
 export async function loadPrioritization(
     userIds: string[],
-    eventPools: EventPool[],
+    event: EventPriorityRules,
     enforcesPreviousStrikes: boolean,
     db: NodePgDatabase<DbSchema>,
 ): Promise<PrioritizationLookup> {
@@ -131,12 +201,17 @@ export async function loadPrioritization(
         strikes.map((row) => [row.userId, Number(row.total)]),
     );
 
+    const namedIndividually = new Set(
+        event.priorityUsers.map((entry) => entry.userId),
+    );
+
     return (userId: string) =>
         isUserPrioritized({
             userGroupSlugs: groupsByUser.get(userId) ?? new Set<string>(),
-            eventPools,
+            event,
             strikeCount: strikesByUser.get(userId) ?? 0,
             enforcesPreviousStrikes,
+            isNamedIndividually: namedIndividually.has(userId),
         });
 }
 
@@ -155,7 +230,7 @@ interface Registration {
  */
 export async function findSwapTarget(
     registeredUsers: Registration[],
-    eventPools: EventPool[],
+    event: EventPriorityRules,
     enforcesPreviousStrikes: boolean,
     db: NodePgDatabase<DbSchema>,
 ): Promise<Registration | null> {
@@ -166,7 +241,7 @@ export async function findSwapTarget(
 
     const isPrioritized = await loadPrioritization(
         registered.map((r) => r.userId),
-        eventPools,
+        event,
         enforcesPreviousStrikes,
         db,
     );
@@ -189,7 +264,7 @@ export async function findSwapTarget(
  */
 export async function calculateWaitlistPositions(
     eventId: string,
-    eventPools: EventPool[],
+    event: EventPriorityRules,
     enforcesPreviousStrikes: boolean,
     db: NodePgDatabase<DbSchema>,
 ): Promise<Map<string, number>> {
@@ -201,7 +276,7 @@ export async function calculateWaitlistPositions(
 
     const isPrioritized = await loadPrioritization(
         waitlisted.map((reg) => reg.userId),
-        eventPools,
+        event,
         enforcesPreviousStrikes,
         db,
     );
@@ -234,13 +309,13 @@ export async function calculateWaitlistPositions(
 export async function calculateWaitlistPosition(
     userId: string,
     eventId: string,
-    eventPools: EventPool[],
+    event: EventPriorityRules,
     enforcesPreviousStrikes: boolean,
     db: NodePgDatabase<DbSchema>,
 ): Promise<number> {
     const positions = await calculateWaitlistPositions(
         eventId,
-        eventPools,
+        event,
         enforcesPreviousStrikes,
         db,
     );

--- a/apps/api/src/lib/event/resolve-registration.ts
+++ b/apps/api/src/lib/event/resolve-registration.ts
@@ -78,6 +78,7 @@ export async function resolveRegistrationsForEvent(
                         groups: true,
                     },
                 },
+                priorityUsers: true,
             },
         });
 
@@ -121,7 +122,7 @@ export async function resolveRegistrationsForEvent(
          */
         const isUserPrioritizedForEvent = await loadPrioritization(
             pendingRegistrations.map((registration) => registration.userId),
-            event.pools,
+            event,
             event.enforcesPreviousStrikes,
             tx,
         );
@@ -189,7 +190,7 @@ export async function resolveRegistrationsForEvent(
                 // Try to swap with non-prioritized user
                 const swapTarget = await findSwapTarget(
                     event.registrations,
-                    event.pools,
+                    event,
                     event.enforcesPreviousStrikes,
                     tx,
                 );
@@ -257,7 +258,7 @@ export async function resolveRegistrationsForEvent(
             if (finalStatus === "waitlisted") {
                 const positions = await calculateWaitlistPositions(
                     eventId,
-                    event.pools,
+                    event,
                     event.enforcesPreviousStrikes,
                     tx,
                 );
@@ -332,7 +333,7 @@ export async function resolveRegistrationsForEvent(
                 // One pass over the waitlist, not one pass per member of it.
                 const positions = await calculateWaitlistPositions(
                     eventId,
-                    event.pools,
+                    event,
                     event.enforcesPreviousStrikes,
                     tx,
                 );

--- a/apps/api/src/routes/event/create.ts
+++ b/apps/api/src/routes/event/create.ts
@@ -4,6 +4,7 @@ import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { promoteAssetUrls } from "~/lib/asset";
 import { canActOnEventsForGroup } from "~/lib/event/access";
+import { resolvePriorityUserIds } from "~/lib/event/priority";
 import { describeRoute } from "~/lib/openapi";
 import { requireAccess } from "~/middleware/access";
 import { generateUniqueEventSlug } from "../../lib/event/slug";
@@ -216,6 +217,21 @@ export const createRoute = route().post(
                         });
                     }
                 }
+            }
+
+            // Navngitte enkeltpersoner. Duplikater og ukjente id-er tas av
+            // `resolvePriorityUserIds`, som kontaktpersonen over.
+            const priorityUserIds = await resolvePriorityUserIds(
+                body.priorityUserIds ?? [],
+                tx,
+            );
+            if (priorityUserIds.length > 0) {
+                await tx.insert(schema.eventPriorityUser).values(
+                    priorityUserIds.map((priorityUserId) => ({
+                        eventId,
+                        userId: priorityUserId,
+                    })),
+                );
             }
         });
 

--- a/apps/api/src/routes/event/get.ts
+++ b/apps/api/src/routes/event/get.ts
@@ -1,6 +1,7 @@
 import { schema } from "@photon/db";
 import { and, eq, inArray } from "drizzle-orm";
 import type z from "zod";
+import { hasPermission, hasScopedPermission } from "@photon/auth/rbac";
 import { isMemberAudience } from "~/lib/auth";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "../../lib/route";
@@ -24,7 +25,8 @@ export const getRoute = route().get(
         .build(),
     captureAuth,
     async (c) => {
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const identifier = c.req.param("eventId");
         // The public frontend routes events by slug, while other clients use
         // the UUID. Accept either: match by id when the param is a UUID,
@@ -48,6 +50,19 @@ export const getRoute = route().get(
                 },
                 restrictedToInstitute: {
                     columns: { slug: true, shortName: true, name: true },
+                },
+                priorityUsers: {
+                    columns: {},
+                    with: {
+                        user: {
+                            columns: {
+                                id: true,
+                                name: true,
+                                username: true,
+                                image: true,
+                            },
+                        },
+                    },
                 },
                 pools: {
                     columns: { priorityScore: true, id: true },
@@ -174,6 +189,47 @@ export const getRoute = route().get(
               }
             : null;
 
+        /**
+         * Hvem som er prioritert som gruppe er en regel; hvem som er
+         * prioritert ved navn er en opplysning om enkeltpersoner. Lista deles
+         * derfor bare med de som kan redigere arrangementet — de trenger den
+         * for å redigere den. Alle andre får en tom liste, ikke et hull i
+         * responsen, så klientene slipper å skille «ingen» fra «vet ikke».
+         *
+         * Samme regel som PUT-en krever (`requireEventAccess` + eierskap), så
+         * den som får se lista er nøyaktig den som får skrive den.
+         *
+         * Rekkefølgen i betingelsen er ikke tilfeldig: dette er den mest
+         * trafikkerte ruten på nettsiden, og de aller fleste arrangementer har
+         * ingen navngitte i det hele tatt. Da skal ingen rettighetssjekk
+         * kjøre. Scopet leses fra raden vi allerede har lastet, framfor å be
+         * `canActOnEvent` hente arrangørgruppa på nytt.
+         */
+        const maySeePriorityUsers =
+            event.priorityUsers.length > 0 &&
+            user != null &&
+            (event.createdByUserId === user.id ||
+                (event.organizerGroupSlug
+                    ? await hasScopedPermission(
+                          ctx,
+                          user.id,
+                          ["events:update", "events:manage"],
+                          `group:${event.organizerGroupSlug}`,
+                      )
+                    : await hasPermission(ctx, user.id, [
+                          "events:update",
+                          "events:manage",
+                      ])));
+
+        const priorityUsers = maySeePriorityUsers
+            ? event.priorityUsers.map((entry) => ({
+                  id: entry.user.id,
+                  name: entry.user.name,
+                  username: entry.user.username,
+                  image: entry.user.image,
+              }))
+            : [];
+
         const priorityPools = event.pools.map((pool) => ({
             groups: pool.groups.map((g) => ({
                 name: g.group.name,
@@ -219,6 +275,7 @@ export const getRoute = route().get(
             restrictedToInstitute: event.restrictedToInstitute ?? null,
             visibility: event.visibility,
             priorityPools,
+            priorityUsers,
             registration,
         };
 

--- a/apps/api/src/routes/event/registration/create.ts
+++ b/apps/api/src/routes/event/registration/create.ts
@@ -80,6 +80,7 @@ export const registerToEventRoute = route().post(
                             groups: true,
                         },
                     },
+                    priorityUsers: true,
                     restrictedToInstitute: true,
                 },
             }),
@@ -164,9 +165,12 @@ export const registerToEventRoute = route().post(
 
             const isPrioritized = isUserPrioritized({
                 userGroupSlugs,
-                eventPools: event.pools,
+                event,
                 strikeCount,
                 enforcesPreviousStrikes: event.enforcesPreviousStrikes,
+                isNamedIndividually: event.priorityUsers.some(
+                    (entry) => entry.userId === userId,
+                ),
             });
 
             if (!isPrioritized) {

--- a/apps/api/src/routes/event/registration/delete.ts
+++ b/apps/api/src/routes/event/registration/delete.ts
@@ -48,6 +48,7 @@ export const deleteEventRegistrationRoute = route().delete(
                         groups: true,
                     },
                 },
+                priorityUsers: true,
             },
             where: eq(schema.event.id, eventId),
         });

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -93,9 +93,20 @@ const eventMutationSchema = z.object({
             description:
                 "List of priority pools, with priority in descending order. Each pool contains a list of group slugs. Users in groups in the first pool have highest priority, then second pool, etc. Users not in any pool have lowest priority.",
         }),
+    priorityUserIds: z
+        .array(z.string())
+        .nullable()
+        // Valgfritt, i motsetning til `priorityPools`: feltet kom etter at
+        // API-et var i bruk, og et kall som ikke nevner det skal fortsatt
+        // opprette arrangementer — ikke feile på et felt det ikke kjenner.
+        .optional()
+        .meta({
+            description:
+                "User IDs prioritized individually, independent of the priority pools. A user named here is prioritized on their own — the pools' all-groups-must-match rule does not apply to them.",
+        }),
     onlyAllowPrioritized: z.boolean().meta({
         description:
-            "Only allow users in at least one priority pool to sign up. Can only be true if at least one group is in priorityPools.",
+            "Only allow prioritized users to sign up. Can only be true if at least one group is in priorityPools, or at least one user is in priorityUserIds.",
     }),
     restrictedToInstituteSlug: z.string().nullable().optional().meta({
         description:
@@ -136,17 +147,31 @@ const eventMutationSchema = z.object({
     }),
 });
 
+/**
+ * «Bare prioriterte kan melde seg på» trenger noen å slippe inn.
+ *
+ * Enten en pool eller en navngitt person holder: en pool uten grupper matcher
+ * ingen, og et arrangement som bare slipper inn prioriterte uten å ha noen
+ * prioriterte er stengt for alle uten å si det.
+ */
+function hasAnyPriority(val: {
+    priorityPools?: Array<{ groups: string[] }> | null;
+    priorityUserIds?: string[] | null;
+}): boolean {
+    const hasPool = (val.priorityPools ?? []).some(
+        (pool) => pool.groups.length > 0,
+    );
+    return hasPool || (val.priorityUserIds ?? []).length > 0;
+}
+
 export const createEventSchema = Schema(
     "CreateEventSchema",
     eventMutationSchema.superRefine((val, ctx) => {
-        if (
-            val.onlyAllowPrioritized &&
-            (!val.priorityPools || val.priorityPools.length === 0)
-        ) {
+        if (val.onlyAllowPrioritized && !hasAnyPriority(val)) {
             ctx.addIssue({
                 code: "custom",
                 message:
-                    "onlyAllowPrioritized cannot be true if priorityPools is empty",
+                    "onlyAllowPrioritized cannot be true if both priorityPools and priorityUserIds are empty",
                 path: ["onlyAllowPrioritized"],
             });
         }
@@ -275,11 +300,11 @@ export const updateEventSchema = Schema(
             val.onlyAllowPrioritized !== undefined &&
             val.onlyAllowPrioritized
         ) {
-            if (!val.priorityPools || val.priorityPools.length === 0) {
+            if (!hasAnyPriority(val)) {
                 ctx.addIssue({
                     code: "custom",
                     message:
-                        "onlyAllowPrioritized cannot be true if priorityPools is empty",
+                        "onlyAllowPrioritized cannot be true if both priorityPools and priorityUserIds are empty",
                     path: ["onlyAllowPrioritized"],
                 });
             }
@@ -630,6 +655,28 @@ export const eventDetailSchema = Schema(
                 }),
             )
             .meta({ description: "Priority registration pools" }),
+        priorityUsers: z
+            .array(
+                z.object({
+                    id: z.string().meta({ description: "User ID" }),
+                    name: z
+                        .string()
+                        .nullable()
+                        .meta({ description: "Full name" }),
+                    username: z
+                        .string()
+                        .nullable()
+                        .meta({ description: "Username" }),
+                    image: z
+                        .string()
+                        .nullable()
+                        .meta({ description: "Avatar URL (nullable)" }),
+                }),
+            )
+            .meta({
+                description:
+                    "Users prioritized individually, independent of the pools",
+            }),
         enforcesPreviousStrikes: z.boolean().meta({
             description:
                 "Does the event enforce previous strikes for registration",

--- a/apps/api/src/routes/event/update.ts
+++ b/apps/api/src/routes/event/update.ts
@@ -1,10 +1,14 @@
 import { type DbSchema, schema } from "@photon/db";
-import { type InferInsertModel, eq } from "drizzle-orm";
+import { type InferInsertModel, and, eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { promoteAssetUrls } from "~/lib/asset";
 import { describeRoute } from "~/lib/openapi";
 import { canActOnEventsForGroup, requireEventAccess } from "~/lib/event/access";
+import {
+    calculateWaitlistPositions,
+    resolvePriorityUserIds,
+} from "~/lib/event/priority";
 import { isEventOwner } from "../../lib/event/middleware";
 import { generateUniqueEventSlug } from "../../lib/event/slug";
 import { route } from "../../lib/route";
@@ -199,6 +203,28 @@ export const updateRoute = route().put(
                 }
             }
 
+            // Som poolene over: feltet erstattes i sin helhet når det er med,
+            // og røres ikke når det mangler — en PATCH som ikke nevner
+            // prioriterte personer skal ikke fjerne dem.
+            if (body.priorityUserIds) {
+                await tx
+                    .delete(schema.eventPriorityUser)
+                    .where(eq(schema.eventPriorityUser.eventId, eventId));
+
+                const priorityUserIds = await resolvePriorityUserIds(
+                    body.priorityUserIds,
+                    tx,
+                );
+                if (priorityUserIds.length > 0) {
+                    await tx.insert(schema.eventPriorityUser).values(
+                        priorityUserIds.map((priorityUserId) => ({
+                            eventId,
+                            userId: priorityUserId,
+                        })),
+                    );
+                }
+            }
+
             const updateDateNullable = (
                 date: string | null | undefined,
             ): Date | null | undefined => {
@@ -270,6 +296,64 @@ export const updateRoute = route().put(
                 .update(schema.event)
                 .set(updatedEvent)
                 .where(eq(schema.event.id, eventId));
+
+            /**
+             * Ventelista står i den rekkefølgen prioriteringen ga den, og
+             * `waitlistPosition` er det lagrede svaret — både medlemmet og
+             * `promoteFromWaitlist` leser den kolonnen, ikke reglene.
+             *
+             * Uten denne omregningen ville en nettopp lagt til prioritert
+             * blitt stående der hen sto til noen andre meldte seg på og
+             * resolveren regnet om lista som en bieffekt. Det er nettopp det
+             * tilfellet feltet er laget for: arrangementet er fullt, noen får
+             * plass lovet, og de legges til etterpå.
+             *
+             * Kjøres når prioriteringen faktisk er rørt — endres bare
+             * tittelen, er rekkefølgen den samme. Prikkehåndhevingen teller
+             * med, siden den avgjør hvem prioriteringen gjelder for.
+             */
+            const priorityChanged =
+                body.priorityPools !== undefined ||
+                body.priorityUserIds !== undefined ||
+                body.enforcesPreviousStrikes !== undefined;
+
+            if (priorityChanged) {
+                const refreshed = await tx.query.event.findFirst({
+                    where: (e, { eq }) => eq(e.id, eventId),
+                    columns: { enforcesPreviousStrikes: true },
+                    with: {
+                        pools: { with: { groups: true } },
+                        priorityUsers: true,
+                    },
+                });
+
+                if (refreshed) {
+                    const positions = await calculateWaitlistPositions(
+                        eventId,
+                        refreshed,
+                        refreshed.enforcesPreviousStrikes,
+                        tx,
+                    );
+
+                    for (const [waitlistedUserId, position] of positions) {
+                        await tx
+                            .update(schema.eventRegistration)
+                            .set({ waitlistPosition: position })
+                            .where(
+                                and(
+                                    eq(
+                                        schema.eventRegistration.eventId,
+                                        eventId,
+                                    ),
+                                    eq(
+                                        schema.eventRegistration.userId,
+                                        waitlistedUserId,
+                                    ),
+                                ),
+                            );
+                    }
+                }
+            }
 
             return slug;
         });

--- a/apps/api/src/routes/user/search.ts
+++ b/apps/api/src/routes/user/search.ts
@@ -1,4 +1,8 @@
-import { hasPermission, hasScopedPermission } from "@photon/auth/rbac";
+import {
+    hasPermission,
+    hasPermissionInAnyGroupScope,
+    hasScopedPermission,
+} from "@photon/auth/rbac";
 import { schema } from "@photon/db";
 import { ilike, or } from "drizzle-orm";
 import { createMiddleware } from "hono/factory";
@@ -24,12 +28,19 @@ export const userSearchResultSchema = Schema(
 );
 
 /**
- * Søket brukes til to ting: å tildele roller/verv (admin), og å finne noen som
- * skal legges til i en gruppe. Tilgangen speiler handlingen søket tjener — en
+ * Søket brukes til tre ting: å tildele roller/verv (admin), å finne noen som
+ * skal legges til i en gruppe, og å peke ut enkeltpersoner på et arrangement
+ * (prioritert påmelding). Tilgangen speiler handlingen søket tjener — en
  * undergruppeleder har lov til å legge til medlemmer i sin egen gruppe, og må
  * derfor kunne søke opp folk når `groupSlug` peker på den gruppen. Uten
  * `groupSlug` er det fortsatt bare `users:view`/`roles:assign` som gjelder, så
  * hele brukerregisteret ikke blir åpent for enhver leder.
+ *
+ * Arrangøren slipper inn på `events:create`/`events:update`/`events:manage`
+ * holdt for minst én gruppe. Den prioriterte kan være hvem som helst på
+ * nettsiden — en foredragsholder, en fadder, en som fikk plass lovet — så det
+ * finnes ingen gruppe å begrense søket til, og et arrangement er ikke bundet
+ * til arrangørgruppas medlemmer.
  */
 const requireUserSearchAccess = createMiddleware<{
     Variables: {
@@ -44,6 +55,17 @@ const requireUserSearchAccess = createMiddleware<{
     const ctx = c.get("ctx");
 
     if (await hasPermission(ctx, user.id, ["users:view", "roles:assign"])) {
+        await next();
+        return;
+    }
+
+    if (
+        await hasPermissionInAnyGroupScope(ctx, user.id, [
+            "events:create",
+            "events:update",
+            "events:manage",
+        ])
+    ) {
         await next();
         return;
     }
@@ -65,7 +87,7 @@ const requireUserSearchAccess = createMiddleware<{
 
     throw new HTTPException(403, {
         message:
-            "Forbidden - requires permission: users:view or roles:assign, or the right to manage the given group",
+            "Forbidden - requires permission: users:view, roles:assign or an events permission, or the right to manage the given group",
     });
 });
 
@@ -76,7 +98,7 @@ export const searchUsersRoute = route().get(
         summary: "Search users",
         operationId: "searchUsers",
         description:
-            "Search users by name or username (case-insensitive substring). Used by admin UIs to assign roles and positions. Requires 'users:view' or 'roles:assign' — or, when 'groupSlug' is given, the right to manage that group's roster ('groups:manage' scoped to it, or being its leader).",
+            "Search users by name or username (case-insensitive substring). Used by admin UIs to assign roles and positions, and to name individually prioritized users on an event. Requires 'users:view' or 'roles:assign', or an event permission ('events:create'/'events:update'/'events:manage') held for at least one group — or, when 'groupSlug' is given, the right to manage that group's roster ('groups:manage' scoped to it, or being its leader).",
     })
         .schemaResponse({
             statusCode: 200,

--- a/apps/api/src/test/event/priority-users.test.ts
+++ b/apps/api/src/test/event/priority-users.test.ts
@@ -1,0 +1,537 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { resolveRegistrationsForEvent } from "~/lib/event/resolve-registration";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * Enkeltpersoner prioritert ved navn, ved siden av gruppene i poolene.
+ *
+ * Regelen er flat der poolene er sammensatte: står du i lista, er du
+ * prioritert, uten at noen gruppe må stemme. Testene under fester de tre
+ * stedene det avgjøres — bytte om plassen på et fullt arrangement, «bare
+ * prioriterte» ved påmelding, og prikkegrensa, som gjelder her også.
+ */
+describe("individually prioritized users", () => {
+    integrationTest(
+        "a named individual swaps into a full event",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.setupGroups();
+
+            const event = await ctx.utils.createTestEvent({ capacity: 1 });
+
+            const ordinary = await ctx.utils.createTestUser();
+            const named = await ctx.utils.createTestUser();
+
+            // Prioritert uten å være med i en eneste gruppe: det er nettopp
+            // dette navngivningen skal kunne.
+            await ctx.db.insert(schema.eventPriorityUser).values({
+                eventId: event.id,
+                userId: named.id,
+            });
+
+            await ctx.utils.createPendingRegistration(event.id, ordinary.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            await ctx.utils.createPendingRegistration(event.id, named.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const namedReg = await ctx.db.query.eventRegistration.findFirst({
+                where: (reg, { and, eq }) =>
+                    and(eq(reg.eventId, event.id), eq(reg.userId, named.id)),
+            });
+            const ordinaryReg = await ctx.db.query.eventRegistration.findFirst({
+                where: (reg, { and, eq }) =>
+                    and(eq(reg.eventId, event.id), eq(reg.userId, ordinary.id)),
+            });
+
+            expect(namedReg?.status).toBe("registered");
+            expect(ordinaryReg?.status).toBe("waitlisted");
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "three strikes still block a named individual",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.setupGroups();
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 1,
+                enforcesPreviousStrikes: true,
+            });
+
+            const ordinary = await ctx.utils.createTestUser();
+            const named = await ctx.utils.createTestUser();
+
+            await ctx.db.insert(schema.eventPriorityUser).values({
+                eventId: event.id,
+                userId: named.id,
+            });
+            await ctx.db.insert(schema.eventStrike).values({
+                eventId: event.id,
+                userId: named.id,
+                count: 3,
+                reason: "Test",
+            });
+
+            await ctx.utils.createPendingRegistration(event.id, ordinary.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            await ctx.utils.createPendingRegistration(event.id, named.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const namedReg = await ctx.db.query.eventRegistration.findFirst({
+                where: (reg, { and, eq }) =>
+                    and(eq(reg.eventId, event.id), eq(reg.userId, named.id)),
+            });
+            const ordinaryReg = await ctx.db.query.eventRegistration.findFirst({
+                where: (reg, { and, eq }) =>
+                    and(eq(reg.eventId, event.id), eq(reg.userId, ordinary.id)),
+            });
+
+            // Prikkene slår inn før prioriteringen: den navngitte tar ikke
+            // plassen fra noen. (Selve statusen er `cancelled`, fordi tre
+            // prikker også utsetter påmeldingstidspunktet — se
+            // `canRegisterBasedOnStrikes`.)
+            expect(namedReg?.status).not.toBe("registered");
+            expect(ordinaryReg?.status).toBe("registered");
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "onlyAllowPrioritized admits a named individual and rejects everyone else",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.setupGroups();
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 10,
+                onlyAllowPrioritized: true,
+            });
+
+            const named = await ctx.utils.createTestUser();
+            const stranger = await ctx.utils.createTestUser();
+
+            await ctx.db.insert(schema.eventPriorityUser).values({
+                eventId: event.id,
+                userId: named.id,
+            });
+
+            for (const user of [named, stranger]) {
+                await ctx.utils.giveUserPermissions(user, [
+                    "events:registrations:create",
+                ]);
+                await ctx.utils.acceptEventRules(user.id);
+            }
+
+            const namedClient = await ctx.utils.clientForUser(named);
+            const namedResponse = await namedClient.api.event[
+                ":eventId"
+            ].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+            expect(namedResponse.status).toBe(200);
+
+            const strangerClient = await ctx.utils.clientForUser(stranger);
+            const strangerResponse = await strangerClient.api.event[
+                ":eventId"
+            ].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+            expect(strangerResponse.status).toBe(403);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "create stores the named individuals, update replaces them",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const organizer = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(organizer, [
+                "events:create",
+                "events:update",
+            ]);
+            const client = await ctx.utils.clientForUser(organizer);
+
+            const first = await ctx.utils.createTestUser();
+            const second = await ctx.utils.createTestUser();
+
+            const createResponse = await client.api.event.$post({
+                json: {
+                    title: "Prioritert arrangement",
+                    description: "…",
+                    categorySlug: "bedpres",
+                    organizerGroupSlug: "index",
+                    location: "Trondheim",
+                    imageUrl: null,
+                    start: "2026-12-01T18:00:00Z",
+                    end: "2026-12-01T20:00:00Z",
+                    registrationStart: null,
+                    registrationEnd: "2026-11-30T23:59:59Z",
+                    cancellationDeadline: null,
+                    capacity: 50,
+                    isRegistrationClosed: false,
+                    requiresSigningUp: true,
+                    allowWaitlist: true,
+                    priorityPools: null,
+                    // Duplikatet er med med vilje: primærnøkkelen ville
+                    // avvist hele arrangementet om det ikke ble luket bort.
+                    priorityUserIds: [first.id, first.id],
+                    onlyAllowPrioritized: true,
+                    canCauseStrikes: false,
+                    enforcesPreviousStrikes: false,
+                    isPaidEvent: false,
+                    price: null,
+                    paymentGracePeriodMinutes: null,
+                    contactPersonUserId: null,
+                    reactionsAllowed: true,
+                },
+            });
+
+            expect(createResponse.status).toBe(201);
+            const { eventId } = await createResponse.json();
+
+            const afterCreate = await ctx.db
+                .select({ userId: schema.eventPriorityUser.userId })
+                .from(schema.eventPriorityUser)
+                .where(eq(schema.eventPriorityUser.eventId, eventId));
+            expect(afterCreate).toEqual([{ userId: first.id }]);
+
+            const updateResponse = await client.api.event[":id"].$put({
+                param: { id: eventId },
+                json: { priorityUserIds: [second.id] },
+            });
+            expect(updateResponse.status).toBe(200);
+
+            const afterUpdate = await ctx.db
+                .select({ userId: schema.eventPriorityUser.userId })
+                .from(schema.eventPriorityUser)
+                .where(eq(schema.eventPriorityUser.eventId, eventId));
+            expect(afterUpdate).toEqual([{ userId: second.id }]);
+
+            // Et kall som ikke nevner feltet skal ikke tømme det. Det samme
+            // gjelder `null`, som betyr «ikke rør» — nøyaktig som for
+            // `priorityPools`. Bare en tom liste tømmer.
+            for (const json of [
+                { title: "Nytt navn" },
+                { priorityUserIds: null },
+            ]) {
+                const untouched = await client.api.event[":id"].$put({
+                    param: { id: eventId },
+                    json,
+                });
+                expect(untouched.status).toBe(200);
+
+                const afterUnrelatedUpdate = await ctx.db
+                    .select({ userId: schema.eventPriorityUser.userId })
+                    .from(schema.eventPriorityUser)
+                    .where(eq(schema.eventPriorityUser.eventId, eventId));
+                expect(afterUnrelatedUpdate).toEqual([{ userId: second.id }]);
+            }
+
+            const emptied = await client.api.event[":id"].$put({
+                param: { id: eventId },
+                json: { priorityUserIds: [] },
+            });
+            expect(emptied.status).toBe(200);
+
+            const afterEmptied = await ctx.db
+                .select({ userId: schema.eventPriorityUser.userId })
+                .from(schema.eventPriorityUser)
+                .where(eq(schema.eventPriorityUser.eventId, eventId));
+            expect(afterEmptied).toEqual([]);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "onlyAllowPrioritized is rejected when nobody is prioritized",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const organizer = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(organizer, ["events:create"]);
+            const client = await ctx.utils.clientForUser(organizer);
+
+            const response = await client.api.event.$post({
+                json: {
+                    title: "Stengt for alle",
+                    description: "…",
+                    categorySlug: "bedpres",
+                    organizerGroupSlug: "index",
+                    location: "Trondheim",
+                    imageUrl: null,
+                    start: "2026-12-01T18:00:00Z",
+                    end: "2026-12-01T20:00:00Z",
+                    registrationStart: null,
+                    registrationEnd: "2026-11-30T23:59:59Z",
+                    cancellationDeadline: null,
+                    capacity: 50,
+                    isRegistrationClosed: false,
+                    requiresSigningUp: true,
+                    allowWaitlist: true,
+                    // En pool uten grupper matcher ingen: sammen med «bare
+                    // prioriterte» stenger den arrangementet for alle.
+                    priorityPools: [{ groups: [] }],
+                    priorityUserIds: [],
+                    onlyAllowPrioritized: true,
+                    canCauseStrikes: false,
+                    enforcesPreviousStrikes: false,
+                    isPaidEvent: false,
+                    price: null,
+                    paymentGracePeriodMinutes: null,
+                    contactPersonUserId: null,
+                    reactionsAllowed: true,
+                },
+            });
+
+            expect(response.status).toBe(400);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "the named individuals are shown to an editor and hidden from everyone else",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                organizerGroupSlug: "index",
+            });
+            const named = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.eventPriorityUser).values({
+                eventId: event.id,
+                userId: named.id,
+            });
+
+            const editor = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(editor, ["events:update"]);
+            const editorClient = await ctx.utils.clientForUser(editor);
+            const editorResponse = await editorClient.api.event[
+                ":eventId"
+            ].$get({
+                param: { eventId: event.id },
+            });
+            expect(editorResponse.status).toBe(200);
+            const editorJson = await editorResponse.json();
+            expect(editorJson).toMatchObject({
+                priorityUsers: [{ id: named.id }],
+            });
+
+            const member = await ctx.utils.createTestUser();
+            const memberClient = await ctx.utils.clientForUser(member);
+            const memberResponse = await memberClient.api.event[
+                ":eventId"
+            ].$get({
+                param: { eventId: event.id },
+            });
+            expect(memberResponse.status).toBe(200);
+            const memberJson = await memberResponse.json();
+            expect(memberJson).toMatchObject({ priorityUsers: [] });
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "an event organizer may search the whole user register",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+
+            const organizer = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(organizer, ["events:create"]);
+            const client = await ctx.utils.clientForUser(organizer);
+
+            const response = await client.api.user.search.$get({
+                query: { q: "Brotherman" },
+            });
+
+            expect(response.status).toBe(200);
+            const results = await response.json();
+            expect(Array.isArray(results)).toBe(true);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "someone without an events permission still cannot search",
+        async ({ ctx }) => {
+            const nobody = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(nobody);
+
+            const response = await client.api.user.search.$get({
+                query: { q: "Brotherman" },
+            });
+
+            expect(response.status).toBe(403);
+        },
+        500_000,
+    );
+    integrationTest(
+        "an unknown user id is rejected with 400, not a failed insert",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const organizer = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(organizer, ["events:create"]);
+            const client = await ctx.utils.clientForUser(organizer);
+
+            const response = await client.api.event.$post({
+                json: {
+                    title: "Ukjent prioritert",
+                    description: "…",
+                    categorySlug: "bedpres",
+                    organizerGroupSlug: "index",
+                    location: "Trondheim",
+                    imageUrl: null,
+                    start: "2026-12-01T18:00:00Z",
+                    end: "2026-12-01T20:00:00Z",
+                    registrationStart: null,
+                    registrationEnd: "2026-11-30T23:59:59Z",
+                    cancellationDeadline: null,
+                    capacity: 50,
+                    isRegistrationClosed: false,
+                    requiresSigningUp: true,
+                    allowWaitlist: true,
+                    priorityPools: null,
+                    // Nåbart i praksis: arrangøren søker opp noen, brukeren
+                    // slettes, og lagringen skjer etterpå.
+                    priorityUserIds: ["finnes-ikke"],
+                    onlyAllowPrioritized: false,
+                    canCauseStrikes: false,
+                    enforcesPreviousStrikes: false,
+                    isPaidEvent: false,
+                    price: null,
+                    paymentGracePeriodMinutes: null,
+                    contactPersonUserId: null,
+                    reactionsAllowed: true,
+                },
+            });
+
+            expect(response.status).toBe(400);
+
+            // Ingenting av arrangementet skal ha overlevd forsøket.
+            const events = await ctx.db.query.event.findMany({
+                where: (e, { eq }) => eq(e.title, "Ukjent prioritert"),
+            });
+            expect(events).toEqual([]);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "a leader of another group sees neither the list nor a way to save over it",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                organizerGroupSlug: "index",
+            });
+            const named = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.eventPriorityUser).values({
+                eventId: event.id,
+                userId: named.id,
+            });
+
+            // Rettigheten gjelder en annen gruppe enn den som arrangerer.
+            const outsider = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.userPermission).values({
+                userId: outsider.id,
+                permission: "events:update",
+                scope: "group:drift",
+            });
+            const client = await ctx.utils.clientForUser(outsider);
+
+            const read = await client.api.event[":eventId"].$get({
+                param: { eventId: event.id },
+            });
+            expect(read.status).toBe(200);
+            expect(await read.json()).toMatchObject({ priorityUsers: [] });
+
+            // Og skrivetilgangen følger lesetilgangen, så den tomme lista
+            // ikke kan lagres tilbake over de navngitte.
+            const write = await client.api.event[":id"].$put({
+                param: { id: event.id },
+                json: { priorityUserIds: [] },
+            });
+            expect(write.status).toBe(403);
+
+            const rows = await ctx.db
+                .select({ userId: schema.eventPriorityUser.userId })
+                .from(schema.eventPriorityUser)
+                .where(eq(schema.eventPriorityUser.eventId, event.id));
+            expect(rows).toEqual([{ userId: named.id }]);
+        },
+        500_000,
+    );
+    integrationTest(
+        "naming someone on a full event moves them to the front of the waitlist",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            // Fullt arrangement med to på venteliste — tilfellet feltet er
+            // laget for: plassen er lovet bort etter at påmeldingen stengte.
+            const event = await ctx.utils.createTestEvent({
+                capacity: 1,
+                organizerGroupSlug: "index",
+                enforcesPreviousStrikes: false,
+            });
+
+            const holder = await ctx.utils.createTestUser();
+            const first = await ctx.utils.createTestUser();
+            const promised = await ctx.utils.createTestUser();
+
+            for (const user of [holder, first, promised]) {
+                await ctx.utils.createPendingRegistration(event.id, user.id);
+                await resolveRegistrationsForEvent(event.id, ctx);
+            }
+
+            const before = await ctx.db.query.eventRegistration.findFirst({
+                where: (reg, { and, eq }) =>
+                    and(eq(reg.eventId, event.id), eq(reg.userId, promised.id)),
+            });
+            expect(before?.status).toBe("waitlisted");
+            expect(before?.waitlistPosition).toBe(2);
+
+            const organizer = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(organizer, ["events:update"]);
+            const client = await ctx.utils.clientForUser(organizer);
+
+            const response = await client.api.event[":id"].$put({
+                param: { id: event.id },
+                json: { priorityUserIds: [promised.id] },
+            });
+            expect(response.status).toBe(200);
+
+            const after = await ctx.db.query.eventRegistration.findMany({
+                where: (reg, { and, eq }) =>
+                    and(
+                        eq(reg.eventId, event.id),
+                        eq(reg.status, "waitlisted"),
+                    ),
+            });
+
+            expect(
+                after.find((reg) => reg.userId === promised.id)
+                    ?.waitlistPosition,
+            ).toBe(1);
+            expect(
+                after.find((reg) => reg.userId === first.id)?.waitlistPosition,
+            ).toBe(2);
+        },
+        500_000,
+    );
+});

--- a/apps/api/src/test/event/waitlist-scaling.test.ts
+++ b/apps/api/src/test/event/waitlist-scaling.test.ts
@@ -80,7 +80,7 @@ describe("waitlist position calculation scales linearly", () => {
                         await calculateWaitlistPosition(
                             userId,
                             event.id,
-                            [],
+                            { pools: [], priorityUsers: [] },
                             false,
                             ctx.db,
                         ),
@@ -99,7 +99,7 @@ describe("waitlist position calculation scales linearly", () => {
             try {
                 const all = await calculateWaitlistPositions(
                     event.id,
-                    [],
+                    { pools: [], priorityUsers: [] },
                     false,
                     ctx.db,
                 );

--- a/apps/kvark/src/components/event-form.tsx
+++ b/apps/kvark/src/components/event-form.tsx
@@ -5,6 +5,8 @@ import {
     PriorityPoolEditor,
     type PoolGroup,
     type PriorityPool,
+    type PriorityUser,
+    type UserSearchState,
 } from "#/components/priority-pool-editor";
 import { Checkbox } from "@tihlde/ui/ui/checkbox";
 import { DateTimePicker } from "@tihlde/ui/ui/date-time-picker";
@@ -71,6 +73,8 @@ export type EventFormValues = {
      * holder å treffe én av poolene — se `PriorityPoolEditor`.
      */
     priorityPools: PriorityPool[];
+    /** Enkeltpersoner som er prioritert uavhengig av poolene. */
+    priorityUsers: PriorityUser[];
     /** Avvis alle utenfor en pool i stedet for å sette dem på venteliste. */
     onlyAllowPrioritized: boolean;
 };
@@ -85,6 +89,11 @@ type EventFormProps = {
      * en pool peker typisk på kull og studier arrangøren ikke er medlem av.
      */
     poolGroups: PoolGroup[];
+    /**
+     * Søket etter prioriterte enkeltpersoner. Eies av ruten fordi
+     * komponentene her ikke henter data selv.
+     */
+    priorityUserSearch: UserSearchState;
     institutes: Array<{ slug: string; shortName: string; name: string }>;
     /** Medlemmene i den valgte arrangørgruppen — kandidatene til kontaktperson. */
     contactPersonCandidates: Array<{ id: string; name: string }>;
@@ -111,6 +120,7 @@ export function EventForm({
     onChange,
     groups,
     poolGroups,
+    priorityUserSearch,
     institutes,
     contactPersonCandidates,
     addressSuggestions,
@@ -582,6 +592,11 @@ export function EventForm({
                     pools={values.priorityPools}
                     groups={poolGroups}
                     onChange={(priorityPools) => onChange({ priorityPools })}
+                    users={values.priorityUsers}
+                    userSearch={priorityUserSearch}
+                    onUsersChange={(priorityUsers) =>
+                        onChange({ priorityUsers })
+                    }
                     onlyAllowPrioritized={values.onlyAllowPrioritized}
                     onOnlyAllowPrioritizedChange={(onlyAllowPrioritized) =>
                         onChange({ onlyAllowPrioritized })

--- a/apps/kvark/src/components/priority-pool-editor.tsx
+++ b/apps/kvark/src/components/priority-pool-editor.tsx
@@ -23,7 +23,13 @@ import { Label } from "@tihlde/ui/ui/label";
 import { Switch } from "@tihlde/ui/ui/switch";
 import { Plus, Trash2 } from "lucide-react";
 
-import { computeClassYear } from "#/lib/utils";
+import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
+import {
+    UserSearchCombobox,
+    type UserSearchOption,
+} from "#/components/user-search-combobox";
+import { avatarImageUrl } from "#/lib/assets";
+import { computeClassYear, initials } from "#/lib/utils";
 
 /** Det minste en pool-velger trenger for å sende en slug videre. */
 export type PoolGroup = {
@@ -49,11 +55,22 @@ export function poolsForSubmit(pools: PriorityPool[]): PriorityPool[] {
     return pools.filter((pool) => pool.groups.length > 0);
 }
 
+/**
+ * En prioritert enkeltperson, med nok til å vise hvem det er etter at siden er
+ * lastet på nytt. Bare `id` sendes til API-et.
+ */
+export type PriorityUser = UserSearchOption;
+
 type PriorityPoolEditorProps = {
     pools: PriorityPool[];
     /** Alle grupper i TIHLDE — ikke bare de brukeren kan arrangere for. */
     groups: PoolGroup[];
     onChange: (pools: PriorityPool[]) => void;
+    /** Enkeltpersoner som er prioritert uavhengig av gruppene. */
+    users: PriorityUser[];
+    onUsersChange: (users: PriorityUser[]) => void;
+    /** Søket etter personer eies av ruten — se `userSearch` i `EventForm`. */
+    userSearch: UserSearchState;
     onlyAllowPrioritized: boolean;
     onOnlyAllowPrioritizedChange: (next: boolean) => void;
 };
@@ -123,6 +140,9 @@ export function PriorityPoolEditor({
     pools,
     groups,
     onChange,
+    users,
+    onUsersChange,
+    userSearch,
     onlyAllowPrioritized,
     onOnlyAllowPrioritizedChange,
 }: PriorityPoolEditorProps) {
@@ -141,13 +161,20 @@ export function PriorityPoolEditor({
      * et valg.
      */
     const effectivePools = pools.filter((p) => p.groups.length > 0);
+    /**
+     * Bryteren trenger noen å slippe inn, og en navngitt person teller like
+     * mye som en gruppe. Uten den ville «bare prioriterte» vært utilgjengelig
+     * på et arrangement der de prioriterte er tre personer og ingen gruppe.
+     */
+    const hasSomethingPrioritized =
+        effectivePools.length > 0 || users.length > 0;
 
     function updatePool(index: number, next: string[]) {
         const updated = pools.map((p, i) =>
             i === index ? { groups: next } : p,
         );
         onChange(updated);
-        if (!updated.some((p) => p.groups.length > 0)) {
+        if (!updated.some((p) => p.groups.length > 0) && users.length === 0) {
             onOnlyAllowPrioritizedChange(false);
         }
     }
@@ -158,7 +185,15 @@ export function PriorityPoolEditor({
         // Kravet i API-et: «bare prioriterte» kan ikke stå igjen uten pooler.
         // Å la den henge ville gitt en 400 ved lagring, uten at feltet som
         // forårsaket den er synlig lenger.
-        if (!next.some((p) => p.groups.length > 0)) {
+        if (!next.some((p) => p.groups.length > 0) && users.length === 0) {
+            onOnlyAllowPrioritizedChange(false);
+        }
+    }
+
+    function removeUser(userId: string) {
+        const next = users.filter((u) => u.id !== userId);
+        onUsersChange(next);
+        if (effectivePools.length === 0 && next.length === 0) {
             onOnlyAllowPrioritizedChange(false);
         }
     }
@@ -229,10 +264,20 @@ export function PriorityPoolEditor({
                     </Button>
                 </div>
 
+                <PriorityUserPicker
+                    users={users}
+                    search={userSearch}
+                    onAdd={(user) => {
+                        if (users.some((u) => u.id === user.id)) return;
+                        onUsersChange([...users, user]);
+                    }}
+                    onRemove={removeUser}
+                />
+
                 <Label className="flex items-start gap-3">
                     <Switch
                         checked={onlyAllowPrioritized}
-                        disabled={effectivePools.length === 0}
+                        disabled={!hasSomethingPrioritized}
                         onCheckedChange={onOnlyAllowPrioritizedChange}
                     />
                     <span className="flex flex-col gap-1">
@@ -240,7 +285,7 @@ export function PriorityPoolEditor({
                         <CardDescription>
                             Uten denne havner alle andre på venteliste i stedet
                             for å bli avvist. Krever minst én prioritert gruppe
-                            med et kriterium.
+                            med et kriterium, eller én prioritert person.
                         </CardDescription>
                     </span>
                 </Label>
@@ -319,5 +364,112 @@ function GroupPicker({
                 </ComboboxList>
             </ComboboxContent>
         </Combobox>
+    );
+}
+
+/**
+ * Søket etter personer, slik ruten leverer det.
+ *
+ * Komponentene her henter ikke data selv (se `apps/kvark/CLAUDE.md`), så
+ * spørringen og teksten det søkes på eies av siden som bruker skjemaet.
+ */
+export type UserSearchState = {
+    query: string;
+    onQueryChange: (query: string) => void;
+    results: PriorityUser[];
+    isSearching: boolean;
+};
+
+/**
+ * Prioriterte enkeltpersoner.
+ *
+ * Egen liste, ikke enda et kriterium i en prioritert gruppe: kriteriene i en
+ * gruppe må stemme samtidig, og «personen er Ola» sammen med «personen går
+ * første klasse» ville betydd noe annet enn arrangøren mener. Her er regelen
+ * flat — står du i lista, er du prioritert.
+ *
+ * Søket går mot hele brukerregisteret og ikke bare arrangørgruppa. Den som
+ * skal prioriteres er ofte nettopp en utenfor: en fadder, en foredragsholder,
+ * en som fikk plass lovet.
+ */
+function PriorityUserPicker({
+    users,
+    search,
+    onAdd,
+    onRemove,
+}: {
+    users: PriorityUser[];
+    search: UserSearchState;
+    onAdd: (user: PriorityUser) => void;
+    onRemove: (userId: string) => void;
+}) {
+    // De som allerede står i lista filtreres bort fra treffene: å klikke dem
+    // igjen gjør ingenting, og et valg uten virkning ser ut som en feil.
+    const selectable = search.results.filter(
+        (user) => !users.some((selected) => selected.id === user.id),
+    );
+
+    return (
+        <div className="flex flex-col gap-2">
+            <Label>Prioriterte personer</Label>
+            {users.length === 0 ? (
+                <CardDescription>
+                    Ingen enkeltpersoner er prioritert.
+                </CardDescription>
+            ) : (
+                <ul className="flex flex-col gap-1">
+                    {users.map((user) => (
+                        <li
+                            key={user.id}
+                            className="flex items-center justify-between gap-2"
+                        >
+                            <span className="flex min-w-0 items-center gap-2">
+                                <Avatar className="size-7">
+                                    <AvatarImage
+                                        src={avatarImageUrl(
+                                            user.image ?? undefined,
+                                        )}
+                                    />
+                                    <AvatarFallback>
+                                        {initials(user.name ?? "?")}
+                                    </AvatarFallback>
+                                </Avatar>
+                                <span className="flex min-w-0 flex-col">
+                                    <span className="truncate text-sm">
+                                        {user.name ?? user.username}
+                                    </span>
+                                    {user.username ? (
+                                        <CardDescription className="truncate">
+                                            {user.username}
+                                        </CardDescription>
+                                    ) : null}
+                                </span>
+                            </span>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => onRemove(user.id)}
+                                aria-label={`Fjern ${user.name ?? user.username ?? "person"} fra prioriterte`}
+                            >
+                                <Trash2 />
+                            </Button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+            <UserSearchCombobox
+                holder={null}
+                query={search.query}
+                onQueryChange={search.onQueryChange}
+                results={selectable}
+                isSearching={search.isSearching}
+                onSelect={(user) => {
+                    onAdd(user);
+                    search.onQueryChange("");
+                }}
+                emptyLabel="Legg til person"
+            />
+        </div>
     );
 }

--- a/apps/kvark/src/hooks/use-priority-user-search.ts
+++ b/apps/kvark/src/hooks/use-priority-user-search.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { searchUsersQuery } from "#/api/queries/roles";
+import type { UserSearchState } from "#/components/priority-pool-editor";
+import { useDebounced } from "#/lib/use-debounced";
+
+/**
+ * Søket etter enkeltpersoner som skal prioriteres på et arrangement.
+ *
+ * Ligger her og ikke i editoren fordi komponentene i `components/` ikke
+ * henter data selv, og begge adminsidene for arrangementer trenger nøyaktig
+ * det samme søket.
+ *
+ * Søket treffer hele brukerregisteret — den prioriterte er ofte en utenfor
+ * arrangørgruppa — og API-et slipper arrangøren inn på
+ * `events:create`/`events:update`/`events:manage`.
+ */
+export function usePriorityUserSearch(): UserSearchState {
+    const [query, setQuery] = useState("");
+    const debouncedQuery = useDebounced(query);
+    const { data, isFetching } = useQuery({
+        ...searchUsersQuery(debouncedQuery),
+        // Under to tegn svarer API-et 400: minstelengden ligger i validatoren.
+        enabled: debouncedQuery.length >= 2,
+    });
+
+    return {
+        query,
+        onQueryChange: setQuery,
+        results: data ?? [],
+        isSearching: isFetching,
+    };
+}

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -66,6 +66,7 @@ import { ConfirmDeleteDialog } from "#/components/confirm-delete-dialog";
 import type { EventFormValues } from "#/components/event-form";
 import { ALL_INSTITUTES, EventForm } from "#/components/event-form";
 import { poolsForSubmit } from "#/components/priority-pool-editor";
+import { usePriorityUserSearch } from "#/hooks/use-priority-user-search";
 import type { NewFormValues } from "#/components/new-form-dialog";
 import { NewFormDialog } from "#/components/new-form-dialog";
 import {
@@ -224,6 +225,10 @@ function valuesFromEvent(event: Event): EventFormValues {
         priorityPools: (event.priorityPools ?? []).map((pool) => ({
             groups: pool.groups.map((g) => g.slug),
         })),
+        // Navn og bilde er med så lista kan vise hvem det er; bare id-ene
+        // sendes tilbake. Feltet er tomt for de som ikke kan redigere
+        // arrangementet — API-et deler ikke navngitte personer med andre.
+        priorityUsers: event.priorityUsers ?? [],
         onlyAllowPrioritized: event.onlyAllowPrioritized,
         title: event.title,
         description: event.description,
@@ -292,6 +297,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
     );
     const [uploadError, setUploadError] = useState<string | null>(null);
     const [confirmDelete, setConfirmDelete] = useState(false);
+    const priorityUserSearch = usePriorityUserSearch();
 
     const debouncedLocation = useDebounced(values.location, 250);
     const { data: addressSuggestions, isFetching: isSearchingAddress } =
@@ -377,6 +383,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
             requiresSigningUp: values.requiresSigningUp,
             allowWaitlist: values.requiresSigningUp,
             priorityPools: poolsForSubmit(values.priorityPools),
+            priorityUserIds: values.priorityUsers.map((user) => user.id),
             onlyAllowPrioritized: values.onlyAllowPrioritized,
             canCauseStrikes: values.canCauseStrikes,
             enforcesPreviousStrikes: values.canCauseStrikes,
@@ -423,6 +430,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
                 onChange={handleChange}
                 groups={groups}
                 poolGroups={allGroups}
+                priorityUserSearch={priorityUserSearch}
                 institutes={institutes}
                 contactPersonCandidates={contactPersonCandidates}
                 existingImageUrl={event.image}

--- a/apps/kvark/src/routes/admin/arrangementer.ny.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.ny.tsx
@@ -19,6 +19,7 @@ import { AdminPageHeader } from "#/components/admin-page-header";
 import type { EventFormValues } from "#/components/event-form";
 import { ALL_INSTITUTES, EventForm } from "#/components/event-form";
 import { poolsForSubmit } from "#/components/priority-pool-editor";
+import { usePriorityUserSearch } from "#/hooks/use-priority-user-search";
 import {
     useAnyScopePermission,
     useCanActForGroup,
@@ -66,6 +67,7 @@ function eventDateDefaults() {
 
 const emptyValues: EventFormValues = {
     priorityPools: [],
+    priorityUsers: [],
     onlyAllowPrioritized: false,
     title: "",
     description: "",
@@ -114,6 +116,7 @@ function NewEventPage() {
             : "",
     }));
     const [uploadError, setUploadError] = useState<string | null>(null);
+    const priorityUserSearch = usePriorityUserSearch();
 
     const debouncedLocation = useDebounced(values.location, 250);
     const { data: addressSuggestions, isFetching: isSearchingAddress } =
@@ -216,6 +219,9 @@ function NewEventPage() {
                     requiresSigningUp: values.requiresSigningUp,
                     allowWaitlist: values.requiresSigningUp,
                     priorityPools: poolsForSubmit(values.priorityPools),
+                    priorityUserIds: values.priorityUsers.map(
+                        (user) => user.id,
+                    ),
                     onlyAllowPrioritized: values.onlyAllowPrioritized,
                     canCauseStrikes: values.canCauseStrikes,
                     enforcesPreviousStrikes: values.canCauseStrikes,
@@ -271,6 +277,7 @@ function NewEventPage() {
                 onChange={handleChange}
                 groups={groups}
                 poolGroups={allGroups}
+                priorityUserSearch={priorityUserSearch}
                 institutes={institutes}
                 contactPersonCandidates={contactPersonCandidates}
                 addressSuggestions={addressSuggestions ?? []}

--- a/packages/db/drizzle/0062_silly_reaper.sql
+++ b/packages/db/drizzle/0062_silly_reaper.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "event_priority_user" (
+	"event_id" uuid NOT NULL,
+	"user_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "event_priority_user_event_id_user_id_pk" PRIMARY KEY("event_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "event_priority_user" ADD CONSTRAINT "event_priority_user_event_id_event_event_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."event_event"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "event_priority_user" ADD CONSTRAINT "event_priority_user_user_id_auth_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."auth_user"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/drizzle/meta/0062_snapshot.json
+++ b/packages/db/drizzle/meta/0062_snapshot.json
@@ -1,0 +1,7429 @@
+{
+  "id": "2681ff4d-b8e9-49ca-ad7e-ed886995ba83",
+  "prevId": "a5a3a47f-e12c-4817-8916-7cf6d14afb49",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apikey_api_key": {
+      "name": "apikey_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_api_key_created_by_user_id_auth_user_id_fk": {
+          "name": "apikey_api_key_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "apikey_api_key",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "apikey_api_key_key_hash_unique": {
+          "name": "apikey_api_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "application_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "submitted_by_id": {
+          "name": "submitted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_asset_key": {
+          "name": "pdf_asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_comment": {
+          "name": "internal_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled_by_id": {
+          "name": "handled_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled_at": {
+          "name": "handled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_submitted_by_id_created_at_index": {
+          "name": "application_submitted_by_id_created_at_index",
+          "columns": [
+            {
+              "expression": "submitted_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_type_status_created_at_index": {
+          "name": "application_type_status_created_at_index",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_submitted_by_id_auth_user_id_fk": {
+          "name": "application_submitted_by_id_auth_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "submitted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_handled_by_id_auth_user_id_fk": {
+          "name": "application_handled_by_id_auth_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "handled_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_attachment": {
+      "name": "application_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "application_attachment_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_attachment_application_id_index": {
+          "name": "application_attachment_application_id_index",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_attachment_application_id_application_id_fk": {
+          "name": "application_attachment_application_id_application_id_fk",
+          "tableFrom": "application_attachment",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_company_contact": {
+      "name": "application_company_contact",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semesters": {
+          "name": "semesters",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_company_contact_application_id_application_id_fk": {
+          "name": "application_company_contact_application_id_application_id_fk",
+          "tableFrom": "application_company_contact",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_expense": {
+      "name": "application_expense",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cc_email": {
+          "name": "cc_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_nok": {
+          "name": "amount_nok",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expense_date": {
+          "name": "expense_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_type": {
+          "name": "budget_type",
+          "type": "application_budget_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_expense_application_id_application_id_fk": {
+          "name": "application_expense_application_id_application_id_fk",
+          "tableFrom": "application_expense",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_expense_group_slug_org_group_slug_fk": {
+          "name": "application_expense_group_slug_org_group_slug_fk",
+          "tableFrom": "application_expense",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_hs_case": {
+      "name": "application_hs_case",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_name": {
+          "name": "case_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_type": {
+          "name": "case_type",
+          "type": "application_case_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_hs_case_application_id_application_id_fk": {
+          "name": "application_hs_case_application_id_application_id_fk",
+          "tableFrom": "application_hs_case",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_support": {
+      "name": "application_support",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_description": {
+          "name": "event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_nok": {
+          "name": "total_amount_nok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_link": {
+          "name": "budget_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_support_application_id_application_id_fk": {
+          "name": "application_support_application_id_application_id_fk",
+          "tableFrom": "application_support",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_support_group_slug_org_group_slug_fk": {
+          "name": "application_support_group_slug_org_group_slug_fk",
+          "tableFrom": "application_support",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_file": {
+      "name": "asset_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "asset_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_file_uploaded_by_id_auth_user_id_fk": {
+          "name": "asset_file_uploaded_by_id_auth_user_id_fk",
+          "tableFrom": "asset_file",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_file_key_unique": {
+          "name": "asset_file_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_source": {
+          "name": "password_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_session_id_auth_session_id_fk": {
+          "name": "auth_oauth_access_token_session_id_auth_session_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_refresh_id_auth_oauth_refresh_token_id_fk": {
+          "name": "auth_oauth_access_token_refresh_id_auth_oauth_refresh_token_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_token_unique": {
+          "name": "auth_oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_client": {
+      "name": "auth_oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_client_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_client_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_client",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_client_client_id_unique": {
+          "name": "auth_oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_refresh_token": {
+      "name": "auth_oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_refresh_token_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_refresh_token_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_refresh_token_session_id_auth_session_id_fk": {
+          "name": "auth_oauth_refresh_token_session_id_auth_session_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_refresh_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_refresh_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_refresh_token_token_unique": {
+          "name": "auth_oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_session_token_unique": {
+          "name": "auth_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_approvalStatus_idx": {
+          "name": "user_approvalStatus_idx",
+          "columns": [
+            {
+              "expression": "approval_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_user_email_unique": {
+          "name": "auth_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "auth_user_username_unique": {
+          "name": "auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banner_banner": {
+      "name": "banner_banner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_text": {
+          "name": "link_text",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_from": {
+          "name": "visible_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visible_until": {
+          "name": "visible_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banner_banner_created_by_user_id_auth_user_id_fk": {
+          "name": "banner_banner_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "banner_banner",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_event": {
+      "name": "event_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lat": {
+          "name": "location_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lng": {
+          "name": "location_lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_waitlist": {
+          "name": "allow_waitlist",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "contact_person_id": {
+          "name": "contact_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_by_user_id": {
+          "name": "update_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_start": {
+          "name": "registration_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_end": {
+          "name": "registration_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_deadline": {
+          "name": "cancellation_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_registration_closed": {
+          "name": "is_registration_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_paid_event": {
+          "name": "is_paid_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_signing_up": {
+          "name": "requires_signing_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_grace_period_minutes": {
+          "name": "payment_grace_period_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions_allowed": {
+          "name": "reactions_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizer_group_slug": {
+          "name": "organizer_group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforces_previous_strikes": {
+          "name": "enforces_previous_strikes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_cause_strikes": {
+          "name": "can_cause_strikes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "no_show_processed_at": {
+          "name": "no_show_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_reminder_sent_at": {
+          "name": "registration_reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_allow_prioritized": {
+          "name": "only_allow_prioritized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restricted_to_institute_id": {
+          "name": "restricted_to_institute_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "event_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_event_category_slug_event_category_slug_fk": {
+          "name": "event_event_category_slug_event_category_slug_fk",
+          "tableFrom": "event_event",
+          "tableTo": "event_category",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_event_contact_person_id_auth_user_id_fk": {
+          "name": "event_event_contact_person_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "contact_person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_created_by_user_id_auth_user_id_fk": {
+          "name": "event_event_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_update_by_user_id_auth_user_id_fk": {
+          "name": "event_event_update_by_user_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "update_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_organizer_group_slug_org_group_slug_fk": {
+          "name": "event_event_organizer_group_slug_org_group_slug_fk",
+          "tableFrom": "event_event",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "organizer_group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_restricted_to_institute_id_org_institute_id_fk": {
+          "name": "event_event_restricted_to_institute_id_org_institute_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "org_institute",
+          "columnsFrom": [
+            "restricted_to_institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_event_slug_unique": {
+          "name": "event_event_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_category": {
+      "name": "event_category",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_favorite": {
+      "name": "event_favorite",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_favorite_user_id_auth_user_id_fk": {
+          "name": "event_favorite_user_id_auth_user_id_fk",
+          "tableFrom": "event_favorite",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_favorite_event_id_event_event_id_fk": {
+          "name": "event_favorite_event_id_event_event_id_fk",
+          "tableFrom": "event_favorite",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_favorite_user_id_event_id_pk": {
+          "name": "event_favorite_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_feedback": {
+      "name": "event_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_feedback_event_id_event_event_id_fk": {
+          "name": "event_feedback_event_id_event_event_id_fk",
+          "tableFrom": "event_feedback",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_feedback_user_id_auth_user_id_fk": {
+          "name": "event_feedback_user_id_auth_user_id_fk",
+          "tableFrom": "event_feedback",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_payment": {
+      "name": "event_payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOK'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_payment_id": {
+          "name": "provider_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "received_payment_at": {
+          "name": "received_payment_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_event_id_user_id_idx": {
+          "name": "payment_event_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_payment_event_id_event_event_id_fk": {
+          "name": "event_payment_event_id_event_event_id_fk",
+          "tableFrom": "event_payment",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_payment_user_id_auth_user_id_fk": {
+          "name": "event_payment_user_id_auth_user_id_fk",
+          "tableFrom": "event_payment",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_pool": {
+      "name": "event_priority_pool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority_score": {
+          "name": "priority_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_pool_event_id_event_event_id_fk": {
+          "name": "event_priority_pool_event_id_event_event_id_fk",
+          "tableFrom": "event_priority_pool",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_pool_group": {
+      "name": "event_priority_pool_group",
+      "schema": "",
+      "columns": {
+        "priority_pool_id": {
+          "name": "priority_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_pool_group_priority_pool_id_event_priority_pool_id_fk": {
+          "name": "event_priority_pool_group_priority_pool_id_event_priority_pool_id_fk",
+          "tableFrom": "event_priority_pool_group",
+          "tableTo": "event_priority_pool",
+          "columnsFrom": [
+            "priority_pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_priority_pool_group_group_slug_org_group_slug_fk": {
+          "name": "event_priority_pool_group_group_slug_org_group_slug_fk",
+          "tableFrom": "event_priority_pool_group",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_priority_pool_group_priority_pool_id_group_slug_pk": {
+          "name": "event_priority_pool_group_priority_pool_id_group_slug_pk",
+          "columns": [
+            "priority_pool_id",
+            "group_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_user": {
+      "name": "event_priority_user",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_user_event_id_event_event_id_fk": {
+          "name": "event_priority_user_event_id_event_event_id_fk",
+          "tableFrom": "event_priority_user",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_priority_user_user_id_auth_user_id_fk": {
+          "name": "event_priority_user_user_id_auth_user_id_fk",
+          "tableFrom": "event_priority_user",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_priority_user_event_id_user_id_pk": {
+          "name": "event_priority_user_event_id_user_id_pk",
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reaction": {
+      "name": "event_reaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reaction_event_id_idx": {
+          "name": "reaction_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_reaction_user_id_auth_user_id_fk": {
+          "name": "event_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "event_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reaction_event_id_event_event_id_fk": {
+          "name": "event_reaction_event_id_event_event_id_fk",
+          "tableFrom": "event_reaction",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_reaction_user_id_event_id_pk": {
+          "name": "event_reaction_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_registration": {
+      "name": "event_registration",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "waitlist_position": {
+          "name": "waitlist_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended_at": {
+          "name": "attended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_photo": {
+          "name": "allow_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "registration_event_id_status_idx": {
+          "name": "registration_event_id_status_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "registration_pending_idx": {
+          "name": "registration_pending_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"event_registration\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_registration_event_id_event_event_id_fk": {
+          "name": "event_registration_event_id_event_event_id_fk",
+          "tableFrom": "event_registration",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_registration_user_id_auth_user_id_fk": {
+          "name": "event_registration_user_id_auth_user_id_fk",
+          "tableFrom": "event_registration",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_registration_user_id_event_id_pk": {
+          "name": "event_registration_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_strike": {
+      "name": "event_strike",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_strike_event_id_event_event_id_fk": {
+          "name": "event_strike_event_id_event_event_id_fk",
+          "tableFrom": "event_strike",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_strike_user_id_auth_user_id_fk": {
+          "name": "event_strike_user_id_auth_user_id_fk",
+          "tableFrom": "event_strike",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_item": {
+      "name": "feedback_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "feedback_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_item_created_at_idx": {
+          "name": "feedback_item_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_item_author_id_auth_user_id_fk": {
+          "name": "feedback_item_author_id_auth_user_id_fk",
+          "tableFrom": "feedback_item",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_vote": {
+      "name": "feedback_vote",
+      "schema": "",
+      "columns": {
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "feedback_vote_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_vote_feedback_id_feedback_item_id_fk": {
+          "name": "feedback_vote_feedback_id_feedback_item_id_fk",
+          "tableFrom": "feedback_vote",
+          "tableTo": "feedback_item",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_vote_user_id_auth_user_id_fk": {
+          "name": "feedback_vote_user_id_auth_user_id_fk",
+          "tableFrom": "feedback_vote",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_vote_feedback_id_user_id_pk": {
+          "name": "feedback_vote_feedback_id_user_id_pk",
+          "columns": [
+            "feedback_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_form": {
+      "name": "form_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_answer": {
+      "name": "form_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_text": {
+          "name": "answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_answer_submission_id_form_submission_id_fk": {
+          "name": "form_answer_submission_id_form_submission_id_fk",
+          "tableFrom": "form_answer",
+          "tableTo": "form_submission",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_answer_field_id_form_field_id_fk": {
+          "name": "form_answer_field_id_form_field_id_fk",
+          "tableFrom": "form_answer",
+          "tableTo": "form_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_answer_option": {
+      "name": "form_answer_option",
+      "schema": "",
+      "columns": {
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "answer_option_answer_id_idx": {
+          "name": "answer_option_answer_id_idx",
+          "columns": [
+            {
+              "expression": "answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_answer_option_answer_id_form_answer_id_fk": {
+          "name": "form_answer_option_answer_id_form_answer_id_fk",
+          "tableFrom": "form_answer_option",
+          "tableTo": "form_answer",
+          "columnsFrom": [
+            "answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_answer_option_option_id_form_option_id_fk": {
+          "name": "form_answer_option_option_id_form_option_id_fk",
+          "tableFrom": "form_answer_option",
+          "tableTo": "form_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_event_form": {
+      "name": "form_event_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_event_form_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_event_form_form_id_form_form_id_fk": {
+          "name": "form_event_form_form_id_form_form_id_fk",
+          "tableFrom": "form_event_form",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_event_form_event_id_event_event_id_fk": {
+          "name": "form_event_form_event_id_event_event_id_fk",
+          "tableFrom": "form_event_form",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_type": {
+          "name": "unique_event_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_field": {
+      "name": "form_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_field_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_field_form_id_form_form_id_fk": {
+          "name": "form_field_form_id_form_form_id_fk",
+          "tableFrom": "form_field",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_group_form": {
+      "name": "form_group_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_receiver_on_submit": {
+          "name": "email_receiver_on_submit",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_submit_multiple": {
+          "name": "can_submit_multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_open_for_submissions": {
+          "name": "is_open_for_submissions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "opens_at": {
+          "name": "opens_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_for_group_members": {
+          "name": "only_for_group_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_group_form_form_id_form_form_id_fk": {
+          "name": "form_group_form_form_id_form_form_id_fk",
+          "tableFrom": "form_group_form",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_group_form_group_slug_org_group_slug_fk": {
+          "name": "form_group_form_group_slug_org_group_slug_fk",
+          "tableFrom": "form_group_form",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_form": {
+          "name": "unique_group_form",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "group_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_option": {
+      "name": "form_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_option_field_id_form_field_id_fk": {
+          "name": "form_option_field_id_form_field_id_fk",
+          "tableFrom": "form_option",
+          "tableTo": "form_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_submission": {
+      "name": "form_submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_submission_form_id_form_form_id_fk": {
+          "name": "form_submission_form_id_form_form_id_fk",
+          "tableFrom": "form_submission",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_submission_user_id_auth_user_id_fk": {
+          "name": "form_submission_user_id_auth_user_id_fk",
+          "tableFrom": "form_submission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gallery_album": {
+      "name": "gallery_album",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gallery_album_event_id_event_event_id_fk": {
+          "name": "gallery_album_event_id_event_event_id_fk",
+          "tableFrom": "gallery_album",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gallery_album_created_by_user_id_auth_user_id_fk": {
+          "name": "gallery_album_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "gallery_album",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gallery_album_slug_unique": {
+          "name": "gallery_album_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gallery_picture": {
+      "name": "gallery_picture",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gallery_picture_album_id_idx": {
+          "name": "gallery_picture_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gallery_picture_album_id_gallery_album_id_fk": {
+          "name": "gallery_picture_album_id_gallery_album_id_fk",
+          "tableFrom": "gallery_picture",
+          "tableTo": "gallery_album",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_contract": {
+      "name": "org_contract",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signature_placement": {
+          "name": "signature_placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_placement": {
+          "name": "name_placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_contract_created_by_user_id_auth_user_id_fk": {
+          "name": "org_contract_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_contract",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_contract_signature": {
+      "name": "org_contract_signature",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signed_name": {
+          "name": "signed_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_pdf_key": {
+          "name": "signed_pdf_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_pdf_hash": {
+          "name": "signed_pdf_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_file_key": {
+          "name": "signature_file_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signer_ip": {
+          "name": "signer_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer_ua": {
+          "name": "signer_ua",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contract_signature_unique_idx": {
+          "name": "contract_signature_unique_idx",
+          "columns": [
+            {
+              "expression": "contract_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_contract_signature_contract_id_org_contract_id_fk": {
+          "name": "org_contract_signature_contract_id_org_contract_id_fk",
+          "tableFrom": "org_contract_signature",
+          "tableTo": "org_contract",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_contract_signature_user_id_auth_user_id_fk": {
+          "name": "org_contract_signature_user_id_auth_user_id_fk",
+          "tableFrom": "org_contract_signature",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_fine": {
+      "name": "org_fine",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "law_id": {
+          "name": "law_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defense": {
+          "name": "defense",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "org_fine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fine_group_slug_user_id_idx": {
+          "name": "fine_group_slug_user_id_idx",
+          "columns": [
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_fine_user_id_auth_user_id_fk": {
+          "name": "org_fine_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_fine_group_slug_org_group_slug_fk": {
+          "name": "org_fine_group_slug_org_group_slug_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_fine_law_id_org_group_law_id_fk": {
+          "name": "org_fine_law_id_org_group_law_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "org_group_law",
+          "columnsFrom": [
+            "law_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_fine_created_by_user_id_auth_user_id_fk": {
+          "name": "org_fine_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_fine_approved_by_user_id_auth_user_id_fk": {
+          "name": "org_fine_approved_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group": {
+      "name": "org_group",
+      "schema": "",
+      "columns": {
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fine_info": {
+          "name": "fine_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fines_activated": {
+          "name": "fines_activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fines_admin_id": {
+          "name": "fines_admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leader_permissions": {
+          "name": "leader_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "leader_global_permissions": {
+          "name": "leader_global_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "leader_title": {
+          "name": "leader_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_permissions": {
+          "name": "member_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "member_global_permissions": {
+          "name": "member_global_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "contract_signing_required": {
+          "name": "contract_signing_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "institute_id": {
+          "name": "institute_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_fines_admin_id_auth_user_id_fk": {
+          "name": "org_group_fines_admin_id_auth_user_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "fines_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_group_institute_id_org_institute_id_fk": {
+          "name": "org_group_institute_id_org_institute_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "org_institute",
+          "columnsFrom": [
+            "institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_law": {
+      "name": "org_group_law",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paragraph": {
+          "name": "paragraph",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_law_group_slug_org_group_slug_fk": {
+          "name": "org_group_law_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_law",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_membership": {
+      "name": "org_group_membership",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_group_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_membership_group_slug_idx": {
+          "name": "group_membership_group_slug_idx",
+          "columns": [
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_group_membership_user_id_auth_user_id_fk": {
+          "name": "org_group_membership_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_membership_group_slug_org_group_slug_fk": {
+          "name": "org_group_membership_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_membership",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_group_membership_user_id_group_slug_pk": {
+          "name": "org_group_membership_user_id_group_slug_pk",
+          "columns": [
+            "user_id",
+            "group_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_membership_history": {
+      "name": "org_group_membership_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_membership_history_group_slug_idx": {
+          "name": "group_membership_history_group_slug_idx",
+          "columns": [
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_membership_history_user_id_idx": {
+          "name": "group_membership_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_membership_history_stint_idx": {
+          "name": "group_membership_history_stint_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_group_membership_history_user_id_auth_user_id_fk": {
+          "name": "org_group_membership_history_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_membership_history",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_membership_history_group_slug_org_group_slug_fk": {
+          "name": "org_group_membership_history_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_membership_history",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_position": {
+      "name": "org_group_position",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "org_group_position_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'group'"
+        },
+        "linked_group_slug": {
+          "name": "linked_group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_position_group_slug_org_group_slug_fk": {
+          "name": "org_group_position_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_position",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_linked_group_slug_org_group_slug_fk": {
+          "name": "org_group_position_linked_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_position",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "linked_group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_position_holder": {
+      "name": "org_group_position_holder",
+      "schema": "",
+      "columns": {
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_position_holder_position_id_org_group_position_id_fk": {
+          "name": "org_group_position_holder_position_id_org_group_position_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "org_group_position",
+          "columnsFrom": [
+            "position_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_holder_user_id_auth_user_id_fk": {
+          "name": "org_group_position_holder_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_holder_granted_by_auth_user_id_fk": {
+          "name": "org_group_position_holder_granted_by_auth_user_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_institute": {
+      "name": "org_institute",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_institute_slug_unique": {
+          "name": "org_institute_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_study_program": {
+      "name": "org_study_program",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feide_code": {
+          "name": "feide_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "org_study_program_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_study_program_slug_unique": {
+          "name": "org_study_program_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "org_study_program_feide_code_unique": {
+          "name": "org_study_program_feide_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feide_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_study_program_membership": {
+      "name": "org_study_program_membership",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_program_id": {
+          "name": "study_program_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_year_source": {
+          "name": "start_year_source",
+          "type": "org_study_year_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_campus": {
+          "name": "confirmed_campus",
+          "type": "org_campus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feide_active": {
+          "name": "feide_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feide_checked_at": {
+          "name": "feide_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_study_program_membership_user_id_auth_user_id_fk": {
+          "name": "org_study_program_membership_user_id_auth_user_id_fk",
+          "tableFrom": "org_study_program_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_study_program_membership_study_program_id_org_study_program_id_fk": {
+          "name": "org_study_program_membership_study_program_id_org_study_program_id_fk",
+          "tableFrom": "org_study_program_membership",
+          "tableTo": "org_study_program",
+          "columnsFrom": [
+            "study_program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_study_program_membership_user_id_study_program_id_pk": {
+          "name": "org_study_program_membership_user_id_study_program_id_pk",
+          "columns": [
+            "user_id",
+            "study_program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_role": {
+      "name": "rbac_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rbac_role_name_unique": {
+          "name": "rbac_role_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_user_permission": {
+      "name": "rbac_user_permission",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'*'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rbac_user_permission_user_id_auth_user_id_fk": {
+          "name": "rbac_user_permission_user_id_auth_user_id_fk",
+          "tableFrom": "rbac_user_permission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_user_permission_granted_by_auth_user_id_fk": {
+          "name": "rbac_user_permission_granted_by_auth_user_id_fk",
+          "tableFrom": "rbac_user_permission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rbac_user_permission_user_id_permission_scope_pk": {
+          "name": "rbac_user_permission_user_id_permission_scope_pk",
+          "columns": [
+            "user_id",
+            "permission",
+            "scope"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_user_role": {
+      "name": "rbac_user_role",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rbac_user_role_user_id_auth_user_id_fk": {
+          "name": "rbac_user_role_user_id_auth_user_id_fk",
+          "tableFrom": "rbac_user_role",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_user_role_role_id_rbac_role_id_fk": {
+          "name": "rbac_user_role_role_id_rbac_role_id_fk",
+          "tableFrom": "rbac_user_role",
+          "tableTo": "rbac_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rbac_user_role_user_id_role_id_pk": {
+          "name": "rbac_user_role_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_notification": {
+      "name": "notification_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_id_created_at_idx": {
+          "name": "notification_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_notification_user_id_auth_user_id_fk": {
+          "name": "notification_notification_user_id_auth_user_id_fk",
+          "tableFrom": "notification_notification",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_device": {
+      "name": "notification_device",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_device_userId_idx": {
+          "name": "notification_device_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_device_user_id_auth_user_id_fk": {
+          "name": "notification_device_user_id_auth_user_id_fk",
+          "tableFrom": "notification_device",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_device_token_unique": {
+          "name": "notification_device_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_news": {
+      "name": "news_news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emojis_allowed": {
+          "name": "emojis_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_news_created_by_user_id_auth_user_id_fk": {
+          "name": "news_news_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "news_news",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_reaction": {
+      "name": "news_reaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "news_id": {
+          "name": "news_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_reaction_user_id_auth_user_id_fk": {
+          "name": "news_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "news_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "news_reaction_news_id_news_news_id_fk": {
+          "name": "news_reaction_news_id_news_news_id_fk",
+          "tableFrom": "news_reaction",
+          "tableTo": "news_news",
+          "columnsFrom": [
+            "news_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "news_reaction_user_id_news_id_pk": {
+          "name": "news_reaction_user_id_news_id_pk",
+          "columns": [
+            "user_id",
+            "news_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_job_post": {
+      "name": "job_job_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingress": {
+          "name": "ingress",
+          "type": "varchar(800)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_continuously_hiring": {
+          "name": "is_continuously_hiring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_start": {
+          "name": "class_start",
+          "type": "user_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'first'"
+        },
+        "class_end": {
+          "name": "class_end",
+          "type": "user_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fifth'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_job_post_created_by_user_id_auth_user_id_fk": {
+          "name": "job_job_post_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "job_job_post",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_allergy": {
+      "name": "user_allergy",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_user_setting_allergy": {
+      "name": "user_user_setting_allergy",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergy_slug": {
+          "name": "allergy_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_user_setting_allergy_user_id_user_settings_user_id_fk": {
+          "name": "user_user_setting_allergy_user_id_user_settings_user_id_fk",
+          "tableFrom": "user_user_setting_allergy",
+          "tableTo": "user_settings",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_user_setting_allergy_allergy_slug_user_allergy_slug_fk": {
+          "name": "user_user_setting_allergy_allergy_slug_user_allergy_slug_fk",
+          "tableFrom": "user_user_setting_allergy",
+          "tableTo": "user_allergy",
+          "columnsFrom": [
+            "allergy_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_user_setting_allergy_user_id_allergy_slug_pk": {
+          "name": "user_user_setting_allergy_user_id_allergy_slug_pk",
+          "columns": [
+            "user_id",
+            "allergy_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_calendar_token": {
+      "name": "user_calendar_token",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_calendar_token_user_id_auth_user_id_fk": {
+          "name": "user_calendar_token_user_id_auth_user_id_fk",
+          "tableFrom": "user_calendar_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_calendar_token_token_unique": {
+          "name": "user_calendar_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "user_gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allows_photos_by_default": {
+          "name": "allows_photos_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_event_rules": {
+          "name": "accepts_event_rules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_description": {
+          "name": "bio_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_mail_communication": {
+          "name": "receive_mail_communication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_event_registrations": {
+          "name": "public_event_registrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_onboarded": {
+          "name": "is_onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_auth_user_id_fk": {
+          "name": "user_settings_user_id_auth_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.toddel_issue": {
+      "name": "toddel_issue",
+      "schema": "",
+      "columns": {
+        "edition": {
+          "name": "edition",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qrcode_qr_code": {
+      "name": "qrcode_qr_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "qrcode_qr_code_user_id_auth_user_id_fk": {
+          "name": "qrcode_qr_code_user_id_auth_user_id_fk",
+          "tableFrom": "qrcode_qr_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_event": {
+      "name": "motetid_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_mode": {
+          "name": "date_mode",
+          "type": "motetid_date_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DATES'"
+        },
+        "dates": {
+          "name": "dates",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_duration": {
+          "name": "slot_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "motetid_event_created_by_id_index": {
+          "name": "motetid_event_created_by_id_index",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_event_created_by_id_auth_user_id_fk": {
+          "name": "motetid_event_created_by_id_auth_user_id_fk",
+          "tableFrom": "motetid_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "motetid_event_slug_unique": {
+          "name": "motetid_event_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_google_credential": {
+      "name": "motetid_google_credential",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "motetid_google_credential_user_id_auth_user_id_fk": {
+          "name": "motetid_google_credential_user_id_auth_user_id_fk",
+          "tableFrom": "motetid_google_credential",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_participant": {
+      "name": "motetid_participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "motetid_participant_event_id_user_id_index": {
+          "name": "motetid_participant_event_id_user_id_index",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "motetid_participant_user_id_index": {
+          "name": "motetid_participant_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_participant_event_id_motetid_event_id_fk": {
+          "name": "motetid_participant_event_id_motetid_event_id_fk",
+          "tableFrom": "motetid_participant",
+          "tableTo": "motetid_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "motetid_participant_user_id_auth_user_id_fk": {
+          "name": "motetid_participant_user_id_auth_user_id_fk",
+          "tableFrom": "motetid_participant",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_slot": {
+      "name": "motetid_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "motetid_slot_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "motetid_slot_participant_id_date_time_index": {
+          "name": "motetid_slot_participant_id_date_time_index",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "motetid_slot_event_id_date_time_index": {
+          "name": "motetid_slot_event_id_date_time_index",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_slot_participant_id_motetid_participant_id_fk": {
+          "name": "motetid_slot_participant_id_motetid_participant_id_fk",
+          "tableFrom": "motetid_slot",
+          "tableTo": "motetid_participant",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "motetid_slot_event_id_motetid_event_id_fk": {
+          "name": "motetid_slot_event_id_motetid_event_id_fk",
+          "tableFrom": "motetid_slot",
+          "tableTo": "motetid_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.application_attachment_kind": {
+      "name": "application_attachment_kind",
+      "schema": "public",
+      "values": [
+        "receipt",
+        "budget",
+        "attachment"
+      ]
+    },
+    "public.application_budget_type": {
+      "name": "application_budget_type",
+      "schema": "public",
+      "values": [
+        "social_budget",
+        "group_budget",
+        "approved_hs_application",
+        "approved_idkom_application"
+      ]
+    },
+    "public.application_case_type": {
+      "name": "application_case_type",
+      "schema": "public",
+      "values": [
+        "discussion",
+        "decision",
+        "orientation"
+      ]
+    },
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "in_progress",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.application_type": {
+      "name": "application_type",
+      "schema": "public",
+      "values": [
+        "expense",
+        "support",
+        "sports_support",
+        "hs_case",
+        "company_contact"
+      ]
+    },
+    "public.asset_status": {
+      "name": "asset_status",
+      "schema": "public",
+      "values": [
+        "staged",
+        "ready"
+      ]
+    },
+    "public.asset_visibility": {
+      "name": "asset_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "private"
+      ]
+    },
+    "public.event_visibility": {
+      "name": "event_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "members"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "refunded",
+        "failed"
+      ]
+    },
+    "public.event_registration_status": {
+      "name": "event_registration_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "waitlisted",
+        "cancelled",
+        "attended",
+        "no_show",
+        "pending"
+      ]
+    },
+    "public.feedback_status": {
+      "name": "feedback_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "in_progress",
+        "closed",
+        "rejected"
+      ]
+    },
+    "public.feedback_type": {
+      "name": "feedback_type",
+      "schema": "public",
+      "values": [
+        "idea",
+        "bug"
+      ]
+    },
+    "public.feedback_vote_value": {
+      "name": "feedback_vote_value",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    },
+    "public.form_event_form_type": {
+      "name": "form_event_form_type",
+      "schema": "public",
+      "values": [
+        "survey",
+        "evaluation"
+      ]
+    },
+    "public.form_field_type": {
+      "name": "form_field_type",
+      "schema": "public",
+      "values": [
+        "text_answer",
+        "multiple_select",
+        "single_select"
+      ]
+    },
+    "public.org_campus": {
+      "name": "org_campus",
+      "schema": "public",
+      "values": [
+        "trondheim",
+        "gjovik",
+        "alesund"
+      ]
+    },
+    "public.org_fine_status": {
+      "name": "org_fine_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "paid",
+        "rejected"
+      ]
+    },
+    "public.org_group_membership_role": {
+      "name": "org_group_membership_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "leader"
+      ]
+    },
+    "public.org_group_position_scope": {
+      "name": "org_group_position_scope",
+      "schema": "public",
+      "values": [
+        "group",
+        "global"
+      ]
+    },
+    "public.org_group_type": {
+      "name": "org_group_type",
+      "schema": "public",
+      "values": [
+        "studyyear",
+        "interestgroup",
+        "committee",
+        "study",
+        "private",
+        "board",
+        "subgroup",
+        "tihlde"
+      ]
+    },
+    "public.org_study_program_type": {
+      "name": "org_study_program_type",
+      "schema": "public",
+      "values": [
+        "bachelor",
+        "master"
+      ]
+    },
+    "public.org_study_year_source": {
+      "name": "org_study_year_source",
+      "schema": "public",
+      "values": [
+        "feide",
+        "assumed",
+        "manual",
+        "migrated"
+      ]
+    },
+    "public.job_type": {
+      "name": "job_type",
+      "schema": "public",
+      "values": [
+        "full_time",
+        "part_time",
+        "summer_job",
+        "other"
+      ]
+    },
+    "public.user_class": {
+      "name": "user_class",
+      "schema": "public",
+      "values": [
+        "first",
+        "second",
+        "third",
+        "fourth",
+        "fifth",
+        "alumni"
+      ]
+    },
+    "public.user_gender": {
+      "name": "user_gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other"
+      ]
+    },
+    "public.motetid_date_mode": {
+      "name": "motetid_date_mode",
+      "schema": "public",
+      "values": [
+        "DATES",
+        "WEEKDAYS"
+      ]
+    },
+    "public.motetid_slot_status": {
+      "name": "motetid_slot_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "IF_NEEDED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1786971846852,
       "tag": "0061_wide_night_nurse",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1787049324426,
+      "tag": "0062_silly_reaper",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/event.ts
+++ b/packages/db/src/schema/event.ts
@@ -179,6 +179,7 @@ export const eventRelations = relations(event, ({ one, many }) => ({
     }),
     reactions: many(eventReaction),
     pools: many(eventPriorityPool),
+    priorityUsers: many(eventPriorityUser),
     favorites: many(eventFavorite),
     registrations: many(eventRegistration),
 }));
@@ -425,6 +426,43 @@ export const eventPriorityPoolGroupRelations = relations(
         group: one(group, {
             fields: [eventPriorityPoolGroup.groupSlug],
             references: [group.slug],
+        }),
+    }),
+);
+
+/**
+ * Enkeltpersoner som er prioritert på et arrangement.
+ *
+ * Bevisst en egen tabell og ikke enda et kriterium i en pool: en pool er et
+ * OG av grupper, og «brukeren er Ola» kan ikke stå sammen med «brukeren er i
+ * 1. klasse» uten å bety noe annet enn arrangøren mener. Her er regelen
+ * flat — står du i lista, er du prioritert, på lik linje med å treffe en
+ * pool.
+ */
+export const eventPriorityUser = pgTable(
+    "priority_user",
+    {
+        eventId: uuid("event_id")
+            .notNull()
+            .references(() => event.id, { onDelete: "cascade" }),
+        userId: text("user_id")
+            .notNull()
+            .references(() => user.id, { onDelete: "cascade" }),
+        ...timestamps,
+    },
+    (t) => [primaryKey({ columns: [t.eventId, t.userId] })],
+);
+
+export const eventPriorityUserRelations = relations(
+    eventPriorityUser,
+    ({ one }) => ({
+        event: one(event, {
+            fields: [eventPriorityUser.eventId],
+            references: [event.id],
+        }),
+        user: one(user, {
+            fields: [eventPriorityUser.userId],
+            references: [user.id],
         }),
     }),
 );

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2679,7 +2679,7 @@ export interface paths {
         };
         /**
          * Search users
-         * @description Search users by name or username (case-insensitive substring). Used by admin UIs to assign roles and positions. Requires 'users:view' or 'roles:assign' — or, when 'groupSlug' is given, the right to manage that group's roster ('groups:manage' scoped to it, or being its leader).
+         * @description Search users by name or username (case-insensitive substring). Used by admin UIs to assign roles and positions, and to name individually prioritized users on an event. Requires 'users:view' or 'roles:assign', or an event permission ('events:create'/'events:update'/'events:manage') held for at least one group — or, when 'groupSlug' is given, the right to manage that group's roster ('groups:manage' scoped to it, or being its leader).
          */
         get: operations["searchUsers"];
         put?: never;
@@ -3605,7 +3605,9 @@ export interface components {
                 /** @description Group slugs in this pool */
                 groups: string[];
             }[] | null;
-            /** @description Only allow users in at least one priority pool to sign up. Can only be true if at least one group is in priorityPools. */
+            /** @description User IDs prioritized individually, independent of the priority pools. A user named here is prioritized on their own — the pools' all-groups-must-match rule does not apply to them. */
+            priorityUserIds?: string[] | null;
+            /** @description Only allow prioritized users to sign up. Can only be true if at least one group is in priorityPools, or at least one user is in priorityUserIds. */
             onlyAllowPrioritized: boolean;
             /** @description Slug of the NTNU institute this event is reserved for (e.g. 'idi' or 'iik'). Only members of a study group belonging to that institute may sign up. Null — the default — leaves the event open to every institute. */
             restrictedToInstituteSlug?: string | null;
@@ -3754,7 +3756,9 @@ export interface components {
                 /** @description Group slugs in this pool */
                 groups: string[];
             }[] | null;
-            /** @description Only allow users in at least one priority pool to sign up. Can only be true if at least one group is in priorityPools. */
+            /** @description User IDs prioritized individually, independent of the priority pools. A user named here is prioritized on their own — the pools' all-groups-must-match rule does not apply to them. */
+            priorityUserIds?: string[] | null;
+            /** @description Only allow prioritized users to sign up. Can only be true if at least one group is in priorityPools, or at least one user is in priorityUserIds. */
             onlyAllowPrioritized?: boolean;
             /** @description Slug of the NTNU institute this event is reserved for (e.g. 'idi' or 'iik'). Only members of a study group belonging to that institute may sign up. Null — the default — leaves the event open to every institute. */
             restrictedToInstituteSlug?: string | null;
@@ -3902,6 +3906,17 @@ export interface components {
                     /** @description Group logo URL (nullable) */
                     logoUrl: string | null;
                 }[];
+            }[];
+            /** @description Users prioritized individually, independent of the pools */
+            priorityUsers: {
+                /** @description User ID */
+                id: string;
+                /** @description Full name */
+                name: string | null;
+                /** @description Username */
+                username: string | null;
+                /** @description Avatar URL (nullable) */
+                image: string | null;
             }[];
             /** @description Does the event enforce previous strikes for registration */
             enforcesPreviousStrikes: boolean;


### PR DESCRIPTION
Prioritering kunne bare uttrykkes som grupper. Det dekker ikke tilfellet arrangørene faktisk står i: **én person skal ha plass**. En foredragsholder, en fadder, noen som fikk plass lovet. I dag løses det ved å ta dem inn manuelt etterpå — eller ikke i det hele tatt.

Arrangøren kan nå søke opp hvem som helst på nettsiden og legge dem til som prioritert, ved siden av de prioriterte gruppene.

## Hvorfor egen liste, ikke enda et kriterium

Kriteriene i én prioritert gruppe må stemme **samtidig**. «Personen er Ola» sammen med «personen går første klasse» ville derfor betydd noe annet enn arrangøren mener. Regelen for enkeltpersoner er flat: står du i lista, er du prioritert — på lik linje med å treffe en gruppe.

Prikkegrensa gjelder også for navngitte. Å bli pekt ut sier at arrangøren vil ha deg foran i køa, ikke at prikkene dine er strøket, og et arrangement som håndhever prikker skulle ellers hatt en stille vei utenom.

## Ventelista regnes om når prioriteringen endres

`waitlistPosition` er en lagret kolonne, og både medlemmet og framrykkingen leser den framfor reglene. Uten omregning ville en nettopp navngitt person blitt stående **nøyaktig like langt bak som før** — helt til noen andre tilfeldigvis meldte seg på og resolveren regnet om lista som en bieffekt.

Det er nettopp tilfellet feltet er laget for: arrangementet er fullt, noen får plass lovet, og de legges til etterpå. Testen `naming someone on a full event moves them to the front of the waitlist` feiler med «expected 2 to be 1» hvis omregningen slås av.

## Hvem får se lista

Hvem som er prioritert som gruppe er en regel; hvem som er prioritert ved navn er en opplysning om enkeltpersoner. Lista deles bare med dem som kan redigere arrangementet — og lesetilgangen er nøyaktig den lagringen krever, så en tom liste ikke kan leses av noen som senere kan skrive den tilbake over de navngitte. En leder i en annen gruppe får `[]` på lesing og 403 på lagring.

Sjekken kortslutter på arrangementer uten navngitte. Dette er den mest trafikkerte ruta på nettsiden, og de aller fleste arrangementer har ingen.

## Søket

Arrangøren slipper inn på `events:create`/`events:update`/`events:manage` holdt for minst én gruppe. Den prioriterte er ofte nettopp en utenfor arrangørgruppa, så det finnes ingen gruppe å begrense søket til. Uten en slik rettighet er søket like stengt som før.

## API-detaljer

- `priorityUserIds` er **valgfritt**, i motsetning til `priorityPools`: feltet kom etter at API-et var i bruk, og et kall som ikke nevner det skal fortsatt opprette arrangementer.
- Som poolene erstattes lista i sin helhet når feltet er med. `null` og utelatt betyr «ikke rør», tom liste tømmer.
- Ukjente bruker-id-er gir **400**, ikke et fremmednøkkelbrudd midt i transaksjonen. Nåbart uten å prøve: arrangøren søker opp noen, brukeren slettes, lagringen skjer etterpå.
- «Bare prioriterte kan melde seg på» godtar nå én navngitt person som grunnlag — og avviser en prioritert gruppe uten kriterier, som matcher ingen og tidligere passerte validering og gjorde arrangementet umulig å melde seg på.

## Verifisering

- 11 nye integrasjonstester i `priority-users.test.ts`; hele suiten grønn (624).
- Typecheck, build, lint og format passerer.
- Kjørt i nettleser mot lokal API/DB: søkte opp en bruker, la til, publiserte, kontrollerte raden i basen, og lastet redigeringssiden på nytt (hard reload, så serverrenderingen — skjemaets tilstand settes én gang fra første render).

## Migrasjon

`0062_silly_reaper.sql` — ny tabell `event_priority_user`, kaskade på både arrangement og bruker.

Refs #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)
