### PR TITLE
fix(arrangement): la ventelisteknappen si «Meld meg på»

### DIFF
--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -308,7 +308,7 @@ function getStateRendering(
                     >
                         {props.isSubmitting
                             ? "Setter deg på ventelista …"
-                            : "Sett meg på venteliste"}
+                            : "Meld meg på"}
                     </Button>
                 ),
             };


### PR DESCRIPTION
## Hva

Knappen på fulle arrangementer sa «Sett meg på venteliste». Nå sier den «Meld meg på», som den vanlige påmeldingsknappen.

Teksten over knappen forklarer allerede situasjonen («Arrangementet er fullt» + hvor mange som står på venteliste), så vi trenger ikke skille de to knappene.

## Merk

Funksjonen er uendret — knappen melder deg fortsatt på ventelista. Laste-teksten står fremdeles som «Setter deg på ventelista …».

🤖 Generated with [Claude Code](https://claude.com/claude-code)