### PR TITLE
fix(admin): steng adminpanelet for dem som ikke har noe der å gjøre

### DIFF
--- a/apps/api/src/routes/event/list.ts
+++ b/apps/api/src/routes/event/list.ts
@@ -179,6 +179,7 @@ export const listRoute = route().get(
                 organizer,
                 image: e.imageUrl,
                 imageAlt: e.imageAlt,
+                createdById: e.createdByUserId,
                 createdAt: e.createdAt.toISOString(),
                 updatedAt: e.updatedAt.toISOString(),
                 category: {

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -834,6 +834,10 @@ export const eventListItemSchema = Schema(
             .string()
             .nullable()
             .meta({ description: "Alt text for the event image (nullable)" }),
+        createdById: z.string().nullable().meta({
+            description:
+                "Creator user ID. The creator may update and delete their own event, so an admin listing needs it to tell an event the caller can manage from one they may only look at.",
+        }),
         createdAt: z.iso
             .date()
             .meta({ description: "Event creation time (ISO 8601)" }),

--- a/apps/kvark/src/components/admin-image-field.tsx
+++ b/apps/kvark/src/components/admin-image-field.tsx
@@ -1,6 +1,9 @@
 import { Field, FieldDescription, FieldLabel } from "@tihlde/ui/ui/field";
 import { ImageDropzone } from "@tihlde/ui/ui/image-dropzone";
-import type { ImagePresetName } from "@tihlde/ui/ui/image-preset";
+import {
+    ImagePresetFrame,
+    type ImagePresetName,
+} from "@tihlde/ui/ui/image-preset";
 
 import { imageDropzoneLabels } from "#/lib/image";
 
@@ -18,6 +21,11 @@ type AdminImageFieldProps = {
     /** Image already saved on the resource, shown until a new one is picked. */
     existingImageUrl?: string | null;
     disabled?: boolean;
+    /**
+     * Vis bildet uten opplastingsflate. `disabled` alene holder ikke: sonen
+     * blir inert, men fortsetter å be om en fil den ikke tar imot.
+     */
+    readOnly?: boolean;
     /** Layout-only classes for the field wrapper, e.g. a grid column span. */
     className?: string;
 };
@@ -37,6 +45,7 @@ export function AdminImageField({
     onChange,
     existingImageUrl,
     disabled,
+    readOnly,
     className,
 }: AdminImageFieldProps) {
     return (
@@ -45,15 +54,24 @@ export function AdminImageField({
             {description ? (
                 <FieldDescription>{description}</FieldDescription>
             ) : null}
-            <ImageDropzone
-                preset={preset}
-                value={value ? [value] : []}
-                onValueChange={(next) => onChange(next[0] ?? null)}
-                existingImageUrl={existingImageUrl}
-                accept={{ "image/*": [] }}
-                disabled={disabled}
-                labels={imageDropzoneLabels}
-            />
+            {readOnly ? (
+                <ImagePresetFrame
+                    preset={preset}
+                    src={existingImageUrl ?? undefined}
+                    alt=""
+                    fallback={<span>Ingen bilde</span>}
+                />
+            ) : (
+                <ImageDropzone
+                    preset={preset}
+                    value={value ? [value] : []}
+                    onValueChange={(next) => onChange(next[0] ?? null)}
+                    existingImageUrl={existingImageUrl}
+                    accept={{ "image/*": [] }}
+                    disabled={disabled}
+                    labels={imageDropzoneLabels}
+                />
+            )}
         </Field>
     );
 }

--- a/apps/kvark/src/components/event-form.tsx
+++ b/apps/kvark/src/components/event-form.tsx
@@ -1,4 +1,4 @@
-import { RichEditor } from "@tihlde/ui/complex/markdown";
+import { MarkdownView, RichEditor } from "@tihlde/ui/complex/markdown";
 import { Button } from "@tihlde/ui/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@tihlde/ui/ui/card";
 import {
@@ -118,6 +118,17 @@ type EventFormProps = {
     secondaryAction?: ReactNode;
     /** Statusmeldinger som vises rett over knappen. */
     children?: ReactNode;
+    /**
+     * Vis skjemaet, men la det ikke røres. Brukes av dem som kan se et
+     * arrangement i adminlista uten å kunne redigere det: de skal få se hva
+     * som står i feltene, ikke et skjema som svarer 403 når de lagrer.
+     *
+     * Feltene låses av `fieldset[disabled]`, som slår av alle skjemakontroller
+     * under seg. De to unntakene er tekstredigereren, som er en
+     * contenteditable og ikke en skjemakontroll, og bildefeltet, som tar imot
+     * filer som slippes på det — de får hver sin behandling nedenfor.
+     */
+    readOnly?: boolean;
 };
 
 /**
@@ -141,6 +152,7 @@ export function EventForm({
     isSubmitting,
     secondaryAction,
     children,
+    readOnly = false,
 }: EventFormProps) {
     /** Sist valgte adresse, se `handleLocationChange`. */
     const selectedAddressRef = useRef<EventFormValues["locationCoords"]>(null);
@@ -256,508 +268,571 @@ export function EventForm({
 
     return (
         <form onSubmit={onSubmit} className="flex flex-col gap-6">
-            <Card>
-                <CardHeader>
-                    <CardTitle>Detaljer</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <FieldGroup>
-                        <div className="grid gap-4 lg:grid-cols-2">
-                            <Field>
-                                <FieldLabel htmlFor="event-title">
-                                    Tittel
-                                </FieldLabel>
-                                <Input
-                                    id="event-title"
-                                    type="text"
-                                    required
-                                    value={values.title}
-                                    onChange={(event) =>
-                                        onChange({ title: event.target.value })
-                                    }
-                                />
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-category">
-                                    Kategori
-                                </FieldLabel>
-                                <Select
-                                    items={ALL_EVENT_CATEGORIES}
-                                    value={values.categorySlug}
-                                    onValueChange={(value) =>
-                                        onChange({ categorySlug: value ?? "" })
-                                    }
-                                >
-                                    <SelectTrigger id="event-category">
-                                        <SelectValue placeholder="Velg kategori" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {ALL_EVENT_CATEGORIES.map(
-                                            (category) => (
-                                                <SelectItem
-                                                    key={category.value}
-                                                    value={category.value}
-                                                >
-                                                    {category.label}
-                                                </SelectItem>
-                                            ),
-                                        )}
-                                    </SelectContent>
-                                </Select>
-                            </Field>
-                        </div>
-                        <div className="grid gap-4 lg:grid-cols-2">
-                            <Field>
-                                <FieldLabel htmlFor="event-organizer">
-                                    Arrangørgruppe
-                                </FieldLabel>
-                                <Select
-                                    items={groups.map((group) => ({
-                                        value: group.slug,
-                                        label: group.name,
-                                    }))}
-                                    value={values.organizerGroupSlug}
-                                    onValueChange={(value) => {
-                                        const organizerGroupSlug = value ?? "";
-
-                                        // Arrangøren avgjør hvilke valg som
-                                        // finnes: en interessegruppe kan bare
-                                        // prioriteres på sitt eget arrangement.
-                                        // Bytter man arrangør bort fra den,
-                                        // må kriteriet gå med — ellers gir
-                                        // lagring en 400 om et felt brukeren
-                                        // ikke lenger kan se.
-                                        const allowed = new Set(
-                                            buildPoolItems(
-                                                poolGroups,
-                                                organizerGroupSlug,
-                                            ).map(
-                                                (item) => item.pool.groupSlug,
-                                            ),
-                                        );
-
-                                        onChange({
-                                            organizerGroupSlug,
-                                            priorityPools:
-                                                values.priorityPools.filter(
-                                                    (pool) =>
-                                                        pool.groupSlug ===
-                                                            null ||
-                                                        allowed.has(
-                                                            pool.groupSlug,
-                                                        ),
-                                                ),
-                                        });
-                                    }}
-                                >
-                                    <SelectTrigger id="event-organizer">
-                                        <SelectValue placeholder="Velg gruppe" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {groups.map((group) => (
-                                            <SelectItem
-                                                key={group.slug}
-                                                value={group.slug}
-                                            >
-                                                {group.name}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-contact">
-                                    Kontaktperson (valgfritt)
-                                </FieldLabel>
-                                <Select
-                                    items={contactPersonOptions}
-                                    value={
-                                        values.contactPersonUserId || NO_CONTACT
-                                    }
-                                    onValueChange={(value) =>
-                                        onChange({
-                                            contactPersonUserId:
-                                                !value || value === NO_CONTACT
-                                                    ? ""
-                                                    : value,
-                                        })
-                                    }
-                                >
-                                    <SelectTrigger id="event-contact">
-                                        <SelectValue placeholder="Ingen kontaktperson" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {contactPersonOptions.map((option) => (
-                                            <SelectItem
-                                                key={option.value}
-                                                value={option.value}
-                                            >
-                                                {option.label}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                                <FieldDescription>
-                                    Velg blant medlemmene i arrangørgruppen.
-                                </FieldDescription>
-                            </Field>
-                        </div>
-                        <Field>
-                            <FieldLabel htmlFor="event-location">
-                                Sted
-                            </FieldLabel>
-                            <AddressCombobox
-                                id="event-location"
-                                required
-                                value={values.location}
-                                onValueChange={handleLocationChange}
-                                suggestions={addressSuggestions}
-                                isSearching={isSearchingAddress}
-                                onSelectSuggestion={handleSelectAddress}
-                            />
-                            <FieldDescription>
-                                {values.locationCoords
-                                    ? "Adressen er lenket til kart på arrangementssiden."
-                                    : "Søk opp en adresse for å legge ved kartlenke, eller skriv fritt (f.eks. «Digitalt»)."}
-                            </FieldDescription>
-                        </Field>
-                        <div className="grid gap-4 lg:grid-cols-2">
-                            <Field>
-                                <FieldLabel htmlFor="event-start">
-                                    Starttidspunkt
-                                </FieldLabel>
-                                <DateTimePicker
-                                    id="event-start"
-                                    locale={nb}
-                                    placeholder="Velg startdato"
-                                    value={values.start}
-                                    onValueChange={handleStartChange}
-                                />
-                            </Field>
-                            <Field>
-                                <FieldLabel htmlFor="event-end">
-                                    Sluttidspunkt
-                                </FieldLabel>
-                                <DateTimePicker
-                                    id="event-end"
-                                    locale={nb}
-                                    placeholder="Velg sluttdato"
-                                    minDate={values.start ?? undefined}
-                                    value={values.end}
-                                    onValueChange={(end) => onChange({ end })}
-                                />
-                            </Field>
-                        </div>
-                        <Field orientation="horizontal" className="w-fit gap-3">
-                            <Checkbox
-                                id="event-requires-signup"
-                                checked={values.requiresSigningUp}
-                                onCheckedChange={(checked) =>
-                                    onChange({
-                                        requiresSigningUp: Boolean(checked),
-                                    })
-                                }
-                            />
-                            <FieldLabel htmlFor="event-requires-signup">
-                                Arrangementet har påmelding
-                            </FieldLabel>
-                        </Field>
-                        {values.requiresSigningUp ? (
+            {/* `contents` gjør at låsen ikke koster oss layouten: fieldset
+                slutter å være en boks, og kortene under står som før. */}
+            <fieldset disabled={readOnly} className="contents">
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Detaljer</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <FieldGroup>
                             <div className="grid gap-4 lg:grid-cols-2">
                                 <Field>
-                                    <FieldLabel htmlFor="event-reg-start">
-                                        Påmelding åpner
-                                    </FieldLabel>
-                                    <DateTimePicker
-                                        id="event-reg-start"
-                                        locale={nb}
-                                        placeholder="Velg dato"
-                                        value={values.registrationStart}
-                                        onValueChange={(registrationStart) =>
-                                            onChange({ registrationStart })
-                                        }
-                                        aria-invalid={registrationOrderInvalid}
-                                    />
-                                    {registrationOrderInvalid ? (
-                                        <FieldError>
-                                            Påmeldingen må åpne før
-                                            påmeldingsfristen.
-                                        </FieldError>
-                                    ) : null}
-                                </Field>
-                                <Field>
-                                    <FieldLabel htmlFor="event-reg-end">
-                                        Påmeldingsfrist
-                                    </FieldLabel>
-                                    <DateTimePicker
-                                        id="event-reg-end"
-                                        locale={nb}
-                                        placeholder="Velg dato"
-                                        maxDate={values.start ?? undefined}
-                                        value={values.registrationEnd}
-                                        onValueChange={(registrationEnd) =>
-                                            onChange({ registrationEnd })
-                                        }
-                                        aria-invalid={registrationOrderInvalid}
-                                    />
-                                </Field>
-                                {!values.isPaidEvent ? (
-                                    <Field>
-                                        <FieldLabel htmlFor="event-cancel-deadline">
-                                            Avmeldingsfrist (valgfritt)
-                                        </FieldLabel>
-                                        <DateTimePicker
-                                            id="event-cancel-deadline"
-                                            locale={nb}
-                                            placeholder="Velg dato"
-                                            maxDate={values.start ?? undefined}
-                                            value={values.cancellationDeadline}
-                                            onValueChange={(
-                                                cancellationDeadline,
-                                            ) =>
-                                                onChange({
-                                                    cancellationDeadline,
-                                                })
-                                            }
-                                        />
-                                        <FieldDescription>
-                                            Avmelding etter denne fristen gir
-                                            prikk, forutsatt at «Kan gi prikker»
-                                            er huket av.
-                                        </FieldDescription>
-                                    </Field>
-                                ) : null}
-                            </div>
-                        ) : null}
-                        <div className="grid gap-4 lg:grid-cols-4">
-                            {values.requiresSigningUp ? (
-                                <Field className="lg:col-span-2">
-                                    <FieldLabel htmlFor="event-capacity">
-                                        Kapasitet (valgfritt)
+                                    <FieldLabel htmlFor="event-title">
+                                        Tittel
                                     </FieldLabel>
                                     <Input
-                                        id="event-capacity"
-                                        type="number"
-                                        min={1}
-                                        value={values.capacity}
+                                        id="event-title"
+                                        type="text"
+                                        required
+                                        value={values.title}
                                         onChange={(event) =>
                                             onChange({
-                                                capacity: event.target.value,
+                                                title: event.target.value,
                                             })
                                         }
                                     />
                                 </Field>
-                            ) : null}
-                            <Field className={wideWhenNoCapacity}>
-                                <FieldLabel htmlFor="event-visibility">
-                                    Synlighet
+                                <Field>
+                                    <FieldLabel htmlFor="event-category">
+                                        Kategori
+                                    </FieldLabel>
+                                    <Select
+                                        items={ALL_EVENT_CATEGORIES}
+                                        value={values.categorySlug}
+                                        onValueChange={(value) =>
+                                            onChange({
+                                                categorySlug: value ?? "",
+                                            })
+                                        }
+                                    >
+                                        <SelectTrigger id="event-category">
+                                            <SelectValue placeholder="Velg kategori" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {ALL_EVENT_CATEGORIES.map(
+                                                (category) => (
+                                                    <SelectItem
+                                                        key={category.value}
+                                                        value={category.value}
+                                                    >
+                                                        {category.label}
+                                                    </SelectItem>
+                                                ),
+                                            )}
+                                        </SelectContent>
+                                    </Select>
+                                </Field>
+                            </div>
+                            <div className="grid gap-4 lg:grid-cols-2">
+                                <Field>
+                                    <FieldLabel htmlFor="event-organizer">
+                                        Arrangørgruppe
+                                    </FieldLabel>
+                                    <Select
+                                        items={groups.map((group) => ({
+                                            value: group.slug,
+                                            label: group.name,
+                                        }))}
+                                        value={values.organizerGroupSlug}
+                                        onValueChange={(value) => {
+                                            const organizerGroupSlug =
+                                                value ?? "";
+
+                                            // Arrangøren avgjør hvilke valg som
+                                            // finnes: en interessegruppe kan bare
+                                            // prioriteres på sitt eget arrangement.
+                                            // Bytter man arrangør bort fra den,
+                                            // må kriteriet gå med — ellers gir
+                                            // lagring en 400 om et felt brukeren
+                                            // ikke lenger kan se.
+                                            const allowed = new Set(
+                                                buildPoolItems(
+                                                    poolGroups,
+                                                    organizerGroupSlug,
+                                                ).map(
+                                                    (item) =>
+                                                        item.pool.groupSlug,
+                                                ),
+                                            );
+
+                                            onChange({
+                                                organizerGroupSlug,
+                                                priorityPools:
+                                                    values.priorityPools.filter(
+                                                        (pool) =>
+                                                            pool.groupSlug ===
+                                                                null ||
+                                                            allowed.has(
+                                                                pool.groupSlug,
+                                                            ),
+                                                    ),
+                                            });
+                                        }}
+                                    >
+                                        <SelectTrigger id="event-organizer">
+                                            <SelectValue placeholder="Velg gruppe" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {groups.map((group) => (
+                                                <SelectItem
+                                                    key={group.slug}
+                                                    value={group.slug}
+                                                >
+                                                    {group.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-contact">
+                                        Kontaktperson (valgfritt)
+                                    </FieldLabel>
+                                    <Select
+                                        items={contactPersonOptions}
+                                        value={
+                                            values.contactPersonUserId ||
+                                            NO_CONTACT
+                                        }
+                                        onValueChange={(value) =>
+                                            onChange({
+                                                contactPersonUserId:
+                                                    !value ||
+                                                    value === NO_CONTACT
+                                                        ? ""
+                                                        : value,
+                                            })
+                                        }
+                                    >
+                                        <SelectTrigger id="event-contact">
+                                            <SelectValue placeholder="Ingen kontaktperson" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {contactPersonOptions.map(
+                                                (option) => (
+                                                    <SelectItem
+                                                        key={option.value}
+                                                        value={option.value}
+                                                    >
+                                                        {option.label}
+                                                    </SelectItem>
+                                                ),
+                                            )}
+                                        </SelectContent>
+                                    </Select>
+                                    <FieldDescription>
+                                        Velg blant medlemmene i arrangørgruppen.
+                                    </FieldDescription>
+                                </Field>
+                            </div>
+                            <Field>
+                                <FieldLabel htmlFor="event-location">
+                                    Sted
                                 </FieldLabel>
-                                <Select
-                                    items={[
-                                        { value: "public", label: "Offentlig" },
-                                        {
-                                            value: "members",
-                                            label: "Kun for medlemmer",
-                                        },
-                                    ]}
-                                    value={values.visibility}
-                                    onValueChange={(value) =>
-                                        onChange({
-                                            visibility:
-                                                value === "members"
-                                                    ? "members"
-                                                    : "public",
-                                        })
-                                    }
-                                >
-                                    <SelectTrigger id="event-visibility">
-                                        <SelectValue placeholder="Velg synlighet" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="public">
-                                            Offentlig
-                                        </SelectItem>
-                                        <SelectItem value="members">
-                                            Kun for medlemmer
-                                        </SelectItem>
-                                    </SelectContent>
-                                </Select>
-                            </Field>
-                            <Field className={wideWhenNoCapacity}>
-                                <FieldLabel htmlFor="event-institute">
-                                    Institutt
-                                </FieldLabel>
-                                <Select
-                                    items={[
-                                        {
-                                            value: ALL_INSTITUTES,
-                                            label: "Alle institutt",
-                                        },
-                                        ...institutes.map((institute) => ({
-                                            value: institute.slug,
-                                            label: institute.shortName,
-                                        })),
-                                    ]}
-                                    value={values.instituteSlug}
-                                    onValueChange={(value) =>
-                                        onChange({
-                                            instituteSlug:
-                                                value ?? ALL_INSTITUTES,
-                                        })
-                                    }
-                                >
-                                    <SelectTrigger id="event-institute">
-                                        <SelectValue placeholder="Velg institutt" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value={ALL_INSTITUTES}>
-                                            Alle institutt
-                                        </SelectItem>
-                                        {institutes.map((institute) => (
-                                            <SelectItem
-                                                key={institute.slug}
-                                                value={institute.slug}
-                                            >
-                                                {institute.shortName} –{" "}
-                                                {institute.name}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
+                                <AddressCombobox
+                                    id="event-location"
+                                    required
+                                    value={values.location}
+                                    onValueChange={handleLocationChange}
+                                    suggestions={addressSuggestions}
+                                    isSearching={isSearchingAddress}
+                                    onSelectSuggestion={handleSelectAddress}
+                                />
                                 <FieldDescription>
-                                    Begrenser påmelding til studenter ved dette
-                                    instituttet.
+                                    {values.locationCoords
+                                        ? "Adressen er lenket til kart på arrangementssiden."
+                                        : "Søk opp en adresse for å legge ved kartlenke, eller skriv fritt (f.eks. «Digitalt»)."}
                                 </FieldDescription>
                             </Field>
-                        </div>
-                        <Field orientation="horizontal" className="w-fit gap-3">
-                            <Checkbox
-                                id="event-paid"
-                                checked={values.isPaidEvent}
-                                onCheckedChange={(checked) =>
-                                    handlePaidChange(Boolean(checked))
-                                }
-                            />
-                            <FieldLabel htmlFor="event-paid">
-                                Betalt arrangement
-                            </FieldLabel>
-                        </Field>
-                        {values.isPaidEvent && (
-                            <Field>
-                                <FieldLabel htmlFor="event-price">
-                                    Pris (NOK)
-                                </FieldLabel>
-                                <Input
-                                    id="event-price"
-                                    type="number"
-                                    min={0}
-                                    value={values.price}
-                                    onChange={(event) =>
-                                        onChange({ price: event.target.value })
-                                    }
-                                />
-                            </Field>
-                        )}
-                        {!values.isPaidEvent ? (
+                            <div className="grid gap-4 lg:grid-cols-2">
+                                <Field>
+                                    <FieldLabel htmlFor="event-start">
+                                        Starttidspunkt
+                                    </FieldLabel>
+                                    <DateTimePicker
+                                        id="event-start"
+                                        locale={nb}
+                                        placeholder="Velg startdato"
+                                        value={values.start}
+                                        onValueChange={handleStartChange}
+                                    />
+                                </Field>
+                                <Field>
+                                    <FieldLabel htmlFor="event-end">
+                                        Sluttidspunkt
+                                    </FieldLabel>
+                                    <DateTimePicker
+                                        id="event-end"
+                                        locale={nb}
+                                        placeholder="Velg sluttdato"
+                                        minDate={values.start ?? undefined}
+                                        value={values.end}
+                                        onValueChange={(end) =>
+                                            onChange({ end })
+                                        }
+                                    />
+                                </Field>
+                            </div>
                             <Field
                                 orientation="horizontal"
                                 className="w-fit gap-3"
                             >
                                 <Checkbox
-                                    id="event-strikes"
-                                    checked={values.canCauseStrikes}
+                                    id="event-requires-signup"
+                                    checked={values.requiresSigningUp}
                                     onCheckedChange={(checked) =>
                                         onChange({
-                                            canCauseStrikes: Boolean(checked),
+                                            requiresSigningUp: Boolean(checked),
                                         })
                                     }
                                 />
-                                <FieldLabel htmlFor="event-strikes">
-                                    Kan gi prikker (avmelding etter frist og
-                                    no-show)
+                                <FieldLabel htmlFor="event-requires-signup">
+                                    Arrangementet har påmelding
                                 </FieldLabel>
                             </Field>
-                        ) : null}
-                        <Field>
-                            <FieldLabel>Beskrivelse</FieldLabel>
-                            <RichEditor
-                                registry={richRegistry}
-                                value={values.description}
-                                onChange={(description) =>
-                                    onChange({ description })
-                                }
-                            />
-                        </Field>
-                    </FieldGroup>
-                </CardContent>
-            </Card>
+                            {values.requiresSigningUp ? (
+                                <div className="grid gap-4 lg:grid-cols-2">
+                                    <Field>
+                                        <FieldLabel htmlFor="event-reg-start">
+                                            Påmelding åpner
+                                        </FieldLabel>
+                                        <DateTimePicker
+                                            id="event-reg-start"
+                                            locale={nb}
+                                            placeholder="Velg dato"
+                                            value={values.registrationStart}
+                                            onValueChange={(
+                                                registrationStart,
+                                            ) =>
+                                                onChange({ registrationStart })
+                                            }
+                                            aria-invalid={
+                                                registrationOrderInvalid
+                                            }
+                                        />
+                                        {registrationOrderInvalid ? (
+                                            <FieldError>
+                                                Påmeldingen må åpne før
+                                                påmeldingsfristen.
+                                            </FieldError>
+                                        ) : null}
+                                    </Field>
+                                    <Field>
+                                        <FieldLabel htmlFor="event-reg-end">
+                                            Påmeldingsfrist
+                                        </FieldLabel>
+                                        <DateTimePicker
+                                            id="event-reg-end"
+                                            locale={nb}
+                                            placeholder="Velg dato"
+                                            maxDate={values.start ?? undefined}
+                                            value={values.registrationEnd}
+                                            onValueChange={(registrationEnd) =>
+                                                onChange({ registrationEnd })
+                                            }
+                                            aria-invalid={
+                                                registrationOrderInvalid
+                                            }
+                                        />
+                                    </Field>
+                                    {!values.isPaidEvent ? (
+                                        <Field>
+                                            <FieldLabel htmlFor="event-cancel-deadline">
+                                                Avmeldingsfrist (valgfritt)
+                                            </FieldLabel>
+                                            <DateTimePicker
+                                                id="event-cancel-deadline"
+                                                locale={nb}
+                                                placeholder="Velg dato"
+                                                maxDate={
+                                                    values.start ?? undefined
+                                                }
+                                                value={
+                                                    values.cancellationDeadline
+                                                }
+                                                onValueChange={(
+                                                    cancellationDeadline,
+                                                ) =>
+                                                    onChange({
+                                                        cancellationDeadline,
+                                                    })
+                                                }
+                                            />
+                                            <FieldDescription>
+                                                Avmelding etter denne fristen
+                                                gir prikk, forutsatt at «Kan gi
+                                                prikker» er huket av.
+                                            </FieldDescription>
+                                        </Field>
+                                    ) : null}
+                                </div>
+                            ) : null}
+                            <div className="grid gap-4 lg:grid-cols-4">
+                                {values.requiresSigningUp ? (
+                                    <Field className="lg:col-span-2">
+                                        <FieldLabel htmlFor="event-capacity">
+                                            Kapasitet (valgfritt)
+                                        </FieldLabel>
+                                        <Input
+                                            id="event-capacity"
+                                            type="number"
+                                            min={1}
+                                            value={values.capacity}
+                                            onChange={(event) =>
+                                                onChange({
+                                                    capacity:
+                                                        event.target.value,
+                                                })
+                                            }
+                                        />
+                                    </Field>
+                                ) : null}
+                                <Field className={wideWhenNoCapacity}>
+                                    <FieldLabel htmlFor="event-visibility">
+                                        Synlighet
+                                    </FieldLabel>
+                                    <Select
+                                        items={[
+                                            {
+                                                value: "public",
+                                                label: "Offentlig",
+                                            },
+                                            {
+                                                value: "members",
+                                                label: "Kun for medlemmer",
+                                            },
+                                        ]}
+                                        value={values.visibility}
+                                        onValueChange={(value) =>
+                                            onChange({
+                                                visibility:
+                                                    value === "members"
+                                                        ? "members"
+                                                        : "public",
+                                            })
+                                        }
+                                    >
+                                        <SelectTrigger id="event-visibility">
+                                            <SelectValue placeholder="Velg synlighet" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="public">
+                                                Offentlig
+                                            </SelectItem>
+                                            <SelectItem value="members">
+                                                Kun for medlemmer
+                                            </SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </Field>
+                                <Field className={wideWhenNoCapacity}>
+                                    <FieldLabel htmlFor="event-institute">
+                                        Institutt
+                                    </FieldLabel>
+                                    <Select
+                                        items={[
+                                            {
+                                                value: ALL_INSTITUTES,
+                                                label: "Alle institutt",
+                                            },
+                                            ...institutes.map((institute) => ({
+                                                value: institute.slug,
+                                                label: institute.shortName,
+                                            })),
+                                        ]}
+                                        value={values.instituteSlug}
+                                        onValueChange={(value) =>
+                                            onChange({
+                                                instituteSlug:
+                                                    value ?? ALL_INSTITUTES,
+                                            })
+                                        }
+                                    >
+                                        <SelectTrigger id="event-institute">
+                                            <SelectValue placeholder="Velg institutt" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value={ALL_INSTITUTES}>
+                                                Alle institutt
+                                            </SelectItem>
+                                            {institutes.map((institute) => (
+                                                <SelectItem
+                                                    key={institute.slug}
+                                                    value={institute.slug}
+                                                >
+                                                    {institute.shortName} –{" "}
+                                                    {institute.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    <FieldDescription>
+                                        Begrenser påmelding til studenter ved
+                                        dette instituttet.
+                                    </FieldDescription>
+                                </Field>
+                            </div>
+                            <Field
+                                orientation="horizontal"
+                                className="w-fit gap-3"
+                            >
+                                <Checkbox
+                                    id="event-paid"
+                                    checked={values.isPaidEvent}
+                                    onCheckedChange={(checked) =>
+                                        handlePaidChange(Boolean(checked))
+                                    }
+                                />
+                                <FieldLabel htmlFor="event-paid">
+                                    Betalt arrangement
+                                </FieldLabel>
+                            </Field>
+                            {values.isPaidEvent && (
+                                <Field>
+                                    <FieldLabel htmlFor="event-price">
+                                        Pris (NOK)
+                                    </FieldLabel>
+                                    <Input
+                                        id="event-price"
+                                        type="number"
+                                        min={0}
+                                        value={values.price}
+                                        onChange={(event) =>
+                                            onChange({
+                                                price: event.target.value,
+                                            })
+                                        }
+                                    />
+                                </Field>
+                            )}
+                            {!values.isPaidEvent ? (
+                                <Field
+                                    orientation="horizontal"
+                                    className="w-fit gap-3"
+                                >
+                                    <Checkbox
+                                        id="event-strikes"
+                                        checked={values.canCauseStrikes}
+                                        onCheckedChange={(checked) =>
+                                            onChange({
+                                                canCauseStrikes:
+                                                    Boolean(checked),
+                                            })
+                                        }
+                                    />
+                                    <FieldLabel htmlFor="event-strikes">
+                                        Kan gi prikker (avmelding etter frist og
+                                        no-show)
+                                    </FieldLabel>
+                                </Field>
+                            ) : null}
+                            <Field>
+                                <FieldLabel>Beskrivelse</FieldLabel>
+                                {/* Editoren er en contenteditable, og den bryr
+                                seg ikke om at et fieldset over den er
+                                disabled. Uten tilgang vises teksten ferdig
+                                rendret i stedet — samme innhold, ingen
+                                markør. */}
+                                {readOnly ? (
+                                    <MarkdownView
+                                        registry={richRegistry}
+                                        source={values.description}
+                                        className="rounded-md border p-4"
+                                    />
+                                ) : (
+                                    <RichEditor
+                                        registry={richRegistry}
+                                        value={values.description}
+                                        onChange={(description) =>
+                                            onChange({ description })
+                                        }
+                                    />
+                                )}
+                            </Field>
+                        </FieldGroup>
+                    </CardContent>
+                </Card>
 
-            {/*
-             * Bare relevant når arrangementet har påmelding i det hele tatt —
-             * prioritering uten påmelding er ingenting å prioritere.
-             */}
-            {values.requiresSigningUp ? (
-                <PriorityPoolEditor
-                    pools={values.priorityPools}
-                    groups={poolGroups}
-                    organizerGroupSlug={values.organizerGroupSlug || null}
-                    onChange={(priorityPools) => onChange({ priorityPools })}
-                    users={values.priorityUsers}
-                    userSearch={priorityUserSearch}
-                    onUsersChange={(priorityUsers) =>
-                        onChange({ priorityUsers })
-                    }
-                    onlyAllowPrioritized={values.onlyAllowPrioritized}
-                    onOnlyAllowPrioritizedChange={(onlyAllowPrioritized) =>
-                        onChange({ onlyAllowPrioritized })
-                    }
-                />
-            ) : null}
+                {/*
+                 * Bare relevant når arrangementet har påmelding i det hele tatt —
+                 * prioritering uten påmelding er ingenting å prioritere.
+                 */}
+                {values.requiresSigningUp ? (
+                    <PriorityPoolEditor
+                        pools={values.priorityPools}
+                        groups={poolGroups}
+                        organizerGroupSlug={values.organizerGroupSlug || null}
+                        onChange={(priorityPools) =>
+                            onChange({ priorityPools })
+                        }
+                        users={values.priorityUsers}
+                        userSearch={priorityUserSearch}
+                        onUsersChange={(priorityUsers) =>
+                            onChange({ priorityUsers })
+                        }
+                        onlyAllowPrioritized={values.onlyAllowPrioritized}
+                        onOnlyAllowPrioritizedChange={(onlyAllowPrioritized) =>
+                            onChange({ onlyAllowPrioritized })
+                        }
+                    />
+                ) : null}
 
-            <Card>
-                <CardHeader>
-                    <CardTitle>Forsidebilde</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <FieldGroup>
-                        <AdminImageField
-                            label="Bilde"
-                            description="Vises på arrangementskortet og øverst på arrangementssiden. Forhåndsvisningen er samme utsnitt som besøkende ser."
-                            preset="cover-wide"
-                            value={values.image}
-                            onChange={(image) => onChange({ image })}
-                            existingImageUrl={existingImageUrl}
-                        />
-                        <Field>
-                            <FieldLabel htmlFor="event-image-alt">
-                                Bildebeskrivelse
-                            </FieldLabel>
-                            <Input
-                                id="event-image-alt"
-                                type="text"
-                                maxLength={255}
-                                placeholder="Kort beskrivelse for skjermlesere"
-                                value={values.imageAlt}
-                                onChange={(event) =>
-                                    onChange({ imageAlt: event.target.value })
-                                }
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Forsidebilde</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <FieldGroup>
+                            <AdminImageField
+                                label="Bilde"
+                                description="Vises på arrangementskortet og øverst på arrangementssiden. Forhåndsvisningen er samme utsnitt som besøkende ser."
+                                preset="cover-wide"
+                                value={values.image}
+                                onChange={(image) => onChange({ image })}
+                                existingImageUrl={existingImageUrl}
+                                // Dropsonen tar imot filer som slippes på den
+                                // uansett hva fieldsettet over sier, og ber om
+                                // et bilde den ikke kan ta imot.
+                                disabled={readOnly}
+                                readOnly={readOnly}
                             />
-                        </Field>
-                    </FieldGroup>
-                </CardContent>
-            </Card>
+                            <Field>
+                                <FieldLabel htmlFor="event-image-alt">
+                                    Bildebeskrivelse
+                                </FieldLabel>
+                                <Input
+                                    id="event-image-alt"
+                                    type="text"
+                                    maxLength={255}
+                                    placeholder="Kort beskrivelse for skjermlesere"
+                                    value={values.imageAlt}
+                                    onChange={(event) =>
+                                        onChange({
+                                            imageAlt: event.target.value,
+                                        })
+                                    }
+                                />
+                            </Field>
+                        </FieldGroup>
+                    </CardContent>
+                </Card>
+            </fieldset>
 
             {children}
 
-            <div className="flex justify-end gap-2">
-                {secondaryAction}
-                <Button
-                    type="submit"
-                    disabled={isSubmitting || !values.organizerGroupSlug}
-                >
-                    {submitLabel}
-                </Button>
-            </div>
+            {readOnly ? null : (
+                <div className="flex justify-end gap-2">
+                    {secondaryAction}
+                    <Button
+                        type="submit"
+                        disabled={isSubmitting || !values.organizerGroupSlug}
+                    >
+                        {submitLabel}
+                    </Button>
+                </div>
+            )}
         </form>
     );
 }

--- a/apps/kvark/src/hooks/use-permission.ts
+++ b/apps/kvark/src/hooks/use-permission.ts
@@ -100,6 +100,46 @@ export function useCanActOnResource(
 }
 
 /**
+ * Returns a predicate for "may act on this one resource, which belongs to a
+ * group".
+ *
+ * The scoped counterpart to {@link useCanActOnResource}, and what the API
+ * actually asks for an event: `requireEventAccess` checks the permission
+ * against the *arranging group*, lets the creator through, and falls back to
+ * the global check when the resource has no group (events migrated from
+ * Lepton have no organiser). Using the any-scope check here instead offered
+ * Sosialen's members the edit form on Index' arrangementer, where saving
+ * could only ever answer 403.
+ *
+ * Pass a module-level constant as `required` — the predicate's identity
+ * depends on it.
+ */
+export function useCanActOnGroupResource(
+    required: string | readonly string[],
+): (
+    groupSlug: string | null | undefined,
+    createdById?: string | null,
+) => boolean {
+    const { data: session } = useQuery(authQueryOptions);
+    const permissions = session?.permissions;
+    const userId = session?.user?.id;
+
+    return useCallback(
+        (groupSlug: string | null | undefined, createdById?: string | null) => {
+            if (createdById && createdById === userId) return true;
+            return groupSlug
+                ? sessionHasScopedPermission(
+                      permissions,
+                      required,
+                      `group:${groupSlug}`,
+                  )
+                : sessionHasPermission(permissions, required);
+        },
+        [permissions, userId, required],
+    );
+}
+
+/**
  * Permissions that grant access to at least one section of the admin panel.
  * Holding any of these (or `"root"`) makes a user an "admin" for the purpose
  * of showing admin entry points that live outside the panel (e.g. the "Admin"

--- a/apps/kvark/src/lib/admin-access.ts
+++ b/apps/kvark/src/lib/admin-access.ts
@@ -1,0 +1,115 @@
+import { redirect } from "@tanstack/react-router";
+
+import {
+    authClientWithRedirect,
+    sessionHasPermissionInAnyScope,
+} from "#/api/auth";
+import {
+    ADMIN_SECTION_PERMISSIONS,
+    ALL_ADMIN_SECTION_PERMISSIONS,
+    type AdminSection,
+} from "#/lib/admin-sections";
+
+/**
+ * Just enough of the session to answer "may this person open the panel".
+ * Structural so both the route context's `auth` and the cached session query
+ * fit without either having to know about this module.
+ */
+type AdminSession = {
+    permissions?: string[] | null;
+    groups?: readonly { role?: string | null }[] | null;
+};
+
+/** Group leaders act on their own group without holding a global grant. */
+function leadsAnyGroup(session: AdminSession): boolean {
+    return Boolean(session.groups?.some((group) => group.role === "leader"));
+}
+
+/**
+ * Whether the session has anything at all to do in the admin panel.
+ *
+ * The same question {@link useIsAdmin} answers for the command menu and the
+ * sidebar, read straight off a session so the router can ask it before the
+ * page renders. Reading the section map means the guard cannot drift from
+ * what the sidebar offers.
+ */
+export function canOpenAdminPanel(session: AdminSession): boolean {
+    return (
+        sessionHasPermissionInAnyScope(
+            session.permissions ?? undefined,
+            ALL_ADMIN_SECTION_PERMISSIONS,
+        ) || leadsAnyGroup(session)
+    );
+}
+
+/** Whether the session may open one specific section of the panel. */
+export function canOpenAdminSection(
+    session: AdminSession,
+    section: AdminSection,
+    options: { allowGroupLeader?: boolean } = {},
+): boolean {
+    if (options.allowGroupLeader && leadsAnyGroup(session)) return true;
+    return sessionHasPermissionInAnyScope(
+        session.permissions ?? undefined,
+        ADMIN_SECTION_PERMISSIONS[section],
+    );
+}
+
+/**
+ * Route guard for the admin shell: signed in, and holding something that
+ * opens at least one section.
+ *
+ * Unauthenticated visitors go to the login page and back afterwards. A
+ * signed-in member without any admin work is sent to the front page —
+ * logging in again would not help them.
+ */
+export async function requireAdminPanel(url: string) {
+    const auth = await authClientWithRedirect(url);
+
+    if (!canOpenAdminPanel(auth)) {
+        throw redirect({ to: "/" });
+    }
+
+    return auth;
+}
+
+/**
+ * Route guard for one section. Mirrors the sidebar entry exactly, including
+ * `allowGroupLeader` — a leader reaches Grupper and Tilganger without any
+ * global grant, because the API lets them act on their own group.
+ *
+ * Cosmetic, like every check in this app: the API enforces the same
+ * permissions on each request, and that is what protects the data. This only
+ * keeps people out of pages that could never answer them anything.
+ */
+export async function requireAdminSection(
+    url: string,
+    section: AdminSection,
+    options: {
+        allowGroupLeader?: boolean;
+        /**
+         * Narrower requirement for a single page inside the section — "Nytt
+         * arrangement" takes `events:create`, not merely something that opens
+         * Arrangementer.
+         */
+        permission?: string | readonly string[];
+    } = {},
+) {
+    const auth = await requireAdminPanel(url);
+
+    if (!canOpenAdminSection(auth, section, options)) {
+        throw redirect({ to: "/admin" });
+    }
+
+    if (
+        options.permission &&
+        !sessionHasPermissionInAnyScope(
+            auth.permissions ?? undefined,
+            options.permission,
+        )
+    ) {
+        throw redirect({ to: "/admin" });
+    }
+
+    return auth;
+}

--- a/apps/kvark/src/routes/admin.tsx
+++ b/apps/kvark/src/routes/admin.tsx
@@ -41,11 +41,8 @@ import {
 } from "lucide-react";
 import * as React from "react";
 
-import {
-    authClientWithRedirect,
-    authQueryOptions,
-    sessionHasPermissionInAnyScope,
-} from "#/api/auth";
+import { authQueryOptions, sessionHasPermissionInAnyScope } from "#/api/auth";
+import { requireAdminPanel } from "#/lib/admin-access";
 import { ADMIN_SECTION_PERMISSIONS } from "#/lib/admin-sections";
 import { AdminLayoutHeader } from "#/components/AdminLayoutHeader";
 import { TihldeLogo } from "#/components/icons/tihlde";
@@ -53,9 +50,11 @@ import { TihldeLogo } from "#/components/icons/tihlde";
 export const Route = createFileRoute("/admin")({
     component: AdminLayout,
     async beforeLoad({ location }) {
-        // Baseline: you must be signed in to reach the admin shell at all.
-        // Each section still relies on the API enforcing its own permission.
-        const auth = await authClientWithRedirect(location.href);
+        // Signed in AND holding something that opens a section — otherwise the
+        // shell is an empty sidebar and a dashboard of public numbers. Each
+        // section guards itself on top of this, and the API remains the thing
+        // that actually enforces access.
+        const auth = await requireAdminPanel(location.href);
         return { auth };
     },
 });

--- a/apps/kvark/src/routes/admin/annonser.tsx
+++ b/apps/kvark/src/routes/admin/annonser.tsx
@@ -49,6 +49,7 @@ import { RichEditor } from "@tihlde/ui/complex/markdown";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { useImageUploader } from "#/api/queries/assets";
 import {
     createJobMutation,
@@ -106,6 +107,9 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/admin/annonser")({
     component: JobsAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "annonser");
+    },
     validateSearch: searchSchema,
     loader: async ({ context }) => {
         await context.queryClient.ensureQueryData(

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -19,6 +19,7 @@ import {
     CheckCircle2,
     CircleCheckBigIcon,
     ExternalLink,
+    EyeIcon,
     PlusIcon,
     TriangleAlertIcon,
     UsersIcon,
@@ -61,6 +62,7 @@ import { Tabs, TabsList, TabsTrigger } from "@tihlde/ui/ui/tabs";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { searchAddressQuery } from "#/api/queries/address";
 import { useImageUploader } from "#/api/queries/assets";
 import {
@@ -94,7 +96,7 @@ import { NewFormDialog } from "#/components/new-form-dialog";
 import {
     useAnyScopePermission,
     useCanActForGroup,
-    useCanActOnResource,
+    useCanActOnGroupResource,
 } from "#/hooks/use-permission";
 import { extractErrorMessage } from "#/lib/api-error";
 import { cn } from "#/lib/utils";
@@ -111,8 +113,14 @@ const TABS = [
 ] as const;
 type TabValue = (typeof TABS)[number];
 
-/** Module-level so the permission predicate keeps a stable identity. */
+/** Module-level so the permission predicates keep a stable identity. */
 const EVENT_UPDATE_PERMISSIONS = ["events:update", "events:manage"] as const;
+const EVENT_DELETE_PERMISSIONS = ["events:delete", "events:manage"] as const;
+const EVENT_PAYMENT_VIEW_PERMISSIONS = [
+    "events:payments:view",
+    "events:manage",
+    "events:update",
+] as const;
 
 // Defaulted (not required) so plain links to the page need no search param,
 // while the tab stays deep-linkable and survives a bad value.
@@ -122,6 +130,9 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/admin/arrangementer/$eventId")({
     component: EventAdminDetailPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "arrangementer");
+    },
     validateSearch: searchSchema,
     loader: async ({ context, params }) => {
         const event = await context.queryClient.ensureQueryData(
@@ -147,23 +158,37 @@ function EventAdminDetailPage() {
     const navigate = useNavigate({ from: Route.fullPath });
     const { data: event } = useSuspenseQuery(getEventByIdQuery(eventId));
 
-    const canSeePayments = useAnyScopePermission([
-        "events:payments:view",
-        "events:manage",
-        "events:update",
-    ]);
+    const organizerSlug = event.organizer?.slug ?? null;
 
+    // Rettigheten må gjelde arrangørgruppa — det er det API-et spør om. Uten
+    // den er sida en lesevisning: du ser hva som står i feltene, ingenting
+    // mer. Se `useCanActOnGroupResource`.
+    const canManage = useCanActOnGroupResource(EVENT_UPDATE_PERMISSIONS)(
+        organizerSlug,
+        event.createdById,
+    );
+    const canSeePayments = useCanActOnGroupResource(
+        EVENT_PAYMENT_VIEW_PERMISSIONS,
+    )(organizerSlug, event.createdById);
+
+    // Påmeldte, oppmøte og skjemaer er administrasjon av arrangementet, og
+    // endepunktene bak dem svarer bare den som kan det. Uten tilgang står
+    // detaljfanen igjen alene, i lesemodus.
     const visibleTabs = useMemo(
         () => [
             { value: "detaljer" as const, label: "Detaljer" },
-            { value: "pameldte" as const, label: "Påmeldte" },
-            { value: "oppmote" as const, label: "Oppmøte" },
-            { value: "skjemaer" as const, label: "Skjemaer" },
+            ...(canManage
+                ? [
+                      { value: "pameldte" as const, label: "Påmeldte" },
+                      { value: "oppmote" as const, label: "Oppmøte" },
+                      { value: "skjemaer" as const, label: "Skjemaer" },
+                  ]
+                : []),
             ...(canSeePayments
                 ? [{ value: "betalinger" as const, label: "Betalinger" }]
                 : []),
         ],
-        [canSeePayments],
+        [canManage, canSeePayments],
     );
 
     // A tab the user cannot see falls back to the first one they can.
@@ -317,12 +342,15 @@ function DetailsTab({ eventId }: { eventId: string }) {
         [allGroups, canArrangeFor, event.organizer?.slug],
     );
 
-    // Samme regel som API-et: rettigheten (også gruppescopet), eller å ha
-    // opprettet arrangementet selv.
-    const canEdit = useCanActOnResource(["events:update", "events:manage"])(
+    // Samme regel som API-et: rettigheten for arrangørgruppa, eller å ha
+    // opprettet arrangementet selv. Any-scope holdt ikke — den ga
+    // redigeringsskjemaet for andre gruppers arrangementer også.
+    const canEdit = useCanActOnGroupResource(EVENT_UPDATE_PERMISSIONS)(
+        event.organizer?.slug ?? null,
         event.createdById,
     );
-    const canDelete = useCanActOnResource(["events:delete", "events:manage"])(
+    const canDelete = useCanActOnGroupResource(EVENT_DELETE_PERMISSIONS)(
+        event.organizer?.slug ?? null,
         event.createdById,
     );
 
@@ -487,23 +515,25 @@ function DetailsTab({ eventId }: { eventId: string }) {
         );
     }
 
-    if (!canEdit) {
-        return (
-            <Card>
-                <CardContent>
-                    <AdminEmptyState
-                        icon={UsersIcon}
-                        title="Ingen tilgang"
-                        description="Du har ikke tilgang til å redigere dette arrangementet."
-                    />
-                </CardContent>
-            </Card>
-        );
-    }
-
     return (
         <div className="flex flex-col gap-4">
-            {droppedPoolCount > 0 ? (
+            {/*
+             * Lesevisning: du kom hit fra øyeikonet i lista, på et arrangement
+             * en annen gruppe eier. Skjemaet vises som det er, låst — så man
+             * kan se hvordan arrangementet er satt opp uten å kunne endre det.
+             */}
+            {canEdit ? null : (
+                <Alert>
+                    <EyeIcon className="size-4" />
+                    <AlertTitle>Lesevisning</AlertTitle>
+                    <AlertDescription>
+                        {event.organizer
+                            ? `Arrangementet eies av ${event.organizer.name}. Du kan se hvordan det er satt opp, men ikke endre det.`
+                            : "Du kan se hvordan arrangementet er satt opp, men ikke endre det."}
+                    </AlertDescription>
+                </Alert>
+            )}
+            {canEdit && droppedPoolCount > 0 ? (
                 <Alert variant="destructive">
                     <AlertTitle>
                         {droppedPoolCount === 1
@@ -528,6 +558,7 @@ function DetailsTab({ eventId }: { eventId: string }) {
                 addressSuggestions={addressSuggestions ?? []}
                 isSearchingAddress={isSearchingAddress}
                 onSubmit={handleSubmit}
+                readOnly={!canEdit}
                 submitLabel={
                     isUploading ? "Laster opp bilde …" : "Lagre endringer"
                 }

--- a/apps/kvark/src/routes/admin/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.index.tsx
@@ -2,7 +2,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { nb } from "date-fns/locale";
-import { CalendarDaysIcon, PlusIcon } from "lucide-react";
+import { CalendarDaysIcon, EyeIcon, PlusIcon } from "lucide-react";
 import { Suspense, startTransition, useState } from "react";
 
 import { Badge } from "@tihlde/ui/ui/badge";
@@ -30,11 +30,16 @@ import {
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { getEventsQuery } from "#/api/queries/events";
 import { AdminEmptyState } from "#/components/admin-empty-state";
+import { IconActionButton } from "#/components/icon-action-button";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { useDebouncedValue } from "#/hooks/use-debounced-value";
-import { useAnyScopePermission } from "#/hooks/use-permission";
+import {
+    useAnyScopePermission,
+    useCanActOnGroupResource,
+} from "#/hooks/use-permission";
 
 const PAGE_SIZE = 25;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -49,6 +54,9 @@ const SORT_OPTIONS: { value: EventSort; label: string }[] = [
 
 const DEFAULT_SORT: EventSort = "upcoming";
 
+/** Module-level so the permission predicate keeps a stable identity. */
+const EVENT_UPDATE_PERMISSIONS = ["events:update", "events:manage"] as const;
+
 /**
  * Søk, tidsrom og rekkefølge avgjøres server-side. Listen er paginert, så et
  * klientfilter ville bare skjult treff på siden du står på — og «eldste først»
@@ -62,6 +70,9 @@ const toFilters = (search: string, showPast: boolean, sort: EventSort) => ({
 
 export const Route = createFileRoute("/admin/arrangementer/")({
     component: EventsAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "arrangementer");
+    },
     loader: async ({ context }) => {
         await context.queryClient.ensureQueryData(
             getEventsQuery(0, toFilters("", false, DEFAULT_SORT), PAGE_SIZE),
@@ -187,6 +198,9 @@ function EventsTable({
     const { data } = useSuspenseQuery(
         getEventsQuery(page, toFilters(search, showPast, sort), PAGE_SIZE),
     );
+    // Lista viser alle arrangementer — det er poenget med en oversikt — men
+    // bare de du kan arrangere for lar seg redigere. Resten får øyeikonet.
+    const canManage = useCanActOnGroupResource(EVENT_UPDATE_PERMISSIONS);
 
     const events = data.items;
 
@@ -243,20 +257,13 @@ function EventsTable({
                                         />
                                     </TableCell>
                                     <TableCell className="text-right">
-                                        <Button
-                                            variant="outline"
-                                            size="sm"
-                                            render={
-                                                <Link
-                                                    to="/admin/arrangementer/$eventId"
-                                                    params={{
-                                                        eventId: event.id,
-                                                    }}
-                                                />
-                                            }
-                                        >
-                                            Administrer
-                                        </Button>
+                                        <EventRowAction
+                                            eventId={event.id}
+                                            canManage={canManage(
+                                                event.organizer?.slug ?? null,
+                                                event.createdById,
+                                            )}
+                                        />
                                     </TableCell>
                                 </TableRow>
                             ))}
@@ -289,6 +296,39 @@ function EventsTable({
                 </div>
             ) : null}
         </>
+    );
+}
+
+/**
+ * Handlingen på en rad. «Administrer» for arrangementene du kan redigere;
+ * for de andre et øyeikon som åpner samme side i lesevisning, slik at man kan
+ * se hvordan et arrangement er satt opp uten å kunne endre det.
+ */
+function EventRowAction({
+    eventId,
+    canManage,
+}: {
+    eventId: string;
+    canManage: boolean;
+}) {
+    const link = (
+        <Link to="/admin/arrangementer/$eventId" params={{ eventId }} />
+    );
+
+    if (!canManage) {
+        return (
+            <IconActionButton
+                icon={EyeIcon}
+                label="Se oppsettet – du kan ikke redigere dette arrangementet"
+                render={link}
+            />
+        );
+    }
+
+    return (
+        <Button variant="outline" size="sm" render={link}>
+            Administrer
+        </Button>
     );
 }
 

--- a/apps/kvark/src/routes/admin/arrangementer.ny.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.ny.tsx
@@ -9,6 +9,7 @@ import { XCircle } from "lucide-react";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { searchAddressQuery } from "#/api/queries/address";
 import { useImageUploader } from "#/api/queries/assets";
 import { createEventMutation } from "#/api/queries/events";
@@ -39,6 +40,11 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/admin/arrangementer/ny")({
     component: NewEventPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "arrangementer", {
+            permission: ["events:create", "events:manage"],
+        });
+    },
     validateSearch: searchSchema,
     loader: async ({ context }) => {
         await Promise.all([

--- a/apps/kvark/src/routes/admin/bannere.tsx
+++ b/apps/kvark/src/routes/admin/bannere.tsx
@@ -39,12 +39,16 @@ import {
 } from "#/api/queries/banners";
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 
 export const Route = createFileRoute("/admin/bannere")({
     component: BannersAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "bannere");
+    },
     loader: async ({ context }) => {
         await context.queryClient.ensureQueryData(getBannersQuery());
         return { breadcrumbs: "Bannere" };

--- a/apps/kvark/src/routes/admin/brukere.tsx
+++ b/apps/kvark/src/routes/admin/brukere.tsx
@@ -54,6 +54,7 @@ import {
 } from "#/api/queries/groups";
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { searchUsersQuery } from "#/api/queries/roles";
 import {
     approveUserMutation,
@@ -118,6 +119,9 @@ function formatStudy(
 
 export const Route = createFileRoute("/admin/brukere")({
     component: UsersAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "brukere");
+    },
     loader: async ({ context }) => {
         await context.queryClient.ensureQueryData(getGroupsQuery(0));
         return { breadcrumbs: "Brukere" };

--- a/apps/kvark/src/routes/admin/galleri.tsx
+++ b/apps/kvark/src/routes/admin/galleri.tsx
@@ -53,6 +53,7 @@ import { useEffect, useState } from "react";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { uploadAssetMutation } from "#/api/queries/assets";
 import { getEventsQuery } from "#/api/queries/events";
 import {
@@ -84,6 +85,9 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/admin/galleri")({
     component: GalleryAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "galleri");
+    },
     validateSearch: searchSchema,
     loader: async ({ context }) => {
         await Promise.all([

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -65,6 +65,7 @@ import { useState } from "react";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { useImageUploader } from "#/api/queries/assets";
 import {
     createGroupMutation,
@@ -99,6 +100,11 @@ import {
 
 export const Route = createFileRoute("/admin/grupper")({
     component: GrupperAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "grupper", {
+            allowGroupLeader: true,
+        });
+    },
     loader: async ({ context }) => {
         await context.queryClient.ensureQueryData(getGroupsQuery(0));
         return { breadcrumbs: "Grupper" };

--- a/apps/kvark/src/routes/admin/kontaktskjema.tsx
+++ b/apps/kvark/src/routes/admin/kontaktskjema.tsx
@@ -22,6 +22,7 @@ import {
     getApplicationsQuery,
     updateApplicationStatusMutation,
 } from "#/api/queries/applications";
+import { requireAdminSection } from "#/lib/admin-access";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { AdminDetailDialog } from "#/components/soknader/admin-detail-dialog";
@@ -35,6 +36,9 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/admin/kontaktskjema")({
     component: AdminCompanyContactPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "kontaktskjema");
+    },
     validateSearch: searchSchema,
     loader: () => ({ breadcrumbs: "Kontaktskjema" }),
 });

--- a/apps/kvark/src/routes/admin/nyheter.tsx
+++ b/apps/kvark/src/routes/admin/nyheter.tsx
@@ -33,6 +33,7 @@ import z from "zod";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { useImageUploader } from "#/api/queries/assets";
 import {
     createNewsMutation,
@@ -57,6 +58,9 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/admin/nyheter")({
     component: NewsAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "nyheter");
+    },
     validateSearch: searchSchema,
     loader: async ({ context }) => {
         await context.queryClient.ensureQueryData(getNewsQuery(0));

--- a/apps/kvark/src/routes/admin/opptak.tsx
+++ b/apps/kvark/src/routes/admin/opptak.tsx
@@ -28,6 +28,7 @@ import { Suspense, lazy, useEffect, useState } from "react";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { uploadAssetMutation } from "#/api/queries/assets";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { useAnyScopePermission } from "#/hooks/use-permission";
@@ -45,6 +46,9 @@ const PdfPlacement = lazy(async () => ({
 
 export const Route = createFileRoute("/admin/opptak")({
     component: OpptakAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "opptak");
+    },
     loader: ({ context }) =>
         context.queryClient.ensureQueryData(getContractListQuery()),
 });

--- a/apps/kvark/src/routes/admin/prikker.tsx
+++ b/apps/kvark/src/routes/admin/prikker.tsx
@@ -43,6 +43,7 @@ import {
 } from "#/api/queries/events";
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { searchUsersQuery } from "#/api/queries/roles";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
@@ -57,6 +58,9 @@ import { avatarImageUrl } from "#/lib/assets";
 
 export const Route = createFileRoute("/admin/prikker")({
     component: StrikesAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "prikker");
+    },
     loader: () => ({ breadcrumbs: "Prikker" }),
 });
 

--- a/apps/kvark/src/routes/admin/roller.tsx
+++ b/apps/kvark/src/routes/admin/roller.tsx
@@ -42,6 +42,7 @@ import { useMemo, useState } from "react";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { getGroupMembersQuery, getGroupsQuery } from "#/api/queries/groups";
 import {
     assignPositionMutation,
@@ -81,6 +82,11 @@ import { avatarImageUrl } from "#/lib/assets";
 
 export const Route = createFileRoute("/admin/roller")({
     component: RolesAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "roller", {
+            allowGroupLeader: true,
+        });
+    },
     loader: async ({ context }) => {
         await context.queryClient.ensureQueryData(getGroupsQuery(0));
         return { breadcrumbs: "Tilganger" };

--- a/apps/kvark/src/routes/admin/soknader.tsx
+++ b/apps/kvark/src/routes/admin/soknader.tsx
@@ -17,6 +17,7 @@ import { z } from "zod";
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { authQueryOptions, sessionHasPermission } from "#/api/auth";
 import {
     type ApplicationType,
@@ -42,6 +43,9 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/admin/soknader")({
     component: AdminApplicationsPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "soknader");
+    },
     validateSearch: searchSchema,
     loader: () => ({ breadcrumbs: "Søknader" }),
 });

--- a/apps/kvark/src/routes/admin/toddel.tsx
+++ b/apps/kvark/src/routes/admin/toddel.tsx
@@ -28,6 +28,7 @@ import {
 
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import { requireAdminSection } from "#/lib/admin-access";
 import { uploadAssetMutation } from "#/api/queries/assets";
 import {
     createToddelMutation,
@@ -42,6 +43,9 @@ import { useAnyScopePermission } from "#/hooks/use-permission";
 
 export const Route = createFileRoute("/admin/toddel")({
     component: ToddelAdminPage,
+    beforeLoad: async ({ location }) => {
+        await requireAdminSection(location.href, "toddel");
+    },
     loader: async ({ context }) => {
         await context.queryClient.ensureQueryData(getToddelIssuesQuery());
         return { breadcrumbs: "TÖDDEL" };

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -3669,6 +3669,8 @@ export interface components {
             image: string | null;
             /** @description Alt text for the event image (nullable) */
             imageAlt: string | null;
+            /** @description Creator user ID. The creator may update and delete their own event, so an admin listing needs it to tell an event the caller can manage from one they may only look at. */
+            createdById: string | null;
             /**
              * Format: date
              * @description Event creation time (ISO 8601)


### PR DESCRIPTION
Meldt inn internt: adminsiden var åpen via kommandomenyen, og det så ut som man kunne endre arrangementer.

Kommandomenyen var faktisk allerede gated — den vises bare til dem som har en admin-rettighet i en eller annen scope, eller som leder en gruppe. Men to reelle hull lå bak:

1. **`/admin` krevde bare innlogging.** Hvem som helst kunne skrive URL-en og lande i adminskallet. Sidemenyen var tom og sidene svarte 403, men man skal ikke komme dit i det hele tatt.
2. **Rediger-sjekken var any-scope.** Et Sosialen-medlem fikk fullt redigeringsskjema på Index sine arrangementer. Lagring svarte 403 fra API-et, men skjemaet skulle aldri vært vist.

Backenden har hele tiden vært tett: `PUT`/`DELETE` på arrangementer går gjennom `requireEventAccess` scoped til arrangørgruppa. Dette er ryddearbeid i grensesnittet, ikke en sikkerhetsfiks.

## Endringer

**Guard på panelet** — ny `admin-access.ts` med `requireAdminPanel` og `requireAdminSection`, koblet på `/admin` og alle 15 undersidene. Guarden leser samme `ADMIN_SECTION_PERMISSIONS` som sidemenyen og kommandomenyen, så de tre kan ikke drifte fra hverandre. Gruppeledere slipper inn på Grupper og Tilganger som før, og «Nytt arrangement» krever `events:create` — ikke bare noe som åpner Arrangementer.

**Scoped rediger-sjekk** — ny `useCanActOnGroupResource` som speiler `requireEventAccess`: rettigheten må gjelde arrangørgruppa, den som opprettet arrangementet slipper alltid til, og arrangementer uten arrangør (migrert fra Lepton) faller tilbake til den globale sjekken. Fanene Påmeldte, Oppmøte og Skjemaer følger samme sjekk, siden endepunktene bak dem bare svarer den som kan administrere arrangementet.

**Lista og lesevisningen** — «Administrer» der du kan redigere, øyeikon ellers. Øyet åpner samme side i lesevisning: skjemaet med alle verdiene låst av et `fieldset[disabled]`, beskrivelsen rendret som markdown i stedet for editoren, bildet som ren forhåndsvisning, ingen lagre- eller slett-knapp, og en melding om hvem som eier arrangementet. Lista viser fortsatt alle arrangementer — det er poenget med en oversikt.

`createdById` er lagt til på listeelementene i API-et. Uten det kan ikke lista skille et arrangement du selv har opprettet fra ett du bare kan se på. SDK-en er regenerert.

## Verifisering

Lokal DB satt i tre tilstander, hver testet i nettleseren:

- **Vanlig student:** `/admin`, `/admin/arrangementer`, `/admin/brukere`, `/admin/arrangementer/ny` og `/admin/roller` sender alle til forsiden — også gjennom SSR, ikke bare klientsiden.
- **Medlem med `events:*` for én gruppe:** lista viste øyeikon på andres arrangementer og «Administrer» på egne. I lesevisningen matchet alle 29 skjemakontroller `:disabled`; jeg klikket og skrev i tittelfeltet uten at verdien endret seg, ingen nedtrekk lot seg åpne, ingen submit-knapp fantes. Med `events:create` fjernet ble `/ny` avvist mens seksjonen forble åpen.
- **Root:** full sidemeny, «Administrer» på alt, redigerbart skjema med alle fem faner og lagreknapp.

`bun run typecheck`, `bun run lint` og `bun run build` er grønne.

Én ting verdt å vite: det ligger en hydreringsfeil i konsollet på adminsidene. Den reproduserer på `main` uten disse endringene, så den kommer ikke herfra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)