### PR TITLE
fix(arrangement): vis ekte QR-kode i påmeldingsbeviset

### DIFF
--- a/apps/kvark/src/components/event-qr-dialog.tsx
+++ b/apps/kvark/src/components/event-qr-dialog.tsx
@@ -6,19 +6,25 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@tihlde/ui/ui/dialog";
-import { QrCode } from "lucide-react";
+import { QRCode } from "@tihlde/ui/ui/qr-code";
 import type { ReactElement } from "react";
 
 type EventQrDialogProps = {
     trigger: ReactElement;
     title: string;
     registrantName: string;
+    /**
+     * Bruker-id-en som skannes ved innsjekk. Uten den finnes det ikke noe
+     * gyldig bevis, så dialogen sier fra i stedet for å vise en tom ramme.
+     */
+    userId?: string;
 };
 
 export function EventQrDialog({
     trigger,
     title,
     registrantName,
+    userId,
 }: EventQrDialogProps) {
     return (
         <Dialog>
@@ -29,13 +35,26 @@ export function EventQrDialog({
                     <DialogDescription>{title}</DialogDescription>
                 </DialogHeader>
                 <div className="flex flex-col items-center gap-3 p-4">
-                    <div className="flex aspect-square w-full max-w-64 items-center justify-center rounded-lg border bg-muted">
-                        <QrCode className="size-32 text-muted-foreground" />
-                    </div>
-                    <span>{registrantName}</span>
-                    <span className="text-sm text-muted-foreground">
-                        Vis denne koden ved oppmøte
-                    </span>
+                    {userId ? (
+                        <>
+                            <QRCode
+                                className="w-full max-w-64"
+                                value={userId}
+                            />
+                            <span>{registrantName}</span>
+                            <span className="text-sm text-muted-foreground">
+                                Vis denne koden ved oppmøte
+                            </span>
+                        </>
+                    ) : (
+                        <>
+                            <span>{registrantName}</span>
+                            <span className="text-sm text-muted-foreground">
+                                Logg inn på nytt for å hente medlemsbeviset
+                                ditt.
+                            </span>
+                        </>
+                    )}
                 </div>
             </DialogContent>
         </Dialog>

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -469,6 +469,7 @@ function EventDetailPage() {
                                     registrantName={
                                         session?.user?.name ?? "Deltaker"
                                     }
+                                    userId={session?.user?.id}
                                     trigger={
                                         <Button className="w-full">
                                             <QrCode />


### PR DESCRIPTION
## Problem

Trykker du på beviset inne på et arrangement, kommer det ingen QR-kode. På profilen fungerer medlemsbeviset som det skal.

## Årsak

`EventQrDialog` tegnet et statisk `QrCode`-ikon fra lucide inne i en grå ramme — en illustrasjon av en QR-kode, ikke selve beviset. Bruker-id-en, som er det innsjekkingen skanner, ble aldri sendt inn i dialogen. Profilen bruker `MembershipQrDialog`, som rendrer en ekte `<QRCode value={userId} />`.

## Endring

- `EventQrDialog` tar imot `userId` og bruker samme `QRCode`-komponent som profilen. Mangler id-en, sier dialogen fra i stedet for å vise en tom ramme.
- Arrangementssiden sender inn `session?.user?.id`.

## Verifisert

Lokal dev, innlogget: opprettet et arrangement med åpen påmelding, meldte meg på og åpnet «Påmeldingsbevis» — QR-koden vises. Sammenlignet canvasen med medlemsbeviset på profilen: pixel-identisk, altså samme bruker-id som skanneren forventer. Testarrangementet er slettet igjen.

`typecheck`, `lint` og `format` er grønne.

## Merk

Knappen heter «Påmeldingsbevis» på arrangementet og «Medlemsbevis» på profilen selv om koden er den samme. Ikke endret her.

🤖 Generated with [Claude Code](https://claude.com/claude-code)