### PR TITLE
fix(arrangement): rett opp arrangementsskjemaet og reglene for betalte arrangementer

### DIFF
--- a/apps/api/src/lib/event/no-show.ts
+++ b/apps/api/src/lib/event/no-show.ts
@@ -24,12 +24,25 @@ const NO_SHOW_REASON = "Møtte ikke opp på arrangementet";
  *   up once an organizer performs check-in.
  * - Every remaining `registered` user is flipped to `no_show` and given strikes.
  * - Marks the event processed so strikes are issued at most once.
+ * - Paid events never give strikes, no matter what `canCauseStrikes` says.
  */
 export async function processEventNoShows(
     eventId: string,
     ctx: AppContext,
 ): Promise<{ processed: boolean; struck: number }> {
     return ctx.db.transaction(async (tx) => {
+        // Betalte arrangementer gir aldri prikker. Skjemaet avviser
+        // kombinasjonen, men arrangementer opprettet før regelen kan fortsatt
+        // ha begge deler satt i databasen.
+        const event = await tx.query.event.findFirst({
+            columns: { isPaidEvent: true },
+            where: eq(schema.event.id, eventId),
+        });
+
+        if (event?.isPaidEvent) {
+            return { processed: false, struck: 0 };
+        }
+
         const registrations = await tx.query.eventRegistration.findMany({
             columns: { userId: true, status: true },
             where: eq(schema.eventRegistration.eventId, eventId),
@@ -85,8 +98,8 @@ export async function processEventNoShows(
 
 /**
  * Scan for events that have ended and issue no-show strikes for each. Skips
- * events that already were processed, that cannot cause strikes, or that ended
- * outside the lookback window.
+ * events that already were processed, that cannot cause strikes, that are paid,
+ * or that ended outside the lookback window.
  */
 export async function processNoShowStrikesForEndedEvents(
     ctx: AppContext,
@@ -100,6 +113,7 @@ export async function processNoShowStrikesForEndedEvents(
         columns: { id: true },
         where: and(
             eq(schema.event.canCauseStrikes, true),
+            eq(schema.event.isPaidEvent, false),
             isNull(schema.event.noShowProcessedAt),
             lt(schema.event.end, now),
             gt(schema.event.end, lookbackCutoff),

--- a/apps/api/src/routes/event/get.ts
+++ b/apps/api/src/routes/event/get.ts
@@ -121,6 +121,20 @@ export const getRoute = route().get(
             });
 
             if (dbRegistration) {
+                // Betalingen ligger i sin egen tabell. Frontend trenger å vite
+                // om den er gjennomført, for en betalt plass kan ikke meldes av.
+                const paidPayment = event.isPaidEvent
+                    ? await db.query.eventPayment.findFirst({
+                          columns: { id: true },
+                          where: (payment, { eq, and }) =>
+                              and(
+                                  eq(payment.userId, user.id),
+                                  eq(payment.eventId, event.id),
+                                  eq(payment.status, "paid"),
+                              ),
+                      })
+                    : undefined;
+
                 registration = {
                     attendedAt:
                         dbRegistration.attendedAt?.toISOString() ?? null,
@@ -128,6 +142,7 @@ export const getRoute = route().get(
                     status: dbRegistration.status,
                     updatedAt: dbRegistration.updatedAt.toISOString(),
                     waitlistPosition: dbRegistration.waitlistPosition,
+                    hasPaid: paidPayment != null,
                 };
             }
         }

--- a/apps/api/src/routes/event/registration/delete.ts
+++ b/apps/api/src/routes/event/registration/delete.ts
@@ -14,7 +14,7 @@ export const deleteEventRegistrationRoute = route().delete(
         summary: "Unregister from event",
         operationId: "deleteEventRegistration",
         description:
-            "Remove the authenticated user's registration from an event. If the event can cause strikes and the user unregisters from a confirmed spot after the cancellation deadline, they are given 1 strike.",
+            "Remove the authenticated user's registration from an event. If the event can cause strikes and the user unregisters from a confirmed spot after the cancellation deadline, they are given 1 strike. Registrations with a completed payment cannot be cancelled by the user.",
     })
         .response({ statusCode: 200, description: "OK" })
         .build(),
@@ -52,6 +52,28 @@ export const deleteEventRegistrationRoute = route().delete(
             where: eq(schema.event.id, eventId),
         });
 
+        // En betalt plass kan ikke gis fra seg av brukeren selv: pengene er
+        // allerede trukket, og systemet refunderer ikke automatisk. Sjekken må
+        // skje før slettingen, ellers er registreringen borte uansett utfall.
+        if (event?.isPaidEvent) {
+            const paidPayment = await db.query.eventPayment.findFirst({
+                columns: { id: true },
+                where: (payment, { eq, and }) =>
+                    and(
+                        eq(payment.userId, userId),
+                        eq(payment.eventId, eventId),
+                        eq(payment.status, "paid"),
+                    ),
+            });
+
+            if (paidPayment) {
+                throw new HTTPException(400, {
+                    message:
+                        "Du kan ikke melde deg av et arrangement du har betalt for. Ta kontakt med arrangøren for refusjon.",
+                });
+            }
+        }
+
         const [deleted] = await db
             .delete(schema.eventRegistration)
             .where(
@@ -68,8 +90,12 @@ export const deleteEventRegistrationRoute = route().delete(
 
         // Late cancellation: only a confirmed ("registered") spot given up after
         // the cancellation deadline earns a strike — waitlisted users are exempt.
+        // `!isPaidEvent` er ikke bare et belte til skjemavalideringens
+        // bukseseler: arrangementer opprettet før regelen kan fortsatt ha
+        // `canCauseStrikes` satt sammen med betaling.
         const isLateCancellation =
             event?.canCauseStrikes &&
+            !event.isPaidEvent &&
             event.cancellationDeadline != null &&
             deleted.status === "registered" &&
             new Date() > event.cancellationDeadline;

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -176,6 +176,26 @@ export const createEventSchema = Schema(
                     path: ["paymentGracePeriod"],
                 });
             }
+            // Betalte arrangementer gir aldri prikker. Regelen er absolutt:
+            // har man betalt, er pengene straffen nok, og man kan uansett
+            // ikke melde seg av (se registration/delete.ts). Da gir verken
+            // en avmeldingsfrist eller prikkflagget mening.
+            if (val.canCauseStrikes) {
+                ctx.addIssue({
+                    code: "custom",
+                    message:
+                        "canCauseStrikes cannot be true if isPaidEvent is true",
+                    path: ["canCauseStrikes"],
+                });
+            }
+            if (val.cancellationDeadline) {
+                ctx.addIssue({
+                    code: "custom",
+                    message:
+                        "cancellationDeadline cannot be set if isPaidEvent is true",
+                    path: ["cancellationDeadline"],
+                });
+            }
         }
 
         if (new Date(val.end) <= new Date(val.start)) {
@@ -228,6 +248,20 @@ export const createEventSchema = Schema(
                 message:
                     "registrationEnd is required if requiresSigningUp is true",
                 path: ["registrationEnd"],
+            });
+        }
+
+        // Feltene fylles ut i vilkårlig rekkefølge i admin-skjemaet, så
+        // rekkefølgen håndheves her i stedet for i datovelgeren.
+        if (
+            val.registrationStart &&
+            val.registrationEnd &&
+            new Date(val.registrationStart) >= new Date(val.registrationEnd)
+        ) {
+            ctx.addIssue({
+                code: "custom",
+                message: "registrationStart must be before registrationEnd",
+                path: ["registrationStart"],
             });
         }
 
@@ -309,6 +343,23 @@ export const updateEventSchema = Schema(
                     path: ["paymentGracePeriod"],
                 });
             }
+            // Se create-skjemaet: betalte arrangementer gir aldri prikker.
+            if (val.canCauseStrikes) {
+                ctx.addIssue({
+                    code: "custom",
+                    message:
+                        "canCauseStrikes cannot be true if isPaidEvent is true",
+                    path: ["canCauseStrikes"],
+                });
+            }
+            if (val.cancellationDeadline) {
+                ctx.addIssue({
+                    code: "custom",
+                    message:
+                        "cancellationDeadline cannot be set if isPaidEvent is true",
+                    path: ["cancellationDeadline"],
+                });
+            }
         }
         if (val.start && val.end && new Date(val.end) <= new Date(val.start)) {
             ctx.addIssue({
@@ -359,6 +410,18 @@ export const updateEventSchema = Schema(
                     path: ["capacity"],
                 });
             }
+        }
+        // Se create-skjemaet.
+        if (
+            val.registrationStart &&
+            val.registrationEnd &&
+            new Date(val.registrationStart) >= new Date(val.registrationEnd)
+        ) {
+            ctx.addIssue({
+                code: "custom",
+                message: "registrationStart must be before registrationEnd",
+                path: ["registrationStart"],
+            });
         }
         if (
             val.cancellationDeadline &&
@@ -670,6 +733,10 @@ export const eventDetailSchema = Schema(
                 attendedAt: z.iso.datetime().nullable().meta({
                     description:
                         "When the user was registered as an attendee by TIHLDE for this event. Is null if not attended.",
+                }),
+                hasPaid: z.boolean().meta({
+                    description:
+                        "Whether the user has a completed payment for this event. Always false for free events. A paid registration cannot be cancelled by the user.",
                 }),
             })
             .nullable()

--- a/apps/api/src/test/event/paid-event-rules.test.ts
+++ b/apps/api/src/test/event/paid-event-rules.test.ts
@@ -1,0 +1,273 @@
+import { schema } from "@photon/db";
+import { describe, expect } from "vitest";
+import { processEventNoShows } from "~/lib/event/no-show";
+import { integrationTest } from "~/test/config/integration";
+import type { IntegrationTestContext } from "~/test/config/integration";
+
+const HOUR = 60 * 60 * 1000;
+
+/**
+ * To faste regler for betalte arrangementer:
+ * - de gir aldri prikker, verken for sen avmelding eller no-show
+ * - en plass man har betalt for kan ikke meldes av
+ */
+
+async function strikeTotal(
+    ctx: IntegrationTestContext,
+    eventId: string,
+    userId: string,
+) {
+    const rows = await ctx.db.query.eventStrike.findMany({
+        where: (s, { and, eq }) =>
+            and(eq(s.userId, userId), eq(s.eventId, eventId)),
+    });
+    return rows.reduce((total, r) => total + r.count, 0);
+}
+
+/** Standardkroppen til POST /event, med feltene testen bryr seg om overstyrt. */
+function createEventBody(overrides: Record<string, unknown>) {
+    return {
+        title: "Test Event",
+        description: "A test event description",
+        categorySlug: "bedpres",
+        organizerGroupSlug: "index",
+        location: "Oslo, Norway",
+        imageUrl: null,
+        start: "2025-12-01T18:00:00Z",
+        end: "2025-12-01T20:00:00Z",
+        registrationStart: null,
+        registrationEnd: "2025-11-30T23:59:59Z",
+        cancellationDeadline: null,
+        capacity: 50,
+        isRegistrationClosed: false,
+        requiresSigningUp: true,
+        allowWaitlist: true,
+        priorityPools: null,
+        onlyAllowPrioritized: false,
+        canCauseStrikes: false,
+        enforcesPreviousStrikes: false,
+        isPaidEvent: false,
+        price: null,
+        paymentGracePeriodMinutes: null,
+        contactPersonUserId: null,
+        reactionsAllowed: true,
+        ...overrides,
+    };
+}
+
+describe("Paid event rules", () => {
+    integrationTest(
+        "a paid event cannot be created with canCauseStrikes",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.giveUserPermissions(user, ["events:create"]);
+
+            const response = await client.api.event.$post({
+                // biome-ignore lint: testen sender med vilje en ugyldig kropp
+                json: createEventBody({
+                    isPaidEvent: true,
+                    price: 100,
+                    paymentGracePeriodMinutes: 30,
+                    canCauseStrikes: true,
+                }) as never,
+            });
+
+            expect(response.status).toBe(400);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "a paid event cannot be created with a cancellation deadline",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.giveUserPermissions(user, ["events:create"]);
+
+            const response = await client.api.event.$post({
+                json: createEventBody({
+                    isPaidEvent: true,
+                    price: 100,
+                    paymentGracePeriodMinutes: 30,
+                    cancellationDeadline: "2025-11-30T12:00:00Z",
+                }) as never,
+            });
+
+            expect(response.status).toBe(400);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "registrationStart must be before registrationEnd",
+        async ({ ctx }) => {
+            const user = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(user);
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.giveUserPermissions(user, ["events:create"]);
+
+            const response = await client.api.event.$post({
+                json: createEventBody({
+                    registrationStart: "2025-11-30T23:59:59Z",
+                    registrationEnd: "2025-11-29T12:00:00Z",
+                }) as never,
+            });
+
+            expect(response.status).toBe(400);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "a paid registration cannot be cancelled by the user",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            const now = Date.now();
+            const event = await ctx.utils.createTestEvent({
+                isPaidEvent: true,
+                priceMinor: 10_000,
+                paymentGracePeriodMinutes: 30,
+                start: new Date(now + 3 * HOUR),
+                end: new Date(now + 5 * HOUR),
+            });
+            const user = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: user.id,
+                status: "registered",
+            });
+            await ctx.db.insert(schema.eventPayment).values({
+                eventId: event.id,
+                userId: user.id,
+                amountMinor: 10_000,
+                status: "paid",
+            });
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[":eventId"].registration.$delete(
+                { param: { eventId: event.id } },
+            );
+
+            expect(res.status).toBe(400);
+
+            // Registreringen skal fortsatt stå — sjekken kjører før slettingen.
+            const registration = await ctx.db.query.eventRegistration.findFirst(
+                {
+                    where: (r, { and, eq }) =>
+                        and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+                },
+            );
+            expect(registration).toBeDefined();
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "an unpaid registration on a paid event can still be cancelled",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            const now = Date.now();
+            const event = await ctx.utils.createTestEvent({
+                isPaidEvent: true,
+                priceMinor: 10_000,
+                paymentGracePeriodMinutes: 30,
+                start: new Date(now + 3 * HOUR),
+                end: new Date(now + 5 * HOUR),
+            });
+            const user = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: user.id,
+                status: "registered",
+            });
+            await ctx.db.insert(schema.eventPayment).values({
+                eventId: event.id,
+                userId: user.id,
+                amountMinor: 10_000,
+                status: "pending",
+            });
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[":eventId"].registration.$delete(
+                { param: { eventId: event.id } },
+            );
+
+            expect(res.status).toBe(200);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "no late-cancellation strike on a paid event",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            const now = Date.now();
+            // Kombinasjonen avvises av skjemaet i dag, men gamle rader kan ha
+            // den — derfor sperren i selve avmeldingen.
+            const event = await ctx.utils.createTestEvent({
+                canCauseStrikes: true,
+                cancellationDeadline: new Date(now - 2 * HOUR),
+                isPaidEvent: true,
+                priceMinor: 10_000,
+                start: new Date(now + HOUR),
+                end: new Date(now + 3 * HOUR),
+            });
+            const user = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: user.id,
+                status: "registered",
+            });
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[":eventId"].registration.$delete(
+                { param: { eventId: event.id } },
+            );
+
+            expect(res.status).toBe(200);
+            expect(await strikeTotal(ctx, event.id, user.id)).toBe(0);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "no no-show strikes on a paid event",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            const now = Date.now();
+            const event = await ctx.utils.createTestEvent({
+                canCauseStrikes: true,
+                isPaidEvent: true,
+                priceMinor: 10_000,
+                start: new Date(now - 3 * HOUR),
+                end: new Date(now - HOUR),
+            });
+            const attendee = await ctx.utils.createTestUser();
+            const noShow = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.eventRegistration).values([
+                {
+                    eventId: event.id,
+                    userId: attendee.id,
+                    status: "attended",
+                },
+                {
+                    eventId: event.id,
+                    userId: noShow.id,
+                    status: "registered",
+                },
+            ]);
+
+            const result = await processEventNoShows(event.id, ctx);
+
+            expect(result).toEqual({ processed: false, struck: 0 });
+            expect(await strikeTotal(ctx, event.id, noShow.id)).toBe(0);
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/components/event-form.tsx
+++ b/apps/kvark/src/components/event-form.tsx
@@ -11,6 +11,7 @@ import { DateTimePicker } from "@tihlde/ui/ui/date-time-picker";
 import {
     Field,
     FieldDescription,
+    FieldError,
     FieldGroup,
     FieldLabel,
 } from "@tihlde/ui/ui/field";
@@ -31,6 +32,7 @@ import { AddressCombobox } from "#/components/address-combobox";
 import { AdminImageField } from "#/components/admin-image-field";
 import { richRegistry } from "#/components/markdown/directives/presets";
 import { ALL_EVENT_CATEGORIES } from "#/lib/event-categories";
+import { alignEventEnd } from "#/lib/event";
 
 /** Sentinel for "no institute restriction" — Select has no empty value. */
 export const ALL_INSTITUTES = "all";
@@ -58,6 +60,12 @@ export type EventFormValues = {
     /** Når påmeldingen åpner. */
     registrationStart: Date | null;
     registrationEnd: Date | null;
+    /**
+     * Siste frist for å melde seg av. Avmelding etter fristen gir prikk, så
+     * feltet gjelder bare arrangementer som ikke er betalte — betalte
+     * arrangementer kan uansett ikke meldes av etter betaling.
+     */
+    cancellationDeadline: Date | null;
     capacity: string;
     visibility: "public" | "members";
     instituteSlug: string;
@@ -179,6 +187,50 @@ export function EventForm({
     const wideWhenNoCapacity = values.requiresSigningUp
         ? undefined
         : "lg:col-span-2";
+
+    /**
+     * Å flytte starten forbi slutten skal ikke etterlate et arrangement som
+     * varer negativt lenge — slutten drar med seg, se `alignEventEnd`.
+     */
+    function handleStartChange(start: Date | null) {
+        if (!start) {
+            onChange({ start });
+            return;
+        }
+        onChange({
+            start,
+            end: alignEventEnd(start, values.end, values.start),
+        });
+    }
+
+    /**
+     * Betalte arrangementer gir aldri prikker, og kan ikke meldes av etter at
+     * pengene er trukket. Begge feltene forsvinner fra skjemaet, så verdiene
+     * deres må nullstilles — ellers ville en avhuket boks blitt sendt videre
+     * usett, og API-et ville avvist lagringen.
+     */
+    function handlePaidChange(isPaidEvent: boolean) {
+        onChange(
+            isPaidEvent
+                ? {
+                      isPaidEvent,
+                      canCauseStrikes: false,
+                      cancellationDeadline: null,
+                  }
+                : { isPaidEvent },
+        );
+    }
+
+    /**
+     * Datovelgerne begrenser ikke lenger hverandre — da kunne man ikke sette
+     * påmeldingsstart før fristen var flyttet — så rekkefølgen vises som feil
+     * i stedet. Rutene blokkerer lagring på det samme.
+     */
+    const registrationOrderInvalid = Boolean(
+        values.registrationStart &&
+        values.registrationEnd &&
+        values.registrationStart >= values.registrationEnd,
+    );
 
     function handleSelectAddress(suggestion: AddressSuggestion) {
         const coords = {
@@ -340,9 +392,7 @@ export function EventForm({
                                     locale={nb}
                                     placeholder="Velg startdato"
                                     value={values.start}
-                                    onValueChange={(start) =>
-                                        onChange({ start })
-                                    }
+                                    onValueChange={handleStartChange}
                                 />
                             </Field>
                             <Field>
@@ -359,7 +409,7 @@ export function EventForm({
                                 />
                             </Field>
                         </div>
-                        <Field orientation="horizontal" className="gap-3">
+                        <Field orientation="horizontal" className="w-fit gap-3">
                             <Checkbox
                                 id="event-requires-signup"
                                 checked={values.requiresSigningUp}
@@ -383,16 +433,18 @@ export function EventForm({
                                         id="event-reg-start"
                                         locale={nb}
                                         placeholder="Velg dato"
-                                        maxDate={
-                                            values.registrationEnd ??
-                                            values.start ??
-                                            undefined
-                                        }
                                         value={values.registrationStart}
                                         onValueChange={(registrationStart) =>
                                             onChange({ registrationStart })
                                         }
+                                        aria-invalid={registrationOrderInvalid}
                                     />
+                                    {registrationOrderInvalid ? (
+                                        <FieldError>
+                                            Påmeldingen må åpne før
+                                            påmeldingsfristen.
+                                        </FieldError>
+                                    ) : null}
                                 </Field>
                                 <Field>
                                     <FieldLabel htmlFor="event-reg-end">
@@ -402,17 +454,40 @@ export function EventForm({
                                         id="event-reg-end"
                                         locale={nb}
                                         placeholder="Velg dato"
-                                        minDate={
-                                            values.registrationStart ??
-                                            undefined
-                                        }
                                         maxDate={values.start ?? undefined}
                                         value={values.registrationEnd}
                                         onValueChange={(registrationEnd) =>
                                             onChange({ registrationEnd })
                                         }
+                                        aria-invalid={registrationOrderInvalid}
                                     />
                                 </Field>
+                                {!values.isPaidEvent ? (
+                                    <Field>
+                                        <FieldLabel htmlFor="event-cancel-deadline">
+                                            Avmeldingsfrist (valgfritt)
+                                        </FieldLabel>
+                                        <DateTimePicker
+                                            id="event-cancel-deadline"
+                                            locale={nb}
+                                            placeholder="Velg dato"
+                                            maxDate={values.start ?? undefined}
+                                            value={values.cancellationDeadline}
+                                            onValueChange={(
+                                                cancellationDeadline,
+                                            ) =>
+                                                onChange({
+                                                    cancellationDeadline,
+                                                })
+                                            }
+                                        />
+                                        <FieldDescription>
+                                            Avmelding etter denne fristen gir
+                                            prikk, forutsatt at «Kan gi prikker»
+                                            er huket av.
+                                        </FieldDescription>
+                                    </Field>
+                                ) : null}
                             </div>
                         ) : null}
                         <div className="grid gap-4 lg:grid-cols-4">
@@ -516,12 +591,12 @@ export function EventForm({
                                 </FieldDescription>
                             </Field>
                         </div>
-                        <Field orientation="horizontal" className="gap-3">
+                        <Field orientation="horizontal" className="w-fit gap-3">
                             <Checkbox
                                 id="event-paid"
                                 checked={values.isPaidEvent}
                                 onCheckedChange={(checked) =>
-                                    onChange({ isPaidEvent: Boolean(checked) })
+                                    handlePaidChange(Boolean(checked))
                                 }
                             />
                             <FieldLabel htmlFor="event-paid">
@@ -544,21 +619,26 @@ export function EventForm({
                                 />
                             </Field>
                         )}
-                        <Field orientation="horizontal" className="gap-3">
-                            <Checkbox
-                                id="event-strikes"
-                                checked={values.canCauseStrikes}
-                                onCheckedChange={(checked) =>
-                                    onChange({
-                                        canCauseStrikes: Boolean(checked),
-                                    })
-                                }
-                            />
-                            <FieldLabel htmlFor="event-strikes">
-                                Kan gi prikker (avmelding etter frist og
-                                no-show)
-                            </FieldLabel>
-                        </Field>
+                        {!values.isPaidEvent ? (
+                            <Field
+                                orientation="horizontal"
+                                className="w-fit gap-3"
+                            >
+                                <Checkbox
+                                    id="event-strikes"
+                                    checked={values.canCauseStrikes}
+                                    onCheckedChange={(checked) =>
+                                        onChange({
+                                            canCauseStrikes: Boolean(checked),
+                                        })
+                                    }
+                                />
+                                <FieldLabel htmlFor="event-strikes">
+                                    Kan gi prikker (avmelding etter frist og
+                                    no-show)
+                                </FieldLabel>
+                            </Field>
+                        ) : null}
                         <Field>
                             <FieldLabel>Beskrivelse</FieldLabel>
                             <RichEditor

--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -32,6 +32,11 @@ type EventRegistrationCardProps = {
     registrationOpensInLabel?: string;
     registrationClosesAt?: EventDeadline;
     unregisterDeadline?: EventDeadline;
+    /**
+     * Satt når medlemmet har betalt for plassen. Da forsvinner avmeldingen:
+     * systemet refunderer ikke automatisk, og API-et avviser forsøket.
+     */
+    hasPaid?: boolean;
     paymentDeadline?: EventDeadline;
     capacity: number | null;
     registeredCount: number;
@@ -171,6 +176,9 @@ function getStateRendering(
             return {
                 icon: CheckCircle2,
                 message: "Du har plass på arrangementet!",
+                secondary: props.hasPaid
+                    ? "Du har betalt. Ta kontakt med arrangøren hvis du ikke kan komme."
+                    : null,
                 actions: (
                     <>
                         {props.qrSlot ?? (
@@ -179,13 +187,15 @@ function getStateRendering(
                                 Påmeldingsbevis
                             </Button>
                         )}
-                        <Button
-                            variant="destructive"
-                            className="w-full"
-                            onClick={props.onUnregister}
-                        >
-                            Meld deg av
-                        </Button>
+                        {!props.hasPaid && (
+                            <Button
+                                variant="destructive"
+                                className="w-full"
+                                onClick={props.onUnregister}
+                            >
+                                Meld deg av
+                            </Button>
+                        )}
                     </>
                 ),
             };
@@ -309,8 +319,9 @@ function buildTimeline(props: EventRegistrationCardProps): TimelinePoint[] {
         });
     }
     const showUnregister =
-        props.registrationState === "joined" ||
-        props.registrationState === "awaiting-payment";
+        !props.hasPaid &&
+        (props.registrationState === "joined" ||
+            props.registrationState === "awaiting-payment");
     if (showUnregister && props.unregisterDeadline) {
         points.push({
             label: "Avmelding",

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -1,4 +1,9 @@
-import { format, formatDistanceToNowStrict } from "date-fns";
+import {
+    addMilliseconds,
+    format,
+    formatDistanceToNowStrict,
+    set,
+} from "date-fns";
 import { nb } from "date-fns/locale";
 
 // -- Shared display types (previously in mock/events) --
@@ -227,4 +232,41 @@ export function formatTimeUntil(iso: string): string {
  */
 export function formatEventDateTime(iso: string): string {
     return `${formatEventDate(iso)}, ${formatEventTime(iso)}`;
+}
+
+/** Reservevarighet når vi ikke kan utlede hvor langt arrangementet var. */
+const FALLBACK_EVENT_DURATION_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * Sluttidspunktet som hører til et nytt starttidspunkt.
+ *
+ * Flytter man starten forbi slutten, blir arrangementet negativt langt. I
+ * stedet for å la admin rydde opp manuelt drar vi slutten med: den beholder
+ * klokkeslettet sitt og flyttes til samme dato som starten. Er den fortsatt
+ * for tidlig — start 22:00, slutt 09:00 — legger vi den opprinnelige
+ * varigheten til starten i stedet.
+ *
+ * Returnerer `end` uendret når den allerede ligger etter starten.
+ */
+export function alignEventEnd(
+    start: Date,
+    end: Date | null,
+    previousStart: Date | null,
+): Date | null {
+    if (!end || end > start) return end;
+
+    const sameDay = set(start, {
+        hours: end.getHours(),
+        minutes: end.getMinutes(),
+        seconds: 0,
+        milliseconds: 0,
+    });
+    if (sameDay > start) return sameDay;
+
+    const previousDuration =
+        previousStart && end > previousStart
+            ? end.getTime() - previousStart.getTime()
+            : FALLBACK_EVENT_DURATION_MS;
+
+    return addMilliseconds(start, previousDuration);
 }

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -243,6 +243,51 @@ export function isPrivateGroupType(type: string): boolean {
 }
 
 /**
+ * Om gruppa er et kull (klassetrinn). Kull opprettes automatisk og arrangerer
+ * ingenting, så de hører ikke hjemme i arrangørgruppe-lista — men de er
+ * fortsatt helt legitime i prioriterte grupper.
+ *
+ * Case-insensitiv: `type` er en fritekstkolonne, og radene fra Lepton er
+ * store bokstaver.
+ */
+export function isCohortGroupType(type: string | null | undefined): boolean {
+    return type?.toUpperCase() === "STUDYYEAR";
+}
+
+/**
+ * Gruppetypene sortert etter hvor høyt de sitter i TIHLDE. Rekkefølgen er den
+ * samme som organisasjonskartet på /grupper bruker: Hovedorgan øverst, så
+ * undergrupper, komitéer, og til slutt interesse- og idrettsgrupper på samme
+ * nivå.
+ */
+export const GROUP_HIERARCHY_ORDER = [
+    "BOARD",
+    "SUBGROUP",
+    "COMMITTEE",
+    "INTERESTGROUP",
+    "SPORTSTEAM",
+] as const;
+
+function groupHierarchyRank(type: string | null | undefined): number {
+    const index = (GROUP_HIERARCHY_ORDER as readonly string[]).indexOf(
+        type?.toUpperCase() ?? "",
+    );
+    // Ukjente typer (kull, studier, private bøtelag) sorteres bakerst.
+    return index === -1 ? GROUP_HIERARCHY_ORDER.length : index;
+}
+
+/**
+ * Sorterer to grupper etter plassen deres i hierarkiet, høyest først. Brukes
+ * til å velge «den viktigste» gruppa når en bruker leder flere.
+ */
+export function compareGroupHierarchy(
+    a: { type?: string | null },
+    b: { type?: string | null },
+): number {
+    return groupHierarchyRank(a.type) - groupHierarchyRank(b.type);
+}
+
+/**
  * Format an ISO timestamp as a Norwegian long date, e.g. "tor. 30. apr. 2026".
  */
 export function formatGroupDate(iso: string): string {

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -349,15 +349,21 @@ function EventDetailPage() {
                                           icon={UserRound}
                                           label="Kontaktperson"
                                           value={
-                                              // E-posten deles kun med innloggede
-                                              // medlemmer, så den mangler for
-                                              // utloggede besøkende.
+                                              // Profilsiden krever innlogging,
+                                              // så utloggede får navnet som ren
+                                              // tekst. E-posten deles etter
+                                              // samme regel og røper hvem som
+                                              // er innlogget.
                                               event.contactPerson.email ? (
-                                                  <a
-                                                      href={`mailto:${event.contactPerson.email}`}
+                                                  <Link
+                                                      to="/profil/$id"
+                                                      params={{
+                                                          id: event
+                                                              .contactPerson.id,
+                                                      }}
                                                   >
                                                       {event.contactPerson.name}
-                                                  </a>
+                                                  </Link>
                                               ) : (
                                                   event.contactPerson.name
                                               )
@@ -386,6 +392,12 @@ function EventDetailPage() {
                                 ? toEventDeadline(event.registrationEnd)
                                 : undefined
                         }
+                        unregisterDeadline={
+                            event.cancellationDeadline
+                                ? toEventDeadline(event.cancellationDeadline)
+                                : undefined
+                        }
+                        hasPaid={event.registration?.hasPaid ?? false}
                         capacity={event.capacity}
                         registeredCount={registeredCount}
                         waitlistCount={event.waitlistCount}

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -74,6 +74,7 @@ import {
     useCanActOnResource,
 } from "#/hooks/use-permission";
 import { extractErrorMessage } from "#/lib/api-error";
+import { isCohortGroupType } from "#/lib/group";
 import { useDebounced } from "#/lib/use-debounced";
 
 const TABS = [
@@ -244,6 +245,7 @@ function valuesFromEvent(event: Event): EventFormValues {
         requiresSigningUp: event.requiresSigningUp,
         registrationStart: toDate(event.registrationStart),
         registrationEnd: toDate(event.registrationEnd),
+        cancellationDeadline: toDate(event.cancellationDeadline),
         capacity: event.capacity === null ? "" : String(event.capacity),
         visibility: event.visibility === "members" ? "members" : "public",
         instituteSlug: event.restrictedToInstitute?.slug ?? ALL_INSTITUTES,
@@ -273,7 +275,8 @@ function DetailsTab({ eventId }: { eventId: string }) {
             allGroups.filter(
                 (group) =>
                     group.slug === event.organizer?.slug ||
-                    canArrangeFor(group.slug),
+                    (canArrangeFor(group.slug) &&
+                        !isCohortGroupType(group.type)),
             ),
         [allGroups, canArrangeFor, event.organizer?.slug],
     );
@@ -327,6 +330,15 @@ function DetailsTab({ eventId }: { eventId: string }) {
         ) {
             return;
         }
+        // Se skjemaet: datovelgerne begrenser ikke lenger hverandre, så
+        // rekkefølgen stoppes her.
+        if (
+            values.registrationStart &&
+            values.registrationEnd &&
+            values.registrationStart >= values.registrationEnd
+        ) {
+            return;
+        }
 
         // Lastes opp først: en feilet opplasting skal ikke lagre resten av
         // endringene med et bilde som mangler.
@@ -341,6 +353,10 @@ function DetailsTab({ eventId }: { eventId: string }) {
                 return;
             }
         }
+
+        const canCauseStrikes = values.isPaidEvent
+            ? false
+            : values.canCauseStrikes;
 
         const data: UpdateEventSchema = {
             title: values.title,
@@ -363,7 +379,12 @@ function DetailsTab({ eventId }: { eventId: string }) {
             registrationEnd: values.requiresSigningUp
                 ? (values.registrationEnd?.toISOString() ?? null)
                 : null,
-            cancellationDeadline: null,
+            // Avmeldingsfristen gjelder bare arrangementer med påmelding som
+            // ikke er betalte — API-et avviser resten.
+            cancellationDeadline:
+                values.requiresSigningUp && !values.isPaidEvent
+                    ? (values.cancellationDeadline?.toISOString() ?? null)
+                    : null,
             capacity:
                 values.requiresSigningUp && values.capacity
                     ? Number(values.capacity)
@@ -378,8 +399,9 @@ function DetailsTab({ eventId }: { eventId: string }) {
             allowWaitlist: values.requiresSigningUp,
             priorityPools: poolsForSubmit(values.priorityPools),
             onlyAllowPrioritized: values.onlyAllowPrioritized,
-            canCauseStrikes: values.canCauseStrikes,
-            enforcesPreviousStrikes: values.canCauseStrikes,
+            // Betalte arrangementer gir aldri prikker.
+            canCauseStrikes: canCauseStrikes,
+            enforcesPreviousStrikes: canCauseStrikes,
             isPaidEvent: values.isPaidEvent,
             price:
                 values.isPaidEvent && values.price

--- a/apps/kvark/src/routes/admin/arrangementer.ny.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.ny.tsx
@@ -22,7 +22,9 @@ import { poolsForSubmit } from "#/components/priority-pool-editor";
 import {
     useAnyScopePermission,
     useCanActForGroup,
+    useLedGroupSlugs,
 } from "#/hooks/use-permission";
+import { compareGroupHierarchy, isCohortGroupType } from "#/lib/group";
 import { nextWholeHour } from "#/lib/date";
 import { useDebounced } from "#/lib/use-debounced";
 
@@ -79,6 +81,7 @@ const emptyValues: EventFormValues = {
     requiresSigningUp: true,
     registrationStart: null,
     registrationEnd: null,
+    cancellationDeadline: null,
     capacity: "",
     visibility: "public",
     instituteSlug: ALL_INSTITUTES,
@@ -97,7 +100,11 @@ function NewEventPage() {
     // Only offer groups the caller may actually arrange for: a group-scoped
     // grant covers one group, and the API rejects the rest anyway.
     const groups = useMemo(
-        () => allGroups.filter((group) => canArrangeFor(group.slug)),
+        () =>
+            allGroups.filter(
+                (group) =>
+                    canArrangeFor(group.slug) && !isCohortGroupType(group.type),
+            ),
         [allGroups, canArrangeFor],
     );
     const { data: institutes } = useSuspenseQuery(getInstitutesQuery());
@@ -126,7 +133,20 @@ function NewEventPage() {
         enabled: Boolean(values.organizerGroupSlug),
     });
 
+    // Leder man en gruppe, er det nesten alltid den man arrangerer for. Leder
+    // man flere, vinner den som sitter høyest i TIHLDE — Hovedstyret før
+    // undergruppe før komité.
+    const ledGroupSlugs = useLedGroupSlugs();
+    const defaultOrganizerSlug = useMemo(() => {
+        const led = groups.filter((group) => ledGroupSlugs.has(group.slug));
+        if (led.length === 0) return "";
+        return [...led].sort(compareGroupHierarchy)[0]?.slug ?? "";
+    }, [groups, ledGroupSlugs]);
+
     // Sett standardverdier på klienten for å unngå SSR-hydration-mismatch.
+    // Arrangørgruppa settes her av samme grunn, og bare når feltet står tomt —
+    // et eksplisitt `?gruppe=` eller et valg brukeren har rukket å gjøre selv
+    // skal ikke overskrives.
     useEffect(() => {
         const defaults = eventDateDefaults();
         setValues((current) => ({
@@ -135,8 +155,10 @@ function NewEventPage() {
             end: current.end ?? defaults.end,
             registrationEnd:
                 current.registrationEnd ?? defaults.registrationEnd,
+            organizerGroupSlug:
+                current.organizerGroupSlug || defaultOrganizerSlug,
         }));
-    }, []);
+    }, [defaultOrganizerSlug]);
 
     const contactPersonCandidates = (organizerMembers ?? []).map((member) => ({
         id: member.user.id,
@@ -171,6 +193,15 @@ function NewEventPage() {
         ) {
             return;
         }
+        // Datovelgerne begrenser ikke lenger hverandre, så rekkefølgen stoppes
+        // her. Skjemaet viser den samme feilen ved feltet.
+        if (
+            values.registrationStart &&
+            values.registrationEnd &&
+            values.registrationStart >= values.registrationEnd
+        ) {
+            return;
+        }
 
         // Uploaded first: a failed upload must not leave an event behind that
         // silently lost its cover.
@@ -185,6 +216,10 @@ function NewEventPage() {
                 return;
             }
         }
+
+        const canCauseStrikes = values.isPaidEvent
+            ? false
+            : values.canCauseStrikes;
 
         createEvent.mutate(
             {
@@ -202,7 +237,12 @@ function NewEventPage() {
                     end: endIso,
                     registrationStart: registrationStartIso,
                     registrationEnd: registrationEndIso,
-                    cancellationDeadline: null,
+                    // Avmeldingsfristen gjelder bare arrangementer med
+                    // påmelding som ikke er betalte — API-et avviser resten.
+                    cancellationDeadline:
+                        values.requiresSigningUp && !values.isPaidEvent
+                            ? toIso(values.cancellationDeadline)
+                            : null,
                     capacity:
                         values.requiresSigningUp && values.capacity
                             ? Number(values.capacity)
@@ -217,8 +257,9 @@ function NewEventPage() {
                     allowWaitlist: values.requiresSigningUp,
                     priorityPools: poolsForSubmit(values.priorityPools),
                     onlyAllowPrioritized: values.onlyAllowPrioritized,
-                    canCauseStrikes: values.canCauseStrikes,
-                    enforcesPreviousStrikes: values.canCauseStrikes,
+                    // Betalte arrangementer gir aldri prikker.
+                    canCauseStrikes: canCauseStrikes,
+                    enforcesPreviousStrikes: canCauseStrikes,
                     isPaidEvent: values.isPaidEvent,
                     price:
                         values.isPaidEvent && values.price

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -830,7 +830,7 @@ export interface paths {
         post: operations["createEventRegistration"];
         /**
          * Unregister from event
-         * @description Remove the authenticated user's registration from an event. If the event can cause strikes and the user unregisters from a confirmed spot after the cancellation deadline, they are given 1 strike.
+         * @description Remove the authenticated user's registration from an event. If the event can cause strikes and the user unregisters from a confirmed spot after the cancellation deadline, they are given 1 strike. Registrations with a completed payment cannot be cancelled by the user.
          */
         delete: operations["deleteEventRegistration"];
         options?: never;
@@ -3939,6 +3939,8 @@ export interface components {
                 waitlistPosition: number | null;
                 /** @description When the user was registered as an attendee by TIHLDE for this event. Is null if not attended. */
                 attendedAt: string | null;
+                /** @description Whether the user has a completed payment for this event. Always false for free events. A paid registration cannot be cancelled by the user. */
+                hasPaid: boolean;
             } | null;
         };
         EventRegistration: {


### PR DESCRIPTION
Ni fikser i og rundt admin-skjemaet for arrangementer.

## Skjemaet

**Checkboxen «Arrangementet har påmelding» tok hele bredden.** Den kunne hukes av og på langt ute til høyre. Årsaken lå i `Field`: den er `w-full`, og varianten `horizontal` strekker labelen. Alle tre checkboxene er nå like brede som teksten sin.

**Påmeldingsstart kunne ikke settes før påmeldingsfristen var flyttet.** «Påmelding åpner» hadde `maxDate = registrationEnd`, og fristen forhåndsutfylles til arrangementets starttid — så alle framtidige datoer var grået ut. Klammene mellom de to feltene er fjernet; rekkefølgen valideres i stedet, både i skjemaet og på serveren, der regelen manglet helt.

**Flytter man starten forbi slutten, følger slutten med** til samme dato, med klokkeslettet sitt beholdt. Havner den fortsatt før starten (start 22:00, slutt 09:00), legges den opprinnelige varigheten til i stedet.

**Avmeldingsfrist er nytt felt.** Kolonnen `cancellation_deadline` fantes fra før i DB, API og SDK, men skjemaet sendte alltid `null`. Det betydde at fristen ikke kunne settes i det hele tatt, **og at redigering av et arrangement slettet en eksisterende frist**. Siden prikk-regelen krever at fristen er satt, kunne ingen arrangement laget i dagens UI gi prikk for sen avmelding. Feltet vises for arrangementer med påmelding som ikke er betalte, og fristen dukker nå også opp i tidslinja på arrangementssiden — der `EventRegistrationCard` allerede hadde et ferdig «Avmelding»-punkt som aldri fikk data.

**Kull er ute av arrangørgruppe-lista.** De opprettes automatisk og arrangerer ingenting. De er fortsatt med i prioriterte grupper, der de hører hjemme.

**Leder man en gruppe, er den forhåndsvalgt som arrangør.** Leder man flere, vinner den som sitter høyest i TIHLDE — rekkefølgen er den samme som organisasjonskartet på /grupper bruker. `?gruppe=` i URL-en vinner fortsatt over defaulten.

## Betalte arrangementer

To regler som ikke var håndhevet noe sted:

**Betalte arrangementer gir aldri prikker.** «Kan gi prikker» skjules når «Betalt arrangement» er huket av, API-et avviser kombinasjonen i både create og update, og både avmeldingen og no-show-jobben sperrer for arrangementer som ble opprettet før regelen. Eksisterende rader i databasen er ikke rørt — kjøretidssperrene gjør flagget virkningsløst.

**En plass man har betalt for kan ikke meldes av.** `DELETE /event/:id/registration` svarer 400 når det finnes en betaling med status `paid` (sjekket før slettingen, så et avvist forsøk lar registreringen stå). De som venter på betaling kan fortsatt melde seg av, så plassen frigjøres til ventelista. Arrangementssiden erstatter knappen med en forklaring — `registration` i API-svaret har fått `hasPaid` for å kunne vise det.

## Ellers

**Kontaktpersonen lenker til profilsiden** i stedet for `mailto:`. Utloggede ser navnet som ren tekst, samme gating som e-posten har i dag, siden profilsiden krever innlogging.

## Verifisering

7 nye integrasjonstester i `paid-event-rules.test.ts`, alle 142 event-tester grønne, typecheck/lint/build/format rene.

Kjørt manuelt mot lokal API og database:

- klikk på x=700 i checkbox-raden gjør ingenting lenger (feltet er 228px, ikke 960px)
- Index forhåndsvalgt for `brotherman`, som er **leder** av index og bare **medlem** av hs — så det er lederskap, ikke hierarkiet alene, som avgjør
- alle 9 STUDYYEAR-gruppene borte fra de 50 valgene i nedtrekkslista
- september er nåbar i «Påmelding åpner» uten å røre fristen; setter man den etter fristen, blir begge feltene røde
- start flyttet til 24. aug dro slutten til 24. aug 16:00
- avmeldingsfrist lagret, lest tilbake ved redigering, og synlig som «Avmelding» i tidslinja
- med en `paid`-betaling forsvant «Meld deg av» og API-et svarte 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)