### PR TITLE
fix(arrangement): la betalingen starte på nytt etter «tilbake»

### DIFF
--- a/apps/api/src/lib/vipps.ts
+++ b/apps/api/src/lib/vipps.ts
@@ -230,6 +230,27 @@ export async function refundPayment(
 }
 
 /**
+ * Cancel a Vipps payment that has not been paid yet.
+ *
+ * A checkout the member walked away from — they pressed back in the browser
+ * instead of paying — stays `CREATED` in Vipps and blocks a new checkout for
+ * the same event. Cancelling it is what lets "Betal med Vipps" work on the
+ * second press.
+ */
+export async function cancelPayment(reference: string): Promise<void> {
+    const token = await getVippsToken();
+    const vipps = getVippsClient();
+
+    const response = await vipps.payment.cancel(token, reference);
+
+    if (!response.ok) {
+        throw new Error(
+            `Failed to cancel payment: ${response.error instanceof Error ? response.error.message : "title" in response.error ? response.error.title : "Unknown error"}`,
+        );
+    }
+}
+
+/**
  * Get payment details from Vipps
  */
 export async function getPaymentDetails(

--- a/apps/api/src/routes/event/payment/create.ts
+++ b/apps/api/src/routes/event/payment/create.ts
@@ -6,7 +6,12 @@ import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { buildPaymentDescription, createPayment } from "~/lib/vipps";
+import {
+    buildPaymentDescription,
+    cancelPayment,
+    createPayment,
+    getPaymentDetails,
+} from "~/lib/vipps";
 import { requireAuth } from "~/middleware/auth";
 import {
     createPaymentBodySchema,
@@ -85,27 +90,68 @@ export const createPaymentRoute = route().post(
         // An unstarted obligation (created automatically on registration) is a
         // pending payment without a provider reference. Reuse it instead of
         // creating a duplicate — the countdown timer already tracks its id.
-        const obligation = existingPayments.find(
+        let obligation = existingPayments.find(
             (p) => p.status === "pending" && !p.providerPaymentId,
         );
-
-        // A pending payment that has already been handed to Vipps blocks a new
-        // checkout for the same event.
-        if (
-            existingPayments.some(
-                (p) => p.status === "pending" && p.providerPaymentId,
-            )
-        ) {
-            throw new HTTPException(409, {
-                message: "A pending payment already exists for this event",
-            });
-        }
 
         // Check if already paid
         if (existingPayments.some((p) => p.status === "paid")) {
             throw new HTTPException(409, {
                 message: "The user has already paid for the event",
             });
+        }
+
+        // A pending payment that has already been handed to Vipps is usually a
+        // checkout the member walked away from — they pressed back in the
+        // browser instead of paying — and it must not become a dead end. Ask
+        // Vipps what actually happened to it: an unfinished checkout is
+        // cancelled so this press gets a fresh one, and only a checkout that is
+        // genuinely underway blocks a new attempt.
+        const startedPayment = existingPayments.find(
+            (p) => p.status === "pending" && p.providerPaymentId,
+        );
+
+        if (startedPayment?.providerPaymentId) {
+            const reference = startedPayment.providerPaymentId;
+            let details: Awaited<ReturnType<typeof getPaymentDetails>>;
+
+            try {
+                details = await getPaymentDetails(reference);
+            } catch {
+                // Without an answer from Vipps we cannot tell a paid checkout
+                // from an abandoned one, so we keep the safe old behaviour.
+                throw new HTTPException(409, {
+                    message: "A pending payment already exists for this event",
+                });
+            }
+
+            // Money has been reserved or drawn: the webhook settles this one,
+            // and a second checkout would charge the member twice.
+            if (
+                details.state === "AUTHORIZED" ||
+                details.aggregate.capturedAmount.value > 0 ||
+                details.aggregate.authorizedAmount.value > 0
+            ) {
+                throw new HTTPException(409, {
+                    message: "A pending payment already exists for this event",
+                });
+            }
+
+            if (details.state === "CREATED") {
+                try {
+                    await cancelPayment(reference);
+                } catch {
+                    throw new HTTPException(409, {
+                        message:
+                            "A pending payment already exists for this event",
+                    });
+                }
+            }
+
+            // Nothing was paid, so the row is free to carry the new checkout —
+            // and reusing it keeps the payment deadline the member already
+            // sees counting down.
+            obligation = startedPayment;
         }
 
         // Remaining states are either aborted or refunded. In that case they can create a new payment

--- a/apps/api/src/test/event/payment-restart.test.ts
+++ b/apps/api/src/test/event/payment-restart.test.ts
@@ -1,0 +1,170 @@
+import { schema } from "@photon/db";
+import { beforeEach, describe, expect, vi } from "vitest";
+import * as vipps from "~/lib/vipps";
+import type { IntegrationTestContext } from "~/test/config/integration";
+import { integrationTest } from "~/test/config/integration";
+
+// The checkout talks to Vipps; stub the whole module. Every export the app
+// imports must be present here — this factory *replaces* the module.
+vi.mock("~/lib/vipps", () => ({
+    buildPaymentDescription: vi.fn(() => "Test - Arrangement"),
+    cancelPayment: vi.fn().mockResolvedValue(undefined),
+    capturePayment: vi.fn().mockResolvedValue(undefined),
+    createPayment: vi.fn(),
+    getPaymentDetails: vi.fn(),
+    refundPayment: vi.fn().mockResolvedValue(undefined),
+    setupWebhooks: vi.fn(),
+    verifyVippsWebhookRequest: vi.fn(),
+}));
+
+const NO_AMOUNTS = {
+    authorizedAmount: { currency: "NOK", value: 0 },
+    capturedAmount: { currency: "NOK", value: 0 },
+    refundedAmount: { currency: "NOK", value: 0 },
+    cancelledAmount: { currency: "NOK", value: 0 },
+};
+
+/** Make the provider report an existing checkout in a given state. */
+function mockVippsState(
+    state: "CREATED" | "ABORTED" | "AUTHORIZED",
+    amounts: Partial<typeof NO_AMOUNTS> = {},
+) {
+    vi.mocked(vipps.getPaymentDetails).mockResolvedValue({
+        state,
+        aggregate: { ...NO_AMOUNTS, ...amounts },
+    } as unknown as Awaited<ReturnType<typeof vipps.getPaymentDetails>>);
+}
+
+/**
+ * A member who is registered for a paid event and has already been sent to
+ * Vipps once — the state you are in the moment you press the browser's back
+ * button on the checkout page.
+ */
+async function seedStartedCheckout(ctx: IntegrationTestContext) {
+    await ctx.utils.setupEventCategories();
+    const event = await ctx.utils.createTestEvent({
+        capacity: 10,
+        isPaidEvent: true,
+        priceMinor: 10000,
+    });
+    const user = await ctx.utils.createTestUser();
+
+    await ctx.db.insert(schema.eventRegistration).values({
+        eventId: event.id,
+        userId: user.id,
+        status: "registered",
+    });
+
+    const expiresAt = new Date(Date.now() + 30 * 60 * 1000);
+    const [payment] = await ctx.db
+        .insert(schema.eventPayment)
+        .values({
+            eventId: event.id,
+            userId: user.id,
+            amountMinor: 10000,
+            currency: "NOK",
+            provider: "vipps",
+            providerPaymentId: "vipps-ref-abandoned",
+            status: "pending",
+            expiresAt,
+        })
+        .returning();
+
+    if (!payment) throw new Error("Failed to seed payment");
+    return { event, user, payment, expiresAt };
+}
+
+beforeEach(() => {
+    vi.mocked(vipps.cancelPayment).mockClear();
+    vi.mocked(vipps.createPayment).mockClear();
+    vi.mocked(vipps.getPaymentDetails).mockClear();
+});
+
+describe("Restarting an abandoned Vipps checkout", () => {
+    integrationTest(
+        "cancels the checkout the member walked away from and hands out a new one",
+        async ({ ctx }) => {
+            const { event, user, payment, expiresAt } =
+                await seedStartedCheckout(ctx);
+            mockVippsState("CREATED");
+            vi.mocked(vipps.createPayment).mockResolvedValue(
+                "https://vipps.test/checkout-2",
+            );
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[":eventId"].payment.$post({
+                param: { eventId: event.id },
+                json: {
+                    returnUrl: "https://tihlde.org/arrangementer/test",
+                    userFlow: "WEB_REDIRECT",
+                },
+            });
+
+            expect(res.status).toBe(201);
+            const body = await res.json();
+            expect(body.checkoutUrl).toBe("https://vipps.test/checkout-2");
+
+            expect(vi.mocked(vipps.cancelPayment)).toHaveBeenCalledWith(
+                "vipps-ref-abandoned",
+            );
+
+            // The obligation row is reused, so the payment deadline the member
+            // sees keeps counting down instead of restarting.
+            const rows = await ctx.db.query.eventPayment.findMany({
+                where: (p, { eq }) => eq(p.eventId, event.id),
+            });
+            expect(rows).toHaveLength(1);
+            expect(rows[0]?.id).toBe(payment.id);
+            expect(rows[0]?.providerPaymentId).not.toBe("vipps-ref-abandoned");
+            expect(rows[0]?.expiresAt?.getTime()).toBe(expiresAt.getTime());
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "does not cancel a checkout the member actually paid",
+        async ({ ctx }) => {
+            const { event, user } = await seedStartedCheckout(ctx);
+            mockVippsState("AUTHORIZED", {
+                authorizedAmount: { currency: "NOK", value: 10000 },
+            });
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[":eventId"].payment.$post({
+                param: { eventId: event.id },
+                json: {
+                    returnUrl: "https://tihlde.org/arrangementer/test",
+                    userFlow: "WEB_REDIRECT",
+                },
+            });
+
+            expect(res.status).toBe(409);
+            expect(vi.mocked(vipps.cancelPayment)).not.toHaveBeenCalled();
+            expect(vi.mocked(vipps.createPayment)).not.toHaveBeenCalled();
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "keeps blocking when Vipps cannot say what happened to the checkout",
+        async ({ ctx }) => {
+            const { event, user } = await seedStartedCheckout(ctx);
+            vi.mocked(vipps.getPaymentDetails).mockRejectedValue(
+                new Error("Vipps is down"),
+            );
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[":eventId"].payment.$post({
+                param: { eventId: event.id },
+                json: {
+                    returnUrl: "https://tihlde.org/arrangementer/test",
+                    userFlow: "WEB_REDIRECT",
+                },
+            });
+
+            expect(res.status).toBe(409);
+            expect(vi.mocked(vipps.createPayment)).not.toHaveBeenCalled();
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -233,6 +233,24 @@ function EventDetailPage() {
         unregisterMutation.mutate({ eventId: event.id });
     }
 
+    // Nettleseren fryser siden når vi sender medlemmet til Vipps, og gir den
+    // tilbake akkurat slik den var hvis de trykker «tilbake». Uten dette sto
+    // knappen igjen som opptatt, og en betaling som ble avbrutt underveis lyste
+    // rødt som om noe hadde gått galt. Vi nullstiller derfor betalingen og
+    // henter arrangementet på nytt, så kortet viser tilstanden slik den faktisk
+    // er nå.
+    const resetPayment = payMutation.reset;
+    useEffect(() => {
+        function handlePageShow(pageEvent: PageTransitionEvent) {
+            if (!pageEvent.persisted) return;
+            resetPayment();
+            void refetchEvent();
+        }
+
+        window.addEventListener("pageshow", handlePageShow);
+        return () => window.removeEventListener("pageshow", handlePageShow);
+    }, [resetPayment, refetchEvent]);
+
     // Betalingen skjer hos Vipps: vi ber API-et om en kasse og sender
     // medlemmet dit. `returnUrl` er siden de står på, så de kommer tilbake hit
     // med betalingen registrert.

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -31,6 +31,8 @@ import {
     CardTitle,
 } from "@tihlde/ui/ui/card";
 import { Checkbox } from "@tihlde/ui/ui/checkbox";
+import { Input } from "@tihlde/ui/ui/input";
+import { Label } from "@tihlde/ui/ui/label";
 import { Skeleton } from "@tihlde/ui/ui/skeleton";
 import {
     Table,
@@ -738,6 +740,7 @@ function AttendanceTab({ eventId }: { eventId: string }) {
         getEventRegistrationsQuery(eventId, 0, {}, MAX_PAGE_SIZE),
     );
     const setAttendance = useMutation(setAttendanceMutation);
+    const [search, setSearch] = useState("");
 
     const participants = data?.registeredUsers ?? [];
 
@@ -747,6 +750,19 @@ function AttendanceTab({ eventId }: { eventId: string }) {
         ).length;
         return { attended, total: participants.length };
     }, [participants]);
+
+    // Hele lista ligger allerede i minnet, så søket filtrerer den her. På et
+    // arrangement med hundrevis av påmeldte er det forskjellen på å finne én
+    // person og å skrolle etter navnet i døra.
+    const query = search.trim().toLowerCase();
+    const visibleParticipants = useMemo(() => {
+        if (!query) return participants;
+        return participants.filter((participant) =>
+            [participant.name, participant.email]
+                .filter(Boolean)
+                .some((field) => field?.toLowerCase().includes(query)),
+        );
+    }, [participants, query]);
 
     if (isPending) {
         return <TableSkeleton />;
@@ -799,71 +815,101 @@ function AttendanceTab({ eventId }: { eventId: string }) {
             ) : null}
 
             <Card>
-                <CardContent className="p-0">
-                    <Table>
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead>Navn</TableHead>
-                                <TableHead>Status</TableHead>
-                                <TableHead className="text-right">
-                                    Møtt
-                                </TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {participants.map((participant) => {
-                                const status =
-                                    participant.status ?? "registered";
-                                return (
-                                    <TableRow key={participant.id}>
-                                        <TableCell>
-                                            {participant.name}
-                                        </TableCell>
-                                        <TableCell>
-                                            <Badge
-                                                variant={
-                                                    REGISTRATION_STATUS_VARIANTS[
-                                                        status
-                                                    ] ?? "outline"
-                                                }
-                                            >
-                                                {REGISTRATION_STATUS_LABELS[
-                                                    status
-                                                ] ?? status}
-                                            </Badge>
-                                        </TableCell>
-                                        <TableCell>
-                                            <div className="flex justify-end">
-                                                <Checkbox
-                                                    checked={
-                                                        status === "attended"
-                                                    }
-                                                    disabled={
-                                                        !canSetAttendance ||
-                                                        setAttendance.isPending
-                                                    }
-                                                    onCheckedChange={(
-                                                        checked,
-                                                    ) =>
-                                                        setAttendance.mutate({
-                                                            eventId,
-                                                            userId: participant.id,
-                                                            attended:
-                                                                Boolean(
-                                                                    checked,
-                                                                ),
-                                                        })
-                                                    }
-                                                />
-                                            </div>
-                                        </TableCell>
-                                    </TableRow>
-                                );
-                            })}
-                        </TableBody>
-                    </Table>
+                <CardContent>
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="attendance-search">Søk</Label>
+                        <Input
+                            id="attendance-search"
+                            type="search"
+                            placeholder="Søk etter navn eller e-post…"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                        />
+                    </div>
                 </CardContent>
             </Card>
+
+            {visibleParticipants.length === 0 ? (
+                <Card>
+                    <CardContent>
+                        <AdminEmptyState
+                            icon={UsersIcon}
+                            title="Ingen treff"
+                            description={`Ingen påmeldte matcher «${search.trim()}».`}
+                        />
+                    </CardContent>
+                </Card>
+            ) : (
+                <Card>
+                    <CardContent className="p-0">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Navn</TableHead>
+                                    <TableHead>Status</TableHead>
+                                    <TableHead className="text-right">
+                                        Møtt
+                                    </TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {visibleParticipants.map((participant) => {
+                                    const status =
+                                        participant.status ?? "registered";
+                                    return (
+                                        <TableRow key={participant.id}>
+                                            <TableCell>
+                                                {participant.name}
+                                            </TableCell>
+                                            <TableCell>
+                                                <Badge
+                                                    variant={
+                                                        REGISTRATION_STATUS_VARIANTS[
+                                                            status
+                                                        ] ?? "outline"
+                                                    }
+                                                >
+                                                    {REGISTRATION_STATUS_LABELS[
+                                                        status
+                                                    ] ?? status}
+                                                </Badge>
+                                            </TableCell>
+                                            <TableCell>
+                                                <div className="flex justify-end">
+                                                    <Checkbox
+                                                        checked={
+                                                            status ===
+                                                            "attended"
+                                                        }
+                                                        disabled={
+                                                            !canSetAttendance ||
+                                                            setAttendance.isPending
+                                                        }
+                                                        onCheckedChange={(
+                                                            checked,
+                                                        ) =>
+                                                            setAttendance.mutate(
+                                                                {
+                                                                    eventId,
+                                                                    userId: participant.id,
+                                                                    attended:
+                                                                        Boolean(
+                                                                            checked,
+                                                                        ),
+                                                                },
+                                                            )
+                                                        }
+                                                    />
+                                                </div>
+                                            </TableCell>
+                                        </TableRow>
+                                    );
+                                })}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Hva

To ting fra samme sted i påmeldingskortet:

1. **Betalingen kunne ikke startes på nytt.** Trykket man tilbake i nettleseren på veien til Vipps, sto plassen igjen med en påbegynt betaling. Neste trykk på «Betal med Vipps» ble avvist med 409, og kortet svarte med en rød «Betalingen kunne ikke startes» — en blindvei helt til fristen løp ut.
2. **Søk på Oppmøte-siden**, så man finner én påmeldt blant hundrevis i stedet for å skrolle etter navnet i døra.

## Betalingen

**Backend** (`apps/api/src/routes/event/payment/create.ts`) spør nå Vipps hva som faktisk skjedde med den påbegynte kassa:

| Tilstand hos Vipps | Hva vi gjør |
| --- | --- |
| `CREATED` (medlemmet gikk fra kassa) | Kansellerer den, gir en ny checkout |
| `AUTHORIZED`, eller beløp reservert/trukket | Fortsatt 409 — ingen skal betale to ganger |
| `ABORTED` / `EXPIRED` / `TERMINATED` uten trekk | Ny checkout |
| Vipps svarer ikke | Fortsatt 409, altså den trygge gamle oppførselen |

Betalingsraden gjenbrukes i stedet for at det lages en ny, så fristen medlemmet ser fortsetter å telle ned der den var. Ny `cancelPayment` i `apps/api/src/lib/vipps.ts`.

**Frontend** (`apps/kvark/src/routes/_app/arrangementer.$slug.tsx`) nullstiller betalingen og henter arrangementet på nytt når nettleseren gir tilbake den frosne siden. Uten det sto Vipps-knappen igjen som opptatt, og en betaling som ble avbrutt underveis lyste rødt som om noe hadde gått galt.

## Oppmøte-søket

Søkefelt over deltakerlista som filtrerer på navn og e-post i lista som allerede er lastet, med egen «Ingen treff»-tilstand. Statistikken («Møtt 77 / 100») viser fortsatt hele arrangementet.

## Verifisert

- `typecheck`, `lint`, `format` og `build` er grønne
- 3 nye integrasjonstester i `apps/api/src/test/event/payment-restart.test.ts`: avbrutt kasse kanselleres og gjenbrukes med fristen intakt, betalt kasse blokkerer, Vipps nede blokkerer. De 30 eksisterende betalingstestene passerer.
- Oppmøte-søket kjørt i nettleseren mot lokal DB på et arrangement med 100 påmeldte: «edvard» filtrerte til én rad, «edvardzzz» ga «Ingen treff»

Selve Vipps-redirecten kunne ikke kjøres lokalt (ingen Vipps-nøkler i `.env`), så den er dekket av integrasjonstester med mocket Vipps — ikke av en ekte betaling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)