### PR TITLE
fix(skjema): send «Se spørreskjema» til svarene på nettsiden

### DIFF
--- a/apps/api/src/lib/event/payment-review.ts
+++ b/apps/api/src/lib/event/payment-review.ts
@@ -125,7 +125,7 @@ export async function notifyOrganizersOfPaymentsWithoutSpot(
                     userId,
                     title: `Betalinger uten plass på ${claimed.title}`,
                     description,
-                    link: `${env.ROOT_URL}/admin/arrangementer/${claimed.id}`,
+                    link: `${env.WEBSITE_URL}/admin/arrangementer/${claimed.id}`,
                 },
                 ctx,
             );

--- a/apps/api/src/lib/event/payment.ts
+++ b/apps/api/src/lib/event/payment.ts
@@ -62,7 +62,7 @@ type PaidEventLike = {
 };
 
 function eventUrl(slug: string): string {
-    return `${env.ROOT_URL}/arrangementer/${slug}`;
+    return `${env.WEBSITE_URL}/arrangementer/${slug}`;
 }
 
 /**

--- a/apps/api/src/lib/event/resolve-registration.ts
+++ b/apps/api/src/lib/event/resolve-registration.ts
@@ -141,7 +141,7 @@ export async function resolveRegistrationsForEvent(
                     userId,
                     title: "Påmelding ikke godkjent",
                     description: `Din påmelding til ${event.title} ble ikke godkjent: ${reason}`,
-                    link: `${env.ROOT_URL}/arrangementer/${event.slug}`,
+                    link: `${env.WEBSITE_URL}/arrangementer/${event.slug}`,
                     emailTemplate: {
                         name: "RegistrationBlockedEmail",
                         props: {
@@ -262,7 +262,7 @@ export async function resolveRegistrationsForEvent(
             }
 
             // Send notification to user based on finalStatus
-            const eventUrl = `${env.ROOT_URL}/arrangementer/${event.slug}`;
+            const eventUrl = `${env.WEBSITE_URL}/arrangementer/${event.slug}`;
 
             if (finalStatus === "registered") {
                 notifications.add({
@@ -333,7 +333,7 @@ export async function resolveRegistrationsForEvent(
 
                     // Send email to swapped user
                     if (waitlistedUserId === swappedUserId) {
-                        const eventUrl = `${env.ROOT_URL}/arrangementer/${event.slug}`;
+                        const eventUrl = `${env.WEBSITE_URL}/arrangementer/${event.slug}`;
                         notifications.add({
                             userId: waitlistedUserId,
                             title: `Endring i din påmelding til ${event.title}`,

--- a/apps/api/src/routes/form/submission/create.ts
+++ b/apps/api/src/routes/form/submission/create.ts
@@ -95,7 +95,7 @@ export const createSubmissionRoute = route().post(
                     {
                         formTitle: form.title,
                         submitterName: submitter.name,
-                        formUrl: `${env.ROOT_URL}/grupper/${groupForm.groupSlug}/`,
+                        formUrl: `${env.WEBSITE_URL}/sporreskjema/${formId}/svar`,
                         logoUrl: `${env.WEBSITE_URL}/logo512.png`,
                     },
                 );

--- a/apps/api/src/test/form/submission-notification-email.test.ts
+++ b/apps/api/src/test/form/submission-notification-email.test.ts
@@ -1,0 +1,78 @@
+import { schema } from "@photon/db";
+import { env } from "@photon/core/env";
+import { describe, expect, vi } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+describe("Varsel-e-post om nytt skjemasvar", () => {
+    integrationTest(
+        "«Se spørreskjema» peker på svarsiden på nettsiden, ikke på API-et",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            const member = await ctx.utils.createTestUser();
+
+            await ctx.utils.setupGroups();
+
+            await ctx.db.insert(schema.groupMembership).values([
+                { userId: leader.id, groupSlug: "index", role: "leader" },
+                { userId: member.id, groupSlug: "index", role: "member" },
+            ]);
+
+            const leaderClient = await ctx.utils.clientForUser(leader);
+            const memberClient = await ctx.utils.clientForUser(member);
+
+            const createResponse = await leaderClient.api.groups[
+                ":slug"
+            ].forms.$post({
+                param: { slug: "index" },
+                json: {
+                    title: "Opptaksskjema",
+                    template: false,
+                    group: "index",
+                    can_submit_multiple: false,
+                    is_open_for_submissions: true,
+                    only_for_group_members: false,
+                    email_receiver_on_submit: "opptak@tihlde.org",
+                    fields: [
+                        {
+                            title: "Hvorfor søker du?",
+                            type: "text_answer",
+                            required: true,
+                            order: 0,
+                        },
+                    ],
+                },
+            });
+
+            expect(createResponse.status).toBe(201);
+            const form = await createResponse.json();
+
+            const sendEmailTemplate = vi.spyOn(ctx.email, "sendEmailTemplate");
+
+            const submitResponse = await memberClient.api.forms[
+                ":formId"
+            ].submissions.$post({
+                param: { formId: form.id! },
+                json: {
+                    answers: [
+                        {
+                            field: { id: form.fields?.[0]?.id! },
+                            answer_text: "Fordi det er gøy",
+                        },
+                    ],
+                },
+            });
+
+            expect(submitResponse.status).toBe(201);
+
+            const call = sendEmailTemplate.mock.calls.find(
+                ([, template]) => template === "FormSubmissionEmail",
+            );
+            expect(call).toBeDefined();
+
+            const props = call?.[2] as { formUrl: string };
+            expect(props.formUrl).toBe(
+                `${env.WEBSITE_URL}/sporreskjema/${form.id}/svar`,
+            );
+        },
+    );
+});


### PR DESCRIPTION
## Problem

Varsel-e-posten om nytt skjemasvar bygget lenken av `ROOT_URL` — som peker på API-et — og gikk dessuten til gruppesiden i stedet for svarene. Knappen «Se spørreskjema» havnet derfor på `https://photon.tihlde.org/grupper/<slug>/`.

## Endring

`formUrl` bygges nå av `WEBSITE_URL` og peker på svarsiden: `<nettside>/sporreskjema/<id>/svar`.

Samme feil traff flere e-poster og varsler som også bygget frontend-lenker av `ROOT_URL`, og de er rettet i samme slengen:

- `lib/event/payment.ts` — «du har fått plass»
- `lib/event/resolve-registration.ts` — påmelding bekreftet, venteliste, flyttet til venteliste
- `lib/event/payment-review.ts` — admin-varsel om betalinger uten plass

## Test

Ny integrasjonstest sender inn et svar på et gruppeskjema med e-postmottaker og sjekker at `formUrl` blir `<WEBSITE_URL>/sporreskjema/<id>/svar`.

Typecheck, build og format er grønt lokalt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)