### PR TITLE
feat(arrangement): tell ned betalingsfristen og bekreft betalingen ved retur fra Vipps

### DIFF
--- a/apps/api/src/lib/event/payment.ts
+++ b/apps/api/src/lib/event/payment.ts
@@ -480,6 +480,62 @@ async function reconcileWithProvider(
 }
 
 /**
+ * What a member's own "did my payment go through?" check found.
+ *
+ * `none` means there is nothing outstanding to confirm — either the member
+ * never started a checkout, or the payment is already settled in our own rows.
+ */
+export type PaymentConfirmation = "paid" | "pending" | "failed" | "none";
+
+/**
+ * Ask Vipps about *this* member's outstanding checkout, and record the payment
+ * if it went through.
+ *
+ * The webhook is the normal path to `paid`, but Vipps sends the member back to
+ * us the instant they confirm in the app — often before the webhook has landed.
+ * Without this the page they return to still says "venter på betaling", and the
+ * only way out was to reload until the webhook happened to arrive.
+ *
+ * Reads from the provider rather than our own row, for the same reason
+ * [reconcileWithProvider] does: a late or lost webhook must not decide whether
+ * a member has their spot.
+ *
+ * **Never call this inside a transaction** — it talks to Vipps.
+ */
+export async function confirmPaymentForUser(
+    ctx: AppContext,
+    { eventId, userId }: { eventId: string; userId: string },
+): Promise<PaymentConfirmation> {
+    const payments = await ctx.db.query.eventPayment.findMany({
+        where: (payment, { and, eq }) =>
+            and(eq(payment.eventId, eventId), eq(payment.userId, userId)),
+    });
+
+    // The webhook may already have settled it while the member was on their way
+    // back. Then there is nothing to ask about — our own row is the answer.
+    if (payments.some((payment) => payment.status === "paid")) return "paid";
+
+    const started = payments.find(
+        (payment) => payment.status === "pending" && payment.providerPaymentId,
+    );
+    if (!started) return "none";
+
+    const verdict = await reconcileWithProvider(ctx, started);
+
+    switch (verdict) {
+        case "paid":
+            return "paid";
+        case "dead":
+            return "failed";
+        // A checkout that is still open, or a Vipps we could not reach. Both
+        // mean "ask again in a moment" — neither is a verdict to show a member.
+        case "live":
+        case "unknown":
+            return "pending";
+    }
+}
+
+/**
  * Grant this registration its single deadline extension: push the obligation's
  * deadline out and re-arm the countdown.
  *

--- a/apps/api/src/routes/event/index.ts
+++ b/apps/api/src/routes/event/index.ts
@@ -9,6 +9,7 @@ import { getEventFormRoute } from "./form/get";
 import { listEventFormsRoute } from "./form/list";
 import { getRoute } from "./get";
 import { listRoute } from "./list";
+import { confirmPaymentRoute } from "./payment/confirm";
 import { createPaymentRoute } from "./payment/create";
 import { listEventPaymentsRoute } from "./payment/list";
 import { refundEventPaymentRoute } from "./payment/refund";
@@ -57,6 +58,7 @@ export const eventRoutes = route()
 
     // Payment
     .route("/", createPaymentRoute)
+    .route("/", confirmPaymentRoute)
     .route("/", listEventPaymentsRoute)
     .route("/", refundEventPaymentRoute)
     .route("/", paymentWebhookRoute)

--- a/apps/api/src/routes/event/payment/confirm.ts
+++ b/apps/api/src/routes/event/payment/confirm.ts
@@ -1,0 +1,58 @@
+import { HTTPException } from "hono/http-exception";
+import { confirmPaymentForUser } from "~/lib/event/payment";
+import { describeRoute } from "~/lib/openapi";
+import { route } from "~/lib/route";
+import { requireAuth } from "~/middleware/auth";
+import { confirmPaymentResponseSchema } from "../schema";
+
+/**
+ * "Did my payment go through?", asked by the member who just came back from
+ * Vipps.
+ *
+ * Vipps returns the member to the event page the moment they confirm, which is
+ * regularly before the webhook has reached us. Until this route existed the
+ * page they landed on still said "venter på betaling", and the only way out was
+ * to reload until the webhook happened to arrive.
+ *
+ * The route only ever looks at the caller's own payment, so it cannot be used
+ * to poke at anybody else's.
+ */
+export const confirmPaymentRoute = route().post(
+    "/:eventId/payment/confirm",
+    describeRoute({
+        tags: ["events", "payments"],
+        summary: "Confirm own payment for event",
+        operationId: "confirmEventPayment",
+        description:
+            "Asks the payment provider what happened to the caller's outstanding checkout for this event, and records a completed payment. Meant for the moment the member returns from Vipps, before the webhook has arrived.",
+    })
+        .schemaResponse({
+            statusCode: 200,
+            schema: confirmPaymentResponseSchema,
+            description: "The provider's answer for the caller's checkout",
+        })
+        .notFound({ description: "Event not found" })
+        .build(),
+    requireAuth,
+    async (c) => {
+        const eventId = c.req.param("eventId");
+        const user = c.get("user");
+        const ctx = c.get("ctx");
+
+        const event = await ctx.db.query.event.findFirst({
+            columns: { id: true },
+            where: (event, { eq }) => eq(event.id, eventId),
+        });
+
+        if (!event) {
+            throw new HTTPException(404, { message: "Event not found" });
+        }
+
+        const status = await confirmPaymentForUser(ctx, {
+            eventId,
+            userId: user.id,
+        });
+
+        return c.json({ status }, 200);
+    },
+);

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -1184,6 +1184,16 @@ export const refundEventPaymentResponseSchema = Schema(
     }),
 );
 
+export const confirmPaymentResponseSchema = Schema(
+    "ConfirmPaymentResponse",
+    z.object({
+        status: z.enum(["paid", "pending", "failed", "none"]).meta({
+            description:
+                "What the payment provider says about the caller's outstanding checkout. 'pending' means the checkout is still open or the provider could not be reached — ask again shortly. 'none' means there is nothing outstanding to confirm.",
+        }),
+    }),
+);
+
 export const createPaymentResponseSchema = Schema(
     "CreatePaymentResponse",
     z.object({

--- a/apps/api/src/test/event/payment-confirm.test.ts
+++ b/apps/api/src/test/event/payment-confirm.test.ts
@@ -1,0 +1,214 @@
+import { schema } from "@photon/db";
+import { beforeEach, describe, expect, vi } from "vitest";
+import * as vipps from "~/lib/vipps";
+import type { IntegrationTestContext } from "~/test/config/integration";
+import { integrationTest } from "~/test/config/integration";
+
+// The confirmation asks Vipps what happened; stub the whole module. Every
+// export the app imports must be present here — this factory *replaces* the
+// module.
+vi.mock("~/lib/vipps", () => ({
+    buildPaymentDescription: vi.fn(() => "Test - Arrangement"),
+    cancelPayment: vi.fn().mockResolvedValue(undefined),
+    capturePayment: vi.fn().mockResolvedValue(undefined),
+    createPayment: vi.fn(),
+    getPaymentDetails: vi.fn(),
+    refundPayment: vi.fn().mockResolvedValue(undefined),
+    setupWebhooks: vi.fn(),
+    verifyVippsWebhookRequest: vi.fn(),
+}));
+
+const NO_AMOUNTS = {
+    authorizedAmount: { currency: "NOK", value: 0 },
+    capturedAmount: { currency: "NOK", value: 0 },
+    refundedAmount: { currency: "NOK", value: 0 },
+    cancelledAmount: { currency: "NOK", value: 0 },
+};
+
+/** Make the provider report the checkout in a given state. */
+function mockVippsState(
+    state: "CREATED" | "ABORTED" | "AUTHORIZED" | "EXPIRED",
+    amounts: Partial<typeof NO_AMOUNTS> = {},
+) {
+    vi.mocked(vipps.getPaymentDetails).mockResolvedValue({
+        state,
+        aggregate: { ...NO_AMOUNTS, ...amounts },
+    } as unknown as Awaited<ReturnType<typeof vipps.getPaymentDetails>>);
+}
+
+/**
+ * A member who is registered for a paid event and has been sent to Vipps —
+ * the state they are in the moment Vipps sends them back to us.
+ */
+async function seedCheckout(
+    ctx: IntegrationTestContext,
+    payment: Partial<{
+        status: "pending" | "paid";
+        providerPaymentId: string;
+    }> = {},
+) {
+    await ctx.utils.setupEventCategories();
+    const event = await ctx.utils.createTestEvent({
+        capacity: 10,
+        isPaidEvent: true,
+        priceMinor: 10000,
+    });
+    const user = await ctx.utils.createTestUser();
+
+    await ctx.db.insert(schema.eventRegistration).values({
+        eventId: event.id,
+        userId: user.id,
+        status: "registered",
+    });
+
+    await ctx.db.insert(schema.eventPayment).values({
+        eventId: event.id,
+        userId: user.id,
+        amountMinor: 10000,
+        currency: "NOK",
+        provider: "vipps",
+        providerPaymentId: payment.providerPaymentId ?? "vipps-ref-returning",
+        status: payment.status ?? "pending",
+        expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+    });
+
+    return { event, user };
+}
+
+beforeEach(() => {
+    vi.mocked(vipps.capturePayment).mockClear();
+    vi.mocked(vipps.getPaymentDetails).mockClear();
+});
+
+describe("Confirming a payment on the way back from Vipps", () => {
+    integrationTest(
+        "records the payment the webhook has not delivered yet",
+        async ({ ctx }) => {
+            const { event, user } = await seedCheckout(ctx);
+            mockVippsState("AUTHORIZED");
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[
+                ":eventId"
+            ].payment.confirm.$post({ param: { eventId: event.id } });
+
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual({ status: "paid" });
+
+            // AUTHORIZED only reserves the money, so confirming must capture it
+            // — otherwise "paid" would mean a reservation that quietly expires.
+            expect(vi.mocked(vipps.capturePayment)).toHaveBeenCalledWith({
+                reference: "vipps-ref-returning",
+                amount: 10000,
+                currency: "NOK",
+            });
+
+            const rows = await ctx.db.query.eventPayment.findMany({
+                where: (p, { eq }) => eq(p.eventId, event.id),
+            });
+            expect(rows[0]?.status).toBe("paid");
+            expect(rows[0]?.receivedPaymentAt).not.toBeNull();
+
+            // And the event now tells the member they have their spot.
+            const eventRes = await client.api.event[":eventId"].$get({
+                param: { eventId: event.id },
+            });
+            const body = await eventRes.json();
+            // 404-svaret er en streng, så smalne typen inn før feltet leses.
+            if (typeof body === "string") throw new Error(body);
+            expect(body.registration?.hasPaid).toBe(true);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "answers 'pending' while the checkout is still open, without touching the payment",
+        async ({ ctx }) => {
+            const { event, user } = await seedCheckout(ctx);
+            mockVippsState("CREATED");
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[
+                ":eventId"
+            ].payment.confirm.$post({ param: { eventId: event.id } });
+
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual({ status: "pending" });
+
+            const rows = await ctx.db.query.eventPayment.findMany({
+                where: (p, { eq }) => eq(p.eventId, event.id),
+            });
+            expect(rows[0]?.status).toBe("pending");
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "answers 'pending' when Vipps cannot be reached, so the member is asked to wait rather than told it failed",
+        async ({ ctx }) => {
+            const { event, user } = await seedCheckout(ctx);
+            vi.mocked(vipps.getPaymentDetails).mockRejectedValue(
+                new Error("Vipps is down"),
+            );
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[
+                ":eventId"
+            ].payment.confirm.$post({ param: { eventId: event.id } });
+
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual({ status: "pending" });
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "answers 'failed' for a checkout the member aborted",
+        async ({ ctx }) => {
+            const { event, user } = await seedCheckout(ctx);
+            mockVippsState("ABORTED");
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[
+                ":eventId"
+            ].payment.confirm.$post({ param: { eventId: event.id } });
+
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual({ status: "failed" });
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "does not ask Vipps again about a payment the webhook already settled",
+        async ({ ctx }) => {
+            const { event, user } = await seedCheckout(ctx, { status: "paid" });
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[
+                ":eventId"
+            ].payment.confirm.$post({ param: { eventId: event.id } });
+
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual({ status: "paid" });
+            expect(vi.mocked(vipps.getPaymentDetails)).not.toHaveBeenCalled();
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "requires a login",
+        async ({ ctx }) => {
+            const { event } = await seedCheckout(ctx);
+
+            const res = await ctx.utils
+                .client()
+                .api.event[":eventId"].payment.confirm.$post({
+                    param: { eventId: event.id },
+                });
+
+            expect(res.status).toBe(401);
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/api/queries/events.ts
+++ b/apps/kvark/src/api/queries/events.ts
@@ -374,6 +374,18 @@ export const createEventPaymentMutation = mutationOptions({
         }),
 });
 
+/**
+ * «Gikk betalingen min gjennom?», stilt av medlemmet som nettopp kom tilbake
+ * fra Vipps. API-et spør Vipps direkte, så svaret er ikke avhengig av at
+ * webhooken har rukket fram.
+ */
+export const confirmEventPaymentMutation = mutationOptions({
+    mutationFn: ({ eventId }: { eventId: string }) =>
+        apiClient.post("/api/event/{eventId}/payment/confirm", {
+            params: { eventId },
+        }),
+});
+
 type PaymentListFilters = Omit<
     QueryParamsHelper<"get", "/api/event/{eventId}/payments">,
     "page" | "pageSize"

--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -39,6 +39,21 @@ type EventRegistrationCardProps = {
      */
     hasPaid?: boolean;
     paymentDeadline?: EventDeadline;
+    /**
+     * «9:32», «0:14» — tida medlemmet har igjen på å betale, som teller ned
+     * mens sida står åpen.
+     * Betalingsvinduet er kort, så en frist på klokka sier lite: det som
+     * betyr noe er hvor lenge det er til plassen gis videre. Satt til
+     * `null` når fristen allerede har gått ut.
+     */
+    paymentExpiresInLabel?: string | null;
+    /**
+     * Satt mens vi spør Vipps om betalingen som nettopp ble gjennomført.
+     * Da forsvinner både betalings- og avmeldingsknappen: betalingen er ute
+     * av medlemmets hender, og et nytt trykk ville enten startet en betaling
+     * til, eller meldt av en plass de akkurat har betalt for.
+     */
+    isConfirmingPayment?: boolean;
     capacity: number | null;
     registeredCount: number;
     waitlistCount: number;
@@ -236,14 +251,20 @@ function getStateRendering(
             };
 
         case "awaiting-payment":
+            if (props.isConfirmingPayment) {
+                return {
+                    icon: Hourglass,
+                    message: "Bekrefter betalingen …",
+                    secondary: "Vi venter på svar fra Vipps.",
+                };
+            }
+
             return {
                 icon: CreditCard,
                 message: "Plass reservert — venter på betaling",
                 // Uten frist står plassen til arrangøren rydder opp. Da er det
                 // riktigere å si ingenting enn å dikte opp en frist.
-                secondary: props.paymentDeadline
-                    ? `Betal innen ${props.paymentDeadline.day} kl. ${props.paymentDeadline.time}, ellers gis plassen videre.`
-                    : null,
+                secondary: paymentDeadlineText(props),
                 actions: (
                     <>
                         <VippsButton
@@ -344,6 +365,27 @@ function getStateRendering(
             return _exhaustive;
         }
     }
+}
+
+/**
+ * Fristteksten under «Plass reservert — venter på betaling».
+ *
+ * Nedtellingen står først: vinduet er på minutter, og da er «7:31 igjen» det
+ * medlemmet trenger å vite. Klokkeslettet blir stående ved siden av, så
+ * fristen er til å planlegge etter når det er lenge igjen.
+ */
+function paymentDeadlineText(props: EventRegistrationCardProps): string | null {
+    if (!props.paymentDeadline) return null;
+    // Nedtellingen kan ha passert fristen før serveren har rukket å gi plassen
+    // videre. Da er «betal innen 0 sekunder» feil — plassen er ute av
+    // medlemmets hender, og det eneste ærlige er å si det.
+    if (props.paymentExpiresInLabel === null) {
+        return "Betalingsfristen er gått ut. Plassen kan ha gått videre til neste på ventelista.";
+    }
+    if (!props.paymentExpiresInLabel) {
+        return `Betal innen ${props.paymentDeadline.day} kl. ${props.paymentDeadline.time}, ellers gis plassen videre.`;
+    }
+    return `${props.paymentExpiresInLabel} igjen å betale (innen kl. ${props.paymentDeadline.time}), ellers gis plassen videre.`;
 }
 
 type TimelinePoint = {

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -266,6 +266,33 @@ export function formatTimeUntil(iso: string, now: Date = new Date()): string {
 }
 
 /**
+ * "9:32", "0:14" — tida igjen på en frist som løper mens medlemmet ser på.
+ *
+ * `formatTimeUntil` runder til nærmeste enhet, så «2 minutter» blir stående i
+ * et helt minutt. Det duger til påmeldinger som åpner om dager, men en
+ * betalingsfrist på et kvarter må synlig løpe: sekundene er hele poenget med
+ * at den teller ned. Over en time faller vi tilbake på den grove teksten —
+ * «58:12» sier mindre enn «en time».
+ *
+ * Returnerer `null` når fristen er passert.
+ */
+export function formatCountdown(
+    iso: string,
+    now: Date = new Date(),
+): string | null {
+    const remainingMs = new Date(iso).getTime() - now.getTime();
+    if (Number.isNaN(remainingMs) || remainingMs <= 0) return null;
+    if (remainingMs >= 60 * 60 * 1000) return formatTimeUntil(iso, now);
+
+    // Rundes opp: med 200 ms igjen står det «0:01» og ikke «0:00», som ville
+    // sagt at fristen var ute mens den fortsatt løp.
+    const totalSeconds = Math.ceil(remainingMs / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+/**
  * Combined date + time label for cards, e.g. "tor. 30. apr. 2026, 12:00".
  */
 export function formatEventDateTime(iso: string): string {

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
     useInfiniteQuery,
@@ -26,6 +26,7 @@ import {
 
 import { authQueryOptions } from "#/api/auth";
 import {
+    confirmEventPaymentMutation,
     createEventPaymentMutation,
     getEventByIdQuery,
     getEventRegistrationsInfiniteQuery,
@@ -55,6 +56,7 @@ import { buildGoogleCalendarUrl } from "#/lib/calendar-url";
 import { buildMapsUrls } from "#/lib/maps";
 import {
     deriveRegistrationState,
+    formatCountdown,
     formatTimeUntil,
     toEventDeadline,
     formatEventDate,
@@ -65,6 +67,47 @@ import {
     registrationPollInterval,
     TICKET_RESALE_GROUP_URL,
 } from "#/lib/event";
+
+/**
+ * Merket vi henger på `returnUrl` når medlemmet sendes til Vipps, så sida
+ * kjenner igjen at den er kommet tilbake derfra.
+ */
+const VIPPS_RETURN_PARAM = "betaling";
+
+/** Adressa Vipps skal sende medlemmet tilbake til — denne sida, merket. */
+function vippsReturnUrl(): string {
+    const url = new URL(window.location.href);
+    url.searchParams.set(VIPPS_RETURN_PARAM, "vipps");
+    return url.toString();
+}
+
+/**
+ * Sier fra om vi nettopp kom tilbake fra Vipps — én gang. Merket fjernes fra
+ * adressa med det samme: det hører til turen, ikke til sida, og skal ikke bli
+ * med videre i en bokmerket lenke eller en oppfriskning.
+ */
+function consumeVippsReturn(): boolean {
+    if (typeof window === "undefined") return false;
+
+    const url = new URL(window.location.href);
+    if (url.searchParams.get(VIPPS_RETURN_PARAM) !== "vipps") return false;
+
+    url.searchParams.delete(VIPPS_RETURN_PARAM);
+    window.history.replaceState(
+        null,
+        "",
+        `${url.pathname}${url.search}${url.hash}`,
+    );
+    return true;
+}
+
+/**
+ * Hvor mange ganger vi spør Vipps før vi gir opp, og hvor lenge vi venter
+ * mellom forsøkene. Et svar kommer normalt på første forsøk; resten er til for
+ * de gangene medlemmet er raskere tilbake enn Vipps rekker å bli ferdig.
+ */
+const PAYMENT_CONFIRM_ATTEMPTS = 6;
+const PAYMENT_CONFIRM_RETRY_MS = 2_000;
 
 export const Route = createFileRoute("/_app/arrangementer/$slug")({
     component: EventDetailPage,
@@ -132,6 +175,7 @@ function EventDetailPage() {
     const registerMutation = useMutation(registerForEventMutation);
     const unregisterMutation = useMutation(unregisterFromEventMutation);
     const payMutation = useMutation(createEventPaymentMutation);
+    const confirmPaymentMutation = useMutation(confirmEventPaymentMutation);
     const favoriteMutation = useMutation(updateFavoriteEventMutation);
 
     // Arrangementet sier ikke selv om det er en favoritt, så favorittlisten —
@@ -148,6 +192,14 @@ function EventDetailPage() {
     // Klokka som teller ned mot at påmeldingen åpner. Uten den sto både
     // «åpner om …» og selve tilstanden stille til siden ble lastet på nytt.
     const now = useNow(event.registrationStart);
+    // Betalingsfristen har sin egen klokke: den løper i et helt annet vindu
+    // enn påmeldingsåpningen, og en felles klokke ville stått stille i det
+    // ene tilfellet mens den tikket i det andre.
+    const paymentExpiresAt = event.registration?.paymentExpiresAt ?? null;
+    const paymentNow = useNow(paymentExpiresAt);
+    const paymentExpiresInLabel = paymentExpiresAt
+        ? formatCountdown(paymentExpiresAt, paymentNow)
+        : undefined;
     const registrationState = deriveRegistrationState(
         {
             registration: event.registration,
@@ -176,6 +228,72 @@ function EventDetailPage() {
         wasNotOpenRef.current = false;
         void refetchEvent();
     }, [registrationState, refetchEvent]);
+
+    // Når betalingsfristen løper ut mens sida står åpen, er plassen allerede
+    // på vei videre til neste på ventelista. Vi henter arrangementet på nytt
+    // i samme øyeblikk, så kortet viser den plassen medlemmet faktisk har —
+    // ikke en Vipps-knapp som API-et vil avvise.
+    const paymentExpiredRef = useRef(false);
+    useEffect(() => {
+        if (paymentExpiresInLabel !== null) {
+            paymentExpiredRef.current = false;
+            return;
+        }
+        if (paymentExpiredRef.current) return;
+        paymentExpiredRef.current = true;
+        void refetchEvent();
+    }, [paymentExpiresInLabel, refetchEvent]);
+
+    // Vipps sender medlemmet tilbake i det de har godkjent i appen — som
+    // regel før webhooken som registrerer betalingen har rukket fram. Uten
+    // dette landet de på «venter på betaling» og måtte laste sida på nytt til
+    // webhooken tilfeldigvis kom. Vi spør heller Vipps direkte.
+    const [isConfirmingPayment, setIsConfirmingPayment] = useState(false);
+    useEffect(() => {
+        if (consumeVippsReturn()) setIsConfirmingPayment(true);
+    }, []);
+
+    const confirmPayment = confirmPaymentMutation.mutateAsync;
+    useEffect(() => {
+        if (!isConfirmingPayment) return;
+
+        let cancelled = false;
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+
+        const ask = async (attempt: number) => {
+            let status: string | null = null;
+            try {
+                status = (await confirmPayment({ eventId: event.id })).status;
+            } catch {
+                // Nettverket eller API-et svikta. Det er ikke et svar om
+                // betalingen, så vi behandler det som «vet ikke ennå».
+                status = null;
+            }
+            if (cancelled) return;
+
+            // «pending» er det eneste som er verdt å vente på: betalingen er
+            // underveis hos Vipps. Alt annet er et svar, og da er
+            // arrangementet selv fasiten på hva medlemmet sitter igjen med.
+            const keepWaiting = status === null || status === "pending";
+            if (keepWaiting && attempt + 1 < PAYMENT_CONFIRM_ATTEMPTS) {
+                timeout = setTimeout(
+                    () => void ask(attempt + 1),
+                    PAYMENT_CONFIRM_RETRY_MS,
+                );
+                return;
+            }
+
+            await refetchEvent();
+            if (!cancelled) setIsConfirmingPayment(false);
+        };
+
+        void ask(0);
+
+        return () => {
+            cancelled = true;
+            clearTimeout(timeout);
+        };
+    }, [isConfirmingPayment, event.id, confirmPayment, refetchEvent]);
 
     // Feil fra på- eller avmelding. Uten dette så knappen ut til å ikke gjøre
     // noe når API-et avviste forsøket.
@@ -266,7 +384,7 @@ function EventDetailPage() {
             {
                 eventId: event.id,
                 data: {
-                    returnUrl: window.location.href,
+                    returnUrl: vippsReturnUrl(),
                     userFlow: "WEB_REDIRECT",
                 },
             },
@@ -494,12 +612,12 @@ function EventDetailPage() {
                         }
                         hasPaid={event.registration?.hasPaid ?? false}
                         paymentDeadline={
-                            event.registration?.paymentExpiresAt
-                                ? toEventDeadline(
-                                      event.registration.paymentExpiresAt,
-                                  )
+                            paymentExpiresAt
+                                ? toEventDeadline(paymentExpiresAt)
                                 : undefined
                         }
+                        paymentExpiresInLabel={paymentExpiresInLabel}
+                        isConfirmingPayment={isConfirmingPayment}
                         capacity={event.capacity}
                         registeredCount={registeredCount}
                         waitlistCount={event.waitlistCount}

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -878,6 +878,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/event/{eventId}/payment/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Confirm own payment for event
+         * @description Asks the payment provider what happened to the caller's outstanding checkout for this event, and records a completed payment. Meant for the moment the member returns from Vipps, before the webhook has arrived.
+         */
+        post: operations["confirmEventPayment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/event/{eventId}/payments": {
         parameters: {
             query?: never;
@@ -4058,6 +4078,13 @@ export interface components {
              * @enum {string}
              */
             userFlow: "WEB_REDIRECT" | "NATIVE_REDIRECT";
+        };
+        ConfirmPaymentResponse: {
+            /**
+             * @description What the payment provider says about the caller's outstanding checkout. 'pending' means the checkout is still open or the provider could not be reached — ask again shortly. 'none' means there is nothing outstanding to confirm.
+             * @enum {string}
+             */
+            status: "paid" | "pending" | "failed" | "none";
         };
         EventPaymentAdmin: {
             /** Format: uuid */
@@ -8481,6 +8508,53 @@ export interface operations {
             };
             /** @description Payment already exists for this user and event */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    confirmEventPayment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                eventId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The provider's answer for the caller's checkout */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConfirmPaymentResponse"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Not Found - Event not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/sdk/src/generated/schemas.ts
+++ b/packages/sdk/src/generated/schemas.ts
@@ -34,6 +34,7 @@ export type BatchUpdateUserFines = Schemas["BatchUpdateUserFines"];
 export type CalendarSubscription = Schemas["CalendarSubscription"];
 export type CompanyContact = Schemas["CompanyContact"];
 export type CompanyContactResponse = Schemas["CompanyContactResponse"];
+export type ConfirmPaymentResponse = Schemas["ConfirmPaymentResponse"];
 export type Contract = Schemas["Contract"];
 export type ContractList = Schemas["ContractList"];
 export type CreateApiKey = Schemas["CreateApiKey"];


### PR DESCRIPTION
To hull i betalingsflyten på arrangementssiden, begge på samme kort.

## Nedtelling på betalingsfristen

Fristen sto som et klokkeslett, mens vinduet er på minutter — det medlemmet trenger å vite er hvor lenge det er til plassen gis videre. Fristen teller nå ned ved siden av Vipps-knappen, sekund for sekund, på samme klokke som «Påmelding åpner om …» (`useNow`).

Nedtellingen har sin egen formatterer (`formatCountdown`): `formatTimeUntil` runder til nærmeste enhet, så «2 minutter» ville blitt stående i et helt minutt. Under en time vises `m:ss`, over det den grove teksten — «58:12» sier mindre enn «en time».

```
Plass reservert — venter på betaling
7:31 igjen å betale (innen kl. 21:41), ellers gis plassen videre.
[ Betal med Vipps ]  [ Meld deg av ]
```

Løper fristen ut mens sida står åpen, hentes arrangementet på nytt, og kortet sier at fristen er gått ut i stedet for å vise «0:00» og en Vipps-knapp API-et vil avvise.

## Skjermen oppdateres etter betaling

Etter en gjennomført betaling ble kortet stående på «venter på betaling». «Betalt» settes bare av webhooken fra Vipps, men Vipps sender medlemmet tilbake i det de godkjenner i appen — som regel før webhooken har rukket fram — og sida spurte aldri igjen. Eneste vei ut var å laste på nytt til webhooken tilfeldigvis kom.

`returnUrl` merkes nå, og et merket sidelast spør API-et hva som skjedde:

- **Ny rute** `POST /api/event/{eventId}/payment/confirm` ser bare på innsenderens egen kasse, spør Vipps direkte og fanger inn (capture) en betaling som bare var reservert. Den gjenbruker `reconcileWithProvider`, altså samme avstemming som betalingsfrist-jobben allerede hviler på, og kalles utenfor transaksjon.
- Er kassa fortsatt åpen, eller Vipps ikke til å nå, svarer den `pending` — «spør igjen straks», ikke «betalingen feilet». Sida spør opptil seks ganger med to sekunders mellomrom.
- Så lenge den venter viser kortet «Bekrefter betalingen …» uten betalings- og avmeldingsknapp, så et nytt trykk verken starter en betaling til eller melder av en plass som nettopp ble betalt.

## Testing

- 6 nye integrasjonstester i `payment-confirm.test.ts`: capture ved `AUTHORIZED`, `pending` ved åpen kasse og ved Vipps nede, `failed` ved avbrutt kasse, ingen Vipps-kall når webhooken alt har landet, 401 uten innlogging. De 22 eksisterende betalings-/`hasPaid`-testene er fortsatt grønne.
- Manuelt i nettleseren mot lokal API: nedtellingen gikk `1:19 → … → 0:24` og skiftet til utløpt-teksten da fristen passerte. Retur med merket `returnUrl` viste «Bekrefter betalingen …», og da betalingen ble registrert skiftet kortet selv til «Du har plass på arrangementet!» med påmeldingsbevis — uten reload. Faller pent tilbake til betalingskortet med nedtelling hvis Vipps aldri svarer.
- `typecheck`, `lint` og `format` grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)