### PR TITLE
feat(arrangement): vis prioriterte grupper på arrangementssiden

### DIFF
--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -1,5 +1,6 @@
 import { addMilliseconds, format, formatDistanceStrict, set } from "date-fns";
 import { nb } from "date-fns/locale";
+import { MAX_CLASS_YEAR, computeClassYear } from "@photon/auth/academic-year";
 
 // -- Shared display types (previously in mock/events) --
 
@@ -326,3 +327,78 @@ export const EVENT_FORM_ERRORS = {
         "Arrangementer med påmelding må ha en påmeldingsfrist.",
     registrationOrder: "Påmeldingen må åpne før påmeldingsfristen.",
 } as const;
+
+/**
+ * En prioritert gruppe slik arrangementet leverer den.
+ *
+ * Samme form som `priorityPools` i `GET /events/:id`: maks én gruppe og maks
+ * ett klassetrinn, som må stemme samtidig.
+ */
+export type EventPriorityPool = {
+    classYear: number | null;
+    group: { name: string; slug: string } | null;
+};
+
+/** En kull-gruppe har opptaksåret både som slug og som navn, f.eks. «2023». */
+const COHORT_SLUG = /^\d{4}$/;
+
+/**
+ * Navnet et medlem skal se på én prioritert gruppe.
+ *
+ * Etikettene speiler valgene i `PriorityPoolEditor`, så arrangøren kjenner
+ * igjen det hen valgte: «Dataingeniør», «1. klasse», «Digital transformasjon
+ * 4. klasse». Kull-grupper fra det gamle systemet regnes om til klassetrinn —
+ * «2023» sier ingenting om hvem som er prioritert i år.
+ */
+export function priorityPoolLabel(
+    pool: EventPriorityPool,
+    now = new Date(),
+): string | null {
+    if (pool.group && COHORT_SLUG.test(pool.group.slug)) {
+        const classYear = computeClassYear(
+            Number.parseInt(pool.group.slug, 10),
+            now,
+        );
+        return classYear >= 1 && classYear <= MAX_CLASS_YEAR
+            ? `${classYear}. klasse`
+            : null;
+    }
+
+    if (pool.group) {
+        return pool.classYear
+            ? `${pool.group.name} ${pool.classYear}. klasse`
+            : pool.group.name;
+    }
+
+    return pool.classYear ? `${pool.classYear}. klasse` : null;
+}
+
+/**
+ * Etikettene for alle de prioriterte gruppene, i lesbar rekkefølge.
+ *
+ * Klassetrinnene først og stigende, så gruppene alfabetisk — rekkefølgen i
+ * databasen er den arrangøren tilfeldigvis la dem inn i. Pooler uten kriterier
+ * (eller med et utgått kull) faller bort, og duplikater slås sammen: to pooler
+ * som leses likt er én opplysning for medlemmet.
+ */
+export function priorityPoolLabels(
+    pools: readonly EventPriorityPool[],
+    now = new Date(),
+): string[] {
+    const bare: string[] = [];
+    const named: string[] = [];
+
+    for (const pool of pools) {
+        const label = priorityPoolLabel(pool, now);
+        if (!label) continue;
+        if (pool.group && !COHORT_SLUG.test(pool.group.slug)) named.push(label);
+        else bare.push(label);
+    }
+
+    return [
+        ...new Set([
+            ...bare.sort((a, b) => a.localeCompare(b, "nb")),
+            ...named.sort((a, b) => a.localeCompare(b, "nb")),
+        ]),
+    ];
+}

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -7,6 +7,7 @@ import {
     useSuspenseQuery,
 } from "@tanstack/react-query";
 import { MarkdownView } from "@tihlde/ui/complex/markdown";
+import { Badge } from "@tihlde/ui/ui/badge";
 import { Button } from "@tihlde/ui/ui/button";
 import { Separator } from "@tihlde/ui/ui/separator";
 import {
@@ -59,6 +60,7 @@ import {
     formatEventDate,
     formatEventPrice,
     formatEventTime,
+    priorityPoolLabels,
     registrationErrorMessage,
     registrationPollInterval,
     TICKET_RESALE_GROUP_URL,
@@ -211,6 +213,11 @@ function EventDetailPage() {
     ) : (
         locationLabel
     );
+
+    // Hvem som er prioritert avgjør om det er verdt å melde seg på i det hele
+    // tatt, så det står i detaljene sammen med de andre forbeholdene.
+    // Enkeltpersoner står ikke her: den lista er bare for arrangøren.
+    const priorityLabels = priorityPoolLabels(event.priorityPools ?? []);
 
     const calendarUrl = buildGoogleCalendarUrl({
         title: event.title,
@@ -387,6 +394,30 @@ function EventDetailPage() {
                                           label="Kun for"
                                           value={`Studenter ved ${event.restrictedToInstitute.shortName}`}
                                       />,
+                                  ]
+                                : []),
+                            ...(priorityLabels.length > 0
+                                ? [
+                                      <div className="flex flex-col gap-2 text-sm">
+                                          <div className="flex items-center gap-2.5 text-muted-foreground">
+                                              <Star className="size-4 shrink-0" />
+                                              <span>
+                                                  {event.onlyAllowPrioritized
+                                                      ? "Kun for"
+                                                      : "Prioritert"}
+                                              </span>
+                                          </div>
+                                          <div className="flex flex-col items-start gap-1.5">
+                                              {priorityLabels.map((label) => (
+                                                  <Badge
+                                                      key={label}
+                                                      variant="secondary"
+                                                  >
+                                                      {label}
+                                                  </Badge>
+                                              ))}
+                                          </div>
+                                      </div>,
                                   ]
                                 : []),
                             ...(event.contactPerson


### PR DESCRIPTION
## Summary
- Viser hvilke grupper/klassetrinn som er prioritert for et arrangement, som stablede pills i detaljkortet på arrangementssiden medlemmer ser
- Gjenbruker samme etikett-logikk som prioriteringseditoren (kull → klassetrinn, gruppe+trinn-kombinasjoner)
- Navngitte prioriterte personer er fortsatt kun synlig for arrangører

## Test plan
- [x] `bun run typecheck`
- [x] Verifisert visuelt i nettleser mot lokal dev-DB på et arrangement med flere prioriterte pooler (klasse + gruppe)