### PR TITLE
fix(arrangement): la skjemaet si fra i stedet for å avbryte i stillhet

### DIFF
--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -278,3 +278,22 @@ export function alignEventEnd(
 
     return addMilliseconds(start, previousDuration);
 }
+
+/**
+ * Meldingene arrangementsskjemaet viser når det ikke kan lagres.
+ *
+ * Vaktene i «Publiser» og «Lagre endringer» returnerte tidligere uten å si
+ * fra, så knappene så ut til å ikke gjøre noe i det hele tatt — verst på et
+ * nytt arrangement, der påmeldingen er på som standard. Meldingene ligger her
+ * fordi begge skjemaene håndhever de samme reglene.
+ *
+ * Påmeldingsstart står bevisst ikke på lista: API-et tar imot `null` og lar
+ * påmeldingen åpne med én gang.
+ */
+export const EVENT_FORM_ERRORS = {
+    missingTime: "Arrangementet mangler start- eller sluttidspunkt.",
+    missingCategory: "Velg en kategori for arrangementet.",
+    missingRegistrationEnd:
+        "Arrangementer med påmelding må ha en påmeldingsfrist.",
+    registrationOrder: "Påmeldingen må åpne før påmeldingsfristen.",
+} as const;

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -75,6 +75,7 @@ import {
     useCanActOnResource,
 } from "#/hooks/use-permission";
 import { extractErrorMessage } from "#/lib/api-error";
+import { EVENT_FORM_ERRORS } from "#/lib/event";
 import { isCohortGroupType } from "#/lib/group";
 import { useDebounced } from "#/lib/use-debounced";
 
@@ -299,6 +300,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
         valuesFromEvent(event),
     );
     const [uploadError, setUploadError] = useState<string | null>(null);
+    const [formError, setFormError] = useState<string | null>(null);
     const [confirmDelete, setConfirmDelete] = useState(false);
     const priorityUserSearch = usePriorityUserSearch();
 
@@ -327,14 +329,21 @@ function DetailsTab({ eventId }: { eventId: string }) {
     async function handleSubmit(formEvent: React.FormEvent<HTMLFormElement>) {
         formEvent.preventDefault();
         setUploadError(null);
+        setFormError(null);
 
-        if (!values.start || !values.end) return;
-        if (!values.categorySlug) return;
-        if (
-            values.requiresSigningUp &&
-            (!values.registrationStart || !values.registrationEnd)
-        ) {
-            return;
+        // Hver vakt sier fra. Uten dette avbrøt de i stillhet, så «Lagre
+        // endringer» så død ut på ethvert arrangement uten påmeldingsstart.
+        const fail = (message: string) => setFormError(message);
+        if (!values.start || !values.end) {
+            return fail(EVENT_FORM_ERRORS.missingTime);
+        }
+        if (!values.categorySlug) {
+            return fail(EVENT_FORM_ERRORS.missingCategory);
+        }
+        // Bare fristen er påkrevd. Påmeldingsstart kan stå tom: API-et lar
+        // påmeldingen åpne med én gang når den er `null`.
+        if (values.requiresSigningUp && !values.registrationEnd) {
+            return fail(EVENT_FORM_ERRORS.missingRegistrationEnd);
         }
         // Se skjemaet: datovelgerne begrenser ikke lenger hverandre, så
         // rekkefølgen stoppes her.
@@ -343,7 +352,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
             values.registrationEnd &&
             values.registrationStart >= values.registrationEnd
         ) {
-            return;
+            return fail(EVENT_FORM_ERRORS.registrationOrder);
         }
 
         // Lastes opp først: en feilet opplasting skal ikke lagre resten av
@@ -476,6 +485,13 @@ function DetailsTab({ eventId }: { eventId: string }) {
                     ) : undefined
                 }
             >
+                {formError && (
+                    <Alert variant="destructive">
+                        <XCircle className="size-4" />
+                        <AlertTitle>Kunne ikke lagre</AlertTitle>
+                        <AlertDescription>{formError}</AlertDescription>
+                    </Alert>
+                )}
                 {uploadError && (
                     <Alert variant="destructive">
                         <XCircle className="size-4" />

--- a/apps/kvark/src/routes/admin/arrangementer.ny.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.ny.tsx
@@ -27,6 +27,7 @@ import {
 } from "#/hooks/use-permission";
 import { compareGroupHierarchy, isCohortGroupType } from "#/lib/group";
 import { nextWholeHour } from "#/lib/date";
+import { EVENT_FORM_ERRORS } from "#/lib/event";
 import { useDebounced } from "#/lib/use-debounced";
 
 // `?gruppe=<slug>` lar «Nytt arrangement» på en gruppeside sende deg hit med
@@ -123,6 +124,7 @@ function NewEventPage() {
             : "",
     }));
     const [uploadError, setUploadError] = useState<string | null>(null);
+    const [formError, setFormError] = useState<string | null>(null);
     const priorityUserSearch = usePriorityUserSearch();
 
     const debouncedLocation = useDebounced(values.location, 250);
@@ -178,6 +180,7 @@ function NewEventPage() {
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
         setUploadError(null);
+        setFormError(null);
 
         const startIso = toIso(values.start);
         const endIso = toIso(values.end);
@@ -188,13 +191,18 @@ function NewEventPage() {
         const registrationEndIso = values.requiresSigningUp
             ? toIso(values.registrationEnd)
             : null;
-        if (!startIso || !endIso) return;
-        if (!values.categorySlug) return;
-        if (
-            values.requiresSigningUp &&
-            (!registrationStartIso || !registrationEndIso)
-        ) {
-            return;
+        // Hver vakt sier fra. Uten dette avbrøt de i stillhet, og knappen så
+        // ut til å være død — påmeldingsstart var tom som standard, så det
+        // traff hvert eneste nye arrangement.
+        const fail = (message: string) => setFormError(message);
+        if (!startIso || !endIso) return fail(EVENT_FORM_ERRORS.missingTime);
+        if (!values.categorySlug) {
+            return fail(EVENT_FORM_ERRORS.missingCategory);
+        }
+        // Bare fristen er påkrevd. Påmeldingsstart kan stå tom: API-et lar
+        // påmeldingen åpne med én gang når den er `null`.
+        if (values.requiresSigningUp && !registrationEndIso) {
+            return fail(EVENT_FORM_ERRORS.missingRegistrationEnd);
         }
         // Datovelgerne begrenser ikke lenger hverandre, så rekkefølgen stoppes
         // her. Skjemaet viser den samme feilen ved feltet.
@@ -203,7 +211,7 @@ function NewEventPage() {
             values.registrationEnd &&
             values.registrationStart >= values.registrationEnd
         ) {
-            return;
+            return fail(EVENT_FORM_ERRORS.registrationOrder);
         }
 
         // Uploaded first: a failed upload must not leave an event behind that
@@ -327,6 +335,13 @@ function NewEventPage() {
                 submitLabel={isUploading ? "Laster opp bilde …" : "Publiser"}
                 isSubmitting={createEvent.isPending || isUploading}
             >
+                {formError && (
+                    <Alert variant="destructive">
+                        <XCircle className="size-4" />
+                        <AlertTitle>Kunne ikke publisere</AlertTitle>
+                        <AlertDescription>{formError}</AlertDescription>
+                    </Alert>
+                )}
                 {uploadError && (
                     <Alert variant="destructive">
                         <XCircle className="size-4" />


### PR DESCRIPTION
Vaktene i «Publiser» og «Lagre endringer» returnerte uten å si fra. Var noe ikke i orden, skjedde det ingenting i det hele tatt: ingen forespørsel, ingen melding, ingen markering. Knappen så død ut.

Bygger videre på #596, som fikset datovelgerne i samme skjema — denne tar innsendingen.

## Feilen

Verst var påmeldingsstart. Den var med i kravet, men står tom som standard på et nytt arrangement og har ingen standardverdi — så et helt vanlig nytt arrangement med påmelding traff vakten med én gang, og «Publiser» gjorde bokstavelig talt ingenting. På redigering rammet det ethvert arrangement uten påmeldingsstart, der lagringen ble forkastet i stillhet.

Kravet var dessuten feil. API-et dokumenterer `registrationStart: null` som «åpner umiddelbart» og godtar det i både create og update — bekreftet med 201 på create og 200 på update med nøyaktig de verdiene skjemaet nektet å sende. Bare fristen er påkrevd når arrangementet har påmelding.

## Endringen

- Kravet er begrenset til påmeldingsfristen. Påmeldingsstart kan stå tom.
- De øvrige vaktene består, men viser nå hva som mangler, i samme varselfelt som opplastings- og API-feil allerede bruker.
- Meldingene ligger i `lib/event.ts` fordi begge skjemaene håndhever de samme reglene.

## Verifisering

Kjørt manuelt mot lokal API og database:

- nytt arrangement med tom «Påmelding åpner» publiseres nå og lander på admin-sida for arrangementet
- redigering av samme arrangement svarer «Endringene ble lagret», og den nye tittelen ligger i databasen
- arrangement uten kategori gir «Velg en kategori for arrangementet.» rett over knappen, i stedet for ingenting
- typecheck, lint, format og build er rene, kjørt på nytt etter at #596 landet i main

En presisering om omfanget: `title` og `location` er `required` i HTML, så med tomt Sted er det nettleserens egen validering som stopper innsendingen — den delen var aldri stille. Denne PR-en gjelder JS-vaktene, som traff også når skjemaet var nativt gyldig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)