### PR TITLE
fix(bøter): tell bare aktive bøter per medlem

### DIFF
--- a/apps/api/src/routes/groups/fines/users.ts
+++ b/apps/api/src/routes/groups/fines/users.ts
@@ -1,5 +1,5 @@
 import { schema } from "@photon/db";
-import { and, asc, desc, eq, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
@@ -21,7 +21,7 @@ export const listFineUsersRoute = route().get(
         summary: "List a group's members with their fine totals",
         operationId: "listFineUsers",
         description:
-            "Paginated list of the group's members with the sum of their fine amounts, highest first. Members without fines are included with a total of 0. Filter the totals with 'status'.",
+            "Paginated list of the group's members with the sum of their active fine amounts, highest first. Active means not settled: fines awaiting approval and approved but unpaid ones. Paid and rejected fines are left out unless 'status' asks for them. Members without active fines are included with a total of 0.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -41,7 +41,9 @@ export const listFineUsersRoute = route().get(
         PaginationSchema.extend({
             status: fineStatusSchema
                 .optional()
-                .describe("Only count fines with this status"),
+                .describe(
+                    "Only count fines with this status, instead of the active ones",
+                ),
         }),
     ),
     async (c) => {
@@ -63,17 +65,19 @@ export const listFineUsersRoute = route().get(
          * Lepton parity: the list is driven by the membership table, not by the
          * fines, so a member who has stayed out of trouble still shows up with
          * 0. That is what makes "per medlem" a roster rather than a rap sheet.
+         *
+         * Without a status filter only the active fines count: the ones that
+         * have not been settled. Paid fines are history and rejected ones never
+         * happened, and counting both inflated the number a botsjef reads as
+         * "who owes something right now".
          */
-        const fineJoin = status
-            ? and(
-                  eq(schema.fine.userId, schema.groupMembership.userId),
-                  eq(schema.fine.groupSlug, groupSlug),
-                  eq(schema.fine.status, status),
-              )
-            : and(
-                  eq(schema.fine.userId, schema.groupMembership.userId),
-                  eq(schema.fine.groupSlug, groupSlug),
-              );
+        const fineJoin = and(
+            eq(schema.fine.userId, schema.groupMembership.userId),
+            eq(schema.fine.groupSlug, groupSlug),
+            status
+                ? eq(schema.fine.status, status)
+                : inArray(schema.fine.status, ["pending", "approved"]),
+        );
 
         const totalCount = await db.$count(
             schema.groupMembership,

--- a/apps/api/src/test/groups/fines.test.ts
+++ b/apps/api/src/test/groups/fines.test.ts
@@ -1485,7 +1485,7 @@ describe("fines", () => {
 
     describe("fines per member", () => {
         integrationTest(
-            "lists every member, sums their amounts and honours the status filter",
+            "sums only the active fines per member, and honours the status filter",
             async ({ ctx }) => {
                 const user = await ctx.utils.createTestUser();
                 const client = await ctx.utils.clientForUser(user);
@@ -1519,8 +1519,9 @@ describe("fines", () => {
                     { userId: clean.user.id, groupSlug: group.slug },
                 ]);
 
-                // To bøter på samme person: tallet skal være summen av
-                // beløpene (2 + 5 = 7), ikke antall rader.
+                // Flere bøter på samme person: tallet skal være summen av
+                // beløpene, ikke antall rader — og bare de aktive bøtene
+                // (pending + approved) teller. Betalte og avviste er gjort opp.
                 await ctx.db.insert(schema.fine).values([
                     {
                         userId: fined.user.id,
@@ -1535,6 +1536,20 @@ describe("fines", () => {
                         reason: "b",
                         amount: 5,
                         status: "paid",
+                    },
+                    {
+                        userId: fined.user.id,
+                        groupSlug: group.slug,
+                        reason: "c",
+                        amount: 3,
+                        status: "approved",
+                    },
+                    {
+                        userId: fined.user.id,
+                        groupSlug: group.slug,
+                        reason: "d",
+                        amount: 9,
+                        status: "rejected",
                     },
                 ]);
 
@@ -1551,7 +1566,7 @@ describe("fines", () => {
                 expect(json.totalCount).toBe(3);
 
                 const finedRow = json.users.find((u) => u.id === fined.user.id);
-                expect(finedRow?.finesAmount).toBe(7);
+                expect(finedRow?.finesAmount).toBe(5);
                 expect(finedRow?.finesCount).toBe(2);
 
                 // Medlemmer uten bøter skal stå i lista med 0, ikke mangle.
@@ -1566,10 +1581,11 @@ describe("fines", () => {
                     query: { status: "paid" },
                 });
                 const paidJson = await paidOnly.json();
-                expect(
-                    paidJson.users.find((u) => u.id === fined.user.id)
-                        ?.finesAmount,
-                ).toBe(5);
+                const paidRow = paidJson.users.find(
+                    (u) => u.id === fined.user.id,
+                );
+                expect(paidRow?.finesAmount).toBe(5);
+                expect(paidRow?.finesCount).toBe(1);
             },
             500_000,
         );

--- a/apps/kvark/src/components/group-fines-tab.tsx
+++ b/apps/kvark/src/components/group-fines-tab.tsx
@@ -74,6 +74,21 @@ type GroupFinesTabProps = {
     onSettleAllForUser: (userId: string, status: "approved" | "paid") => void;
 };
 
+/**
+ * «Per medlem» summerer bare de aktive bøtene — betalte og avviste er gjort
+ * opp — så det ufiltrerte valget heter noe annet der enn i bøtelista, hvor
+ * det faktisk viser alt.
+ */
+function statusLabel(
+    option: { value: FineStatusFilter; label: string },
+    grouping: FineGrouping,
+): string {
+    if (option.value === "alle" && grouping === "per-medlem") {
+        return "Aktive bøter";
+    }
+    return option.label;
+}
+
 function perMember(value: number, memberCount: number): string {
     if (memberCount <= 0) return "0.0";
     return (value / memberCount).toFixed(1);
@@ -167,7 +182,7 @@ export function GroupFinesTab({
                                             key={option.value}
                                             value={option.value}
                                         >
-                                            {option.label}
+                                            {statusLabel(option, grouping)}
                                         </SelectItem>
                                     ))}
                                 </SelectContent>

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1519,7 +1519,7 @@ export interface paths {
         };
         /**
          * List a group's members with their fine totals
-         * @description Paginated list of the group's members with the sum of their fine amounts, highest first. Members without fines are included with a total of 0. Filter the totals with 'status'.
+         * @description Paginated list of the group's members with the sum of their active fine amounts, highest first. Active means not settled: fines awaiting approval and approved but unpaid ones. Paid and rejected fines are left out unless 'status' asks for them. Members without active fines are included with a total of 0.
          */
         get: operations["listFineUsers"];
         put?: never;
@@ -10663,7 +10663,7 @@ export interface operations {
                 pageSize?: number;
                 /** @description Number of items to skip */
                 page?: number;
-                /** @description Only count fines with this status */
+                /** @description Only count fines with this status, instead of the active ones */
                 status?: "pending" | "approved" | "paid" | "rejected";
             };
             header?: never;


### PR DESCRIPTION
Fixes #593

## Problem

«Per medlem»-lista på bøter-fanen summerte alle bøter et medlem noen gang har fått — også betalte og avviste. Det ga et tall ingen kunne bruke: en botsjef som lurer på hvem som skylder noe *nå*, fikk historikken i stedet.

Statistikk-kortene øverst skilte allerede på status; per-medlem-tallet gjorde ikke det.

## Endring

`GET /groups/:slug/fines/users` teller nå bare aktive bøter når det ikke er satt et statusfilter: `pending` + `approved`. Betalte og avviste holdes utenfor.

Et eksplisitt `status`-filter overstyrer som før, så «Betalt» i nedtrekket fortsatt viser betalte summer.

I frontend heter det ufiltrerte valget «Aktive bøter» når du står i «Per medlem» — «Alle bøter» ville vært direkte feil der nå.

## Verifisering

- Integrasjonstesten er utvidet med en `approved`- og en `rejected`-bot: et medlem med 2 (pending) + 5 (paid) + 3 (approved) + 9 (rejected) gir nå `finesAmount: 5` / `finesCount: 2`, mens `?status=paid` gir 5/1.
- `fines.test.ts` 34/34 og `fines-study-group.test.ts` 9/9 grønne.
- `bun run typecheck` og `bun run format` grønne, ingen nye lint-funn i filene som er rørt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)