### PR TITLE
feat(arrangement): kast av ubetalte plasser uten å refundere de fortrengte

### DIFF
--- a/apps/api/src/lib/event/payment-review.ts
+++ b/apps/api/src/lib/event/payment-review.ts
@@ -1,0 +1,205 @@
+import { schema } from "@photon/db";
+import { and, eq, gt, isNull, lte } from "drizzle-orm";
+import type { AppContext } from "../ctx";
+import { env } from "../env";
+import { sendNotification } from "../notification";
+
+/**
+ * How far back the review sweep looks. An event that started longer ago than
+ * this is given up on rather than rescanned forever — the same bound the
+ * no-show sweep uses.
+ */
+export const PAYMENT_REVIEW_LOOKBACK_DAYS = 14;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * A member who paid for an event they do not hold a spot on.
+ */
+type PaymentWithoutSpot = {
+    userId: string;
+    name: string;
+    /** Why they have no spot: on the waiting list, or off the event entirely. */
+    registrationStatus: string;
+};
+
+/**
+ * Tell the organisers, once their event has started, who paid without holding a
+ * spot — so they can decide whether to refund.
+ *
+ * Nothing is refunded automatically. A member displaced by a prioritised
+ * registration keeps their payment on purpose: it is what lets them take a spot
+ * back without paying again. The moment the event starts that reason expires,
+ * but whether the money goes back is a decision for the arranging group, not
+ * for a cron job. This turns it into a decision somebody is actually asked to
+ * make.
+ *
+ * Covers both `waitlisted` (displaced, still hoping) and `cancelled` (paid,
+ * then left or was removed) — the second group is otherwise invisible.
+ *
+ * The event is claimed first via a conditional update, so two instances cannot
+ * both send it.
+ */
+export async function notifyOrganizersOfPaymentsWithoutSpot(
+    eventId: string,
+    ctx: AppContext,
+): Promise<number | null> {
+    const [claimed] = await ctx.db
+        .update(schema.event)
+        .set({ paymentReviewNotifiedAt: new Date() })
+        .where(
+            and(
+                eq(schema.event.id, eventId),
+                isNull(schema.event.paymentReviewNotifiedAt),
+            ),
+        )
+        .returning({
+            id: schema.event.id,
+            title: schema.event.title,
+            slug: schema.event.slug,
+            organizerGroupSlug: schema.event.organizerGroupSlug,
+            createdByUserId: schema.event.createdByUserId,
+        });
+
+    // Another run got there first.
+    if (!claimed) return null;
+
+    const payments = await ctx.db.query.eventPayment.findMany({
+        columns: { userId: true },
+        where: (p, { and, eq }) =>
+            and(eq(p.eventId, eventId), eq(p.status, "paid")),
+    });
+
+    if (payments.length === 0) return 0;
+
+    const registrations = await ctx.db.query.eventRegistration.findMany({
+        columns: { userId: true, status: true },
+        where: eq(schema.eventRegistration.eventId, eventId),
+        with: { user: { columns: { name: true } } },
+    });
+
+    const registrationByUserId = new Map(
+        registrations.map((r) => [r.userId, r]),
+    );
+
+    const stranded: PaymentWithoutSpot[] = [];
+    for (const { userId } of payments) {
+        const registration = registrationByUserId.get(userId);
+
+        if (
+            registration?.status === "registered" ||
+            registration?.status === "attended"
+        ) {
+            continue;
+        }
+
+        stranded.push({
+            userId,
+            name: registration?.user?.name ?? "Ukjent bruker",
+            registrationStatus: registration?.status ?? "ingen påmelding",
+        });
+    }
+
+    if (stranded.length === 0) return 0;
+
+    const recipients = await findOrganizerRecipients(ctx, claimed);
+
+    if (recipients.length === 0) {
+        console.warn(
+            `Event ${eventId} has ${stranded.length} payment(s) without a spot, but no organiser to notify.`,
+        );
+        return 0;
+    }
+
+    const names = stranded.map((s) => s.name).join(", ");
+    const description =
+        stranded.length === 1
+            ? `${names} har betalt for ${claimed.title} uten å ha plass. Vurder om betalingen skal refunderes.`
+            : `${stranded.length} personer har betalt for ${claimed.title} uten å ha plass: ${names}. Vurder om betalingene skal refunderes.`;
+
+    let notified = 0;
+    for (const userId of recipients) {
+        try {
+            await sendNotification(
+                {
+                    userId,
+                    title: `Betalinger uten plass på ${claimed.title}`,
+                    description,
+                    link: `${env.ROOT_URL}/admin/arrangementer/${claimed.id}`,
+                },
+                ctx,
+            );
+            notified += 1;
+        } catch (error) {
+            // One unreachable organiser must not cost the others the notice.
+            console.error(
+                `Error notifying organiser ${userId} about payments without a spot on event ${eventId}:`,
+                error,
+            );
+        }
+    }
+
+    return notified;
+}
+
+/**
+ * Who to ask: the leaders of the arranging group, or — for an event with no
+ * organiser group (older events migrated from Lepton) — whoever created it.
+ */
+async function findOrganizerRecipients(
+    ctx: AppContext,
+    event: {
+        organizerGroupSlug: string | null;
+        createdByUserId: string | null;
+    },
+): Promise<string[]> {
+    if (event.organizerGroupSlug) {
+        const leaders = await ctx.db.query.groupMembership.findMany({
+            columns: { userId: true },
+            where: and(
+                eq(schema.groupMembership.groupSlug, event.organizerGroupSlug),
+                eq(schema.groupMembership.role, "leader"),
+            ),
+        });
+
+        if (leaders.length > 0) {
+            return leaders.map((l) => l.userId);
+        }
+    }
+
+    return event.createdByUserId ? [event.createdByUserId] : [];
+}
+
+/**
+ * Scan for paid events that have started and not yet had their payments
+ * reviewed, and notify their organisers.
+ */
+export async function reviewPaymentsForStartedEvents(
+    ctx: AppContext,
+): Promise<void> {
+    const now = new Date();
+    const lookback = new Date(
+        now.getTime() - PAYMENT_REVIEW_LOOKBACK_DAYS * DAY_MS,
+    );
+
+    const started = await ctx.db.query.event.findMany({
+        columns: { id: true },
+        where: and(
+            eq(schema.event.isPaidEvent, true),
+            isNull(schema.event.paymentReviewNotifiedAt),
+            lte(schema.event.start, now),
+            gt(schema.event.start, lookback),
+        ),
+    });
+
+    for (const event of started) {
+        try {
+            await notifyOrganizersOfPaymentsWithoutSpot(event.id, ctx);
+        } catch (error) {
+            console.error(
+                `Error reviewing payments for event ${event.id}:`,
+                error,
+            );
+        }
+    }
+}

--- a/apps/api/src/lib/event/payment.ts
+++ b/apps/api/src/lib/event/payment.ts
@@ -1,15 +1,37 @@
 import { schema } from "@photon/db";
+import type { PaymentFlag } from "@photon/db/schema";
 import {
     PAYMENT_QUEUE_NAME,
     type QueueJob,
     type WorkerLike,
 } from "@photon/core/services/queue";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import type { AppContext } from "../ctx";
 import { env } from "../env";
 import { sendNotification } from "../notification";
-import { getPaymentDetails, refundPayment } from "../vipps";
+import { capturePayment, getPaymentDetails, refundPayment } from "../vipps";
 import { calculateWaitlistPositions } from "./priority";
+
+/**
+ * How long a member gets to pay after being promoted from the waiting list.
+ *
+ * Twelve hours, matching Lepton: a promotion can land at any hour, and a member
+ * who is asleep when a spot frees up should not lose it to a two-hour window
+ * they never saw. Deliberately not configurable per event, also matching
+ * Lepton.
+ */
+export const WAITLIST_PROMOTION_GRACE_MINUTES = 12 * 60;
+
+/**
+ * The extra time granted when the deadline falls due while a Vipps checkout is
+ * still alive (or while Vipps cannot be reached).
+ *
+ * Vipps expires an unfinished payment session on its own after ten minutes, so
+ * this is that window plus a little slack for the webhook to land — the
+ * extension cannot become an open-ended hold even before the once-only rule
+ * below applies.
+ */
+export const PAYMENT_DEADLINE_EXTENSION_MS = 12 * 60 * 1000;
 
 /**
  * Payload for the delayed job that enforces a paid event's payment deadline.
@@ -28,6 +50,8 @@ type PaidEventLike = {
     id: string;
     title: string;
     slug: string;
+    /** When the event begins. A payment deadline is never allowed past it. */
+    start?: Date | null;
     capacity?: number | null;
     isPaidEvent: boolean;
     priceMinor: number | null;
@@ -42,33 +66,100 @@ function eventUrl(slug: string): string {
 }
 
 /**
+ * Whether `userId` has already paid for `eventId` — a completed payment that
+ * has not been reversed.
+ *
+ * A member who was pushed to the waiting list by a prioritised registration
+ * keeps their payment, so that they do not have to pay again (and race a fresh
+ * deadline) if a spot frees up. Every place that would otherwise hand out a new
+ * obligation has to ask this first.
+ */
+export async function hasPaidForEvent(
+    ctx: AppContext,
+    eventId: string,
+    userId: string,
+): Promise<boolean> {
+    const paid = await ctx.db.query.eventPayment.findFirst({
+        columns: { id: true },
+        where: (p, { and, eq }) =>
+            and(
+                eq(p.eventId, eventId),
+                eq(p.userId, userId),
+                eq(p.status, "paid"),
+            ),
+    });
+
+    return Boolean(paid);
+}
+
+/**
+ * When a payment obligation created now falls due.
+ *
+ * The deadline is never allowed to run past the event's start: a member who is
+ * promoted three hours before doors open would otherwise hold an unpaid spot
+ * through the whole event, which is exactly the spot the deadline exists to
+ * pass on. Events that have already started are left uncapped — there is no
+ * start left to protect, and capping there would expire the obligation on
+ * arrival.
+ */
+export function paymentDeadline(
+    graceMinutes: number,
+    eventStart: Date | null | undefined,
+    now: Date = new Date(),
+): Date {
+    const deadline = new Date(now.getTime() + graceMinutes * 60 * 1000);
+
+    if (eventStart && eventStart > now && eventStart < deadline) {
+        return eventStart;
+    }
+
+    return deadline;
+}
+
+/**
  * Create a payment obligation for a user who just secured a spot on a paid
  * event, and schedule a countdown timer that reclaims the spot if the payment
- * is not completed before the grace period elapses.
+ * is not completed before the deadline.
  *
- * Returns `null` (no-op) when the event is not a payable event or has no grace
- * period configured — an unpaid, deadline-less "paid" event has no obligation
- * to enforce.
+ * `graceMinutes` overrides the event's own grace period — waiting-list
+ * promotions get {@link WAITLIST_PROMOTION_GRACE_MINUTES} rather than the
+ * shorter window a direct registration gets.
+ *
+ * Returns `null` (no-op) when the event is not a payable event, when no grace
+ * period applies, or when the user has already paid — a member who kept their
+ * payment through a demotion owes nothing on the way back in.
  */
 export async function createPaymentObligation(
     ctx: AppContext,
     event: Pick<
         PaidEventLike,
         "id" | "isPaidEvent" | "priceMinor" | "paymentGracePeriodMinutes"
-    >,
+    > & { start?: Date | null },
     userId: string,
+    options: { graceMinutes?: number } = {},
 ): Promise<{ id: string } | null> {
+    const graceMinutes =
+        options.graceMinutes ?? event.paymentGracePeriodMinutes ?? null;
+
     if (
         !event.isPaidEvent ||
         event.priceMinor == null ||
-        event.paymentGracePeriodMinutes == null ||
-        event.paymentGracePeriodMinutes <= 0
+        graceMinutes == null ||
+        graceMinutes <= 0
     ) {
         return null;
     }
 
-    const graceMs = event.paymentGracePeriodMinutes * 60 * 1000;
-    const expiresAt = new Date(Date.now() + graceMs);
+    // Already paid — see {@link hasPaidForEvent}. Handing this member a fresh
+    // deadline would cancel a spot they have already paid for, since the
+    // checkout route refuses a second payment for the same event.
+    if (await hasPaidForEvent(ctx, event.id, userId)) {
+        return null;
+    }
+
+    const now = new Date();
+    const expiresAt = paymentDeadline(graceMinutes, event.start, now);
+    const delay = Math.max(0, expiresAt.getTime() - now.getTime());
 
     const [payment] = await ctx.db
         .insert(schema.eventPayment)
@@ -95,10 +186,31 @@ export async function createPaymentObligation(
         .add(
             "payment-expiration",
             { eventId: event.id, userId, paymentId: payment.id },
-            { delay: graceMs },
+            { delay },
         );
 
     return { id: payment.id };
+}
+
+/**
+ * Raise (or replace) the flag that puts a payment in front of an organiser.
+ *
+ * Flagging is best-effort bookkeeping around a decision that has already been
+ * made, so a failure here must never take down the caller.
+ */
+export async function flagPayment(
+    ctx: AppContext,
+    paymentId: string,
+    flag: PaymentFlag,
+): Promise<void> {
+    try {
+        await ctx.db
+            .update(schema.eventPayment)
+            .set({ flag, flaggedAt: new Date() })
+            .where(eq(schema.eventPayment.id, paymentId));
+    } catch (error) {
+        console.error(`Failed to flag payment ${paymentId} as ${flag}:`, error);
+    }
 }
 
 /**
@@ -172,95 +284,12 @@ export async function reverseEventPayment(
     return refundable;
 }
 
-/** A refund that has been decided on but not yet carried out with Vipps. */
-export type OwedRefund = {
-    payment: ReversiblePayment;
-    notification: { title: string; description: string; link: string };
-};
-
-/**
- * Find the payment owed back to a user who is losing a registered spot, without
- * contacting Vipps.
- *
- * Split from the refund itself so a caller inside a transaction can decide
- * *that* a refund is due — a cheap indexed read — and carry it out only once
- * the transaction has committed. See {@link refundOwed} for why that split
- * matters.
- *
- * Returns null unless the event is a paid event and a completed ("paid")
- * payment with a provider reference exists for the user.
- */
-export async function findOwedRefund(
-    ctx: AppContext,
-    event: Pick<PaidEventLike, "id" | "title" | "slug" | "isPaidEvent">,
-    userId: string,
-): Promise<OwedRefund | null> {
-    if (!event.isPaidEvent) {
-        return null;
-    }
-
-    const paid = await ctx.db.query.eventPayment.findFirst({
-        where: (p, { and, eq }) =>
-            and(
-                eq(p.eventId, event.id),
-                eq(p.userId, userId),
-                eq(p.status, "paid"),
-            ),
-    });
-
-    if (!paid || !paid.providerPaymentId) {
-        return null;
-    }
-
-    return {
-        payment: paid,
-        notification: {
-            title: `Betaling refundert for ${event.title}`,
-            description: `Du mistet plassen din på ${event.title} og betalingen din har blitt refundert.`,
-            link: eventUrl(event.slug),
-        },
-    };
-}
-
-/**
- * Carry out refunds decided earlier, one Vipps round-trip at a time.
- *
- * **Must be called after the surrounding transaction has committed.** Refunding
- * means up to three calls out to Vipps (token, payment details, refund), and
- * doing that inside a transaction holds every row lock it took for as long as
- * Vipps takes to answer. The registration resolver runs every 5 seconds and
- * locks registration rows `FOR UPDATE`, so a slow Vipps would have parked those
- * locks — the same shape as the outage on 2026-08-13, where one request waiting
- * on a lock it could not get took the whole site down.
- *
- * A refund that fails is logged and the rest still run. That is a deliberate
- * trade: before this split, a Vipps error rolled the registration changes back,
- * which is safer for consistency but pays for it by holding locks across the
- * network. A member whose refund failed keeps their (correct) waitlist status
- * and needs the refund issued by hand — which the log line is there to make
- * possible.
- */
-export async function refundOwed(
-    ctx: AppContext,
-    owed: OwedRefund[],
-): Promise<void> {
-    for (const { payment, notification } of owed) {
-        try {
-            await reverseEventPayment(ctx, { payment, notification });
-        } catch (error) {
-            console.error(
-                `Refund failed for user ${payment.userId} on payment ${payment.id} — ` +
-                    "the registration change stands, so this must be refunded manually:",
-                error,
-            );
-        }
-    }
-}
-
 /**
  * Promote the highest-ranked waitlisted user into a freed spot, recalculating
  * the remaining waitlist positions. For a paid event the promoted user gets a
- * fresh payment obligation (and countdown timer) of their own.
+ * payment obligation (and countdown timer) of their own, with the longer
+ * waiting-list deadline — unless they had already paid before losing the spot,
+ * in which case they owe nothing and get no deadline.
  */
 export async function promoteFromWaitlist(
     ctx: AppContext,
@@ -328,8 +357,12 @@ export async function promoteFromWaitlist(
         ctx,
     );
 
-    // The promoted user now owes payment on a paid event.
-    await createPaymentObligation(ctx, event, promoted.userId);
+    // The promoted user now owes payment on a paid event — with the longer
+    // waiting-list window, and skipped entirely for someone who kept their
+    // payment through an earlier demotion.
+    await createPaymentObligation(ctx, event, promoted.userId, {
+        graceMinutes: WAITLIST_PROMOTION_GRACE_MINUTES,
+    });
 
     // Recalculate positions for everyone still on the waitlist — one pass over
     // the waitlist, not one pass per member of it.
@@ -354,11 +387,159 @@ export async function promoteFromWaitlist(
 }
 
 /**
+ * What the provider says about an obligation whose deadline has just fallen
+ * due.
+ *
+ * - `paid`: the money is in — reconciled and recorded here, so a late or lost
+ *   webhook cannot cost a member their spot.
+ * - `live`: a checkout is still open. Vipps closes an unfinished session on its
+ *   own after ten minutes, so this state cannot last.
+ * - `dead`: no checkout, or one that was aborted, expired or terminated
+ *   without capturing anything.
+ * - `unknown`: Vipps could not be reached, so "unpaid" would be a guess.
+ */
+type ProviderVerdict = "paid" | "live" | "dead" | "unknown";
+
+/**
+ * Ask Vipps what actually happened to a pending obligation, and record a
+ * completed payment if that is the answer.
+ *
+ * Deliberately reads from the provider rather than trusting our own row: the
+ * webhook may be late, may have been lost, or may be racing this very check,
+ * and the cost of guessing wrong is cancelling a spot somebody has paid for.
+ * Lepton does the same thing (`reconcile_orders_from_vipps`) before it touches
+ * a registration.
+ *
+ * **Never call this inside a transaction** — it is up to three round-trips to
+ * Vipps, and holding registration locks across them is what took the site down
+ * on 2026-08-13.
+ */
+async function reconcileWithProvider(
+    ctx: AppContext,
+    payment: {
+        id: string;
+        amountMinor: number;
+        currency: string;
+        providerPaymentId: string | null;
+        receivedPaymentAt: Date | null;
+    },
+): Promise<ProviderVerdict> {
+    // An obligation the member never even opened a checkout for. Nothing to
+    // ask about, and nothing to wait for.
+    if (!payment.providerPaymentId) {
+        return "dead";
+    }
+
+    let details: Awaited<ReturnType<typeof getPaymentDetails>>;
+    try {
+        details = await getPaymentDetails(payment.providerPaymentId);
+    } catch (error) {
+        console.error(
+            `Could not reach Vipps for payment ${payment.id} at its deadline:`,
+            error,
+        );
+        return "unknown";
+    }
+
+    const { capturedAmount } = details.aggregate;
+
+    // AUTHORIZED only reserves the amount; capture it so "paid" means the money
+    // was actually collected, exactly as the webhook does.
+    if (
+        details.state === "AUTHORIZED" &&
+        capturedAmount.value < payment.amountMinor
+    ) {
+        try {
+            await capturePayment({
+                reference: payment.providerPaymentId,
+                amount: payment.amountMinor,
+                currency: payment.currency,
+            });
+        } catch (error) {
+            console.error(
+                `Failed to capture authorized payment ${payment.id} at its deadline:`,
+                error,
+            );
+            return "unknown";
+        }
+    }
+
+    if (details.state === "AUTHORIZED" || capturedAmount.value > 0) {
+        await ctx.db
+            .update(schema.eventPayment)
+            .set({
+                status: "paid",
+                receivedPaymentAt: payment.receivedPaymentAt ?? new Date(),
+            })
+            .where(eq(schema.eventPayment.id, payment.id));
+
+        return "paid";
+    }
+
+    return details.state === "CREATED" ? "live" : "dead";
+}
+
+/**
+ * Grant this registration its single deadline extension: push the obligation's
+ * deadline out and re-arm the countdown.
+ *
+ * Returns false when the extension has already been spent, which is what stops
+ * a member from holding a spot forever by starting a fresh checkout every time
+ * the timer comes round. The claim is a conditional update, so two timer runs
+ * for the same obligation cannot both extend it.
+ */
+async function grantDeadlineExtension(
+    ctx: AppContext,
+    data: PaymentTimerJobData,
+    payment: { id: string; deadlineExtendedAt: Date | null },
+): Promise<boolean> {
+    if (payment.deadlineExtendedAt) {
+        return false;
+    }
+
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + PAYMENT_DEADLINE_EXTENSION_MS);
+
+    const [claimed] = await ctx.db
+        .update(schema.eventPayment)
+        .set({ deadlineExtendedAt: now, expiresAt })
+        .where(
+            and(
+                eq(schema.eventPayment.id, payment.id),
+                isNull(schema.eventPayment.deadlineExtendedAt),
+            ),
+        )
+        .returning({ id: schema.eventPayment.id });
+
+    if (!claimed) {
+        return false;
+    }
+
+    await ctx.queue
+        .getQueue<PaymentTimerJobData>(PAYMENT_QUEUE_NAME)
+        .add("payment-expiration", data, {
+            delay: PAYMENT_DEADLINE_EXTENSION_MS,
+        });
+
+    return true;
+}
+
+/**
  * Enforce a paid event's payment deadline for a single registration.
  *
- * When the countdown timer fires: if the payment was not completed, the unpaid
- * registration is cancelled (freeing the spot), the obligation is marked
- * failed, and the top waitlisted user is promoted into the freed spot.
+ * When the countdown timer fires, the provider is asked what really happened
+ * before anything is taken away:
+ *
+ * - Paid (however late the webhook was) — the member keeps the spot.
+ * - A checkout still in progress, or a Vipps we cannot reach — the deadline is
+ *   extended once, and only once. An unreachable Vipps is also flagged, so an
+ *   organiser knows the eventual outcome rested on a guess.
+ * - Anything else — the obligation is marked failed, the registration is
+ *   **cancelled** (not moved to the waiting list; the member is off the event
+ *   and free to sign up again from scratch), and the top waitlisted member is
+ *   promoted into the freed spot.
+ *
+ * Every provider call happens outside the transaction that changes rows.
  */
 export async function handlePaymentExpiration(
     ctx: AppContext,
@@ -366,52 +547,121 @@ export async function handlePaymentExpiration(
 ): Promise<void> {
     const { eventId, userId, paymentId } = data;
 
+    const payment = await ctx.db.query.eventPayment.findFirst({
+        where: (p, { eq }) => eq(p.id, paymentId),
+    });
+
+    // Obligation gone, already paid, or already refunded — nothing to do.
+    if (
+        !payment ||
+        payment.status === "paid" ||
+        payment.status === "refunded"
+    ) {
+        return;
+    }
+
+    const registration = await ctx.db.query.eventRegistration.findFirst({
+        where: (r, { and, eq }) =>
+            and(eq(r.eventId, eventId), eq(r.userId, userId)),
+    });
+
+    // Only reclaim a spot that is still actively held by this user.
+    if (!registration || registration.status !== "registered") {
+        if (payment.status === "pending") {
+            await ctx.db
+                .update(schema.eventPayment)
+                .set({ status: "failed" })
+                .where(eq(schema.eventPayment.id, paymentId));
+        }
+        return;
+    }
+
+    // A member who aborted one checkout and started another holds a second,
+    // newer obligation row. Judge them on whichever attempt is still alive,
+    // rather than on the one this timer happens to point at — the once-only
+    // extension is what keeps that from becoming a loophole.
+    const attempts = await ctx.db.query.eventPayment.findMany({
+        where: (p, { and, eq }) =>
+            and(
+                eq(p.eventId, eventId),
+                eq(p.userId, userId),
+                eq(p.status, "pending"),
+            ),
+    });
+
+    let verdict: ProviderVerdict = "dead";
+    for (const attempt of attempts) {
+        const attemptVerdict = await reconcileWithProvider(ctx, attempt);
+
+        if (attemptVerdict === "paid") {
+            verdict = "paid";
+            break;
+        }
+        if (attemptVerdict === "live") {
+            verdict = "live";
+        } else if (attemptVerdict === "unknown" && verdict !== "live") {
+            verdict = "unknown";
+        }
+    }
+
+    // The money is in after all — the spot stands.
+    if (verdict === "paid") {
+        return;
+    }
+
+    if (verdict === "live" || verdict === "unknown") {
+        const extended = await grantDeadlineExtension(ctx, data, payment);
+
+        if (verdict === "unknown") {
+            // Whatever we end up doing rests on an answer Vipps never gave, so
+            // put it in front of an organiser either way.
+            await flagPayment(ctx, paymentId, "provider_unreachable");
+        }
+
+        if (extended) {
+            return;
+        }
+        // Extension already spent: fall through and reclaim the spot. Chained
+        // checkouts buy time once, not indefinitely.
+    }
+
     await ctx.db.transaction(async (tx) => {
         const txCtx = { ...ctx, db: tx };
 
-        const payment = await tx.query.eventPayment.findFirst({
-            where: (p, { eq }) => eq(p.id, paymentId),
-        });
-
-        // Obligation gone, already paid, or already refunded — nothing to do.
-        if (
-            !payment ||
-            payment.status === "paid" ||
-            payment.status === "refunded"
-        ) {
-            return;
-        }
-
-        const registration = await tx.query.eventRegistration.findFirst({
-            where: (r, { and, eq }) =>
-                and(eq(r.eventId, eventId), eq(r.userId, userId)),
-        });
-
-        // Only reclaim a spot that is still actively held by this user.
-        if (!registration || registration.status !== "registered") {
-            if (payment.status === "pending") {
-                await tx
-                    .update(schema.eventPayment)
-                    .set({ status: "failed" })
-                    .where(eq(schema.eventPayment.id, paymentId));
-            }
-            return;
-        }
-
-        // 1. Mark the unpaid obligation as failed.
-        await tx
-            .update(schema.eventPayment)
-            .set({ status: "failed" })
-            .where(eq(schema.eventPayment.id, paymentId));
-
-        // 2. Cancel the unpaid registration, freeing the spot.
-        await tx
+        // 1. Claim the spot by cancelling it, conditional on it still being
+        // held. The reads above happened outside this transaction — they have
+        // to, because they talk to Vipps — so a second timer run could
+        // otherwise reach this point too and promote twice off the waiting
+        // list. The registration is what is being reclaimed, so it is what the
+        // claim keys on: keying on the payment row instead would miss the case
+        // where that row was already marked failed (an aborted first checkout)
+        // while the spot itself was never freed.
+        const [claimed] = await tx
             .update(schema.eventRegistration)
             .set({ status: "cancelled", waitlistPosition: null })
             .where(
                 and(
                     eq(schema.eventRegistration.eventId, eventId),
                     eq(schema.eventRegistration.userId, userId),
+                    eq(schema.eventRegistration.status, "registered"),
+                ),
+            )
+            .returning({ userId: schema.eventRegistration.userId });
+
+        if (!claimed) {
+            return;
+        }
+
+        // 2. Every unpaid attempt for this member is now moot — the one this
+        // timer points at and any later checkout they abandoned.
+        await tx
+            .update(schema.eventPayment)
+            .set({ status: "failed" })
+            .where(
+                and(
+                    eq(schema.eventPayment.eventId, eventId),
+                    eq(schema.eventPayment.userId, userId),
+                    eq(schema.eventPayment.status, "pending"),
                 ),
             );
 
@@ -433,7 +683,7 @@ export async function handlePaymentExpiration(
             {
                 userId,
                 title: `Din plass på ${event.title} ble kansellert`,
-                description: `Du fullførte ikke betalingen for ${event.title} innen fristen, og plassen din har blitt gitt videre.`,
+                description: `Du fullførte ikke betalingen for ${event.title} innen fristen, og plassen din har blitt gitt videre. Du kan melde deg på på nytt.`,
                 link: eventUrl(event.slug),
             },
             txCtx,

--- a/apps/api/src/lib/event/resolve-registration.ts
+++ b/apps/api/src/lib/event/resolve-registration.ts
@@ -4,12 +4,7 @@ import { and, eq } from "drizzle-orm";
 import type { AppContext } from "../ctx";
 import { env } from "../env";
 import { createDeferredNotifications } from "../notification/deferred";
-import {
-    createPaymentObligation,
-    findOwedRefund,
-    type OwedRefund,
-    refundOwed,
-} from "./payment";
+import { createPaymentObligation } from "./payment";
 import {
     calculateWaitlistPositions,
     findSwapTarget,
@@ -30,13 +25,6 @@ export async function resolveRegistrationsForEvent(
     eventId: string,
     ctx: AppContext,
 ): Promise<void> {
-    /**
-     * Refunds decided inside the transaction and carried out after it commits.
-     * Talking to Vipps while holding the `FOR UPDATE` locks below would park
-     * those locks for as long as Vipps takes to answer — see {@link refundOwed}.
-     */
-    const owedRefunds: OwedRefund[] = [];
-
     /**
      * Notifications decided inside the transaction and sent once it commits —
      * rendering an email template per affected member while holding the
@@ -212,17 +200,12 @@ export async function resolveRegistrationsForEvent(
                     swappedUserId = swapTarget.userId;
                     finalStatus = "registered";
 
-                    // If the swapped-out user had already paid, they are owed a
-                    // refund. Only the lookup happens here; the Vipps call
-                    // waits until the transaction has let go of its locks.
-                    const owed = await findOwedRefund(
-                        txCtx,
-                        event,
-                        swapTarget.userId,
-                    );
-                    if (owed) {
-                        owedRefunds.push(owed);
-                    }
+                    // A swapped-out member who had already paid keeps their
+                    // payment. Refunding here would mean they had to pay again
+                    // — and race a fresh deadline — if a spot frees up and they
+                    // are promoted back in. Money that ends up owed is returned
+                    // by an organiser instead; they are reminded at the event's
+                    // start. See `notifyOrganizersOfPaymentsWithoutSpot`.
 
                     // Send notification to swapped user (will calculate position later)
                     console.log(
@@ -409,5 +392,4 @@ export async function resolveRegistrationsForEvent(
 
     // Locks are released; now it is safe to spend time on the network.
     await notifications.flush(ctx);
-    await refundOwed(ctx, owedRefunds);
 }

--- a/apps/api/src/lib/jobs.ts
+++ b/apps/api/src/lib/jobs.ts
@@ -3,6 +3,7 @@ import cron from "node-cron";
 import { startAssetCleanupCron } from "./asset/worker";
 import type { AppContext } from "./ctx";
 import { processNoShowStrikesForEndedEvents } from "./event/no-show";
+import { reviewPaymentsForStartedEvents } from "./event/payment-review";
 import { startPaymentTimerWorker } from "./event/payment";
 import { sendUpcomingRegistrationReminders } from "./event/registration-reminder";
 import {
@@ -92,6 +93,23 @@ function startRegistrationReminderCron(ctx: AppContext): void {
 }
 
 /**
+ * Start cron job that asks organisers to review payments made by members who
+ * hold no spot, once their event has started. Runs every 5 minutes — the notice
+ * is not time-critical, it just has to arrive.
+ */
+function startPaymentReviewCron(ctx: AppContext): void {
+    cron.schedule("*/5 * * * *", async () => {
+        try {
+            await reviewPaymentsForStartedEvents(ctx);
+        } catch (error) {
+            console.error("Error in payment review cron:", error);
+        }
+    });
+
+    console.log("⏰ Payment review cron started (runs every 5 minutes)");
+}
+
+/**
  * Initialize all background workers and cron jobs
  * Called once when the application starts
  */
@@ -119,4 +137,7 @@ export function startBackgroundJobs(ctx: AppContext): void {
 
     // Start registration-opening reminder cron
     startRegistrationReminderCron(ctx);
+
+    // Start the payments-without-a-spot review cron
+    startPaymentReviewCron(ctx);
 }

--- a/apps/api/src/routes/event/payment/list.ts
+++ b/apps/api/src/routes/event/payment/list.ts
@@ -86,6 +86,7 @@ export const listEventPaymentsRoute = route().get(
             .select({
                 status: schema.eventPayment.status,
                 amountMinor: schema.eventPayment.amountMinor,
+                flag: schema.eventPayment.flag,
             })
             .from(schema.eventPayment)
             .where(eq(schema.eventPayment.eventId, eventId));
@@ -101,6 +102,7 @@ export const listEventPaymentsRoute = route().get(
             totalPaidMinor: allPayments
                 .filter((p) => p.status === "paid")
                 .reduce((sum, p) => sum + p.amountMinor, 0),
+            flaggedCount: allPayments.filter((p) => p.flag !== null).length,
         };
 
         const totalPages = getTotalPages(totalCount, pageSize);
@@ -125,6 +127,8 @@ export const listEventPaymentsRoute = route().get(
                 status: p.status,
                 receivedPaymentAt: p.receivedPaymentAt?.toISOString() ?? null,
                 expiresAt: p.expiresAt?.toISOString() ?? null,
+                flag: p.flag,
+                flaggedAt: p.flaggedAt?.toISOString() ?? null,
                 createdAt: p.createdAt.toISOString(),
             })),
             summary,

--- a/apps/api/src/routes/event/payment/webhook.ts
+++ b/apps/api/src/routes/event/payment/webhook.ts
@@ -1,6 +1,7 @@
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
+import { flagPayment } from "~/lib/event/payment";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "../../../lib/route";
 import {
@@ -154,6 +155,47 @@ export const paymentWebhookRoute = route().post(
                         (paymentReceived ? new Date() : null),
                 })
                 .where(eq(schema.eventPayment.id, payment.id));
+
+            // Safety net: money can land on a registration that is gone — a
+            // checkout completed just after the deadline reclaimed the spot, or
+            // one finished in another tab after the member unregistered.
+            // Nothing here refunds automatically (that is an organiser's call),
+            // but it must never pass in silence.
+            //
+            // A `waitlisted` payer is deliberately *not* flagged: keeping the
+            // payment of someone displaced by a prioritised registration is the
+            // intended behaviour, not an anomaly, and organisers are reminded
+            // about them when the event starts.
+            if (newStatus === "paid") {
+                const registration = await db.query.eventRegistration.findFirst(
+                    {
+                        columns: { status: true },
+                        where: (r, { and, eq }) =>
+                            and(
+                                eq(r.eventId, payment.eventId),
+                                eq(r.userId, payment.userId),
+                            ),
+                    },
+                );
+
+                // No registration at all, or one that was cancelled. A
+                // `no_show` held their spot and paid correctly; a `waitlisted`
+                // payer is the intended displacement case above.
+                const stranded =
+                    !registration || registration.status === "cancelled";
+
+                if (stranded) {
+                    await flagPayment(
+                        c.get("ctx"),
+                        payment.id,
+                        "paid_without_spot",
+                    );
+                    console.warn(
+                        `Payment ${payment.id} completed for user ${payment.userId} on event ${payment.eventId}, ` +
+                            `but their registration is ${registration?.status ?? "missing"} — flagged for an organiser.`,
+                    );
+                }
+            }
 
             return c.json(
                 {

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -1046,6 +1046,8 @@ export const eventRegistrationResponseSchema = Schema(
 
 const paymentStatusSchema = z.enum(["pending", "paid", "refunded", "failed"]);
 
+const paymentFlagSchema = z.enum(["provider_unreachable", "paid_without_spot"]);
+
 /**
  * Slim payment view attached to an admin's registration listing.
  */
@@ -1136,6 +1138,11 @@ export const eventPaymentAdminSchema = Schema(
         status: paymentStatusSchema,
         receivedPaymentAt: z.iso.datetime().nullable(),
         expiresAt: z.iso.datetime().nullable(),
+        flag: paymentFlagSchema.nullable().meta({
+            description:
+                "Set when this payment needs an organiser to look at it: 'provider_unreachable' means the deadline fell due while Vipps could not be reached, 'paid_without_spot' means the payment completed for someone who no longer holds a spot.",
+        }),
+        flaggedAt: z.iso.datetime().nullable(),
         createdAt: z.iso.datetime(),
     }),
 );
@@ -1155,6 +1162,10 @@ export const eventPaymentListResponseSchema = Schema(
                 totalPaidMinor: z.number().meta({
                     description:
                         "Sum of all completed (paid) payments, in minor units",
+                }),
+                flaggedCount: z.number().meta({
+                    description:
+                        "Payments that need an organiser to look at them",
                 }),
             })
             .describe("Totals across every payment for the event"),

--- a/apps/api/src/test/event/payment-lifecycle.test.ts
+++ b/apps/api/src/test/event/payment-lifecycle.test.ts
@@ -1,9 +1,14 @@
 import { PAYMENT_QUEUE_NAME } from "@photon/core/services/queue";
 import { schema } from "@photon/db";
-import { eq } from "drizzle-orm";
-import { describe, expect, vi } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it, vi } from "vitest";
 import type { PaymentTimerJobData } from "~/lib/event/payment";
-import { handlePaymentExpiration } from "~/lib/event/payment";
+import {
+    handlePaymentExpiration,
+    paymentDeadline,
+    promoteFromWaitlist,
+    WAITLIST_PROMOTION_GRACE_MINUTES,
+} from "~/lib/event/payment";
 import { resolveRegistrationsForEvent } from "~/lib/event/resolve-registration";
 import * as vipps from "~/lib/vipps";
 import { integrationTest } from "~/test/config/integration";
@@ -244,23 +249,19 @@ describe("Paid event payment lifecycle", () => {
         );
     });
 
-    describe("Hull B — refund on swap", () => {
+    describe("Fortrengning — betalingen står", () => {
         integrationTest(
-            "refunds a paid user who is swapped to the waitlist",
+            "keeps the payment when a prioritized user takes the spot",
             async ({ ctx }) => {
+                /**
+                 * A member who is pushed off by a prioritised registration
+                 * keeps their money. Refunding here would mean paying again —
+                 * and racing a fresh deadline — if a spot frees up later.
+                 * Whether the money goes back is an organiser's call at the
+                 * event's start, not the resolver's.
+                 */
                 const refundMock = vi.mocked(vipps.refundPayment);
                 refundMock.mockClear();
-
-                // The refund amount is read back from the provider, so the
-                // payment must look fully captured and not yet refunded.
-                vi.mocked(vipps.getPaymentDetails).mockResolvedValue({
-                    aggregate: {
-                        authorizedAmount: { currency: "NOK", value: 7500 },
-                        capturedAmount: { currency: "NOK", value: 7500 },
-                        refundedAmount: { currency: "NOK", value: 0 },
-                        cancelledAmount: { currency: "NOK", value: 0 },
-                    },
-                } as Awaited<ReturnType<typeof vipps.getPaymentDetails>>);
 
                 await ctx.utils.setupEventCategories();
                 await ctx.utils.setupGroups();
@@ -279,7 +280,7 @@ describe("Paid event payment lifecycle", () => {
                     classYear: null,
                 });
 
-                // Non-prioritized user grabs the single spot first.
+                // Non-prioritized user grabs the single spot first, and pays.
                 const nonPrioritized = await ctx.utils.createTestUser();
                 await ctx.utils.createPendingRegistration(
                     event.id,
@@ -287,7 +288,6 @@ describe("Paid event payment lifecycle", () => {
                 );
                 await resolveRegistrationsForEvent(event.id, ctx);
 
-                // Simulate that they completed payment.
                 const paidPayment = await ctx.db.query.eventPayment.findFirst({
                     where: (p, { and, eq }) =>
                         and(
@@ -326,7 +326,6 @@ describe("Paid event payment lifecycle", () => {
                 );
                 await resolveRegistrationsForEvent(event.id, ctx);
 
-                // Prioritized user has the spot, non-prioritized on waitlist.
                 const priorityReg =
                     await ctx.db.query.eventRegistration.findFirst({
                         where: (r, { and, eq }) =>
@@ -347,54 +346,28 @@ describe("Paid event payment lifecycle", () => {
                     });
                 expect(swappedReg?.status).toBe("waitlisted");
 
-                // Refund was issued for the paid, swapped-out user.
-                expect(refundMock).toHaveBeenCalledTimes(1);
-                expect(refundMock).toHaveBeenCalledWith({
-                    reference: "vipps-ref-123",
-                    amount: 7500,
-                    currency: "NOK",
-                });
+                // No money moved, and the payment is still theirs.
+                expect(refundMock).not.toHaveBeenCalled();
 
-                const refundedPayment =
-                    await ctx.db.query.eventPayment.findFirst({
-                        where: (p, { eq }) => eq(p.id, paidPayment?.id ?? ""),
-                    });
-                expect(refundedPayment?.status).toBe("refunded");
+                const untouched = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { eq }) => eq(p.id, paidPayment?.id ?? ""),
+                });
+                expect(untouched?.status).toBe("paid");
             },
             500_000,
         );
 
         integrationTest(
-            "keeps the swap when Vipps fails, because the refund runs after the transaction",
+            "gives a promoted, already-paid member no new deadline",
             async ({ ctx }) => {
                 /**
-                 * The refund used to run *inside* the resolver's transaction,
-                 * which meant a Vipps call — three round-trips over the public
-                 * internet — happened while `FOR UPDATE` locks were held on the
-                 * registration rows. A slow Vipps parked those locks, and the
-                 * resolver runs every 5 seconds.
-                 *
-                 * Moving the call after the commit has a visible consequence,
-                 * and this test pins it down: a failing refund no longer undoes
-                 * the swap. That is the trade — locks are released promptly,
-                 * and a refund that fails is logged for manual handling instead
-                 * of rolling back a registration decision that was correct.
+                 * The trap this pins down: promoting a member who kept their
+                 * payment used to hand them a fresh obligation and countdown.
+                 * They cannot pay it — the checkout route refuses a second
+                 * payment for the same event — so the timer would cancel the
+                 * spot they had just got back.
                  */
-                const refundMock = vi.mocked(vipps.refundPayment);
-                refundMock.mockClear();
-                refundMock.mockRejectedValueOnce(new Error("Vipps er nede"));
-
-                vi.mocked(vipps.getPaymentDetails).mockResolvedValue({
-                    aggregate: {
-                        authorizedAmount: { currency: "NOK", value: 7500 },
-                        capturedAmount: { currency: "NOK", value: 7500 },
-                        refundedAmount: { currency: "NOK", value: 0 },
-                        cancelledAmount: { currency: "NOK", value: 0 },
-                    },
-                } as Awaited<ReturnType<typeof vipps.getPaymentDetails>>);
-
                 await ctx.utils.setupEventCategories();
-                await ctx.utils.setupGroups();
 
                 const event = await ctx.utils.createTestEvent({
                     capacity: 1,
@@ -403,87 +376,524 @@ describe("Paid event payment lifecycle", () => {
                     paymentGracePeriodMinutes: GRACE_MINUTES,
                 });
 
-                await ctx.db.insert(schema.eventPriorityPool).values({
-                    eventId: event.id,
-                    groupSlug: "index",
-                    classYear: null,
-                });
-
-                const nonPrioritized = await ctx.utils.createTestUser();
+                const paidUser = await ctx.utils.createTestUser();
                 await ctx.utils.createPendingRegistration(
                     event.id,
-                    nonPrioritized.id,
+                    paidUser.id,
                 );
                 await resolveRegistrationsForEvent(event.id, ctx);
 
-                const paidPayment = await ctx.db.query.eventPayment.findFirst({
+                const payment = await ctx.db.query.eventPayment.findFirst({
                     where: (p, { and, eq }) =>
-                        and(
-                            eq(p.eventId, event.id),
-                            eq(p.userId, nonPrioritized.id),
-                        ),
+                        and(eq(p.eventId, event.id), eq(p.userId, paidUser.id)),
                 });
                 await ctx.db
                     .update(schema.eventPayment)
                     .set({
                         status: "paid",
                         provider: "vipps",
-                        providerPaymentId: "vipps-ref-fail",
+                        providerPaymentId: "vipps-ref-promote",
                         receivedPaymentAt: new Date(),
                     })
-                    .where(eq(schema.eventPayment.id, paidPayment?.id ?? ""));
+                    .where(eq(schema.eventPayment.id, payment?.id ?? ""));
 
-                await new Promise((resolve) => setTimeout(resolve, 10));
+                // Put them on the waiting list, as a displacement would.
+                await ctx.db
+                    .update(schema.eventRegistration)
+                    .set({ status: "waitlisted", waitlistPosition: 1 })
+                    .where(
+                        and(
+                            eq(schema.eventRegistration.eventId, event.id),
+                            eq(schema.eventRegistration.userId, paidUser.id),
+                        ),
+                    );
 
-                const prioritizedData = await ctx.auth.api.createUser({
-                    body: {
-                        email: "prioritized-fail@test.com",
-                        name: "Prioritized User",
-                        password: "test123!",
-                    },
+                const eventWithRelations = await ctx.db.query.event.findFirst({
+                    where: (e, { eq }) => eq(e.id, event.id),
+                    with: { pools: true, priorityUsers: true },
                 });
-                await ctx.db.insert(schema.groupMembership).values({
-                    userId: prioritizedData.user.id,
-                    groupSlug: "index",
-                    role: "member",
-                });
-                await ctx.utils.createPendingRegistration(
-                    event.id,
-                    prioritizedData.user.id,
-                );
+                if (!eventWithRelations) throw new Error("event vanished");
 
-                // Must not throw: the refund failure is contained.
+                const jobsBefore = (await getPaymentTimerJobs(ctx)).length;
+
+                await promoteFromWaitlist(ctx, eventWithRelations);
+
+                const reg = await ctx.db.query.eventRegistration.findFirst({
+                    where: (r, { and, eq }) =>
+                        and(eq(r.eventId, event.id), eq(r.userId, paidUser.id)),
+                });
+                expect(reg?.status).toBe("registered");
+
+                // No second obligation, and no new countdown to lose the spot to.
+                const payments = await ctx.db.query.eventPayment.findMany({
+                    where: (p, { and, eq }) =>
+                        and(eq(p.eventId, event.id), eq(p.userId, paidUser.id)),
+                });
+                expect(payments).toHaveLength(1);
+                expect(payments[0]?.status).toBe("paid");
+
+                expect(await getPaymentTimerJobs(ctx)).toHaveLength(jobsBefore);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "gives a promoted, unpaid member the 12-hour waiting-list deadline",
+            async ({ ctx }) => {
+                await ctx.utils.setupEventCategories();
+
+                const event = await ctx.utils.createTestEvent({
+                    capacity: 1,
+                    isPaidEvent: true,
+                    priceMinor: 7500,
+                    paymentGracePeriodMinutes: GRACE_MINUTES,
+                    // Far enough out that the deadline is not capped by it.
+                    start: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+                    end: new Date(Date.now() + 31 * 24 * 60 * 60 * 1000),
+                });
+
+                const waiting = await ctx.utils.createTestUser();
+                await ctx.utils.createPendingRegistration(event.id, waiting.id);
                 await resolveRegistrationsForEvent(event.id, ctx);
 
-                expect(refundMock).toHaveBeenCalledTimes(1);
+                await ctx.db
+                    .update(schema.eventRegistration)
+                    .set({ status: "waitlisted", waitlistPosition: 1 })
+                    .where(
+                        and(
+                            eq(schema.eventRegistration.eventId, event.id),
+                            eq(schema.eventRegistration.userId, waiting.id),
+                        ),
+                    );
+                // Drop the obligation the direct registration created, so only
+                // the promotion's own obligation is left to look at.
+                await ctx.db
+                    .delete(schema.eventPayment)
+                    .where(eq(schema.eventPayment.eventId, event.id));
 
-                // The registration decision stands.
-                const priorityReg =
-                    await ctx.db.query.eventRegistration.findFirst({
-                        where: (r, { and, eq }) =>
-                            and(
-                                eq(r.eventId, event.id),
-                                eq(r.userId, prioritizedData.user.id),
-                            ),
-                    });
-                expect(priorityReg?.status).toBe("registered");
-
-                const swappedReg =
-                    await ctx.db.query.eventRegistration.findFirst({
-                        where: (r, { and, eq }) =>
-                            and(
-                                eq(r.eventId, event.id),
-                                eq(r.userId, nonPrioritized.id),
-                            ),
-                    });
-                expect(swappedReg?.status).toBe("waitlisted");
-
-                // And the payment is still marked paid, so the manual refund
-                // has something to act on.
-                const untouched = await ctx.db.query.eventPayment.findFirst({
-                    where: (p, { eq }) => eq(p.id, paidPayment?.id ?? ""),
+                const eventWithRelations = await ctx.db.query.event.findFirst({
+                    where: (e, { eq }) => eq(e.id, event.id),
+                    with: { pools: true, priorityUsers: true },
                 });
-                expect(untouched?.status).toBe("paid");
+                if (!eventWithRelations) throw new Error("event vanished");
+
+                const before = Date.now();
+                await promoteFromWaitlist(ctx, eventWithRelations);
+
+                const payment = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { and, eq }) =>
+                        and(eq(p.eventId, event.id), eq(p.userId, waiting.id)),
+                });
+                expect(payment?.status).toBe("pending");
+
+                const expected =
+                    before + WAITLIST_PROMOTION_GRACE_MINUTES * 60 * 1000;
+                const expiresAt = payment?.expiresAt?.getTime() ?? 0;
+                expect(expiresAt).toBeGreaterThanOrEqual(expected - 1000);
+                expect(expiresAt).toBeLessThanOrEqual(expected + 5000);
+            },
+            500_000,
+        );
+    });
+
+    describe("Fristen kappes ved arrangementsstart", () => {
+        integrationTest(
+            "never lets a payment deadline run past the event start",
+            async ({ ctx }) => {
+                await ctx.utils.setupEventCategories();
+
+                const start = new Date(Date.now() + 20 * 60 * 1000);
+                const event = await ctx.utils.createTestEvent({
+                    capacity: 10,
+                    isPaidEvent: true,
+                    priceMinor: 5000,
+                    // Two hours, on an event that starts in twenty minutes.
+                    paymentGracePeriodMinutes: 120,
+                    start,
+                    end: new Date(start.getTime() + 2 * 60 * 60 * 1000),
+                });
+
+                const user = await ctx.utils.createTestUser();
+                await ctx.utils.createPendingRegistration(event.id, user.id);
+                await resolveRegistrationsForEvent(event.id, ctx);
+
+                const payment = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { and, eq }) =>
+                        and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+                });
+
+                expect(payment?.expiresAt?.getTime()).toBe(start.getTime());
+
+                const jobs = await getPaymentTimerJobs(ctx);
+                expect(jobs[0]?.delay).toBeLessThanOrEqual(20 * 60 * 1000);
+            },
+            500_000,
+        );
+
+        it("leaves the deadline uncapped once the event has started", () => {
+            const now = new Date();
+            const started = new Date(now.getTime() - 60 * 60 * 1000);
+
+            // An obligation created after the start would otherwise expire on
+            // arrival, cancelling the spot the moment it was given.
+            const deadline = paymentDeadline(120, started, now);
+            expect(deadline.getTime()).toBe(now.getTime() + 120 * 60 * 1000);
+        });
+    });
+
+    describe("Betaling underveis når fristen går ut", () => {
+        integrationTest(
+            "extends the deadline once while a Vipps checkout is still open",
+            async ({ ctx }) => {
+                vi.mocked(vipps.getPaymentDetails).mockResolvedValue({
+                    state: "CREATED",
+                    aggregate: {
+                        authorizedAmount: { currency: "NOK", value: 0 },
+                        capturedAmount: { currency: "NOK", value: 0 },
+                        refundedAmount: { currency: "NOK", value: 0 },
+                        cancelledAmount: { currency: "NOK", value: 0 },
+                    },
+                } as Awaited<ReturnType<typeof vipps.getPaymentDetails>>);
+
+                await ctx.utils.setupEventCategories();
+
+                const event = await ctx.utils.createTestEvent({
+                    capacity: 1,
+                    isPaidEvent: true,
+                    priceMinor: 5000,
+                    paymentGracePeriodMinutes: GRACE_MINUTES,
+                });
+
+                const user = await ctx.utils.createTestUser();
+                await ctx.utils.createPendingRegistration(event.id, user.id);
+                await resolveRegistrationsForEvent(event.id, ctx);
+
+                const payment = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { and, eq }) =>
+                        and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+                });
+
+                // They are in the middle of a checkout when the timer fires.
+                await ctx.db
+                    .update(schema.eventPayment)
+                    .set({
+                        provider: "vipps",
+                        providerPaymentId: "vipps-ref-live",
+                    })
+                    .where(eq(schema.eventPayment.id, payment?.id ?? ""));
+
+                await handlePaymentExpiration(ctx, {
+                    eventId: event.id,
+                    userId: user.id,
+                    paymentId: payment?.id ?? "",
+                });
+
+                // The spot survives, and the extension is recorded.
+                const reg = await ctx.db.query.eventRegistration.findFirst({
+                    where: (r, { and, eq }) =>
+                        and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+                });
+                expect(reg?.status).toBe("registered");
+
+                const extended = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { eq }) => eq(p.id, payment?.id ?? ""),
+                });
+                expect(extended?.status).toBe("pending");
+                expect(extended?.deadlineExtendedAt).not.toBeNull();
+
+                // Fire again, with the checkout still open: the extension is
+                // spent, so this time the spot is reclaimed. That is what stops
+                // a member holding a spot forever by keeping a session alive.
+                await handlePaymentExpiration(ctx, {
+                    eventId: event.id,
+                    userId: user.id,
+                    paymentId: payment?.id ?? "",
+                });
+
+                const afterSecond =
+                    await ctx.db.query.eventRegistration.findFirst({
+                        where: (r, { and, eq }) =>
+                            and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+                    });
+                expect(afterSecond?.status).toBe("cancelled");
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "keeps the spot when Vipps says the payment went through",
+            async ({ ctx }) => {
+                // The webhook is late (or lost). Asking Vipps directly is what
+                // stops a paid member from losing their spot to our own clock.
+                vi.mocked(vipps.getPaymentDetails).mockResolvedValue({
+                    state: "AUTHORIZED",
+                    aggregate: {
+                        authorizedAmount: { currency: "NOK", value: 5000 },
+                        capturedAmount: { currency: "NOK", value: 5000 },
+                        refundedAmount: { currency: "NOK", value: 0 },
+                        cancelledAmount: { currency: "NOK", value: 0 },
+                    },
+                } as Awaited<ReturnType<typeof vipps.getPaymentDetails>>);
+
+                await ctx.utils.setupEventCategories();
+
+                const event = await ctx.utils.createTestEvent({
+                    capacity: 1,
+                    isPaidEvent: true,
+                    priceMinor: 5000,
+                    paymentGracePeriodMinutes: GRACE_MINUTES,
+                });
+
+                const user = await ctx.utils.createTestUser();
+                await ctx.utils.createPendingRegistration(event.id, user.id);
+                await resolveRegistrationsForEvent(event.id, ctx);
+
+                const payment = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { and, eq }) =>
+                        and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+                });
+                await ctx.db
+                    .update(schema.eventPayment)
+                    .set({
+                        provider: "vipps",
+                        providerPaymentId: "vipps-ref-paid-late",
+                    })
+                    .where(eq(schema.eventPayment.id, payment?.id ?? ""));
+
+                await handlePaymentExpiration(ctx, {
+                    eventId: event.id,
+                    userId: user.id,
+                    paymentId: payment?.id ?? "",
+                });
+
+                const reg = await ctx.db.query.eventRegistration.findFirst({
+                    where: (r, { and, eq }) =>
+                        and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+                });
+                expect(reg?.status).toBe("registered");
+
+                const reconciled = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { eq }) => eq(p.id, payment?.id ?? ""),
+                });
+                expect(reconciled?.status).toBe("paid");
+                expect(reconciled?.receivedPaymentAt).not.toBeNull();
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "extends and flags when Vipps cannot be reached",
+            async ({ ctx }) => {
+                vi.mocked(vipps.getPaymentDetails).mockRejectedValue(
+                    new Error("Vipps er nede"),
+                );
+
+                await ctx.utils.setupEventCategories();
+
+                const event = await ctx.utils.createTestEvent({
+                    capacity: 1,
+                    isPaidEvent: true,
+                    priceMinor: 5000,
+                    paymentGracePeriodMinutes: GRACE_MINUTES,
+                });
+
+                const user = await ctx.utils.createTestUser();
+                await ctx.utils.createPendingRegistration(event.id, user.id);
+                await resolveRegistrationsForEvent(event.id, ctx);
+
+                const payment = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { and, eq }) =>
+                        and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+                });
+                await ctx.db
+                    .update(schema.eventPayment)
+                    .set({
+                        provider: "vipps",
+                        providerPaymentId: "vipps-ref-down",
+                    })
+                    .where(eq(schema.eventPayment.id, payment?.id ?? ""));
+
+                await handlePaymentExpiration(ctx, {
+                    eventId: event.id,
+                    userId: user.id,
+                    paymentId: payment?.id ?? "",
+                });
+
+                // Vipps downtime is not the member's fault: the spot stands,
+                // but an organiser is told the outcome rested on a guess.
+                const reg = await ctx.db.query.eventRegistration.findFirst({
+                    where: (r, { and, eq }) =>
+                        and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+                });
+                expect(reg?.status).toBe("registered");
+
+                const flagged = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { eq }) => eq(p.id, payment?.id ?? ""),
+                });
+                expect(flagged?.flag).toBe("provider_unreachable");
+                expect(flagged?.flaggedAt).not.toBeNull();
+                expect(flagged?.deadlineExtendedAt).not.toBeNull();
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "still reclaims the spot when the timer's own payment row already failed",
+            async ({ ctx }) => {
+                /**
+                 * Regression: a member aborts their first checkout (the webhook
+                 * marks that row `failed`) and starts a second one. The timer
+                 * still points at the first row. Idempotency therefore cannot
+                 * key on that row being `pending` — it never is again — or the
+                 * spot is never reclaimed and the member holds it unpaid
+                 * forever. The claim keys on the registration instead.
+                 */
+                vi.mocked(vipps.getPaymentDetails).mockResolvedValue({
+                    state: "ABORTED",
+                    aggregate: {
+                        authorizedAmount: { currency: "NOK", value: 0 },
+                        capturedAmount: { currency: "NOK", value: 0 },
+                        refundedAmount: { currency: "NOK", value: 0 },
+                        cancelledAmount: { currency: "NOK", value: 0 },
+                    },
+                } as Awaited<ReturnType<typeof vipps.getPaymentDetails>>);
+
+                await ctx.utils.setupEventCategories();
+
+                const event = await ctx.utils.createTestEvent({
+                    capacity: 1,
+                    isPaidEvent: true,
+                    priceMinor: 5000,
+                    paymentGracePeriodMinutes: GRACE_MINUTES,
+                });
+
+                const user = await ctx.utils.createTestUser();
+                await ctx.utils.createPendingRegistration(event.id, user.id);
+                await resolveRegistrationsForEvent(event.id, ctx);
+
+                const first = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { and, eq }) =>
+                        and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+                });
+
+                // The abort webhook has already landed on the first attempt.
+                await ctx.db
+                    .update(schema.eventPayment)
+                    .set({
+                        provider: "vipps",
+                        providerPaymentId: "vipps-ref-aborted",
+                        status: "failed",
+                        deadlineExtendedAt: new Date(),
+                    })
+                    .where(eq(schema.eventPayment.id, first?.id ?? ""));
+
+                // A second attempt they also abandoned.
+                await ctx.db.insert(schema.eventPayment).values({
+                    eventId: event.id,
+                    userId: user.id,
+                    amountMinor: 5000,
+                    currency: "NOK",
+                    provider: "vipps",
+                    providerPaymentId: "vipps-ref-abandoned",
+                    status: "pending",
+                });
+
+                await handlePaymentExpiration(ctx, {
+                    eventId: event.id,
+                    userId: user.id,
+                    paymentId: first?.id ?? "",
+                });
+
+                const reg = await ctx.db.query.eventRegistration.findFirst({
+                    where: (r, { and, eq }) =>
+                        and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+                });
+                expect(reg?.status).toBe("cancelled");
+
+                // Both attempts are closed out, so nothing is left pending.
+                const payments = await ctx.db.query.eventPayment.findMany({
+                    where: (p, { and, eq }) =>
+                        and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+                });
+                expect(payments.every((p) => p.status === "failed")).toBe(true);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "judges a member on their newest checkout, not the first one",
+            async ({ ctx }) => {
+                // Abort one checkout, start another: the timer points at the
+                // dead row, but the live attempt is what counts.
+                vi.mocked(vipps.getPaymentDetails).mockImplementation(
+                    async (reference: string) =>
+                        ({
+                            state:
+                                reference === "vipps-ref-second"
+                                    ? "CREATED"
+                                    : "ABORTED",
+                            aggregate: {
+                                authorizedAmount: {
+                                    currency: "NOK",
+                                    value: 0,
+                                },
+                                capturedAmount: { currency: "NOK", value: 0 },
+                                refundedAmount: { currency: "NOK", value: 0 },
+                                cancelledAmount: { currency: "NOK", value: 0 },
+                            },
+                        }) as Awaited<
+                            ReturnType<typeof vipps.getPaymentDetails>
+                        >,
+                );
+
+                await ctx.utils.setupEventCategories();
+
+                const event = await ctx.utils.createTestEvent({
+                    capacity: 1,
+                    isPaidEvent: true,
+                    priceMinor: 5000,
+                    paymentGracePeriodMinutes: GRACE_MINUTES,
+                });
+
+                const user = await ctx.utils.createTestUser();
+                await ctx.utils.createPendingRegistration(event.id, user.id);
+                await resolveRegistrationsForEvent(event.id, ctx);
+
+                const first = await ctx.db.query.eventPayment.findFirst({
+                    where: (p, { and, eq }) =>
+                        and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+                });
+                await ctx.db
+                    .update(schema.eventPayment)
+                    .set({
+                        provider: "vipps",
+                        providerPaymentId: "vipps-ref-first",
+                    })
+                    .where(eq(schema.eventPayment.id, first?.id ?? ""));
+
+                // A second attempt, as the checkout route creates after an
+                // aborted one.
+                await ctx.db.insert(schema.eventPayment).values({
+                    eventId: event.id,
+                    userId: user.id,
+                    amountMinor: 5000,
+                    currency: "NOK",
+                    provider: "vipps",
+                    providerPaymentId: "vipps-ref-second",
+                    status: "pending",
+                });
+
+                await handlePaymentExpiration(ctx, {
+                    eventId: event.id,
+                    userId: user.id,
+                    paymentId: first?.id ?? "",
+                });
+
+                const reg = await ctx.db.query.eventRegistration.findFirst({
+                    where: (r, { and, eq }) =>
+                        and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+                });
+                expect(reg?.status).toBe("registered");
             },
             500_000,
         );

--- a/apps/api/src/test/event/payment-review.test.ts
+++ b/apps/api/src/test/event/payment-review.test.ts
@@ -1,0 +1,219 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import {
+    notifyOrganizersOfPaymentsWithoutSpot,
+    reviewPaymentsForStartedEvents,
+} from "~/lib/event/payment-review";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * A member displaced by a prioritised registration keeps their payment on
+ * purpose — it is what lets them take a spot back without paying again. That
+ * reason expires when the event starts, but the refund itself stays a decision
+ * for the arranging group. These tests pin down that somebody is actually asked
+ * to make it.
+ */
+describe("Betalinger uten plass — varsel til arrangør", () => {
+    integrationTest(
+        "tells the organiser group's leaders who paid without holding a spot",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.setupGroups();
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 1,
+                isPaidEvent: true,
+                priceMinor: 7500,
+                organizerGroupSlug: "index",
+                start: new Date(Date.now() - 60 * 1000),
+                end: new Date(Date.now() + 60 * 60 * 1000),
+            });
+
+            const leader = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.groupMembership).values({
+                userId: leader.id,
+                groupSlug: "index",
+                role: "leader",
+            });
+
+            // Paid, but pushed onto the waiting list.
+            const displaced = await ctx.auth.api.createUser({
+                body: {
+                    email: "displaced@test.com",
+                    name: "Fortrengt Medlem",
+                    password: "test123!",
+                },
+            });
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: displaced.user.id,
+                status: "waitlisted",
+                waitlistPosition: 1,
+            });
+            await ctx.db.insert(schema.eventPayment).values({
+                eventId: event.id,
+                userId: displaced.user.id,
+                amountMinor: 7500,
+                currency: "NOK",
+                provider: "vipps",
+                providerPaymentId: "vipps-displaced",
+                status: "paid",
+                receivedPaymentAt: new Date(),
+            });
+
+            // Paid and holds the spot — must not be reported.
+            const attending = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: attending.id,
+                status: "registered",
+            });
+            await ctx.db.insert(schema.eventPayment).values({
+                eventId: event.id,
+                userId: attending.id,
+                amountMinor: 7500,
+                currency: "NOK",
+                provider: "vipps",
+                providerPaymentId: "vipps-attending",
+                status: "paid",
+                receivedPaymentAt: new Date(),
+            });
+
+            const notified = await notifyOrganizersOfPaymentsWithoutSpot(
+                event.id,
+                ctx,
+            );
+            expect(notified).toBe(1);
+
+            const notifications = await ctx.db.query.notification.findMany({
+                where: (n, { eq }) => eq(n.userId, leader.id),
+            });
+            expect(notifications).toHaveLength(1);
+            expect(notifications[0]?.description).toContain("Fortrengt Medlem");
+            expect(notifications[0]?.description).not.toContain(attending.name);
+
+            // Claimed, so a second sweep sends nothing.
+            const again = await notifyOrganizersOfPaymentsWithoutSpot(
+                event.id,
+                ctx,
+            );
+            expect(again).toBeNull();
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "also reports someone who paid and then left the event",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.setupGroups();
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 5,
+                isPaidEvent: true,
+                priceMinor: 5000,
+                organizerGroupSlug: "index",
+                start: new Date(Date.now() - 60 * 1000),
+                end: new Date(Date.now() + 60 * 60 * 1000),
+            });
+
+            const leader = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.groupMembership).values({
+                userId: leader.id,
+                groupSlug: "index",
+                role: "leader",
+            });
+
+            const gone = await ctx.auth.api.createUser({
+                body: {
+                    email: "gone@test.com",
+                    name: "Avmeldt Medlem",
+                    password: "test123!",
+                },
+            });
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: gone.user.id,
+                status: "cancelled",
+            });
+            await ctx.db.insert(schema.eventPayment).values({
+                eventId: event.id,
+                userId: gone.user.id,
+                amountMinor: 5000,
+                currency: "NOK",
+                provider: "vipps",
+                providerPaymentId: "vipps-gone",
+                status: "paid",
+                receivedPaymentAt: new Date(),
+            });
+
+            await reviewPaymentsForStartedEvents(ctx);
+
+            const notifications = await ctx.db.query.notification.findMany({
+                where: (n, { eq }) => eq(n.userId, leader.id),
+            });
+            expect(notifications).toHaveLength(1);
+            expect(notifications[0]?.description).toContain("Avmeldt Medlem");
+
+            const marked = await ctx.db.query.event.findFirst({
+                where: eq(schema.event.id, event.id),
+            });
+            expect(marked?.paymentReviewNotifiedAt).not.toBeNull();
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "says nothing when every payment belongs to someone with a spot",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            await ctx.utils.setupGroups();
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 5,
+                isPaidEvent: true,
+                priceMinor: 5000,
+                organizerGroupSlug: "index",
+                start: new Date(Date.now() - 60 * 1000),
+                end: new Date(Date.now() + 60 * 60 * 1000),
+            });
+
+            const leader = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.groupMembership).values({
+                userId: leader.id,
+                groupSlug: "index",
+                role: "leader",
+            });
+
+            const attending = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: attending.id,
+                status: "registered",
+            });
+            await ctx.db.insert(schema.eventPayment).values({
+                eventId: event.id,
+                userId: attending.id,
+                amountMinor: 5000,
+                currency: "NOK",
+                provider: "vipps",
+                providerPaymentId: "vipps-ok",
+                status: "paid",
+                receivedPaymentAt: new Date(),
+            });
+
+            const notified = await notifyOrganizersOfPaymentsWithoutSpot(
+                event.id,
+                ctx,
+            );
+            expect(notified).toBe(0);
+
+            const notifications = await ctx.db.query.notification.findMany({
+                where: (n, { eq }) => eq(n.userId, leader.id),
+            });
+            expect(notifications).toHaveLength(0);
+        },
+        500_000,
+    );
+});

--- a/apps/api/src/test/event/webhook-capture.test.ts
+++ b/apps/api/src/test/event/webhook-capture.test.ts
@@ -171,6 +171,70 @@ describe("Vipps webhook — capture and status mapping", () => {
     );
 
     integrationTest(
+        "flags a payment that lands on a registration without a spot",
+        async ({ ctx }) => {
+            /**
+             * Money can arrive after the spot is gone: a checkout finished just
+             * after the deadline reclaimed it, or in another tab after the
+             * member unregistered. Nothing is refunded automatically — that is
+             * an organiser's call — but it must not pass in silence.
+             */
+            const { event, user, payment } = await seedPayment(ctx);
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: user.id,
+                status: "cancelled",
+            });
+            mockVippsState("AUTHORIZED", {
+                authorized: 10000,
+                captured: 10000,
+                refunded: 0,
+            });
+
+            const client = ctx.utils.client();
+            await client.api.event.payment.webhook.$post({
+                json: { reference: "vipps-hook-ref" },
+            });
+
+            const row = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { eq }) => eq(p.id, payment.id),
+            });
+            expect(row?.status).toBe("paid");
+            expect(row?.flag).toBe("paid_without_spot");
+            expect(row?.flaggedAt).not.toBeNull();
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "leaves a payment unflagged when the member holds their spot",
+        async ({ ctx }) => {
+            const { event, user, payment } = await seedPayment(ctx);
+            await ctx.db.insert(schema.eventRegistration).values({
+                eventId: event.id,
+                userId: user.id,
+                status: "registered",
+            });
+            mockVippsState("AUTHORIZED", {
+                authorized: 10000,
+                captured: 10000,
+                refunded: 0,
+            });
+
+            const client = ctx.utils.client();
+            await client.api.event.payment.webhook.$post({
+                json: { reference: "vipps-hook-ref" },
+            });
+
+            const row = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { eq }) => eq(p.id, payment.id),
+            });
+            expect(row?.flag).toBeNull();
+        },
+        500_000,
+    );
+
+    integrationTest(
         "marks an aborted payment as failed",
         async ({ ctx }) => {
             const { payment } = await seedPayment(ctx);

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -12,6 +12,7 @@ import {
     CircleCheckBigIcon,
     ExternalLink,
     PlusIcon,
+    TriangleAlertIcon,
     UsersIcon,
     WalletIcon,
     XCircle,
@@ -1039,6 +1040,29 @@ function PaymentStatusBadge({ status }: { status: string }) {
     );
 }
 
+const PAYMENT_FLAG_LABELS: Record<string, string> = {
+    provider_unreachable: "Vipps svarte ikke",
+    paid_without_spot: "Betalt uten plass",
+};
+
+const PAYMENT_FLAG_HINTS: Record<string, string> = {
+    provider_unreachable:
+        "Betalingsfristen gikk ut mens Vipps ikke kunne nås. Sjekk i Vipps om betalingen faktisk gikk gjennom.",
+    paid_without_spot:
+        "Betalingen gikk gjennom, men personen har ikke plass på arrangementet. Vurder om den skal refunderes.",
+};
+
+function PaymentFlagBadge({ flag }: { flag: string }) {
+    return (
+        <Badge
+            variant="destructive"
+            title={PAYMENT_FLAG_HINTS[flag] ?? undefined}
+        >
+            {PAYMENT_FLAG_LABELS[flag] ?? flag}
+        </Badge>
+    );
+}
+
 function PaymentsTab({ eventId }: { eventId: string }) {
     const { data } = useSuspenseQuery(getEventPaymentsQuery(eventId, 0));
     const canRefund = useAnyScopePermission(["events:payments:refund"]);
@@ -1077,6 +1101,20 @@ function PaymentsTab({ eventId }: { eventId: string }) {
                 />
             </div>
 
+            {data.summary.flaggedCount > 0 ? (
+                <Card className="border-destructive/50">
+                    <CardContent className="flex items-center gap-3 py-4 text-sm">
+                        <TriangleAlertIcon className="size-4 shrink-0 text-destructive" />
+                        <span>
+                            {data.summary.flaggedCount === 1
+                                ? "1 betaling trenger gjennomgang."
+                                : `${data.summary.flaggedCount} betalinger trenger gjennomgang.`}{" "}
+                            Se merkelappene i tabellen under.
+                        </span>
+                    </CardContent>
+                </Card>
+            ) : null}
+
             <Card>
                 <CardContent className="p-0">
                     <Table>
@@ -1101,9 +1139,16 @@ function PaymentsTab({ eventId }: { eventId: string }) {
                                         {formatAmount(payment.amountMinor)}
                                     </TableCell>
                                     <TableCell>
-                                        <PaymentStatusBadge
-                                            status={payment.status}
-                                        />
+                                        <div className="flex flex-wrap items-center gap-1">
+                                            <PaymentStatusBadge
+                                                status={payment.status}
+                                            />
+                                            {payment.flag ? (
+                                                <PaymentFlagBadge
+                                                    flag={payment.flag}
+                                                />
+                                            ) : null}
+                                        </div>
                                     </TableCell>
                                     <TableCell>
                                         {payment.receivedPaymentAt

--- a/packages/db/drizzle/0065_volatile_moondragon.sql
+++ b/packages/db/drizzle/0065_volatile_moondragon.sql
@@ -1,0 +1,6 @@
+CREATE TYPE "public"."event_payment_flag" AS ENUM('provider_unreachable', 'paid_without_spot');--> statement-breakpoint
+ALTER TABLE "event_event" ALTER COLUMN "payment_grace_period_minutes" SET DEFAULT 120;--> statement-breakpoint
+ALTER TABLE "event_event" ADD COLUMN "payment_review_notified_at" timestamp;--> statement-breakpoint
+ALTER TABLE "event_payment" ADD COLUMN "deadline_extended_at" timestamp;--> statement-breakpoint
+ALTER TABLE "event_payment" ADD COLUMN "flag" "event_payment_flag";--> statement-breakpoint
+ALTER TABLE "event_payment" ADD COLUMN "flagged_at" timestamp;

--- a/packages/db/drizzle/meta/0065_snapshot.json
+++ b/packages/db/drizzle/meta/0065_snapshot.json
@@ -1,0 +1,7507 @@
+{
+  "id": "d912495f-eddb-42c2-9874-5bc937042ac0",
+  "prevId": "d0eb73d8-12d7-42f1-917f-2c63b9e1260b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apikey_api_key": {
+      "name": "apikey_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_api_key_created_by_user_id_auth_user_id_fk": {
+          "name": "apikey_api_key_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "apikey_api_key",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "apikey_api_key_key_hash_unique": {
+          "name": "apikey_api_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "application_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "submitted_by_id": {
+          "name": "submitted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_asset_key": {
+          "name": "pdf_asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_comment": {
+          "name": "internal_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled_by_id": {
+          "name": "handled_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled_at": {
+          "name": "handled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_submitted_by_id_created_at_index": {
+          "name": "application_submitted_by_id_created_at_index",
+          "columns": [
+            {
+              "expression": "submitted_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_type_status_created_at_index": {
+          "name": "application_type_status_created_at_index",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_submitted_by_id_auth_user_id_fk": {
+          "name": "application_submitted_by_id_auth_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "submitted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_handled_by_id_auth_user_id_fk": {
+          "name": "application_handled_by_id_auth_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "handled_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_attachment": {
+      "name": "application_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "application_attachment_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_attachment_application_id_index": {
+          "name": "application_attachment_application_id_index",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_attachment_application_id_application_id_fk": {
+          "name": "application_attachment_application_id_application_id_fk",
+          "tableFrom": "application_attachment",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_company_contact": {
+      "name": "application_company_contact",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semesters": {
+          "name": "semesters",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_company_contact_application_id_application_id_fk": {
+          "name": "application_company_contact_application_id_application_id_fk",
+          "tableFrom": "application_company_contact",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_expense": {
+      "name": "application_expense",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cc_email": {
+          "name": "cc_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_nok": {
+          "name": "amount_nok",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expense_date": {
+          "name": "expense_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_type": {
+          "name": "budget_type",
+          "type": "application_budget_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_expense_application_id_application_id_fk": {
+          "name": "application_expense_application_id_application_id_fk",
+          "tableFrom": "application_expense",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_expense_group_slug_org_group_slug_fk": {
+          "name": "application_expense_group_slug_org_group_slug_fk",
+          "tableFrom": "application_expense",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_hs_case": {
+      "name": "application_hs_case",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_name": {
+          "name": "case_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_type": {
+          "name": "case_type",
+          "type": "application_case_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_hs_case_application_id_application_id_fk": {
+          "name": "application_hs_case_application_id_application_id_fk",
+          "tableFrom": "application_hs_case",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_support": {
+      "name": "application_support",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_description": {
+          "name": "event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_nok": {
+          "name": "total_amount_nok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_link": {
+          "name": "budget_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_support_application_id_application_id_fk": {
+          "name": "application_support_application_id_application_id_fk",
+          "tableFrom": "application_support",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_support_group_slug_org_group_slug_fk": {
+          "name": "application_support_group_slug_org_group_slug_fk",
+          "tableFrom": "application_support",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_file": {
+      "name": "asset_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "asset_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_file_uploaded_by_id_auth_user_id_fk": {
+          "name": "asset_file_uploaded_by_id_auth_user_id_fk",
+          "tableFrom": "asset_file",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_file_key_unique": {
+          "name": "asset_file_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_source": {
+          "name": "password_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_session_id_auth_session_id_fk": {
+          "name": "auth_oauth_access_token_session_id_auth_session_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_refresh_id_auth_oauth_refresh_token_id_fk": {
+          "name": "auth_oauth_access_token_refresh_id_auth_oauth_refresh_token_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_token_unique": {
+          "name": "auth_oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_client": {
+      "name": "auth_oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_client_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_client_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_client",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_client_client_id_unique": {
+          "name": "auth_oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_refresh_token": {
+      "name": "auth_oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_refresh_token_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_refresh_token_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_refresh_token_session_id_auth_session_id_fk": {
+          "name": "auth_oauth_refresh_token_session_id_auth_session_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_refresh_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_refresh_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_refresh_token_token_unique": {
+          "name": "auth_oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_session_token_unique": {
+          "name": "auth_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_approvalStatus_idx": {
+          "name": "user_approvalStatus_idx",
+          "columns": [
+            {
+              "expression": "approval_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_user_email_unique": {
+          "name": "auth_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "auth_user_username_unique": {
+          "name": "auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banner_banner": {
+      "name": "banner_banner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_text": {
+          "name": "link_text",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_from": {
+          "name": "visible_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visible_until": {
+          "name": "visible_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banner_banner_created_by_user_id_auth_user_id_fk": {
+          "name": "banner_banner_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "banner_banner",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_event": {
+      "name": "event_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lat": {
+          "name": "location_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lng": {
+          "name": "location_lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_waitlist": {
+          "name": "allow_waitlist",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "contact_person_id": {
+          "name": "contact_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_by_user_id": {
+          "name": "update_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_start": {
+          "name": "registration_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_end": {
+          "name": "registration_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_deadline": {
+          "name": "cancellation_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_registration_closed": {
+          "name": "is_registration_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_paid_event": {
+          "name": "is_paid_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_signing_up": {
+          "name": "requires_signing_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_grace_period_minutes": {
+          "name": "payment_grace_period_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 120
+        },
+        "reactions_allowed": {
+          "name": "reactions_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizer_group_slug": {
+          "name": "organizer_group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforces_previous_strikes": {
+          "name": "enforces_previous_strikes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_cause_strikes": {
+          "name": "can_cause_strikes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "no_show_processed_at": {
+          "name": "no_show_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_reminder_sent_at": {
+          "name": "registration_reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_review_notified_at": {
+          "name": "payment_review_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_allow_prioritized": {
+          "name": "only_allow_prioritized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restricted_to_institute_id": {
+          "name": "restricted_to_institute_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "event_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_event_category_slug_event_category_slug_fk": {
+          "name": "event_event_category_slug_event_category_slug_fk",
+          "tableFrom": "event_event",
+          "tableTo": "event_category",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_event_contact_person_id_auth_user_id_fk": {
+          "name": "event_event_contact_person_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "contact_person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_created_by_user_id_auth_user_id_fk": {
+          "name": "event_event_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_update_by_user_id_auth_user_id_fk": {
+          "name": "event_event_update_by_user_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "update_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_organizer_group_slug_org_group_slug_fk": {
+          "name": "event_event_organizer_group_slug_org_group_slug_fk",
+          "tableFrom": "event_event",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "organizer_group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_restricted_to_institute_id_org_institute_id_fk": {
+          "name": "event_event_restricted_to_institute_id_org_institute_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "org_institute",
+          "columnsFrom": [
+            "restricted_to_institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_event_slug_unique": {
+          "name": "event_event_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_category": {
+      "name": "event_category",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_favorite": {
+      "name": "event_favorite",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_favorite_user_id_auth_user_id_fk": {
+          "name": "event_favorite_user_id_auth_user_id_fk",
+          "tableFrom": "event_favorite",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_favorite_event_id_event_event_id_fk": {
+          "name": "event_favorite_event_id_event_event_id_fk",
+          "tableFrom": "event_favorite",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_favorite_user_id_event_id_pk": {
+          "name": "event_favorite_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_feedback": {
+      "name": "event_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_feedback_event_id_event_event_id_fk": {
+          "name": "event_feedback_event_id_event_event_id_fk",
+          "tableFrom": "event_feedback",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_feedback_user_id_auth_user_id_fk": {
+          "name": "event_feedback_user_id_auth_user_id_fk",
+          "tableFrom": "event_feedback",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_payment": {
+      "name": "event_payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOK'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_payment_id": {
+          "name": "provider_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "received_payment_at": {
+          "name": "received_payment_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_extended_at": {
+          "name": "deadline_extended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flag": {
+          "name": "flag",
+          "type": "event_payment_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagged_at": {
+          "name": "flagged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_event_id_user_id_idx": {
+          "name": "payment_event_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_payment_event_id_event_event_id_fk": {
+          "name": "event_payment_event_id_event_event_id_fk",
+          "tableFrom": "event_payment",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_payment_user_id_auth_user_id_fk": {
+          "name": "event_payment_user_id_auth_user_id_fk",
+          "tableFrom": "event_payment",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_pool": {
+      "name": "event_priority_pool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_year": {
+          "name": "class_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "priority_pool_event_id_idx": {
+          "name": "priority_pool_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_priority_pool_event_id_event_event_id_fk": {
+          "name": "event_priority_pool_event_id_event_event_id_fk",
+          "tableFrom": "event_priority_pool",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_priority_pool_group_slug_org_group_slug_fk": {
+          "name": "event_priority_pool_group_slug_org_group_slug_fk",
+          "tableFrom": "event_priority_pool",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "priority_pool_not_empty": {
+          "name": "priority_pool_not_empty",
+          "value": "\"event_priority_pool\".\"group_slug\" is not null or \"event_priority_pool\".\"class_year\" is not null"
+        },
+        "priority_pool_class_year_range": {
+          "name": "priority_pool_class_year_range",
+          "value": "\"event_priority_pool\".\"class_year\" is null or \"event_priority_pool\".\"class_year\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_priority_pool_group": {
+      "name": "event_priority_pool_group",
+      "schema": "",
+      "columns": {
+        "priority_pool_id": {
+          "name": "priority_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_pool_group_priority_pool_id_event_priority_pool_id_fk": {
+          "name": "event_priority_pool_group_priority_pool_id_event_priority_pool_id_fk",
+          "tableFrom": "event_priority_pool_group",
+          "tableTo": "event_priority_pool",
+          "columnsFrom": [
+            "priority_pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_priority_pool_group_group_slug_org_group_slug_fk": {
+          "name": "event_priority_pool_group_group_slug_org_group_slug_fk",
+          "tableFrom": "event_priority_pool_group",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_priority_pool_group_priority_pool_id_group_slug_pk": {
+          "name": "event_priority_pool_group_priority_pool_id_group_slug_pk",
+          "columns": [
+            "priority_pool_id",
+            "group_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_user": {
+      "name": "event_priority_user",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_user_event_id_event_event_id_fk": {
+          "name": "event_priority_user_event_id_event_event_id_fk",
+          "tableFrom": "event_priority_user",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_priority_user_user_id_auth_user_id_fk": {
+          "name": "event_priority_user_user_id_auth_user_id_fk",
+          "tableFrom": "event_priority_user",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_priority_user_event_id_user_id_pk": {
+          "name": "event_priority_user_event_id_user_id_pk",
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reaction": {
+      "name": "event_reaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reaction_event_id_idx": {
+          "name": "reaction_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_reaction_user_id_auth_user_id_fk": {
+          "name": "event_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "event_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reaction_event_id_event_event_id_fk": {
+          "name": "event_reaction_event_id_event_event_id_fk",
+          "tableFrom": "event_reaction",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_reaction_user_id_event_id_pk": {
+          "name": "event_reaction_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_registration": {
+      "name": "event_registration",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "waitlist_position": {
+          "name": "waitlist_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended_at": {
+          "name": "attended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_photo": {
+          "name": "allow_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "registration_event_id_status_idx": {
+          "name": "registration_event_id_status_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "registration_pending_idx": {
+          "name": "registration_pending_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"event_registration\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_registration_event_id_event_event_id_fk": {
+          "name": "event_registration_event_id_event_event_id_fk",
+          "tableFrom": "event_registration",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_registration_user_id_auth_user_id_fk": {
+          "name": "event_registration_user_id_auth_user_id_fk",
+          "tableFrom": "event_registration",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_registration_user_id_event_id_pk": {
+          "name": "event_registration_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_strike": {
+      "name": "event_strike",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_strike_event_id_event_event_id_fk": {
+          "name": "event_strike_event_id_event_event_id_fk",
+          "tableFrom": "event_strike",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_strike_user_id_auth_user_id_fk": {
+          "name": "event_strike_user_id_auth_user_id_fk",
+          "tableFrom": "event_strike",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_item": {
+      "name": "feedback_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "feedback_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_item_created_at_idx": {
+          "name": "feedback_item_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_item_author_id_auth_user_id_fk": {
+          "name": "feedback_item_author_id_auth_user_id_fk",
+          "tableFrom": "feedback_item",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_vote": {
+      "name": "feedback_vote",
+      "schema": "",
+      "columns": {
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "feedback_vote_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_vote_feedback_id_feedback_item_id_fk": {
+          "name": "feedback_vote_feedback_id_feedback_item_id_fk",
+          "tableFrom": "feedback_vote",
+          "tableTo": "feedback_item",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_vote_user_id_auth_user_id_fk": {
+          "name": "feedback_vote_user_id_auth_user_id_fk",
+          "tableFrom": "feedback_vote",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_vote_feedback_id_user_id_pk": {
+          "name": "feedback_vote_feedback_id_user_id_pk",
+          "columns": [
+            "feedback_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_form": {
+      "name": "form_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_answer": {
+      "name": "form_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_text": {
+          "name": "answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_answer_submission_id_form_submission_id_fk": {
+          "name": "form_answer_submission_id_form_submission_id_fk",
+          "tableFrom": "form_answer",
+          "tableTo": "form_submission",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_answer_field_id_form_field_id_fk": {
+          "name": "form_answer_field_id_form_field_id_fk",
+          "tableFrom": "form_answer",
+          "tableTo": "form_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_answer_option": {
+      "name": "form_answer_option",
+      "schema": "",
+      "columns": {
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "answer_option_answer_id_idx": {
+          "name": "answer_option_answer_id_idx",
+          "columns": [
+            {
+              "expression": "answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_answer_option_answer_id_form_answer_id_fk": {
+          "name": "form_answer_option_answer_id_form_answer_id_fk",
+          "tableFrom": "form_answer_option",
+          "tableTo": "form_answer",
+          "columnsFrom": [
+            "answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_answer_option_option_id_form_option_id_fk": {
+          "name": "form_answer_option_option_id_form_option_id_fk",
+          "tableFrom": "form_answer_option",
+          "tableTo": "form_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_event_form": {
+      "name": "form_event_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_event_form_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_event_form_form_id_form_form_id_fk": {
+          "name": "form_event_form_form_id_form_form_id_fk",
+          "tableFrom": "form_event_form",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_event_form_event_id_event_event_id_fk": {
+          "name": "form_event_form_event_id_event_event_id_fk",
+          "tableFrom": "form_event_form",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_type": {
+          "name": "unique_event_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_field": {
+      "name": "form_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_field_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_field_form_id_form_form_id_fk": {
+          "name": "form_field_form_id_form_form_id_fk",
+          "tableFrom": "form_field",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_group_form": {
+      "name": "form_group_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_receiver_on_submit": {
+          "name": "email_receiver_on_submit",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_submit_multiple": {
+          "name": "can_submit_multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_open_for_submissions": {
+          "name": "is_open_for_submissions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "opens_at": {
+          "name": "opens_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_for_group_members": {
+          "name": "only_for_group_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_group_form_form_id_form_form_id_fk": {
+          "name": "form_group_form_form_id_form_form_id_fk",
+          "tableFrom": "form_group_form",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_group_form_group_slug_org_group_slug_fk": {
+          "name": "form_group_form_group_slug_org_group_slug_fk",
+          "tableFrom": "form_group_form",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_form": {
+          "name": "unique_group_form",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "group_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_option": {
+      "name": "form_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_option_field_id_form_field_id_fk": {
+          "name": "form_option_field_id_form_field_id_fk",
+          "tableFrom": "form_option",
+          "tableTo": "form_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_submission": {
+      "name": "form_submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_submission_form_id_form_form_id_fk": {
+          "name": "form_submission_form_id_form_form_id_fk",
+          "tableFrom": "form_submission",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_submission_user_id_auth_user_id_fk": {
+          "name": "form_submission_user_id_auth_user_id_fk",
+          "tableFrom": "form_submission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gallery_album": {
+      "name": "gallery_album",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gallery_album_event_id_event_event_id_fk": {
+          "name": "gallery_album_event_id_event_event_id_fk",
+          "tableFrom": "gallery_album",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gallery_album_created_by_user_id_auth_user_id_fk": {
+          "name": "gallery_album_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "gallery_album",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gallery_album_slug_unique": {
+          "name": "gallery_album_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gallery_picture": {
+      "name": "gallery_picture",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gallery_picture_album_id_idx": {
+          "name": "gallery_picture_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gallery_picture_album_id_gallery_album_id_fk": {
+          "name": "gallery_picture_album_id_gallery_album_id_fk",
+          "tableFrom": "gallery_picture",
+          "tableTo": "gallery_album",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_contract": {
+      "name": "org_contract",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signature_placement": {
+          "name": "signature_placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_placement": {
+          "name": "name_placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_contract_created_by_user_id_auth_user_id_fk": {
+          "name": "org_contract_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_contract",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_contract_signature": {
+      "name": "org_contract_signature",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signed_name": {
+          "name": "signed_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_pdf_key": {
+          "name": "signed_pdf_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_pdf_hash": {
+          "name": "signed_pdf_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_file_key": {
+          "name": "signature_file_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signer_ip": {
+          "name": "signer_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer_ua": {
+          "name": "signer_ua",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contract_signature_unique_idx": {
+          "name": "contract_signature_unique_idx",
+          "columns": [
+            {
+              "expression": "contract_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_contract_signature_contract_id_org_contract_id_fk": {
+          "name": "org_contract_signature_contract_id_org_contract_id_fk",
+          "tableFrom": "org_contract_signature",
+          "tableTo": "org_contract",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_contract_signature_user_id_auth_user_id_fk": {
+          "name": "org_contract_signature_user_id_auth_user_id_fk",
+          "tableFrom": "org_contract_signature",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_fine": {
+      "name": "org_fine",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "law_id": {
+          "name": "law_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defense": {
+          "name": "defense",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "org_fine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fine_group_slug_user_id_idx": {
+          "name": "fine_group_slug_user_id_idx",
+          "columns": [
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_fine_user_id_auth_user_id_fk": {
+          "name": "org_fine_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_fine_group_slug_org_group_slug_fk": {
+          "name": "org_fine_group_slug_org_group_slug_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_fine_law_id_org_group_law_id_fk": {
+          "name": "org_fine_law_id_org_group_law_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "org_group_law",
+          "columnsFrom": [
+            "law_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_fine_created_by_user_id_auth_user_id_fk": {
+          "name": "org_fine_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_fine_approved_by_user_id_auth_user_id_fk": {
+          "name": "org_fine_approved_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group": {
+      "name": "org_group",
+      "schema": "",
+      "columns": {
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fine_info": {
+          "name": "fine_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fines_activated": {
+          "name": "fines_activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fines_admin_id": {
+          "name": "fines_admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leader_permissions": {
+          "name": "leader_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "leader_global_permissions": {
+          "name": "leader_global_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "leader_title": {
+          "name": "leader_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_permissions": {
+          "name": "member_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "member_global_permissions": {
+          "name": "member_global_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "contract_signing_required": {
+          "name": "contract_signing_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "institute_id": {
+          "name": "institute_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_fines_admin_id_auth_user_id_fk": {
+          "name": "org_group_fines_admin_id_auth_user_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "fines_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_group_institute_id_org_institute_id_fk": {
+          "name": "org_group_institute_id_org_institute_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "org_institute",
+          "columnsFrom": [
+            "institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_law": {
+      "name": "org_group_law",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paragraph": {
+          "name": "paragraph",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_law_group_slug_org_group_slug_fk": {
+          "name": "org_group_law_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_law",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_membership": {
+      "name": "org_group_membership",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_group_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_membership_group_slug_idx": {
+          "name": "group_membership_group_slug_idx",
+          "columns": [
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_group_membership_user_id_auth_user_id_fk": {
+          "name": "org_group_membership_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_membership_group_slug_org_group_slug_fk": {
+          "name": "org_group_membership_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_membership",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_group_membership_user_id_group_slug_pk": {
+          "name": "org_group_membership_user_id_group_slug_pk",
+          "columns": [
+            "user_id",
+            "group_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_membership_history": {
+      "name": "org_group_membership_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_membership_history_group_slug_idx": {
+          "name": "group_membership_history_group_slug_idx",
+          "columns": [
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_membership_history_user_id_idx": {
+          "name": "group_membership_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_membership_history_stint_idx": {
+          "name": "group_membership_history_stint_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_group_membership_history_user_id_auth_user_id_fk": {
+          "name": "org_group_membership_history_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_membership_history",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_membership_history_group_slug_org_group_slug_fk": {
+          "name": "org_group_membership_history_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_membership_history",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_position": {
+      "name": "org_group_position",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "org_group_position_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'group'"
+        },
+        "linked_group_slug": {
+          "name": "linked_group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_position_group_slug_org_group_slug_fk": {
+          "name": "org_group_position_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_position",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_linked_group_slug_org_group_slug_fk": {
+          "name": "org_group_position_linked_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_position",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "linked_group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_position_holder": {
+      "name": "org_group_position_holder",
+      "schema": "",
+      "columns": {
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_position_holder_position_id_org_group_position_id_fk": {
+          "name": "org_group_position_holder_position_id_org_group_position_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "org_group_position",
+          "columnsFrom": [
+            "position_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_holder_user_id_auth_user_id_fk": {
+          "name": "org_group_position_holder_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_holder_granted_by_auth_user_id_fk": {
+          "name": "org_group_position_holder_granted_by_auth_user_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_institute": {
+      "name": "org_institute",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_institute_slug_unique": {
+          "name": "org_institute_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_study_program": {
+      "name": "org_study_program",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feide_code": {
+          "name": "feide_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "org_study_program_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_study_program_slug_unique": {
+          "name": "org_study_program_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "org_study_program_feide_code_unique": {
+          "name": "org_study_program_feide_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feide_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_study_program_membership": {
+      "name": "org_study_program_membership",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_program_id": {
+          "name": "study_program_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_year_source": {
+          "name": "start_year_source",
+          "type": "org_study_year_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_campus": {
+          "name": "confirmed_campus",
+          "type": "org_campus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feide_active": {
+          "name": "feide_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feide_checked_at": {
+          "name": "feide_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_study_program_membership_user_id_auth_user_id_fk": {
+          "name": "org_study_program_membership_user_id_auth_user_id_fk",
+          "tableFrom": "org_study_program_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_study_program_membership_study_program_id_org_study_program_id_fk": {
+          "name": "org_study_program_membership_study_program_id_org_study_program_id_fk",
+          "tableFrom": "org_study_program_membership",
+          "tableTo": "org_study_program",
+          "columnsFrom": [
+            "study_program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_study_program_membership_user_id_study_program_id_pk": {
+          "name": "org_study_program_membership_user_id_study_program_id_pk",
+          "columns": [
+            "user_id",
+            "study_program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_role": {
+      "name": "rbac_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rbac_role_name_unique": {
+          "name": "rbac_role_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_user_permission": {
+      "name": "rbac_user_permission",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'*'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rbac_user_permission_user_id_auth_user_id_fk": {
+          "name": "rbac_user_permission_user_id_auth_user_id_fk",
+          "tableFrom": "rbac_user_permission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_user_permission_granted_by_auth_user_id_fk": {
+          "name": "rbac_user_permission_granted_by_auth_user_id_fk",
+          "tableFrom": "rbac_user_permission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rbac_user_permission_user_id_permission_scope_pk": {
+          "name": "rbac_user_permission_user_id_permission_scope_pk",
+          "columns": [
+            "user_id",
+            "permission",
+            "scope"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_user_role": {
+      "name": "rbac_user_role",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rbac_user_role_user_id_auth_user_id_fk": {
+          "name": "rbac_user_role_user_id_auth_user_id_fk",
+          "tableFrom": "rbac_user_role",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_user_role_role_id_rbac_role_id_fk": {
+          "name": "rbac_user_role_role_id_rbac_role_id_fk",
+          "tableFrom": "rbac_user_role",
+          "tableTo": "rbac_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rbac_user_role_user_id_role_id_pk": {
+          "name": "rbac_user_role_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_notification": {
+      "name": "notification_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_id_created_at_idx": {
+          "name": "notification_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_notification_user_id_auth_user_id_fk": {
+          "name": "notification_notification_user_id_auth_user_id_fk",
+          "tableFrom": "notification_notification",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_device": {
+      "name": "notification_device",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_device_userId_idx": {
+          "name": "notification_device_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_device_user_id_auth_user_id_fk": {
+          "name": "notification_device_user_id_auth_user_id_fk",
+          "tableFrom": "notification_device",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_device_token_unique": {
+          "name": "notification_device_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_news": {
+      "name": "news_news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emojis_allowed": {
+          "name": "emojis_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_news_created_by_user_id_auth_user_id_fk": {
+          "name": "news_news_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "news_news",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_reaction": {
+      "name": "news_reaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "news_id": {
+          "name": "news_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_reaction_user_id_auth_user_id_fk": {
+          "name": "news_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "news_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "news_reaction_news_id_news_news_id_fk": {
+          "name": "news_reaction_news_id_news_news_id_fk",
+          "tableFrom": "news_reaction",
+          "tableTo": "news_news",
+          "columnsFrom": [
+            "news_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "news_reaction_user_id_news_id_pk": {
+          "name": "news_reaction_user_id_news_id_pk",
+          "columns": [
+            "user_id",
+            "news_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_job_post": {
+      "name": "job_job_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingress": {
+          "name": "ingress",
+          "type": "varchar(800)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_continuously_hiring": {
+          "name": "is_continuously_hiring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_start": {
+          "name": "class_start",
+          "type": "user_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'first'"
+        },
+        "class_end": {
+          "name": "class_end",
+          "type": "user_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fifth'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_job_post_created_by_user_id_auth_user_id_fk": {
+          "name": "job_job_post_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "job_job_post",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_allergy": {
+      "name": "user_allergy",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_user_setting_allergy": {
+      "name": "user_user_setting_allergy",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergy_slug": {
+          "name": "allergy_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_user_setting_allergy_user_id_user_settings_user_id_fk": {
+          "name": "user_user_setting_allergy_user_id_user_settings_user_id_fk",
+          "tableFrom": "user_user_setting_allergy",
+          "tableTo": "user_settings",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_user_setting_allergy_allergy_slug_user_allergy_slug_fk": {
+          "name": "user_user_setting_allergy_allergy_slug_user_allergy_slug_fk",
+          "tableFrom": "user_user_setting_allergy",
+          "tableTo": "user_allergy",
+          "columnsFrom": [
+            "allergy_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_user_setting_allergy_user_id_allergy_slug_pk": {
+          "name": "user_user_setting_allergy_user_id_allergy_slug_pk",
+          "columns": [
+            "user_id",
+            "allergy_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_calendar_token": {
+      "name": "user_calendar_token",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_calendar_token_user_id_auth_user_id_fk": {
+          "name": "user_calendar_token_user_id_auth_user_id_fk",
+          "tableFrom": "user_calendar_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_calendar_token_token_unique": {
+          "name": "user_calendar_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "user_gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allows_photos_by_default": {
+          "name": "allows_photos_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_event_rules": {
+          "name": "accepts_event_rules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_description": {
+          "name": "bio_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_mail_communication": {
+          "name": "receive_mail_communication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_event_registrations": {
+          "name": "public_event_registrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_onboarded": {
+          "name": "is_onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_auth_user_id_fk": {
+          "name": "user_settings_user_id_auth_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.toddel_issue": {
+      "name": "toddel_issue",
+      "schema": "",
+      "columns": {
+        "edition": {
+          "name": "edition",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qrcode_qr_code": {
+      "name": "qrcode_qr_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "qrcode_qr_code_user_id_auth_user_id_fk": {
+          "name": "qrcode_qr_code_user_id_auth_user_id_fk",
+          "tableFrom": "qrcode_qr_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_event": {
+      "name": "motetid_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_mode": {
+          "name": "date_mode",
+          "type": "motetid_date_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DATES'"
+        },
+        "dates": {
+          "name": "dates",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_duration": {
+          "name": "slot_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "motetid_event_created_by_id_index": {
+          "name": "motetid_event_created_by_id_index",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_event_created_by_id_auth_user_id_fk": {
+          "name": "motetid_event_created_by_id_auth_user_id_fk",
+          "tableFrom": "motetid_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "motetid_event_slug_unique": {
+          "name": "motetid_event_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_google_credential": {
+      "name": "motetid_google_credential",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "motetid_google_credential_user_id_auth_user_id_fk": {
+          "name": "motetid_google_credential_user_id_auth_user_id_fk",
+          "tableFrom": "motetid_google_credential",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_participant": {
+      "name": "motetid_participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "motetid_participant_event_id_user_id_index": {
+          "name": "motetid_participant_event_id_user_id_index",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "motetid_participant_user_id_index": {
+          "name": "motetid_participant_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_participant_event_id_motetid_event_id_fk": {
+          "name": "motetid_participant_event_id_motetid_event_id_fk",
+          "tableFrom": "motetid_participant",
+          "tableTo": "motetid_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "motetid_participant_user_id_auth_user_id_fk": {
+          "name": "motetid_participant_user_id_auth_user_id_fk",
+          "tableFrom": "motetid_participant",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_slot": {
+      "name": "motetid_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "motetid_slot_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "motetid_slot_participant_id_date_time_index": {
+          "name": "motetid_slot_participant_id_date_time_index",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "motetid_slot_event_id_date_time_index": {
+          "name": "motetid_slot_event_id_date_time_index",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_slot_participant_id_motetid_participant_id_fk": {
+          "name": "motetid_slot_participant_id_motetid_participant_id_fk",
+          "tableFrom": "motetid_slot",
+          "tableTo": "motetid_participant",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "motetid_slot_event_id_motetid_event_id_fk": {
+          "name": "motetid_slot_event_id_motetid_event_id_fk",
+          "tableFrom": "motetid_slot",
+          "tableTo": "motetid_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.application_attachment_kind": {
+      "name": "application_attachment_kind",
+      "schema": "public",
+      "values": [
+        "receipt",
+        "budget",
+        "attachment"
+      ]
+    },
+    "public.application_budget_type": {
+      "name": "application_budget_type",
+      "schema": "public",
+      "values": [
+        "social_budget",
+        "group_budget",
+        "approved_hs_application",
+        "approved_idkom_application"
+      ]
+    },
+    "public.application_case_type": {
+      "name": "application_case_type",
+      "schema": "public",
+      "values": [
+        "discussion",
+        "decision",
+        "orientation"
+      ]
+    },
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "in_progress",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.application_type": {
+      "name": "application_type",
+      "schema": "public",
+      "values": [
+        "expense",
+        "support",
+        "sports_support",
+        "hs_case",
+        "company_contact"
+      ]
+    },
+    "public.asset_status": {
+      "name": "asset_status",
+      "schema": "public",
+      "values": [
+        "staged",
+        "ready"
+      ]
+    },
+    "public.asset_visibility": {
+      "name": "asset_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "private"
+      ]
+    },
+    "public.event_visibility": {
+      "name": "event_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "members"
+      ]
+    },
+    "public.event_payment_flag": {
+      "name": "event_payment_flag",
+      "schema": "public",
+      "values": [
+        "provider_unreachable",
+        "paid_without_spot"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "refunded",
+        "failed"
+      ]
+    },
+    "public.event_registration_status": {
+      "name": "event_registration_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "waitlisted",
+        "cancelled",
+        "attended",
+        "no_show",
+        "pending"
+      ]
+    },
+    "public.feedback_status": {
+      "name": "feedback_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "in_progress",
+        "closed",
+        "rejected"
+      ]
+    },
+    "public.feedback_type": {
+      "name": "feedback_type",
+      "schema": "public",
+      "values": [
+        "idea",
+        "bug"
+      ]
+    },
+    "public.feedback_vote_value": {
+      "name": "feedback_vote_value",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    },
+    "public.form_event_form_type": {
+      "name": "form_event_form_type",
+      "schema": "public",
+      "values": [
+        "survey",
+        "evaluation"
+      ]
+    },
+    "public.form_field_type": {
+      "name": "form_field_type",
+      "schema": "public",
+      "values": [
+        "text_answer",
+        "multiple_select",
+        "single_select"
+      ]
+    },
+    "public.org_campus": {
+      "name": "org_campus",
+      "schema": "public",
+      "values": [
+        "trondheim",
+        "gjovik",
+        "alesund"
+      ]
+    },
+    "public.org_fine_status": {
+      "name": "org_fine_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "paid",
+        "rejected"
+      ]
+    },
+    "public.org_group_membership_role": {
+      "name": "org_group_membership_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "leader"
+      ]
+    },
+    "public.org_group_position_scope": {
+      "name": "org_group_position_scope",
+      "schema": "public",
+      "values": [
+        "group",
+        "global"
+      ]
+    },
+    "public.org_group_type": {
+      "name": "org_group_type",
+      "schema": "public",
+      "values": [
+        "studyyear",
+        "interestgroup",
+        "committee",
+        "study",
+        "private",
+        "board",
+        "subgroup",
+        "tihlde"
+      ]
+    },
+    "public.org_study_program_type": {
+      "name": "org_study_program_type",
+      "schema": "public",
+      "values": [
+        "bachelor",
+        "master"
+      ]
+    },
+    "public.org_study_year_source": {
+      "name": "org_study_year_source",
+      "schema": "public",
+      "values": [
+        "feide",
+        "assumed",
+        "manual",
+        "migrated"
+      ]
+    },
+    "public.job_type": {
+      "name": "job_type",
+      "schema": "public",
+      "values": [
+        "full_time",
+        "part_time",
+        "summer_job",
+        "other"
+      ]
+    },
+    "public.user_class": {
+      "name": "user_class",
+      "schema": "public",
+      "values": [
+        "first",
+        "second",
+        "third",
+        "fourth",
+        "fifth",
+        "alumni"
+      ]
+    },
+    "public.user_gender": {
+      "name": "user_gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other"
+      ]
+    },
+    "public.motetid_date_mode": {
+      "name": "motetid_date_mode",
+      "schema": "public",
+      "values": [
+        "DATES",
+        "WEEKDAYS"
+      ]
+    },
+    "public.motetid_slot_status": {
+      "name": "motetid_slot_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "IF_NEEDED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1787058913437,
       "tag": "0064_common_korvac",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1787073981391,
+      "tag": "0065_volatile_moondragon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/event.ts
+++ b/packages/db/src/schema/event.ts
@@ -56,6 +56,24 @@ export const paymentStatus = pgEnum("event_payment_status", [
 
 export type PaymentStatus = (typeof paymentStatus)["enumValues"][number];
 
+/**
+ * Why a payment needs a human to look at it. Both cases mean money and
+ * registration have drifted apart in a way the system cannot resolve on its
+ * own, so they are surfaced to organisers rather than only logged.
+ *
+ * - `provider_unreachable`: the deadline fell due while Vipps could not be
+ *   reached, so "unpaid" was a guess rather than an answer.
+ * - `paid_without_spot`: the payment completed for someone who no longer holds
+ *   a spot — a checkout that landed after the deadline, or after the member
+ *   unregistered.
+ */
+export const paymentFlag = pgEnum("event_payment_flag", [
+    "provider_unreachable",
+    "paid_without_spot",
+]);
+
+export type PaymentFlag = (typeof paymentFlag)["enumValues"][number];
+
 export const eventVisibilityVariants = [
     // Visible to everyone, including logged-out visitors
     "public",
@@ -111,8 +129,14 @@ export const event = pgTable("event", {
     isPaidEvent: boolean("is_paid_event").default(false).notNull(),
     requiresSigningUp: boolean("requires_signing_up").default(false).notNull(),
     priceMinor: integer("price"),
-    // The time between sign up and it must be paid
-    paymentGracePeriodMinutes: integer("payment_grace_period_minutes"),
+    /**
+     * The time between signing up and the payment falling due. Events that do
+     * not set their own get 120 minutes — the two hours Lepton's organisers
+     * settled on.
+     */
+    paymentGracePeriodMinutes: integer("payment_grace_period_minutes").default(
+        120,
+    ),
     reactionsAllowed: boolean("reactions_allowed").default(true).notNull(),
     organizerGroupSlug: varchar("organizer_group_slug", {
         length: 128,
@@ -136,6 +160,12 @@ export const event = pgTable("event", {
      * is moved, so a rescheduled opening gets its own reminder.
      */
     registrationReminderSentAt: timestamp("registration_reminder_sent_at"),
+    /**
+     * Set once organisers have been told, at the event's start, who paid
+     * without holding a spot. Idempotency marker so the review notice is sent
+     * at most once per event.
+     */
+    paymentReviewNotifiedAt: timestamp("payment_review_notified_at"),
     /** Only members covered by a priority pool may register. */
     onlyAllowPrioritized: boolean("only_allow_prioritized")
         .default(false)
@@ -296,6 +326,17 @@ export const eventPayment = pgTable(
          * this time.
          */
         expiresAt: timestamp("expires_at"),
+        /**
+         * Set when the one — and only — deadline extension has been spent on
+         * this obligation, because a live Vipps checkout (or an unreachable
+         * Vipps) was found at the deadline. A second extension is never
+         * granted, so chained checkouts cannot hold a spot indefinitely.
+         */
+        deadlineExtendedAt: timestamp("deadline_extended_at"),
+        /** Why this payment needs an organiser's attention, if it does. */
+        flag: paymentFlag("flag"),
+        /** When {@link flag} was raised. */
+        flaggedAt: timestamp("flagged_at"),
         ...timestamps,
     },
     (t) => [

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -4079,6 +4079,9 @@ export interface components {
             status: "pending" | "paid" | "refunded" | "failed";
             receivedPaymentAt: string | null;
             expiresAt: string | null;
+            /** @description Set when this payment needs an organiser to look at it: 'provider_unreachable' means the deadline fell due while Vipps could not be reached, 'paid_without_spot' means the payment completed for someone who no longer holds a spot. */
+            flag: ("provider_unreachable" | "paid_without_spot") | null;
+            flaggedAt: string | null;
             /** Format: date-time */
             createdAt: string;
         };
@@ -4099,6 +4102,8 @@ export interface components {
                 failedCount: number;
                 /** @description Sum of all completed (paid) payments, in minor units */
                 totalPaidMinor: number;
+                /** @description Payments that need an organiser to look at them */
+                flaggedCount: number;
             };
         };
         RefundEventPayment: {


### PR DESCRIPTION
## Hva

Betalingsfristen på arrangementer håndhevet ikke det den skulle, og fortrengte medlemmer fikk pengene tilbake på et tidspunkt som gjorde det dyrt for dem å få plassen igjen.

### Frister — som i Lepton

| Situasjon | Frist |
|---|---|
| Direkte påmelding | Arrangementets egen `paymentGracePeriodMinutes`, default **120 min** |
| Opprykk fra venteliste | **12 timer**, fast |

Et opprykk kan lande midt på natten, og da skal ikke plassen ryke fordi du sov. Fristen kappes alltid mot arrangementsstart — et ubetalt opprykk tre timer før dørene åpner ville ellers holdt en plass gjennom hele arrangementet. Arrangementer som allerede har startet får ukappet frist, ellers ville forpliktelsen utløpt i samme øyeblikk den ble laget.

### Ved utløp spørres Vipps først

Som Leptons `reconcile_orders_from_vipps`:

- **Betalt**, uansett hvor sen webhooken var → plassen står, og betalingen bokføres.
- **Levende checkout**, eller **Vipps svarer ikke** → én utsettelse, aldri to. Vipps lukker en ubrukt sesjon etter ti minutter, og én-gangs-regelen hindrer at kjedede checkouts holder en plass i det uendelige. Vipps-nedetid flagges uansett utfall.
- **Ellers** → registreringen **kanselleres** (ikke venteliste, som i Lepton), førstemann på ventelisten rykker opp. Den avmeldte kan melde seg på igjen fritt, uten begrensning.

Alle Vipps-kall ligger utenfor transaksjoner.

### Fortrengning: betalingen står

Et medlem som fortrenges av en prioritert påmelding beholder betalingen. Refusjon der ville betydd å betale på nytt — og kappløp med en ny frist — hvis en plass blir ledig. Rykker de inn igjen får de verken ny forpliktelse eller ny frist.

> Uten den sjekken ville de fått en frist de umulig kan innfri, siden betalingsruta svarer 409 «har allerede betalt», og blitt kastet ut av plassen de nettopp fikk tilbake. Det var en garantert bug i dagens kode gitt den nye regelen.

Pengene refunderes manuelt. Arrangørene varsles ved arrangementsstart om alle som har betalt uten å ha plass — både ventelistede og avmeldte.

### Sikkerhetsnett

Betaling som lander på en kansellert registrering flagges `paid_without_spot` i stedet for å passere i stillhet. Ventelistede flagges bevisst ikke: det er den tiltenkte tilstanden, ikke et avvik.

Admin-panelet viser flaggene i betalingstabellen med forklaring, og et varselkort når noe trenger gjennomgang.

## Verdt å se på i review

Transaksjonen som frigjør plassen låser på **registreringen**, ikke på betalingsraden. Første forsøk: jeg låste på betalingen, som ga en ekte bug — avbryter du første checkout er den raden allerede `failed`, låsen treffer aldri, og plassen ble aldri frigjort. Medlemmet ville holdt en ubetalt plass i evighet. Regresjonstesten `still reclaims the spot when the timer's own payment row already failed` er verifisert mot den gamle varianten og feiler der.

## Migrasjon

`0065_volatile_moondragon.sql` — ny enum `event_payment_flag`, tre kolonner på `event_payment` (`deadline_extended_at`, `flag`, `flagged_at`), `payment_review_notified_at` på `event_event`, og default 120 på `payment_grace_period_minutes`. Ikke kjørt mot noen database ennå.

## Testing

- `bun run typecheck` 9/9, `bun run build` 4/4, `bun run lint` rent
- `bun run test` — 683 API-tester + 15 UI-tester grønne
- Ny dekning: utsettelse brukes én gang, Vipps sier betalt, Vipps nede flagges, nyeste checkout teller, 12t-frist ved opprykk, kapping ved start, betaling beholdes ved fortrengning, ingen ny frist ved opprykk, arrangørvarsel, webhook-flagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)