### PR TITLE
fix(arrangement): la beskrivelsen stå rett under tittelen

### DIFF
--- a/apps/kvark/src/components/detail-page.tsx
+++ b/apps/kvark/src/components/detail-page.tsx
@@ -25,7 +25,12 @@ export function DetailPage({
                 // headeren forbi kolonna så snart et gruppenavn eller en
                 // tittel er lang. Sporet er allerede minmax(0,1fr) — det er
                 // barna som mangler tillatelsen til å krympe.
-                <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem] lg:gap-8">
+                // `lg:grid-rows-[auto_1fr]`: sidefeltet spenner over begge
+                // radene, og med auto-rader ville et høyt sidefelt strekke
+                // rad 1 – da havnet beskrivelsen langt ned på siden. Med en
+                // fleksibel rad 2 tar brødteksten all overskytende høyde, og
+                // headeren beholder sin egen.
+                <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem] lg:grid-rows-[auto_1fr] lg:gap-8">
                     <header className="flex min-w-0 flex-col gap-4 lg:col-start-1 lg:row-start-1">
                         {header}
                     </header>


### PR DESCRIPTION
## Hva

På noen arrangementer havnet beskrivelsen langt ned på siden, på linje med påmeldingskortet i sidefeltet.

## Hvorfor

Sidefeltet i `DetailPage` spenner over begge radene i griden (`lg:row-span-2`). Med `auto`-rader fordeler nettleseren overskuddshøyden fra et høyt sidefelt utover **begge** radene, så header-raden ble strukket og brødteksten dyttet nedover. Jo høyere påmeldingskortet var, desto lenger ned havnet beskrivelsen.

## Fiks

`lg:grid-rows-[auto_1fr]`: header-raden beholder sin egen høyde, og brødtekst-raden tar all overskytende høyde fra sidefeltet.

## Verifisert

Preview på 1440×900 mot lokalt API med ekte data (arrangementet «Kosekveld»):

| | header-høyde | beskrivelsen starter på |
|---|---|---|
| før (`auto auto`) | 160 px | y=844 |
| etter | 140 px | y=824 |

Med et kunstig 600 px høyere sidefelt (simulerer et stort påmeldingskort): før strakk headeren seg til 468 px og beskrivelsen ble dyttet til y=1152; etter står den fortsatt på 140 px / y=824.

`bun run typecheck`, `lint` og `format` er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)