### PR TITLE
fix(arrangement): la påmeldingen telle ned og betalingen komme fram

### DIFF
--- a/apps/api/src/routes/event/get.ts
+++ b/apps/api/src/routes/event/get.ts
@@ -137,17 +137,31 @@ export const getRoute = route().get(
                 // er stengt — en betalt plass kan ikke gis fra seg. Bare
                 // paid-events har rader i betalingstabellen, så
                 // gratisarrangementer slipper spørringen.
-                const payment = event.isPaidEvent
-                    ? await db.query.eventPayment.findFirst({
-                          columns: { id: true },
+                //
+                // De ubetalte radene er med av samme grunn: en plass på et
+                // betalt arrangement kommer med en frist, og uten den vet ikke
+                // klienten om den skal be om betaling eller hvor lenge
+                // plassen holdes av.
+                const payments = event.isPaidEvent
+                    ? await db.query.eventPayment.findMany({
+                          columns: {
+                              status: true,
+                              expiresAt: true,
+                          },
                           where: (payment, { eq, and }) =>
                               and(
                                   eq(payment.eventId, event.id),
                                   eq(payment.userId, user.id),
-                                  eq(payment.status, "paid"),
                               ),
                       })
-                    : undefined;
+                    : [];
+
+                const hasPaid = payments.some(
+                    (payment) => payment.status === "paid",
+                );
+                const pendingPayment = payments.find(
+                    (payment) => payment.status === "pending",
+                );
 
                 registration = {
                     attendedAt:
@@ -156,7 +170,11 @@ export const getRoute = route().get(
                     status: dbRegistration.status,
                     updatedAt: dbRegistration.updatedAt.toISOString(),
                     waitlistPosition: dbRegistration.waitlistPosition,
-                    hasPaid: payment !== undefined,
+                    hasPaid,
+                    paymentExpiresAt:
+                        !hasPaid && pendingPayment?.expiresAt
+                            ? pendingPayment.expiresAt.toISOString()
+                            : null,
                 };
             }
         }

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -833,6 +833,10 @@ export const eventDetailSchema = Schema(
                     description:
                         "Whether the user has a completed payment for this event. Always false on free events. A paid registration cannot be cancelled by the user.",
                 }),
+                paymentExpiresAt: z.iso.datetime().nullable().meta({
+                    description:
+                        "Deadline for paying for the reserved spot (ISO 8601). Null when there is nothing to pay — a free event, an already completed payment, or a spot without a payment deadline. The spot is released when the deadline passes.",
+                }),
             })
             .nullable()
             .meta({

--- a/apps/api/src/test/event/registration-has-paid.test.ts
+++ b/apps/api/src/test/event/registration-has-paid.test.ts
@@ -41,6 +41,88 @@ describe("event detail registration.hasPaid", () => {
     );
 
     integrationTest(
+        "carries the deadline of the unpaid obligation, so the page can ask for payment",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                isPaidEvent: true,
+                priceMinor: 10000,
+                paymentGracePeriodMinutes: 30,
+            });
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, user.id);
+            const expiresAt = new Date(Date.now() + 30 * 60 * 1000);
+            await ctx.db.insert(schema.eventPayment).values({
+                eventId: event.id,
+                userId: user.id,
+                amountMinor: 10000,
+                status: "pending",
+                expiresAt,
+            });
+
+            const client = await ctx.utils.clientForUser(user);
+            const response = await client.api.event[":eventId"].$get({
+                param: { eventId: event.id },
+            });
+            expect(response.status).toBe(200);
+            const body = await response.json();
+            // 404-svaret er en streng, så smalne typen inn før feltet leses.
+            if (typeof body === "string") throw new Error(body);
+            expect(body.registration?.paymentExpiresAt).toBe(
+                expiresAt.toISOString(),
+            );
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "drops the deadline once the payment is completed",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                isPaidEvent: true,
+                priceMinor: 10000,
+                paymentGracePeriodMinutes: 30,
+            });
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, user.id);
+            // Betalingen ble startet på en tidligere, avbrutt runde og står
+            // igjen som «pending» — den betalte raden er den som gjelder.
+            await ctx.db.insert(schema.eventPayment).values([
+                {
+                    eventId: event.id,
+                    userId: user.id,
+                    amountMinor: 10000,
+                    status: "pending",
+                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+                },
+                {
+                    eventId: event.id,
+                    userId: user.id,
+                    amountMinor: 10000,
+                    status: "paid",
+                },
+            ]);
+
+            const client = await ctx.utils.clientForUser(user);
+            const response = await client.api.event[":eventId"].$get({
+                param: { eventId: event.id },
+            });
+            expect(response.status).toBe(200);
+            const body = await response.json();
+            // 404-svaret er en streng, så smalne typen inn før feltet leses.
+            if (typeof body === "string") throw new Error(body);
+            expect(body.registration?.hasPaid).toBe(true);
+            expect(body.registration?.paymentExpiresAt).toBeNull();
+        },
+        500_000,
+    );
+
+    integrationTest(
         "is true once the payment is completed",
         async ({ ctx }) => {
             await ctx.utils.setupGroups();

--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -73,6 +73,13 @@ type EventRegistrationCardProps = {
      * så knappen ut til å ikke gjøre noe når API-et avviste påmeldingen.
      */
     actionError?: string | null;
+    /**
+     * Overskriften over `actionError`. Standarden gjelder påmeldingen; en
+     * betaling som ikke lot seg starte er noe annet, og da ville «Påmeldingen
+     * gikk ikke gjennom» sendt medlemmet ut på leting etter en påmelding som
+     * er helt i orden.
+     */
+    actionErrorTitle?: string;
 };
 
 export function EventRegistrationCard(props: EventRegistrationCardProps) {
@@ -124,7 +131,10 @@ export function EventRegistrationCard(props: EventRegistrationCardProps) {
                 {props.actionError ? (
                     <Alert variant="destructive">
                         <AlertCircle className="size-4" />
-                        <AlertTitle>Påmeldingen gikk ikke gjennom</AlertTitle>
+                        <AlertTitle>
+                            {props.actionErrorTitle ??
+                                "Påmeldingen gikk ikke gjennom"}
+                        </AlertTitle>
                         <AlertDescription>{props.actionError}</AlertDescription>
                     </Alert>
                 ) : null}
@@ -229,15 +239,22 @@ function getStateRendering(
             return {
                 icon: CreditCard,
                 message: "Plass reservert — venter på betaling",
+                // Uten frist står plassen til arrangøren rydder opp. Da er det
+                // riktigere å si ingenting enn å dikte opp en frist.
                 secondary: props.paymentDeadline
-                    ? `Betal innen ${props.paymentDeadline.day} kl. ${props.paymentDeadline.time}`
+                    ? `Betal innen ${props.paymentDeadline.day} kl. ${props.paymentDeadline.time}, ellers gis plassen videre.`
                     : null,
                 actions: (
                     <>
-                        <VippsButton className="w-full" onClick={props.onPay} />
+                        <VippsButton
+                            className="w-full"
+                            loading={props.isSubmitting}
+                            onClick={props.onPay}
+                        />
                         <Button
                             variant="ghost"
                             className="w-full"
+                            disabled={props.isSubmitting}
                             onClick={props.onUnregister}
                         >
                             Meld deg av

--- a/apps/kvark/src/hooks/use-now.ts
+++ b/apps/kvark/src/hooks/use-now.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+
+const SECOND = 1_000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
+/**
+ * En klokke som tikker fram til `until`, og står stille etterpå.
+ *
+ * Alt som telles ned mot et tidspunkt — «Påmelding åpner om 34 sekunder» —
+ * regnes ut fra «nå». Uten en klokke som tikker ble «nå» stående på det
+ * tidspunktet siden ble lastet, så tallet sto stille og påmeldingen åpnet
+ * først når medlemmet lastet siden på nytt.
+ *
+ * Frekvensen følger avstanden: siste timen tikker den hvert sekund, ellers
+ * hvert minutt. Siste tikket legges eksakt på `until`, så tilstanden skifter i
+ * samme øyeblikk som påmeldingen åpner.
+ */
+export function useNow(until?: string | null): Date {
+    const [now, setNow] = useState(() => new Date());
+    const target = until ? new Date(until).getTime() : null;
+
+    useEffect(() => {
+        if (target === null || Number.isNaN(target)) return;
+
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+
+        const schedule = () => {
+            const remaining = target - Date.now();
+            if (remaining <= 0) return;
+
+            const step = remaining > HOUR ? MINUTE : SECOND;
+            // Den lille marginen sørger for at klokka faktisk har passert
+            // `target` når vi våkner — timere fyrer gjerne et hår for tidlig,
+            // og da ville påmeldingen stått som «ikke åpnet» ett tikk til.
+            timeout = setTimeout(
+                () => {
+                    setNow(new Date());
+                    schedule();
+                },
+                Math.min(step, remaining + 50),
+            );
+        };
+
+        schedule();
+        return () => clearTimeout(timeout);
+    }, [target]);
+
+    return now;
+}

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -1,9 +1,4 @@
-import {
-    addMilliseconds,
-    format,
-    formatDistanceToNowStrict,
-    set,
-} from "date-fns";
+import { addMilliseconds, format, formatDistanceStrict, set } from "date-fns";
 import { nb } from "date-fns/locale";
 
 // -- Shared display types (previously in mock/events) --
@@ -44,6 +39,8 @@ type ApiRegistration = {
         | "attended"
         | "no_show"
         | "pending";
+    /** Whether the spot is already paid for. Always false on free events. */
+    hasPaid?: boolean;
 } | null;
 
 type RegistrationStateInput = {
@@ -53,7 +50,7 @@ type RegistrationStateInput = {
     closed: boolean;
     /** Whether the event has sign-up at all. */
     requiresSigningUp: boolean;
-    /** Whether the event costs money — a pending registration then awaits payment. */
+    /** Whether the event costs money — an unpaid spot then awaits payment. */
     isPaidEvent: boolean;
     /** When registration opens. Null means "open immediately". */
     registrationStart?: string | null;
@@ -95,16 +92,27 @@ export function deriveRegistrationState(
     if (!requiresSigningUp) return "no-signup";
 
     switch (registration?.status) {
+        // En plass på et betalt arrangement er reservert, ikke sikret, før
+        // den er betalt: det er her betalingsknappen hører hjemme. Uten dette
+        // fikk medlemmet «Du har plass på arrangementet!» og ingen måte å
+        // betale på — plassen ble så tatt tilbake da fristen gikk ut.
         case "registered":
+            return isPaidEvent && !registration.hasPaid
+                ? "awaiting-payment"
+                : "joined";
+        // Møtt opp betyr at arrangementet er i gang. Da er betalingen et
+        // oppgjør mellom medlemmet og arrangøren, ikke en knapp på nettsida.
         case "attended":
             return "joined";
         case "waitlisted":
             return "on-waitlist";
-        // Påmeldingen ligger som «pending» til cron-en har avgjort om den ble
-        // plass eller venteliste. På et gratis arrangement er det bare noen
-        // sekunders behandling — «venter på betaling» ville vært feil.
+        // Påmeldingen ligger som «pending» til serveren har avgjort om det ble
+        // plass eller venteliste. Betalingen hører til plassen, og API-et
+        // avviser et betalingsforsøk før den er avgjort — derfor «behandler»
+        // også på betalte arrangementer. Ellers blinket Vipps-knappen forbi i
+        // et sekund før medlemmet havnet på venteliste.
         case "pending":
-            return isPaidEvent ? "awaiting-payment" : "processing";
+            return "processing";
         default:
             if (closed) return "closed";
             if (endTime && new Date(endTime) < now) return "closed";
@@ -180,6 +188,23 @@ export function registrationErrorMessage(error: unknown): string {
     if (message.includes("not registered")) {
         return "Du er ikke påmeldt dette arrangementet.";
     }
+    // Betalingsfeilene under kommer fra samme kort: knappen «Betal med Vipps»
+    // ligger i påmeldingskortet, og feilen vises på samme sted.
+    if (message.includes("pending payment already exists")) {
+        return "Du har allerede en betaling på gang i Vipps. Fullfør den der, eller vent et minutt og prøv igjen.";
+    }
+    if (message.includes("already paid")) {
+        return "Plassen er allerede betalt. Last siden på nytt.";
+    }
+    if (message.includes("register for the event before paying")) {
+        return "Du må ha en plass på arrangementet før du kan betale.";
+    }
+    if (message.includes("does not require payment")) {
+        return "Dette arrangementet krever ingen betaling.";
+    }
+    if (message.includes("Failed to initiate Vipps payment")) {
+        return "Vipps svarte ikke. Prøv igjen om litt — plassen din står så lenge fristen ikke har gått ut.";
+    }
 
     return message;
 }
@@ -229,10 +254,14 @@ export function toEventDeadline(iso: string): EventDeadline {
 }
 
 /**
- * "2 dager", "3 timer" — the tail of "Påmelding åpner om …".
+ * "2 dager", "3 timer", "34 sekunder" — the tail of "Påmelding åpner om …".
+ *
+ * `now` kommer utenfra fordi teksten teller ned: siden mater inn en klokke som
+ * tikker (`useNow`), og da må avstanden regnes fra samme klokke som avgjør om
+ * påmeldingen har åpnet.
  */
-export function formatTimeUntil(iso: string): string {
-    return formatDistanceToNowStrict(new Date(iso), { locale: nb });
+export function formatTimeUntil(iso: string, now: Date = new Date()): string {
+    return formatDistanceStrict(new Date(iso), now, { locale: nb });
 }
 
 /**

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
     useInfiniteQuery,
@@ -25,6 +25,7 @@ import {
 
 import { authQueryOptions } from "#/api/auth";
 import {
+    createEventPaymentMutation,
     getEventByIdQuery,
     getEventRegistrationsInfiniteQuery,
     getFavoriteEventsQuery,
@@ -47,6 +48,7 @@ import { MapLink } from "#/components/map-link";
 import { richRegistry } from "#/components/markdown/directives/presets";
 import { ShareButton } from "#/components/share-button";
 import { useEventRulesConsent } from "#/hooks/use-event-rules-consent";
+import { useNow } from "#/hooks/use-now";
 import { useCanActOnResource, usePermission } from "#/hooks/use-permission";
 import { buildGoogleCalendarUrl } from "#/lib/calendar-url";
 import { buildMapsUrls } from "#/lib/maps";
@@ -78,7 +80,7 @@ function EventDetailPage() {
     // trappes ned med hvor lenge den har stått — se
     // `registrationPollInterval`.
     const pendingSinceRef = useRef<number | null>(null);
-    const { data: event } = useSuspenseQuery({
+    const { data: event, refetch: refetchEvent } = useSuspenseQuery({
         ...getEventByIdQuery(slug),
         refetchInterval: (query) => {
             if (query.state.data?.registration?.status !== "pending") {
@@ -127,6 +129,7 @@ function EventDetailPage() {
     const eventRules = useEventRulesConsent();
     const registerMutation = useMutation(registerForEventMutation);
     const unregisterMutation = useMutation(unregisterFromEventMutation);
+    const payMutation = useMutation(createEventPaymentMutation);
     const favoriteMutation = useMutation(updateFavoriteEventMutation);
 
     // Arrangementet sier ikke selv om det er en favoritt, så favorittlisten —
@@ -140,20 +143,42 @@ function EventDetailPage() {
     );
     const organizerSlug = event.organizer?.slug;
 
-    const registrationState = deriveRegistrationState({
-        registration: event.registration,
-        closed: event.closed,
-        requiresSigningUp: event.requiresSigningUp,
-        isPaidEvent: event.isPaidEvent,
-        registrationStart: event.registrationStart,
-        registrationEnd: event.registrationEnd,
-        endTime: event.endTime,
-        capacity: event.capacity,
-        registeredCount: event.registeredCount,
-    });
+    // Klokka som teller ned mot at påmeldingen åpner. Uten den sto både
+    // «åpner om …» og selve tilstanden stille til siden ble lastet på nytt.
+    const now = useNow(event.registrationStart);
+    const registrationState = deriveRegistrationState(
+        {
+            registration: event.registration,
+            closed: event.closed,
+            requiresSigningUp: event.requiresSigningUp,
+            isPaidEvent: event.isPaidEvent,
+            registrationStart: event.registrationStart,
+            registrationEnd: event.registrationEnd,
+            endTime: event.endTime,
+            capacity: event.capacity,
+            registeredCount: event.registeredCount,
+        },
+        now,
+    );
+    // Tallene i kortet — plasser og venteliste — er fra før påmeldingen åpnet,
+    // og på et populært arrangement er de utdaterte i samme sekund. Vi henter
+    // arrangementet på nytt i det klokka passerer åpningen, så knappen som
+    // dukker opp står ved siden av riktige tall.
+    const wasNotOpenRef = useRef(false);
+    useEffect(() => {
+        if (registrationState === "not-open") {
+            wasNotOpenRef.current = true;
+            return;
+        }
+        if (!wasNotOpenRef.current) return;
+        wasNotOpenRef.current = false;
+        void refetchEvent();
+    }, [registrationState, refetchEvent]);
+
     // Feil fra på- eller avmelding. Uten dette så knappen ut til å ikke gjøre
     // noe når API-et avviste forsøket.
-    const failedAction = registerMutation.error ?? unregisterMutation.error;
+    const failedAction =
+        registerMutation.error ?? unregisterMutation.error ?? payMutation.error;
     const registrationError = failedAction
         ? registrationErrorMessage(failedAction)
         : null;
@@ -206,6 +231,26 @@ function EventDetailPage() {
 
     function handleUnregister() {
         unregisterMutation.mutate({ eventId: event.id });
+    }
+
+    // Betalingen skjer hos Vipps: vi ber API-et om en kasse og sender
+    // medlemmet dit. `returnUrl` er siden de står på, så de kommer tilbake hit
+    // med betalingen registrert.
+    function handlePay() {
+        payMutation.mutate(
+            {
+                eventId: event.id,
+                data: {
+                    returnUrl: window.location.href,
+                    userFlow: "WEB_REDIRECT",
+                },
+            },
+            {
+                onSuccess: (payment) => {
+                    window.location.href = payment.checkoutUrl;
+                },
+            },
+        );
     }
 
     return (
@@ -385,7 +430,7 @@ function EventDetailPage() {
                         registrationOpensInLabel={
                             registrationState === "not-open" &&
                             event.registrationStart
-                                ? formatTimeUntil(event.registrationStart)
+                                ? formatTimeUntil(event.registrationStart, now)
                                 : undefined
                         }
                         registrationClosesAt={
@@ -399,6 +444,13 @@ function EventDetailPage() {
                                 : undefined
                         }
                         hasPaid={event.registration?.hasPaid ?? false}
+                        paymentDeadline={
+                            event.registration?.paymentExpiresAt
+                                ? toEventDeadline(
+                                      event.registration.paymentExpiresAt,
+                                  )
+                                : undefined
+                        }
                         capacity={event.capacity}
                         registeredCount={registeredCount}
                         waitlistCount={event.waitlistCount}
@@ -409,11 +461,22 @@ function EventDetailPage() {
                         // det ble plass eller kø.
                         onJoinWaitlist={handleRegister}
                         onUnregister={handleUnregister}
+                        onPay={handlePay}
                         isSubmitting={
                             registerMutation.isPending ||
-                            unregisterMutation.isPending
+                            unregisterMutation.isPending ||
+                            // Vipps-omdirigeringen skjer i `onSuccess`, så
+                            // knappen skal stå som opptatt helt til nettleseren
+                            // faktisk har forlatt siden.
+                            payMutation.isPending ||
+                            payMutation.isSuccess
                         }
                         actionError={registrationError}
+                        actionErrorTitle={
+                            payMutation.error
+                                ? "Betalingen kunne ikke startes"
+                                : undefined
+                        }
                         requiresEventRulesConsent={eventRules.mustAccept}
                         eventRulesSlot={
                             <EventRulesConsent

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -604,7 +604,6 @@ const REGISTRATION_STATUS_VARIANTS: Record<
 const REGISTRATION_FILTERS = [
     { value: "aktive", label: "Påmeldte", status: undefined },
     { value: "venteliste", label: "Venteliste", status: "waitlisted" },
-    { value: "avmeldte", label: "Avmeldte", status: "cancelled,pending" },
 ] as const;
 
 function RegistrationsTab({ eventId }: { eventId: string }) {

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3963,6 +3963,8 @@ export interface components {
                 attendedAt: string | null;
                 /** @description Whether the user has a completed payment for this event. Always false on free events. A paid registration cannot be cancelled by the user. */
                 hasPaid: boolean;
+                /** @description Deadline for paying for the reserved spot (ISO 8601). Null when there is nothing to pay — a free event, an already completed payment, or a spot without a payment deadline. The spot is released when the deadline passes. */
+                paymentExpiresAt: string | null;
             } | null;
         };
         EventRegistration: {


### PR DESCRIPTION
Fire ting på arrangementssiden som krevde at medlemmet lastet siden på nytt — eller som aldri gikk å gjøre i det hele tatt.

## Nedtellingen teller ned

«Påmelding åpner om 34 sekunder» sto stille på tidspunktet siden ble lastet. Ny hook `useNow` tikker hvert sekund den siste timen før åpning (hvert minutt lenger unna), og legger siste tikket eksakt på åpningstidspunktet.

Verifisert i nettleseren: `39 sekunder → 37 → 35 → 33 → 31`.

## «Meld deg på» dukker opp av seg selv

Samme klokke mater `deriveRegistrationState`, så tilstanden skifter uten refresh. Arrangementet hentes samtidig på nytt, så plasstallet ved siden av knappen ikke er tallet fra før påmeldingen åpnet.

Verifisert: `… 2 sekunder → Meld deg på`, uten reload.

## Vipps-knappen kommer fram

To feil her:

- En `registered`-plass på et betalt arrangement ga «Du har plass på arrangementet!» og ingen måte å betale på. Nå viser den «Plass reservert — venter på betaling» så lenge `hasPaid` er false, med knappen koblet til `POST /event/:id/payment` og videresending til kassa.
- Knappen blinket til gjengjeld forbi mens påmeldingen lå som `pending` — der API-et uansett avviser betaling — rett før medlemmet havnet på venteliste. `pending` er nå «Behandler påmeldingen din …» også på betalte arrangementer.

Fristen for å betale lå i databasen, men ble aldri sendt ut. `registration.paymentExpiresAt` er ny i arrangements-responsen, så kortet kan si «Betal innen tir 18. aug. kl. 17:30, ellers gis plassen videre».

## «Avmeldte»-fanen er borte

Fjernet fra filtrene på adminsiden for et arrangement.

## Verifisering

- `bun run typecheck`, `bun run build`, `bun run lint` — grønt
- Hele API-suiten: 665 tester + 2 nye for `paymentExpiresAt`
- Alle fire punktene kjørt i nettleseren mot lokal API og dev-database

**Ett hull:** siste hoppet til Vipps er ikke verifisert. Maskinen har ingen `VIPPS_*`-nøkler, så klikket når API-et og kommer tilbake med 500 («Vipps is not configured properly»). Det bekrefter koblingen fram til provideren og at feilen vises riktig på norsk, men selve videresendingen til kassa må prøves i et miljø med testnøkler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)