### PR TITLE
feat(arrangement): send betalerens navn til Vipps

### DIFF
--- a/apps/api/src/lib/vipps.ts
+++ b/apps/api/src/lib/vipps.ts
@@ -33,6 +33,26 @@ export interface CreatePaymentParams {
     userPhoneNumber?: string;
 }
 
+/** Vipps caps `paymentDescription` at 100 characters. */
+const PAYMENT_DESCRIPTION_MAX = 100;
+
+/**
+ * Build the `paymentDescription` for a payment.
+ *
+ * Vipps has no field for the payer's name, so leading the description with it
+ * is what lets an admin see *who* paid — the merchant portal and the
+ * settlement files otherwise only show a generic label. Mirrors the
+ * "Navn - Arrangement" format the other TIHLDE integrations use.
+ */
+export function buildPaymentDescription(
+    label: string,
+    payerName?: string | null,
+): string {
+    const name = payerName?.trim();
+    const description = name ? `${name} - ${label}` : label;
+    return description.slice(0, PAYMENT_DESCRIPTION_MAX);
+}
+
 const VIPPS_TOKEN_CACHE_KEY = "vipps:access_token";
 
 /**

--- a/apps/api/src/routes/event/payment/create.ts
+++ b/apps/api/src/routes/event/payment/create.ts
@@ -6,7 +6,7 @@ import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { createPayment } from "~/lib/vipps";
+import { buildPaymentDescription, createPayment } from "~/lib/vipps";
 import { requireAuth } from "~/middleware/auth";
 import {
     createPaymentBodySchema,
@@ -38,7 +38,8 @@ export const createPaymentRoute = route().post(
     validator("json", createPaymentBodySchema),
     async (c) => {
         const eventId = c.req.param("eventId");
-        const userId = c.get("user").id;
+        const user = c.get("user");
+        const userId = user.id;
         const body = c.req.valid("json");
         const { db } = c.get("ctx");
 
@@ -120,7 +121,7 @@ export const createPaymentRoute = route().post(
                 reference: vippsReference,
                 userFlow: body.userFlow,
                 returnUrl: body.returnUrl,
-                description: `Payment for ${event.title}`,
+                description: buildPaymentDescription(event.title, user.name),
             });
 
             let payment: InferSelectModel<DbSchema["eventPayment"]> | undefined;

--- a/apps/api/src/test/event/payment-description.test.ts
+++ b/apps/api/src/test/event/payment-description.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildPaymentDescription } from "~/lib/vipps";
+
+describe("buildPaymentDescription", () => {
+    it("leads with the payer's name so admins can see who paid", () => {
+        expect(
+            buildPaymentDescription("Bedpres med Bekk", "Ola Nordmann"),
+        ).toBe("Ola Nordmann - Bedpres med Bekk");
+    });
+
+    it("falls back to the label alone when no name is known", () => {
+        expect(buildPaymentDescription("Bedpres med Bekk")).toBe(
+            "Bedpres med Bekk",
+        );
+        expect(buildPaymentDescription("Bedpres med Bekk", "   ")).toBe(
+            "Bedpres med Bekk",
+        );
+    });
+
+    it("truncates to the 100 character limit Vipps enforces", () => {
+        const description = buildPaymentDescription("x".repeat(200), "Ola");
+        expect(description).toHaveLength(100);
+        expect(description.startsWith("Ola - ")).toBe(true);
+    });
+});


### PR DESCRIPTION
## Hva

Vipps-transaksjoner for arrangementer viste bare `Payment for <tittel>` i merchant-portalen og i oppgjørsfilene. Det gikk ikke an å se hvem en betaling gjaldt.

Nå ledes beskrivelsen med betalerens navn: `Ola Nordmann - Bedpres med Bekk`.

## Hvorfor sånn

Vipps' ePayment-API har **ikke** noe felt for å sende et navn. `CreatePaymentRequest` har bare `customer.phoneNumber` (nummer inn) og `profile.scope` (be om navn *ut* fra Vipps, med eget samtykkesteg). Å legge navnet i `paymentDescription` er derfor den eneste veien — og det er samme grep Fadderuka bruker (`buildPaymentDescription` i `src/server/payment/vipps.ts`).

## Endringer

- `apps/api/src/lib/vipps.ts`: ny `buildPaymentDescription(label, payerName)` — faller tilbake til bare tittelen når navnet mangler, og kutter på Vipps' grense på 100 tegn.
- `apps/api/src/routes/event/payment/create.ts`: bruker `user.name` fra sesjonen. Ingen ekstra DB-spørring.
- Ny test `payment-description.test.ts` for navn, fallback og trunkering.

## Verifisert

- `bun run typecheck` — 9/9
- `bun run build` — 4/4
- `bun run format` — rent
- De 3 nye testene grønne

## Verdt å merke seg

- Beskrivelsen vises også for **betaleren** i Vipps-appen, ikke bare for admin.
- Navnet havner i Vipps' portal og oppgjørsfiler, altså personopplysninger delt med Vipps. Fadderuka gjør allerede det samme, så det er ikke ny praksis for TIHLDE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)