### PR TITLE
fix(arrangement): ikke skriv «undefined» når noen skannes inn

### DIFF
--- a/apps/kvark/src/components/attendance-scanner-dialog.tsx
+++ b/apps/kvark/src/components/attendance-scanner-dialog.tsx
@@ -42,6 +42,17 @@ type ScanResult = {
  */
 const RETRY_COOLDOWN_MS = 3000;
 
+/**
+ * Navnet kommer fra svaret på innsjekken. Står det ikke noe navn der — et API
+ * som er eldre enn denne siden, eller en bruker uten navn — skal skjermen ikke
+ * si «undefined er huket av», men bare at innsjekken gikk gjennom.
+ */
+function checkedInTitle(name: unknown): string {
+    return typeof name === "string" && name.trim()
+        ? `${name.trim()} er huket av`
+        : "Huket av";
+}
+
 /** Hvor ofte bildet analyseres. Raskt nok til å føles umiddelbart. */
 const SCAN_INTERVAL_MS = 120;
 
@@ -135,7 +146,7 @@ export function AttendanceScannerDialog({ eventId }: { eventId: string }) {
                     {
                         key: Date.now(),
                         ok: true,
-                        title: `${result.name} er huket av`,
+                        title: checkedInTitle(result.name),
                         description: "Møtt opp",
                     },
                     ...prev.slice(0, 4),

--- a/bun.lock
+++ b/bun.lock
@@ -2337,11 +2337,11 @@
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
+    "jsqr": ["jsqr@1.4.0", "", {}, "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A=="],
+
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "kvark": ["kvark@workspace:apps/kvark"],
-
-    "jsqr": ["jsqr@1.4.0", "", {}, "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A=="],
 
     "ky": ["ky@2.0.2", "", {}, "sha512-/GmXpo9F9W+f8n4Ivr2iH+7h7wL7jLbLKWkMlpflcCRb6kGjBfTlASEXaZ9qUgNTn4VgS0P2pwxxzQ4EM6Ulgg=="],
 


### PR DESCRIPTION
## Hva

Skanneren for medlemsbevis la navnet fra innsjekk-svaret rett inn i teksten (`` `${result.name} er huket av` ``). Manglet feltet i svaret, sto det **«undefined er huket av»** på skjermen ved døra. Nå går tittelen gjennom en sjekk, og faller tilbake til «Huket av» når navnet ikke er der.

## Om årsaken

Selve dataflyten er riktig i main: [`attendance.ts`](https://github.com/TIHLDE/Photon/blob/main/apps/api/src/routes/event/registration/attendance.ts) returnerer `registration.user.name`, `Attendance`-skjemaet krever `name`, og [`attendance-checkin.test.ts`](https://github.com/TIHLDE/Photon/blob/main/apps/api/src/test/event/attendance-checkin.test.ts) sjekker det. `https://photon.tihlde.org/openapi` viser også `name` som påkrevd, så prod svarer med navnet nå.

Det som mest sannsynlig skjedde: skanningen ble gjort mens API-et fortsatt kjørte imaget fra før #606, etter at Kvark var deployet. Denne PR-en fjerner selve plassholderteksten, slik at et svar uten navn aldri vises som `undefined`.

## Verifisering

- `bun run typecheck` grønn (måtte kjøre `bun install` først — `jsqr` manglet i worktreet, som normaliserte én linje i `bun.lock`)
- `bun run format` rent, `bun run lint` bare eksisterende advarsler i urelaterte filer
- Selve kamera-skanningen er ikke kjørt ende-til-ende; endringen er en ren tekstsjekk på toasten

🤖 Generated with [Claude Code](https://claude.com/claude-code)