### PR TITLE
fix(arrangement): la bachelorstudier velges sammen med klassetrinn

### DIFF
--- a/apps/kvark/src/components/priority-pool-editor.tsx
+++ b/apps/kvark/src/components/priority-pool-editor.tsx
@@ -121,7 +121,8 @@ const SELECTABLE_TYPES = new Set([
  * grensesnittet er at samme valg ikke kan brukes i to pooler.
  *
  * - 1.–3. klasse står alene, og gjelder alle bachelorstudier.
- * - Studieprogrammene står alene, og gjelder alle trinn.
+ * - Bachelorstudiene finnes både alene — da gjelder de alle trinn — og
+ *   kombinert med 1., 2. eller 3. klasse.
  * - Masteren finnes *bare* som «4. klasse» og «5. klasse»: det er de eneste
  *   trinnene den har, og et bart valg ville stilltiende betydd begge.
  * - Arrangørens egen interessegruppe finnes bare som frittstående valg, så den
@@ -187,8 +188,24 @@ export function buildPoolItems(
             pool: { groupSlug: group.slug, classYear: null },
         };
 
-        if (type === "STUDY") studies.push(item);
-        else others.push(item);
+        if (type !== "STUDY") {
+            others.push(item);
+            continue;
+        }
+
+        studies.push(item);
+
+        // Bachelorstudiene finnes også trinn for trinn. Bare studier: API-et
+        // avviser klassetrinn på komiteer, styrer og resten, så et slikt valg
+        // ville vært en 400 i vente.
+        for (let year = 1; year <= MASTER_CLASS_OFFSET; year++) {
+            studies.push({
+                key: `group:${group.slug}+class:${year}`,
+                label: `${group.name} ${year}. klasse`,
+                hint: "Studie",
+                pool: { groupSlug: group.slug, classYear: year },
+            });
+        }
     }
 
     const byLabel = (a: PoolItem, b: PoolItem) =>
@@ -282,10 +299,11 @@ type PriorityPoolEditorProps = {
  *
  * Semantikken er verdt å lese før du endrer noe her: **hver prioritert gruppe
  * er ett kriterium, og det holder å treffe én av dem.** Modellen tillater bare
- * ett valg per prioritert gruppe, så kombinasjoner av studie og trinn finnes
- * bare der de er meningsfulle, som ferdige valg («Digital transformasjon 4.
- * klasse»). En navngitt person teller like mye som en gruppe. Se
- * `isUserPrioritized` i API-et.
+ * ett valg per prioritert gruppe, så et studie og et trinn kommer som ett
+ * ferdig valg («Dataingeniør 2. klasse»), aldri som to felt. Bare de
+ * kombinasjonene som betyr noe finnes: et bachelorstudium med eller uten trinn,
+ * og masteren bare som 4. eller 5. klasse. En navngitt person teller like mye
+ * som en gruppe. Se `isUserPrioritized` i API-et.
  *
  * Klassetrinn er rullerende: det løses mot medlemmets kull ved påmelding, så
  * et arrangement som gjenbrukes til neste år treffer neste års førsteklassinger


### PR DESCRIPTION
## Hva

Det gikk ikke lenger an å sette «1. klasse **og** Dataingeniør» som ett prioriteringskriterium — velgeren tilbød bare ett kriterium om gangen.

Etter #602 fikk hvert bachelorstudium bare ett frittstående valg i kriterielista. Kombinasjonen studie + trinn forsvant som en bieffekt av at tre-veis-kombinasjonene ble fjernet med vilje.

Følgefeil: lagrede pooler med den kombinasjonen falt ut av skjemaet (`toFormPool` dropper alt som ikke finnes i velgeren) og ble skrevet bort ved neste lagring.

## Fiks

`buildPoolItems` lager nå både det frittstående valget og ett per trinn 1–3 for hvert bachelorstudium, etter samme mønster som masteren allerede hadde for 4./5. klasse.

Bare `STUDY` får trinnvarianter — API-et avviser klassetrinn på komiteer, styrer, undergrupper og interessegrupper, så et slikt valg ville vært en 400 i vente.

Ingen endring i API, Zod-skjema eller database: de har hele tiden godtatt `{groupSlug, classYear}` med begge satt.

## Verifisert

- **Nettleser, mot lokal API:** søk på «Dataing» gir «Dataingeniør» + «Dataingeniør 1./2./3. klasse». Masteren finnes fortsatt bare som 4./5. klasse, og ingen komité/styre/undergruppe fikk trinn. Dedupliseringen holder — valgt i én rad, borte fra neste.
- **Lagret pool:** la `{dataingenir, 2}` inn i dev-basen og åpnet redigeringssiden. Vises nå som «Dataingeniør 2. klasse» i stedet for å falle bort, og advarselen om kriterier som ikke kan vises slår ikke ut. (Raden er ryddet bort igjen.)
- `bun run typecheck` grønn, `bun run lint` uten nye funn, `bun run format` rent.
- `apps/api` `priority-pools.test.ts`: 11/11, inkludert testen som runder `{dataingenir, 2}` tur–retur mot API-et.

Ikke klikket gjennom manuelt: å publisere et helt nytt arrangement fra skjemaet i nettleseren (publiser-knappen tok ikke imot de automatiserte klikkene). Samme lagring dekkes av API-testen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)