### PR TITLE
fix(arrangement): høyrejuster de prioriterte pillene

### DIFF
--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -416,26 +416,28 @@ function EventDetailPage() {
                                 : []),
                             ...(priorityLabels.length > 0
                                 ? [
-                                      <div className="flex flex-col gap-2 text-sm">
-                                          <div className="flex items-center gap-2.5 text-muted-foreground">
-                                              <Star className="size-4 shrink-0" />
-                                              <span>
-                                                  {event.onlyAllowPrioritized
-                                                      ? "Kun for"
-                                                      : "Prioritert"}
+                                      <DetailField
+                                          icon={Star}
+                                          label={
+                                              event.onlyAllowPrioritized
+                                                  ? "Kun for"
+                                                  : "Prioritert"
+                                          }
+                                          value={
+                                              <span className="flex flex-wrap justify-end gap-1.5">
+                                                  {priorityLabels.map(
+                                                      (label) => (
+                                                          <Badge
+                                                              key={label}
+                                                              variant="secondary"
+                                                          >
+                                                              {label}
+                                                          </Badge>
+                                                      ),
+                                                  )}
                                               </span>
-                                          </div>
-                                          <div className="flex flex-col items-start gap-1.5">
-                                              {priorityLabels.map((label) => (
-                                                  <Badge
-                                                      key={label}
-                                                      variant="secondary"
-                                                  >
-                                                      {label}
-                                                  </Badge>
-                                              ))}
-                                          </div>
-                                      </div>,
+                                          }
+                                      />,
                                   ]
                                 : []),
                             ...(event.contactPerson


### PR DESCRIPTION
Prioritert-raden i detaljkortet på arrangementssiden hadde sin egen to-etasjes layout: etiketten øverst til venstre og pillene under. Alle andre rader i kortet setter verdien til høyre.

Nå bruker raden vanlig `DetailField`, med pillene høyrejustert i verdikolonnen og `flex-wrap` så flere piller brekker pent over linjer.

## Verifisert
- `tsc --noEmit` grønt, oxfmt/oxlint uten nye funn.
- Kjørt dev-server mot arrangementet «TIHLDE Vårgalla 2026» (to prioriterte grupper) og målt i DOM at begge pillene har høyre kant lik radens høyre kant, mens etiketten står til venstre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)