### PR TITLE
fix(arrangement): få «Åpen påmelding»-filteret til å virke

### DIFF
--- a/apps/api/src/routes/event/list.ts
+++ b/apps/api/src/routes/event/list.ts
@@ -7,8 +7,10 @@ import {
     gte,
     ilike,
     inArray,
+    isNull,
     lt,
     lte,
+    or,
     sql,
 } from "drizzle-orm";
 import { validator } from "hono-openapi";
@@ -112,12 +114,24 @@ export const listRoute = route().get(
                         ? lt(schema.event.end, sql`NOW()`)
                         : gte(schema.event.end, sql`NOW()`)
                     : undefined,
-                // TODO: Test if works :)
+                // Påmeldingen er åpen når vinduet omslutter nå-tidspunktet:
+                // den har startet og ikke gått ut. Begge grensene er
+                // nullbare og betyr da «ingen grense» — åpnet med én gang,
+                // respektive ingen frist — så de teller som innenfor.
+                // `isRegistrationClosed` overstyrer vinduet, slik den gjør
+                // ellers i arrangementslogikken.
                 openSignUp === true
                     ? and(
                           eq(schema.event.requiresSigningUp, true),
-                          lte(schema.event.registrationEnd, new Date()),
-                          gte(schema.event.registrationStart, new Date()),
+                          eq(schema.event.isRegistrationClosed, false),
+                          or(
+                              isNull(schema.event.registrationStart),
+                              lte(schema.event.registrationStart, sql`NOW()`),
+                          ),
+                          or(
+                              isNull(schema.event.registrationEnd),
+                              gte(schema.event.registrationEnd, sql`NOW()`),
+                          ),
                       )
                     : undefined,
             ].filter(Boolean),

--- a/apps/api/src/test/event/list-open-signup.test.ts
+++ b/apps/api/src/test/event/list-open-signup.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+describe("event list openSignUp filter", () => {
+    integrationTest(
+        "returns only events whose registration window is open right now",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+
+            const now = Date.now();
+
+            // Vinduet omslutter nå — den eneste som skal bli med.
+            const open = await ctx.utils.createTestEvent({
+                title: "Open",
+                slug: `open-${now}`,
+                registrationStart: new Date(now - HOUR),
+                registrationEnd: new Date(now + DAY),
+            });
+            const notOpenYet = await ctx.utils.createTestEvent({
+                title: "Not open yet",
+                slug: `not-open-yet-${now}`,
+                registrationStart: new Date(now + DAY),
+                registrationEnd: new Date(now + 2 * DAY),
+            });
+            const deadlinePassed = await ctx.utils.createTestEvent({
+                title: "Deadline passed",
+                slug: `deadline-passed-${now}`,
+                registrationStart: new Date(now - 2 * DAY),
+                registrationEnd: new Date(now - DAY),
+            });
+            // `isRegistrationClosed` overstyrer vinduet, slik den gjør ellers.
+            const manuallyClosed = await ctx.utils.createTestEvent({
+                title: "Manually closed",
+                slug: `manually-closed-${now}`,
+                registrationStart: new Date(now - HOUR),
+                registrationEnd: new Date(now + DAY),
+                isRegistrationClosed: true,
+            });
+            const noSignUp = await ctx.utils.createTestEvent({
+                title: "No sign-up",
+                slug: `no-signup-${now}`,
+                requiresSigningUp: false,
+                registrationStart: null,
+                registrationEnd: null,
+            });
+
+            const client = ctx.utils.client();
+            const response = await client.api.event.$get({
+                query: { openSignUp: "true" },
+            });
+            expect(response.status).toBe(200);
+            const body = await response.json();
+
+            const ids = body.items.map((e) => e.id);
+            expect(ids).toContain(open.id);
+            expect(ids).not.toContain(notOpenYet.id);
+            expect(ids).not.toContain(deadlinePassed.id);
+            expect(ids).not.toContain(manuallyClosed.id);
+            expect(ids).not.toContain(noSignUp.id);
+            // totalCount driver pagineringen, så den må filtreres like hardt.
+            expect(body.totalCount).toBe(1);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "treats missing registration bounds as no bound, not as closed",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+
+            const now = Date.now();
+
+            // Null betyr «åpnet med én gang» og «ingen frist». Uten eksplisitt
+            // null-håndtering faller begge ut av et vindusfilter, og et
+            // arrangement som tar imot påmeldinger ser stengt ut.
+            const noBounds = await ctx.utils.createTestEvent({
+                title: "No bounds",
+                slug: `no-bounds-${now}`,
+                registrationStart: null,
+                registrationEnd: null,
+            });
+            const noStart = await ctx.utils.createTestEvent({
+                title: "No start",
+                slug: `no-start-${now}`,
+                registrationStart: null,
+                registrationEnd: new Date(now + DAY),
+            });
+            const noEnd = await ctx.utils.createTestEvent({
+                title: "No end",
+                slug: `no-end-${now}`,
+                registrationStart: new Date(now - HOUR),
+                registrationEnd: null,
+            });
+
+            const client = ctx.utils.client();
+            const response = await client.api.event.$get({
+                query: { openSignUp: "true" },
+            });
+            expect(response.status).toBe(200);
+            const body = await response.json();
+
+            const ids = body.items.map((e) => e.id);
+            expect(ids).toContain(noBounds.id);
+            expect(ids).toContain(noStart.id);
+            expect(ids).toContain(noEnd.id);
+            expect(body.totalCount).toBe(3);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "omitting openSignUp keeps events regardless of registration state",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+
+            const now = Date.now();
+
+            const open = await ctx.utils.createTestEvent({
+                title: "Open",
+                slug: `open-all-${now}`,
+                registrationStart: new Date(now - HOUR),
+                registrationEnd: new Date(now + DAY),
+            });
+            const closed = await ctx.utils.createTestEvent({
+                title: "Closed",
+                slug: `closed-all-${now}`,
+                isRegistrationClosed: true,
+            });
+
+            const client = ctx.utils.client();
+            const response = await client.api.event.$get({ query: {} });
+            expect(response.status).toBe(200);
+            const body = await response.json();
+
+            const ids = body.items.map((e) => e.id);
+            expect(ids).toContain(open.id);
+            expect(ids).toContain(closed.id);
+            expect(body.totalCount).toBe(2);
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/routes/_app/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.index.tsx
@@ -70,10 +70,15 @@ const toEventListFilters = (
     query: string,
     showPast: boolean,
     category: string[],
+    openRegistration: boolean,
 ) => ({
     search: query.trim() || undefined,
     expired: showPast,
     category,
+    // Utelatt når den er av, slik `search` er: API-et filtrerer bare på
+    // `true`, og en tom boks skal ikke legge igjen en parameter i
+    // spørringsnøkkelen.
+    openSignUp: openRegistration || undefined,
 });
 
 const VIEWS = [
@@ -101,6 +106,7 @@ export const Route = createFileRoute("/_app/arrangementer/")({
                     DEFAULT_EVENT_FILTERS.query,
                     DEFAULT_EVENT_FILTERS.showPast,
                     TAB_SLUGS.arrangementer,
+                    DEFAULT_EVENT_FILTERS.openRegistration,
                 ),
             ),
         ),
@@ -141,8 +147,15 @@ function EventsPage() {
                 filters.category === ALL_CATEGORIES.value
                     ? TAB_SLUGS[tab]
                     : [filters.category],
+                filters.openRegistration,
             ),
-        [debouncedQuery, filters.showPast, filters.category, tab],
+        [
+            debouncedQuery,
+            filters.showPast,
+            filters.category,
+            filters.openRegistration,
+            tab,
+        ],
     );
 
     // useSuspenseQuery has no placeholderData, so a changed key would otherwise


### PR DESCRIPTION
Checkboxen «Åpen påmelding» har vært død siden den ble laget, og filteret bak den var snudd. Begge deler måtte fikses sammen: å koble opp checkboxen mot et API-filter som returnerer tomt ville gjort den verre enn død — fra «gjør ingenting» til «tømmer lista».

## Frontend

`openRegistration` lå i filter-tilstanden og ga en chip i UI-et, men `toEventListFilters` leste den aldri. Avhuking sendte ingen forespørsel, og lista var uendret. Den sendes nå som `openSignUp`, og er med i `useMemo`-avhengighetene så den faktisk utløser et nytt kall.

Parameteren utelates når boksen er av, slik `search` allerede gjør — API-et filtrerer bare på `true`, og en tom boks skal ikke legge igjen en parameter i spørringsnøkkelen.

## API

Filteret krevde `registrationEnd <= NOW` **og** `registrationStart >= NOW` — altså «påmeldingen er allerede lukket og har ikke åpnet ennå». Det er et tomt sett: `?openSignUp=true` ga 0 av 1230 arrangementer. Koden var merket `// TODO: Test if works :)`, og det gjorde den ikke.

Vinduet snus riktig vei. To ting kom i tillegg:

- **Begge grensene er nullbare og betyr da «ingen grense»** — åpnet med én gang, respektive ingen frist. Uten eksplisitt null-håndtering faller de ut av et vindusfilter, og et arrangement som tar imot påmeldinger ser stengt ut. Dette er ikke teoretisk: det eneste reelt åpne arrangementet i dev-basen har begge felt `null`, så filteret ville returnert 0 selv med riktig vei på sammenligningene.
- **`isRegistrationClosed` overstyrer vinduet**, slik den gjør ellers i arrangementslogikken — et manuelt stengt arrangement har ikke åpen påmelding.

`NOW()` i SQL brukes framfor et klient-tidspunkt, likt `expired`-filteret rett over.

## Verifisering

Tre integrasjonstester i `list-open-signup.test.ts` dekker vinduet, null-grensene, og at `totalCount` filtreres like hardt som lista. De to oppførselstestene feiler på den gamle logikken — verifisert ved å kjøre dem mot den.

Kjørt manuelt mot lokal API og database:

- fire testarrangementer (åpen / ikke åpnet / manuelt stengt / frist utgått) går ned til bare det åpne når boksen hukes av, og forespørselen bærer `&openSignUp=true`
- kryssjekket mot rå SQL at treffet stemmer med hva som faktisk har åpent vindu
- alle 627 API-tester, typecheck, lint, format og build er grønne

Kolliderer ikke med #596 — ingen overlappende filer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)