### PR TITLE
feat(arrangement): skann medlemsbevis for å registrere oppmøte

### DIFF
--- a/apps/api/src/routes/event/registration/attendance.ts
+++ b/apps/api/src/routes/event/registration/attendance.ts
@@ -1,5 +1,6 @@
 import { schema } from "@photon/db";
-import { and, eq, inArray } from "drizzle-orm";
+import type { RegistrationStatus } from "@photon/db/schema";
+import { and, eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import type z from "zod";
@@ -8,6 +9,17 @@ import { requireEventAccess } from "~/lib/event/access";
 import { Schema, describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
+
+/**
+ * Only these statuses hold an actual spot on the event. Anyone else — the
+ * waitlist, a cancelled spot, an unresolved registration — cannot be checked
+ * in: they do not have access to the event.
+ */
+const CHECK_IN_STATUSES: readonly RegistrationStatus[] = [
+    "registered",
+    "attended",
+    "no_show",
+];
 
 const setAttendanceSchema = Schema(
     "SetAttendance",
@@ -24,6 +36,9 @@ const attendanceResponseSchema = Schema(
     zod.object({
         userId: zod.string(),
         eventId: zod.string(),
+        // Returned so a check-in scanner can name the person it just checked
+        // in without looking them up in the (paginated) participant list.
+        name: zod.string(),
         status: zod.string().meta({ description: "New registration status" }),
         attendedAt: zod.string().nullable(),
     }),
@@ -47,6 +62,11 @@ export const setAttendanceRoute = route().patch(
             description: "Requires events:update or events:manage permission",
         })
         .notFound({ description: "Registration not found" })
+        .response({
+            statusCode: 409,
+            description:
+                "Conflict - the user does not hold a spot on the event (waitlisted, cancelled or pending)",
+        })
         .build(),
     requireAuth,
     requireEventAccess({ permission: ["events:update", "events:manage"] }),
@@ -56,6 +76,31 @@ export const setAttendanceRoute = route().patch(
         const eventId = c.req.param("eventId");
         const userId = c.req.param("userId");
         const { attended } = c.req.valid("json");
+
+        const registration = await db.query.eventRegistration.findFirst({
+            where: and(
+                eq(schema.eventRegistration.userId, userId),
+                eq(schema.eventRegistration.eventId, eventId),
+            ),
+            with: { user: { columns: { name: true } } },
+        });
+
+        if (!registration) {
+            throw new HTTPException(404, {
+                message: "Registration not found",
+            });
+        }
+
+        // Separate from the 404 on purpose: «not registered» and «on the
+        // waitlist» are different answers for whoever is scanning at the door.
+        if (!CHECK_IN_STATUSES.includes(registration.status)) {
+            throw new HTTPException(409, {
+                message:
+                    registration.status === "waitlisted"
+                        ? "User is on the waitlist and does not have a spot on this event"
+                        : "User does not have a spot on this event",
+            });
+        }
 
         const [updated] = await db
             .update(schema.eventRegistration)
@@ -67,12 +112,6 @@ export const setAttendanceRoute = route().patch(
                 and(
                     eq(schema.eventRegistration.userId, userId),
                     eq(schema.eventRegistration.eventId, eventId),
-                    // Only real spots can be checked in — not waitlisted/pending.
-                    inArray(schema.eventRegistration.status, [
-                        "registered",
-                        "attended",
-                        "no_show",
-                    ]),
                 ),
             )
             .returning();
@@ -86,6 +125,7 @@ export const setAttendanceRoute = route().patch(
         return c.json({
             userId,
             eventId,
+            name: registration.user.name,
             status: updated.status,
             attendedAt: updated.attendedAt?.toISOString() ?? null,
         } satisfies z.infer<typeof attendanceResponseSchema>);

--- a/apps/api/src/test/event/attendance-checkin.test.ts
+++ b/apps/api/src/test/event/attendance-checkin.test.ts
@@ -1,0 +1,129 @@
+import { schema } from "@photon/db";
+import { and, eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * Innsjekk ved døra skanner medlemsbeviset, som bare er brukerens id. Da er
+ * det endepunktet her som må holde på regelen: den som ikke har plass på
+ * arrangementet, blir ikke huket av — uansett hvor fint kortet ser ut.
+ */
+describe("event check-in only accepts users with a spot", () => {
+    integrationTest(
+        "a registered user is marked as attended",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["events:update"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            const attendee = await ctx.utils.createTestUser();
+            const event = await ctx.utils.createTestEvent({
+                slug: `innsjekk-${Date.now()}`,
+            });
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: attendee.id,
+                status: "registered",
+            });
+
+            const response = await client.api.event[":eventId"].registration[
+                ":userId"
+            ].attendance.$patch({
+                param: { eventId: event.id, userId: attendee.id },
+                json: { attended: true },
+            });
+
+            expect(response.status).toBe(200);
+            expect(await response.json()).toMatchObject({
+                userId: attendee.id,
+                name: attendee.name,
+                status: "attended",
+            });
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "a waitlisted user is rejected and keeps their waitlist spot",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["events:update"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            const queued = await ctx.utils.createTestUser();
+            const event = await ctx.utils.createTestEvent({
+                slug: `venteliste-innsjekk-${Date.now()}`,
+                capacity: 1,
+            });
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: queued.id,
+                status: "waitlisted",
+            });
+
+            const response = await client.api.event[":eventId"].registration[
+                ":userId"
+            ].attendance.$patch({
+                param: { eventId: event.id, userId: queued.id },
+                json: { attended: true },
+            });
+
+            expect(response.status).toBe(409);
+
+            const registration = await ctx.db.query.eventRegistration.findFirst(
+                {
+                    where: and(
+                        eq(schema.eventRegistration.eventId, event.id),
+                        eq(schema.eventRegistration.userId, queued.id),
+                    ),
+                },
+            );
+            expect(registration?.status).toBe("waitlisted");
+            expect(registration?.attendedAt).toBeNull();
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "a user who never registered is not found",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["events:update"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            const stranger = await ctx.utils.createTestUser();
+            const event = await ctx.utils.createTestEvent({
+                slug: `ukjent-innsjekk-${Date.now()}`,
+            });
+
+            const response = await client.api.event[":eventId"].registration[
+                ":userId"
+            ].attendance.$patch({
+                param: { eventId: event.id, userId: stranger.id },
+                json: { attended: true },
+            });
+
+            expect(response.status).toBe(404);
+
+            const registration = await ctx.db.query.eventRegistration.findFirst(
+                {
+                    where: and(
+                        eq(schema.eventRegistration.eventId, event.id),
+                        eq(schema.eventRegistration.userId, stranger.id),
+                    ),
+                },
+            );
+            expect(registration).toBeUndefined();
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/package.json
+++ b/apps/kvark/package.json
@@ -42,6 +42,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "dictionary-nb": "^3.0.0",
+        "jsqr": "^1.4.0",
         "ky": "^2.0.2",
         "lucide-react": "^0.577.0",
         "nitro": "latest",

--- a/apps/kvark/src/components/attendance-scanner-dialog.tsx
+++ b/apps/kvark/src/components/attendance-scanner-dialog.tsx
@@ -1,0 +1,370 @@
+import { useMutation } from "@tanstack/react-query";
+import { Button } from "@tihlde/ui/ui/button";
+import {
+    Dialog,
+    DialogBody,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@tihlde/ui/ui/dialog";
+import { cn } from "@tihlde/ui/lib/utils";
+import { CheckCircle2, QrCode, XCircle } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { setAttendanceMutation } from "#/api/queries/events";
+import { extractErrorMessage } from "#/lib/api-error";
+
+/**
+ * Innsjekk ved døra: medlemsbeviset er en QR-kode med brukerens id (se
+ * `membership-qr-dialog`), så en skanning er ikke annet enn et kall på
+ * oppmøte-endepunktet med den id-en.
+ *
+ * Selve regelen om hvem som kan hukes av ligger i API-et: det svarer 409 for
+ * folk på venteliste og 404 for folk som ikke er påmeldt i det hele tatt.
+ * Her vises bare svaret — en avvist skanning huker ikke av noen.
+ */
+
+type ScanResult = {
+    /** Nøkkel for lista; skanninger av samme person skal ikke kollidere. */
+    key: number;
+    ok: boolean;
+    title: string;
+    description?: string;
+};
+
+/**
+ * Et kort som blir liggende foran kameraet leses mange ganger i sekundet. En
+ * vellykket innsjekk gjentas derfor ikke før noen andre er skannet, mens en
+ * avvist skanning kan prøves på nytt etter et par sekunder.
+ */
+const RETRY_COOLDOWN_MS = 3000;
+
+/** Hvor ofte bildet analyseres. Raskt nok til å føles umiddelbart. */
+const SCAN_INTERVAL_MS = 120;
+
+type BarcodeDetectorLike = {
+    detect(source: CanvasImageSource): Promise<{ rawValue: string }[]>;
+};
+
+type BarcodeDetectorConstructor = new (options: {
+    formats: string[];
+}) => BarcodeDetectorLike;
+
+async function createDetector(): Promise<BarcodeDetectorLike> {
+    const Detector = (
+        globalThis as unknown as {
+            BarcodeDetector?: BarcodeDetectorConstructor;
+        }
+    ).BarcodeDetector;
+
+    if (Detector) {
+        try {
+            return new Detector({ formats: ["qr_code"] });
+        } catch {
+            // Nettleseren har API-et, men ikke QR-formatet. Fall videre.
+        }
+    }
+
+    // Safari har ikke BarcodeDetector, og det er iPhone-ene som skanner i
+    // døra. jsQR lastes derfor bare når kameraet faktisk åpnes.
+    const { default: jsQR } = await import("jsqr");
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+
+    return {
+        detect(source) {
+            const video = source as HTMLVideoElement;
+            if (!context || !video.videoWidth || !video.videoHeight) {
+                return Promise.resolve([]);
+            }
+            // Nedskalert: jsQR kjører på hovedtråden, og full oppløsning gjør
+            // hver avlesning merkbart treg på en telefon.
+            const scale = Math.min(1, 640 / video.videoWidth);
+            canvas.width = Math.round(video.videoWidth * scale);
+            canvas.height = Math.round(video.videoHeight * scale);
+            context.drawImage(video, 0, 0, canvas.width, canvas.height);
+            const image = context.getImageData(
+                0,
+                0,
+                canvas.width,
+                canvas.height,
+            );
+            const code = jsQR(image.data, image.width, image.height);
+            return Promise.resolve(code ? [{ rawValue: code.data }] : []);
+        },
+    };
+}
+
+export function AttendanceScannerDialog({ eventId }: { eventId: string }) {
+    const [open, setOpen] = useState(false);
+    const [cameraError, setCameraError] = useState<string | null>(null);
+    const [results, setResults] = useState<ScanResult[]>([]);
+
+    const videoRef = useRef<HTMLVideoElement>(null);
+    /** Sist behandlede kode, slik at samme kort ikke sendes om og om igjen. */
+    const lastScanRef = useRef<{
+        value: string;
+        at: number;
+        ok: boolean;
+    } | null>(null);
+    const inFlightRef = useRef(false);
+
+    const setAttendance = useMutation(setAttendanceMutation);
+    const { mutateAsync } = setAttendance;
+
+    const handleScan = useCallback(
+        async (userId: string) => {
+            inFlightRef.current = true;
+            lastScanRef.current = { value: userId, at: Date.now(), ok: false };
+            try {
+                const result = await mutateAsync({
+                    eventId,
+                    userId,
+                    attended: true,
+                });
+                lastScanRef.current = {
+                    value: userId,
+                    at: Date.now(),
+                    ok: true,
+                };
+                navigator.vibrate?.(60);
+                setResults((prev) => [
+                    {
+                        key: Date.now(),
+                        ok: true,
+                        title: `${result.name} er huket av`,
+                        description: "Møtt opp",
+                    },
+                    ...prev.slice(0, 4),
+                ]);
+            } catch (error) {
+                const description = await describeScanError(error);
+                lastScanRef.current = {
+                    value: userId,
+                    at: Date.now(),
+                    ok: false,
+                };
+                navigator.vibrate?.([60, 60, 60]);
+                setResults((prev) => [
+                    {
+                        key: Date.now(),
+                        ok: false,
+                        title: "Ikke huket av",
+                        description,
+                    },
+                    ...prev.slice(0, 4),
+                ]);
+            } finally {
+                inFlightRef.current = false;
+            }
+        },
+        [eventId, mutateAsync],
+    );
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        let stream: MediaStream | null = null;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        let stopped = false;
+
+        const stop = () => {
+            stopped = true;
+            if (timer) {
+                clearTimeout(timer);
+            }
+            for (const track of stream?.getTracks() ?? []) {
+                track.stop();
+            }
+        };
+
+        const start = async () => {
+            if (!navigator.mediaDevices?.getUserMedia) {
+                setCameraError(
+                    "Denne nettleseren gir ikke tilgang til kamera. Åpne siden i Safari eller Chrome på telefonen.",
+                );
+                return;
+            }
+
+            try {
+                stream = await navigator.mediaDevices.getUserMedia({
+                    // Bakkameraet på telefon; på PC blir det webkameraet.
+                    video: { facingMode: { ideal: "environment" } },
+                    audio: false,
+                });
+            } catch {
+                setCameraError(
+                    "Fikk ikke tilgang til kameraet. Tillat kamera for siden og prøv igjen.",
+                );
+                return;
+            }
+
+            const video = videoRef.current;
+            if (stopped || !video) {
+                stop();
+                return;
+            }
+
+            video.srcObject = stream;
+            video.setAttribute("playsinline", "true");
+            await video.play().catch(() => {});
+
+            const detector = await createDetector();
+            if (stopped) {
+                return;
+            }
+
+            const tick = async () => {
+                if (stopped) {
+                    return;
+                }
+                if (!inFlightRef.current && video.readyState >= 2) {
+                    try {
+                        const [code] = await detector.detect(video);
+                        const value = code?.rawValue.trim();
+                        const last = lastScanRef.current;
+                        const isRepeat =
+                            last?.value === value &&
+                            (last.ok ||
+                                Date.now() - last.at < RETRY_COOLDOWN_MS);
+
+                        if (value && !isRepeat) {
+                            await handleScan(value);
+                        }
+                    } catch {
+                        // En enkelt mislykket avlesning betyr bare at neste
+                        // bilde får prøve seg.
+                    }
+                }
+                if (!stopped) {
+                    timer = setTimeout(tick, SCAN_INTERVAL_MS);
+                }
+            };
+
+            void tick();
+        };
+
+        void start();
+
+        return stop;
+    }, [open, handleScan]);
+
+    const handleOpenChange = (next: boolean) => {
+        setOpen(next);
+        if (!next) {
+            setCameraError(null);
+            setResults([]);
+            lastScanRef.current = null;
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogTrigger
+                render={
+                    <Button variant="outline" type="button">
+                        <QrCode />
+                        Skann medlemsbevis
+                    </Button>
+                }
+            />
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Skann medlemsbevis</DialogTitle>
+                    <DialogDescription>
+                        Hold medlemsbeviset foran kameraet. Den som skannes blir
+                        huket av som møtt.
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogBody className="flex flex-col gap-4">
+                    {cameraError ? (
+                        <p className="text-destructive text-sm">
+                            {cameraError}
+                        </p>
+                    ) : (
+                        <div className="bg-muted relative aspect-square w-full overflow-hidden rounded-md">
+                            <video
+                                ref={videoRef}
+                                muted
+                                playsInline
+                                className="size-full object-cover"
+                            />
+                        </div>
+                    )}
+
+                    {results.length > 0 ? (
+                        <ul className="flex flex-col gap-2">
+                            {results.map((result, index) => (
+                                <li
+                                    key={result.key}
+                                    className={cn(
+                                        "flex items-start gap-2 rounded-md border p-3 text-sm",
+                                        result.ok
+                                            ? "border-emerald-500/40 bg-emerald-500/10"
+                                            : "border-destructive/40 bg-destructive/10",
+                                        // Bare den nyeste skal fange blikket.
+                                        index > 0 && "opacity-60",
+                                    )}
+                                >
+                                    {result.ok ? (
+                                        <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-600" />
+                                    ) : (
+                                        <XCircle className="text-destructive mt-0.5 size-4 shrink-0" />
+                                    )}
+                                    <div>
+                                        <p className="font-medium">
+                                            {result.title}
+                                        </p>
+                                        {result.description ? (
+                                            <p className="text-muted-foreground">
+                                                {result.description}
+                                            </p>
+                                        ) : null}
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : null}
+                </DialogBody>
+                <DialogFooter>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => handleOpenChange(false)}
+                    >
+                        Lukk
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+/**
+ * API-et svarer 404 for folk som ikke er påmeldt og 409 for folk uten plass.
+ * Begge deler er «nei» i døra, men det er stor forskjell på dem for den som
+ * står med skanneren.
+ */
+async function describeScanError(error: unknown): Promise<string> {
+    const response =
+        error && typeof error === "object" && "response" in error
+            ? error.response
+            : null;
+    const status = response instanceof Response ? response.status : null;
+
+    if (status === 404) {
+        return "Personen er ikke påmeldt dette arrangementet.";
+    }
+    if (status === 409) {
+        return "Personen har ikke plass på arrangementet – står på venteliste eller har mistet plassen.";
+    }
+    if (status === 403) {
+        return "Du har ikke tilgang til å registrere oppmøte her.";
+    }
+    return await extractErrorMessage(error);
+}

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -60,6 +60,7 @@ import {
 import { getGroupMembersQuery, getGroupsQuery } from "#/api/queries/groups";
 import { getInstitutesQuery } from "#/api/queries/institutes";
 import { AdminEmptyState } from "#/components/admin-empty-state";
+import { AttendanceScannerDialog } from "#/components/attendance-scanner-dialog";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { AdminStatCard } from "#/components/admin-stat-card";
 import { ConfirmDeleteDialog } from "#/components/confirm-delete-dialog";
@@ -791,6 +792,12 @@ function AttendanceTab({ eventId }: { eventId: string }) {
                     icon={UsersIcon}
                 />
             </div>
+
+            {canSetAttendance ? (
+                <div className="flex justify-end">
+                    <AttendanceScannerDialog eventId={eventId} />
+                </div>
+            ) : null}
 
             <Card>
                 <CardContent className="p-0">

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "dictionary-nb": "^3.0.0",
+        "jsqr": "^1.4.0",
         "ky": "^2.0.2",
         "lucide-react": "^0.577.0",
         "nitro": "latest",
@@ -2339,6 +2340,8 @@
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "kvark": ["kvark@workspace:apps/kvark"],
+
+    "jsqr": ["jsqr@1.4.0", "", {}, "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A=="],
 
     "ky": ["ky@2.0.2", "", {}, "sha512-/GmXpo9F9W+f8n4Ivr2iH+7h7wL7jLbLKWkMlpflcCRb6kGjBfTlASEXaZ9qUgNTn4VgS0P2pwxxzQ4EM6Ulgg=="],
 

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -4026,6 +4026,7 @@ export interface components {
         Attendance: {
             userId: string;
             eventId: string;
+            name: string;
             /** @description New registration status */
             status: string;
             attendedAt: string | null;
@@ -8401,6 +8402,13 @@ export interface operations {
             };
             /** @description Not Found - Registration not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Conflict - the user does not hold a spot on the event (waitlisted, cancelled or pending) */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Oppmøte-fanen på et arrangement får en skanner: hold medlemsbeviset foran kameraet, og den som skannes blir huket av som møtt. Skanner du noen som ikke har plass på arrangementet, blir de ikke huket av.

## Hva som er gjort

**Frontend** — ny `attendance-scanner-dialog.tsx` med knappen «Skann medlemsbevis», synlig for dem som allerede kan huke av (`events:update`/`events:manage`).

- Leser QR med `BarcodeDetector` der den finnes, ellers `jsqr` (ny dependency). Safari/iPhone har ikke `BarcodeDetector`, og det er telefoner som står i døra. jsQR lastes først når kameraet åpnes.
- Hver skanning gir grønn kvittering med navn, eller rød avvisning med grunnen — «ikke påmeldt» og «har ikke plass» er forskjellige svar for den som skanner.
- Et kort som blir liggende foran kameraet huker ikke av samme person om og om igjen: en vellykket innsjekk gjentas ikke før noen andre skannes, mens en avvist skanning kan prøves på nytt etter 3 sekunder.

**Backend** — `PATCH /event/:eventId/registration/:userId/attendance` slår opp påmeldingen før den oppdaterer.

- 409 for venteliste, kansellert eller uavklart plass; 404 for den som ikke er påmeldt. Raden står urørt i begge tilfeller. (Regelen fantes fra før som et `inArray`-filter, men ga samme 404 for begge, som ikke er til å skanne etter.)
- Svaret bærer nå `name`, siden deltakerlista er paginert på 100 og den som skannes ofte ikke ligger i den. SDK-typene er regenerert.

## Verifisering

- Tre nye integrasjonstester (`attendance-checkin.test.ts`): påmeldt → 200 + `attended`, venteliste → 409 med raden urørt, ikke påmeldt → 404. Eksisterende oppmøte-tester er kjørt og er grønne.
- Kjørt i nettleseren mot lokal API med ekte medlemsbevis-QR-koder: påmeldt bruker ble huket av (bekreftet i databasen), ventelistebruker fikk rød avvisning og sto fortsatt som `waitlisted`.
- `typecheck`, `lint`, `format` og `build` er grønne.

## Verdt å vite

Kamera krever HTTPS eller localhost, så skanneren virker på photon-domenet — ikke over en ren http-adresse på LAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)