### PR TITLE
fix: vis og prioriter etter studiet medlemmet går på nå

### DIFF
--- a/apps/api/src/db/backfill-study-start-year.ts
+++ b/apps/api/src/db/backfill-study-start-year.ts
@@ -1,7 +1,9 @@
 /**
  * One-shot backfill: give every study-programme row that has no start year one.
  *
- * 153 rows in production sit with `start_year = NULL` and a NULL source. They
+ * Around 150 rows in production sit with `start_year = NULL` and a NULL source
+ * — 154 when this was written, and the number grows with every login that
+ * creates a row the old guard could not fill. They
  * could never be filled: the old conflict guard on the Feide sync only ever let
  * `feide` replace `assumed`, so a row that already existed without a year was
  * stuck there for good. Two programmes are affected above all — NTNU issues no

--- a/apps/api/src/db/backfill-study-start-year.ts
+++ b/apps/api/src/db/backfill-study-start-year.ts
@@ -1,0 +1,254 @@
+/**
+ * One-shot backfill: give every study-programme row that has no start year one.
+ *
+ * 153 rows in production sit with `start_year = NULL` and a NULL source. They
+ * could never be filled: the old conflict guard on the Feide sync only ever let
+ * `feide` replace `assumed`, so a row that already existed without a year was
+ * stuck there for good. Two programmes are affected above all — NTNU issues no
+ * `fc:fs:kull` for ITBAITBEDR or for the master, 0 of 217 rows between them — so
+ * for those a year we work out ourselves is the only one there will ever be.
+ *
+ * Every affected member already has a cohort *group*, so nobody's class year is
+ * wrong today. What the backfill buys is that a bachelor's intake and a
+ * master's stop being the same number: the group carries the year someone
+ * started their bachelor, and reading it for a master is what made a first-year
+ * master indistinguishable from a third-year bachelor.
+ *
+ * Two rules, deliberately different in how much they trust themselves:
+ *
+ * - **Bachelor rows** take the year straight from the member's own cohort
+ *   group. Exact, no inference. Only when there is exactly one: a member who
+ *   transferred carries a group per intake, and choosing between them is a
+ *   judgement call for a human, not a script. Those rows are left alone.
+ * - **Master rows** take it from when we first saw the member on the programme,
+ *   via `created_at` on the study-group membership. The cohort group cannot
+ *   help here — it belongs to their bachelor. Checked against the 314 rows
+ *   where Feide did supply a year: 282 exact, 21 out by one, 7 by more.
+ *
+ * Both are written as `derived`, the lowest rank, so a real year from Feide or a
+ * correction by hand still overrides them.
+ *
+ * This is stricter than the same derivation at login time, which must produce
+ * *something* for a student who has just arrived. A backfill has no such
+ * pressure: leaving a row for a human to decide is a valid outcome.
+ *
+ * Idempotent — only rows with a NULL start year are touched.
+ *
+ * Run with:
+ *   cd apps/api && bun run src/db/backfill-study-start-year.ts          # dry run
+ *   cd apps/api && bun run src/db/backfill-study-start-year.ts --apply  # writes
+ */
+import {
+    currentAcademicYear,
+    isMasterStudySlug,
+} from "@photon/auth/academic-year";
+import { DISABLED_TIMEOUTS, createDb, schema } from "@photon/db";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { env } from "~/lib/env";
+
+type Candidate = {
+    userId: string;
+    userName: string;
+    studyProgramId: number;
+    programSlug: string;
+    isMaster: boolean;
+    cohortYears: number[];
+    firstSeen: Date | null;
+};
+
+type Resolved =
+    | { candidate: Candidate; year: number; via: "kullgruppe" | "created_at" }
+    | { candidate: Candidate; year: null; via: "hoppes over"; why: string };
+
+function resolve(candidate: Candidate): Resolved {
+    if (candidate.isMaster) {
+        if (!candidate.firstSeen) {
+            return {
+                candidate,
+                year: null,
+                via: "hoppes over",
+                why: "ingen studiegruppe å lese created_at fra",
+            };
+        }
+        return {
+            candidate,
+            year: currentAcademicYear(candidate.firstSeen),
+            via: "created_at",
+        };
+    }
+
+    if (candidate.cohortYears.length === 1) {
+        return {
+            candidate,
+            year: candidate.cohortYears[0] as number,
+            via: "kullgruppe",
+        };
+    }
+
+    return {
+        candidate,
+        year: null,
+        via: "hoppes over",
+        why:
+            candidate.cohortYears.length === 0
+                ? "ingen kullgruppe"
+                : `flere kullgrupper (${candidate.cohortYears.join(", ")})`,
+    };
+}
+
+async function main() {
+    const apply = process.argv.includes("--apply");
+
+    const db = createDb({
+        connectionString: env.DATABASE_URL,
+        timeouts: DISABLED_TIMEOUTS,
+    });
+
+    const rows = await db
+        .select({
+            userId: schema.studyProgramMembership.userId,
+            userName: schema.user.name,
+            studyProgramId: schema.studyProgram.id,
+            programSlug: schema.studyProgram.slug,
+            programType: schema.studyProgram.type,
+            firstSeen: schema.groupMembership.createdAt,
+        })
+        .from(schema.studyProgramMembership)
+        .innerJoin(
+            schema.studyProgram,
+            eq(
+                schema.studyProgram.id,
+                schema.studyProgramMembership.studyProgramId,
+            ),
+        )
+        .innerJoin(
+            schema.user,
+            eq(schema.user.id, schema.studyProgramMembership.userId),
+        )
+        .leftJoin(
+            schema.groupMembership,
+            and(
+                eq(
+                    schema.groupMembership.userId,
+                    schema.studyProgramMembership.userId,
+                ),
+                eq(schema.groupMembership.groupSlug, schema.studyProgram.slug),
+            ),
+        )
+        .where(isNull(schema.studyProgramMembership.startYear));
+
+    const cohortRows = await db
+        .select({
+            userId: schema.groupMembership.userId,
+            slug: schema.groupMembership.groupSlug,
+        })
+        .from(schema.groupMembership)
+        .innerJoin(
+            schema.group,
+            eq(schema.group.slug, schema.groupMembership.groupSlug),
+        )
+        .where(sql`upper(${schema.group.type}) = 'STUDYYEAR'`);
+
+    const cohortsByUser = new Map<string, number[]>();
+    for (const row of cohortRows) {
+        const year = Number.parseInt(row.slug, 10);
+        if (!Number.isFinite(year)) continue;
+        const list = cohortsByUser.get(row.userId) ?? [];
+        list.push(year);
+        cohortsByUser.set(row.userId, list);
+    }
+
+    const resolved = rows.map((row) =>
+        resolve({
+            userId: row.userId,
+            userName: row.userName,
+            studyProgramId: row.studyProgramId,
+            programSlug: row.programSlug,
+            isMaster:
+                row.programType === "master" ||
+                isMasterStudySlug(row.programSlug),
+            cohortYears: (cohortsByUser.get(row.userId) ?? []).sort(),
+            firstSeen: row.firstSeen,
+        }),
+    );
+
+    const writable = resolved.filter(
+        (r): r is Extract<Resolved, { year: number }> => r.year !== null,
+    );
+    const skipped = resolved.filter((r) => r.year === null);
+
+    console.log(
+        `${rows.length} rader uten startår. ${writable.length} kan fylles, ${skipped.length} hoppes over.\n`,
+    );
+
+    const byProgramme = new Map<string, number>();
+    for (const r of writable) {
+        const key = `${r.candidate.programSlug} (${r.via})`;
+        byProgramme.set(key, (byProgramme.get(key) ?? 0) + 1);
+    }
+    for (const [key, count] of [...byProgramme].sort()) {
+        console.log(`  ${count.toString().padStart(4)}  ${key}`);
+    }
+
+    if (skipped.length > 0) {
+        console.log("\nHoppes over:");
+        for (const r of skipped) {
+            if (r.year !== null) continue;
+            console.log(
+                `  ${r.candidate.userName} — ${r.candidate.programSlug}: ${r.why}`,
+            );
+        }
+    }
+
+    console.log("\nMasterrader i detalj (lista André går gjennom):");
+    for (const r of writable) {
+        if (!r.candidate.isMaster) continue;
+        console.log(
+            `  ${r.candidate.userName.padEnd(32)} ${r.year}  ` +
+                `(kullgruppe: ${r.candidate.cohortYears.join(", ") || "ingen"})`,
+        );
+    }
+
+    if (!apply) {
+        console.log("\nTørrkjøring — ingenting er skrevet. Kjør med --apply.");
+        return;
+    }
+
+    let written = 0;
+    for (const r of writable) {
+        const result = await db
+            .update(schema.studyProgramMembership)
+            .set({
+                startYear: r.year,
+                startYearSource: "derived",
+                updatedAt: new Date(),
+            })
+            .where(
+                and(
+                    eq(
+                        schema.studyProgramMembership.userId,
+                        r.candidate.userId,
+                    ),
+                    eq(
+                        schema.studyProgramMembership.studyProgramId,
+                        r.candidate.studyProgramId,
+                    ),
+                    // Idempotent, and safe against a row someone filled while
+                    // this was running: only ever a NULL is replaced.
+                    isNull(schema.studyProgramMembership.startYear),
+                ),
+            )
+            .returning({ userId: schema.studyProgramMembership.userId });
+
+        written += result.length;
+    }
+
+    console.log(`\nSkrev ${written} rader.`);
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/apps/api/src/lib/event/priority.ts
+++ b/apps/api/src/lib/event/priority.ts
@@ -4,6 +4,7 @@ import {
     MIN_CLASS_YEAR,
     computeClassYear,
     isMasterStudySlug,
+    programmeLength,
 } from "@photon/auth/academic-year";
 import type { DbSchema } from "@photon/db";
 import { schema } from "@photon/db";
@@ -58,6 +59,14 @@ type MembershipRow = {
     name: string;
     /** Free-text and upper-case from Lepton — always compare case-insensitively. */
     type: string;
+    /** Whether the slug matches a row in `study_program`. */
+    isStudyProgramme?: boolean;
+    /** Whether that programme is one of the five-year masters. */
+    isMaster?: boolean;
+    /** The member's own start year on that programme, when we have one. */
+    startYear?: number | null;
+    /** Whether Feide reported the programme active at the last login. */
+    feideActive?: boolean | null;
 };
 
 /** What a member is, reduced to the two things a priority pool can ask about. */
@@ -68,64 +77,162 @@ export type UserPriorityFacts = {
 };
 
 /**
- * Which class level a member is on, from their group memberships.
+ * Which class level a member is on.
  *
- * Derived from the `STUDYYEAR`/`STUDY` groups rather than
- * `studyProgramMembership`, for the reason spelled out on {@link UserStudy} in
- * `~/lib/user/study`: the table only gets rows from a Feide login, so a
- * handful of members have one while almost everyone carries the groups from
- * the Lepton migration. Reading the table here would leave the overwhelming
- * majority with no class level at all.
+ * Read from the member's *current* study programme, ranked exactly as
+ * `deriveStudyFromGroups` ranks it, because the answer depends on which
+ * programme you mean. A member who took a three-year bachelor from 2023 and
+ * went on to the master in 2026 is on their fourth year of study and their
+ * first of the master — the same person, two different intakes — and the only
+ * way to tell them apart is to know which programme the year belongs to.
  *
- * Masters are the awkward case. TIHLDE counts the master's first year as 4.
- * klasse, but the cohort group only ever holds a start year — and which start
- * year it is depends on whether Feide handed out a `fc:fs:kull` for the master
- * itself. Rather than guess, we compute both readings and keep the one that
- * lands in the master's own range; a member on a master can only be on 4. or
- * 5. klasse, so at most one of the two can be right.
+ * The cohort groups are still the fallback, and carry most members: they are
+ * all 1423 migrated from Lepton have. A cohort group is programme-less, so
+ * when it is all we have the master ambiguity comes back, and the two-candidate
+ * reading below is what resolves it.
  *
- * Anything outside 1-5 is an alumnus and returns null — they match no class
- * pool, which is the whole point of the range.
+ * The ceiling is the programme's own length, not a flat five. That flat five is
+ * why 398 members who finished a three-year bachelor still counted as fourth-
+ * and fifth-years: nothing capped a bachelor at three, so they stayed
+ * "students" for two years after graduating and would have matched any pool
+ * asking for 4. or 5. klasse. `programmeLength` already encoded the right
+ * answer and was already used in kvark — the frontend called them alumni while
+ * the backend handed them priority.
+ *
+ * Anything outside the programme's range returns null: an alumnus matches no
+ * class pool, which is the whole point of having a range.
  */
 export function computeUserClassYear(
     groups: readonly MembershipRow[],
     now = new Date(),
 ): number | null {
-    let startYear: number | null = null;
-    let onMaster = false;
+    let current: MembershipRow | null = null;
+    let latestCohort: number | null = null;
 
     for (const group of groups) {
         const type = group.type.toLowerCase();
 
         if (type === "study") {
-            onMaster ||= isMasterStudySlug(group.slug);
+            if (current === null || outranksForStudy(group, current)) {
+                current = group;
+            }
             continue;
         }
 
         if (type !== "studyyear") continue;
 
-        // Several cohorts linger on one account — a bachelor who continued
-        // into a master, or someone who transferred — and the newest is the
-        // one the class level follows.
         const year = Number.parseInt(group.name, 10);
-        if (Number.isFinite(year) && (startYear === null || year > startYear)) {
-            startYear = year;
+        if (
+            Number.isFinite(year) &&
+            (latestCohort === null || year > latestCohort)
+        ) {
+            latestCohort = year;
         }
     }
+
+    const onMaster = current
+        ? Boolean(current.isMaster) || isMasterStudySlug(current.slug)
+        : false;
+
+    /**
+     * The programme's own year is unambiguous — it says when *this* degree
+     * started. The cohort group does not: for a master it almost always holds
+     * the year their bachelor began.
+     */
+    const ownYear = current?.startYear ?? null;
+    const startYear = ownYear ?? latestCohort;
 
     if (startYear === null) return null;
 
     const base = computeClassYear(startYear, now);
-    const candidates = onMaster ? [base + MASTER_CLASS_OFFSET, base] : [base];
+
+    /**
+     * With the master's own intake there is nothing to guess: year one of a
+     * master is 4. klasse. Without it we compute both readings and keep the one
+     * that lands in the master's range, since a master student can only be on
+     * 4. or 5. klasse and at most one of the two can be right.
+     */
+    const candidates =
+        onMaster && ownYear !== null
+            ? [base + MASTER_CLASS_OFFSET]
+            : onMaster
+              ? [base + MASTER_CLASS_OFFSET, base]
+              : [base];
+
+    const ceiling = current
+        ? programmeLength(current.slug)
+        : onMaster
+          ? MAX_CLASS_YEAR
+          : MIN_CLASS_YEAR;
 
     for (const candidate of candidates) {
         const floor = onMaster ? MASTER_CLASS_OFFSET + 1 : MIN_CLASS_YEAR;
-        if (candidate >= floor && candidate <= MAX_CLASS_YEAR) {
+        if (candidate >= floor && candidate <= ceiling) {
             return candidate;
         }
     }
 
     return null;
+}
+
+/**
+ * Whether `a` is a more current study than `b`.
+ *
+ * Deliberately the same order as `deriveStudyFromGroups` in `~/lib/user/study`:
+ * the study a member is shown as taking and the study their class level is
+ * computed from must never be two different programmes.
+ */
+function outranksForStudy(a: MembershipRow, b: MembershipRow): boolean {
+    if ((a.isStudyProgramme === false) !== (b.isStudyProgramme === false)) {
+        return b.isStudyProgramme === false;
+    }
+
+    const rank = (active: boolean | null | undefined) =>
+        active === true ? 2 : active === false ? 0 : 1;
+    if (rank(a.feideActive) !== rank(b.feideActive)) {
+        return rank(a.feideActive) > rank(b.feideActive);
+    }
+
+    const yearA = a.startYear ?? null;
+    const yearB = b.startYear ?? null;
+    if (yearA !== yearB) {
+        if (yearA === null) return false;
+        if (yearB === null) return true;
+        return yearA > yearB;
+    }
+
+    const masterA = Boolean(a.isMaster) || isMasterStudySlug(a.slug);
+    const masterB = Boolean(b.isMaster) || isMasterStudySlug(b.slug);
+    if (masterA !== masterB) return masterA;
+
+    return a.slug.localeCompare(b.slug) < 0;
+}
+
+/**
+ * Reshape a joined row into what the class-level maths reads.
+ *
+ * The programme columns come from LEFT joins, so every non-study group in the
+ * same pass carries nulls here — which is exactly right: they are not studies
+ * and must not be ranked as one.
+ */
+function toMembershipRow(row: {
+    slug: string;
+    name: string;
+    type: string;
+    programmeId: number | null;
+    programmeType: string | null;
+    startYear: number | null;
+    feideActive: boolean | null;
+}): MembershipRow {
+    return {
+        slug: row.slug,
+        name: row.name,
+        type: row.type,
+        isStudyProgramme: row.programmeId !== null,
+        isMaster: row.programmeType === "master",
+        startYear: row.startYear,
+        feideActive: row.feideActive,
+    };
 }
 
 /**
@@ -144,17 +251,38 @@ export async function getUserPriorityFacts(
             slug: schema.group.slug,
             name: schema.group.name,
             type: schema.group.type,
+            programmeId: schema.studyProgram.id,
+            programmeType: schema.studyProgram.type,
+            startYear: schema.studyProgramMembership.startYear,
+            feideActive: schema.studyProgramMembership.feideActive,
         })
         .from(schema.groupMembership)
         .innerJoin(
             schema.group,
             eq(schema.group.slug, schema.groupMembership.groupSlug),
         )
+        .leftJoin(
+            schema.studyProgram,
+            eq(schema.studyProgram.slug, schema.group.slug),
+        )
+        .leftJoin(
+            schema.studyProgramMembership,
+            and(
+                eq(
+                    schema.studyProgramMembership.userId,
+                    schema.groupMembership.userId,
+                ),
+                eq(
+                    schema.studyProgramMembership.studyProgramId,
+                    schema.studyProgram.id,
+                ),
+            ),
+        )
         .where(eq(schema.groupMembership.userId, userId));
 
     return {
         groupSlugs: new Set(rows.map((row) => row.slug)),
-        classYear: computeUserClassYear(rows, now),
+        classYear: computeUserClassYear(rows.map(toMembershipRow), now),
     };
 }
 
@@ -277,11 +405,32 @@ export async function loadPrioritization(
                 slug: schema.group.slug,
                 name: schema.group.name,
                 type: schema.group.type,
+                programmeId: schema.studyProgram.id,
+                programmeType: schema.studyProgram.type,
+                startYear: schema.studyProgramMembership.startYear,
+                feideActive: schema.studyProgramMembership.feideActive,
             })
             .from(schema.groupMembership)
             .innerJoin(
                 schema.group,
                 eq(schema.group.slug, schema.groupMembership.groupSlug),
+            )
+            .leftJoin(
+                schema.studyProgram,
+                eq(schema.studyProgram.slug, schema.group.slug),
+            )
+            .leftJoin(
+                schema.studyProgramMembership,
+                and(
+                    eq(
+                        schema.studyProgramMembership.userId,
+                        schema.groupMembership.userId,
+                    ),
+                    eq(
+                        schema.studyProgramMembership.studyProgramId,
+                        schema.studyProgram.id,
+                    ),
+                ),
             )
             .where(inArray(schema.groupMembership.userId, ids)),
         db
@@ -304,7 +453,7 @@ export async function loadPrioritization(
     const rowsByUser = new Map<string, MembershipRow[]>();
     for (const membership of memberships) {
         const rows = rowsByUser.get(membership.userId) ?? [];
-        rows.push(membership);
+        rows.push(toMembershipRow(membership));
         rowsByUser.set(membership.userId, rows);
     }
 

--- a/apps/api/src/lib/user/study.ts
+++ b/apps/api/src/lib/user/study.ts
@@ -20,31 +20,81 @@ export type UserStudy = {
 /** The two group types that make up the projection, lower-cased. */
 export const STUDY_GROUP_TYPES = ["study", "studyyear"] as const;
 
-type StudyGroupRow = {
-    /** Group name; the cohort's name is its year, e.g. "2023". */
+export type StudyGroupRow = {
+    /** Group slug. A cohort group's slug is its year, e.g. "2023". */
+    slug: string;
+    /** Group name; the cohort's name is its year too. */
     name: string;
     /** Group type. Compared case-insensitively — Lepton stored it upper-case. */
     type: string;
+    /**
+     * Whether this slug matches a row in `study_program`.
+     *
+     * `type = 'STUDY'` is not proof of a study: `fondsforvalter` carries that
+     * type in production without being one, and would otherwise read as
+     * someone's degree. Callers join `study_program` and pass the result here;
+     * a group without one sorts last rather than disappearing. See
+     * https://github.com/TIHLDE/Photon/issues/621.
+     */
+    isStudyProgramme?: boolean;
+    /** Whether the programme is one of the five-year masters. */
+    isMaster?: boolean;
+    /** `studyProgramMembership.startYear`, when the caller loaded it. */
+    startYear?: number | null;
+    /** `studyProgramMembership.feideActive`, when the caller loaded it. */
+    feideActive?: boolean | null;
 };
+
+/**
+ * How sure we are that a member is enrolled on a programme *right now*.
+ *
+ * `true` is Feide saying so at the last login. `null` is no answer — the
+ * member has not logged in with Feide since the Lepton migration, which is
+ * most of them. `false` is Feide saying no, which is the only one of the three
+ * that is evidence against, so it sorts below "we have no idea".
+ */
+function enrolmentRank(feideActive: boolean | null | undefined): number {
+    if (feideActive === true) return 2;
+    if (feideActive === false) return 0;
+    return 1;
+}
 
 /**
  * Derive programme and cohort from a member's groups.
  *
  * Pure, so callers that already hold the memberships do not pay for a second
- * query. Several cohorts can linger on one account — a bachelor who continued
- * into a master, or a member who transferred between programmes — and the most
- * recent one is the useful one, since it is what the class year is computed
- * from.
+ * query.
+ *
+ * A member can hold several study groups — the groups are additive on purpose,
+ * so they accumulate everything someone has ever studied — and this used to
+ * take whichever came back first. That is the bug the whole change exists for:
+ * Postgres returns rows in whatever order it likes, so a member who had
+ * switched programmes was shown an arbitrary one of them, and for the member
+ * who reported it that meant his old bachelor rather than the master he had
+ * started.
+ *
+ * The order, most-current first:
+ *
+ * 1. **Feide says enrolled**, the only signal that means "now".
+ * 2. **The later start year**, which is what separates a master begun in 2026
+ *    from the bachelor it followed. Unknown years sort last, never first.
+ * 3. **Master before bachelor**, then **slug** — neither decides a real case,
+ *    but together they mean no caller can ever depend on Postgres's ordering
+ *    again.
+ *
+ * The cohort year follows the programme that wins, falling back to the highest
+ * cohort group when we have no year for it. That fallback carries the 1423
+ * members who have groups but no programme row at all.
  */
 export function deriveStudyFromGroups(groups: StudyGroupRow[]): UserStudy {
-    let studyProgram: string | null = null;
-    let studyStartYear: number | null = null;
+    let chosen: StudyGroupRow | null = null;
+    let latestCohort: number | null = null;
 
     for (const group of groups) {
         const type = group.type.toLowerCase();
 
         if (type === "study") {
-            studyProgram ??= group.name;
+            if (chosen === null || outranks(group, chosen)) chosen = group;
             continue;
         }
 
@@ -53,45 +103,135 @@ export function deriveStudyFromGroups(groups: StudyGroupRow[]): UserStudy {
         const year = Number.parseInt(group.name, 10);
         if (
             Number.isFinite(year) &&
-            (studyStartYear === null || year > studyStartYear)
+            (latestCohort === null || year > latestCohort)
         ) {
-            studyStartYear = year;
+            latestCohort = year;
         }
     }
 
-    return { studyProgram, studyStartYear };
+    return {
+        studyProgram: chosen?.name ?? null,
+        studyStartYear: chosen?.startYear ?? latestCohort,
+    };
+}
+
+/** Whether `a` is a more current programme than `b`; see the order above. */
+function outranks(a: StudyGroupRow, b: StudyGroupRow): boolean {
+    /**
+     * A group that matches a real study programme beats one that does not.
+     * Ranked rather than filtered out: `fondsforvalter` must never win over
+     * someone's actual degree, but a curated study group added before its
+     * `study_program` row exists should still show up rather than leaving the
+     * member with no study at all.
+     */
+    if ((a.isStudyProgramme === false) !== (b.isStudyProgramme === false)) {
+        return b.isStudyProgramme === false;
+    }
+
+    const rankA = enrolmentRank(a.feideActive);
+    const rankB = enrolmentRank(b.feideActive);
+    if (rankA !== rankB) return rankA > rankB;
+
+    const yearA = a.startYear ?? null;
+    const yearB = b.startYear ?? null;
+    if (yearA !== yearB) {
+        if (yearA === null) return false;
+        if (yearB === null) return true;
+        return yearA > yearB;
+    }
+
+    if (Boolean(a.isMaster) !== Boolean(b.isMaster)) return Boolean(a.isMaster);
+
+    return a.slug.localeCompare(b.slug) < 0;
 }
 
 /**
- * Look up a single member's programme and cohort.
+ * The study and cohort groups of a set of members, with everything
+ * {@link deriveStudyFromGroups} needs to rank them.
  *
- * For callers that do not already have the memberships loaded. Prefer
- * {@link deriveStudyFromGroups} when they do.
+ * One query for the whole page or export rather than one per member, so the
+ * ordering stays the shared one instead of each endpoint growing its own. The
+ * join to `study_program` is a LEFT join on purpose: cohort groups have no
+ * programme, and an inner join would drop them along with the cohort year.
  */
-export async function getUserStudy(
+export async function loadStudyGroupRows(
     ctx: AppContext,
-    userId: string,
-): Promise<UserStudy> {
+    userIds: string[],
+): Promise<Map<string, StudyGroupRow[]>> {
+    const byUser = new Map<string, StudyGroupRow[]>();
+    if (userIds.length === 0) return byUser;
+
     const rows = await ctx.db
         .select({
+            userId: schema.groupMembership.userId,
+            slug: schema.group.slug,
             name: schema.group.name,
             type: schema.group.type,
+            programmeId: schema.studyProgram.id,
+            programmeType: schema.studyProgram.type,
+            startYear: schema.studyProgramMembership.startYear,
+            feideActive: schema.studyProgramMembership.feideActive,
         })
         .from(schema.groupMembership)
         .innerJoin(
             schema.group,
             eq(schema.group.slug, schema.groupMembership.groupSlug),
         )
+        .leftJoin(
+            schema.studyProgram,
+            eq(schema.studyProgram.slug, schema.group.slug),
+        )
+        .leftJoin(
+            schema.studyProgramMembership,
+            and(
+                eq(
+                    schema.studyProgramMembership.userId,
+                    schema.groupMembership.userId,
+                ),
+                eq(
+                    schema.studyProgramMembership.studyProgramId,
+                    schema.studyProgram.id,
+                ),
+            ),
+        )
         .where(
             and(
-                eq(schema.groupMembership.userId, userId),
+                inArray(schema.groupMembership.userId, userIds),
                 inArray(sql`lower(${schema.group.type})`, [
                     ...STUDY_GROUP_TYPES,
                 ]),
             ),
         );
 
-    return deriveStudyFromGroups(rows);
+    for (const row of rows) {
+        const entry = byUser.get(row.userId) ?? [];
+        entry.push({
+            slug: row.slug,
+            name: row.name,
+            type: row.type,
+            isStudyProgramme: row.programmeId !== null,
+            isMaster: row.programmeType === "master",
+            startYear: row.startYear,
+            feideActive: row.feideActive,
+        });
+        byUser.set(row.userId, entry);
+    }
+
+    return byUser;
+}
+
+/**
+ * Look up a single member's programme and cohort.
+ *
+ * For callers that do not already have the memberships loaded. Prefer
+ * {@link loadStudyGroupRows} for more than one member.
+ */
+export async function getUserStudy(
+    ctx: AppContext,
+    userId: string,
+): Promise<UserStudy> {
+    const byUser = await loadStudyGroupRows(ctx, [userId]);
+    return deriveStudyFromGroups(byUser.get(userId) ?? []);
 }
 
 /**

--- a/apps/api/src/lib/user/study.ts
+++ b/apps/api/src/lib/user/study.ts
@@ -143,3 +143,117 @@ export async function hasActiveStudyProgram(
 
     return rows.length > 0;
 }
+
+/**
+ * One study programme a member belongs to, with everything the ordering below
+ * needs to rank it.
+ */
+export type MemberStudyProgram = {
+    id: number;
+    slug: string;
+    displayName: string;
+    isMaster: boolean;
+    startYear: number | null;
+    /** Whether Feide reported this programme as active at the last login. */
+    feideActive: boolean;
+};
+
+/**
+ * Every study programme a member has any tie to, most-current first.
+ *
+ * "Current" cannot be read off a single column. The study *groups* are additive
+ * on purpose — "én gang TIHLDE-medlem, alltid TIHLDE-medlem" — so they hold
+ * everything a member has ever studied, and the programme table only gets rows
+ * from a Feide login, so in production just 502 of 1925 members have one at
+ * all. Either source alone answers the wrong question for most people.
+ *
+ * So both are read, and the ordering decides:
+ *
+ * 1. **`feideActive`**, which is the only field that means "enrolled now".
+ * 2. **The later start year**, which separates a master begun in 2026 from the
+ *    bachelor it followed. Rows without a year sort last — never first, or a
+ *    programme we know nothing about would outrank one we do.
+ * 3. **Master before bachelor**, then **slug**. Neither will decide a real case;
+ *    they are here so no caller ever depends on the order Postgres happened to
+ *    return rows in. That arbitrary order is the original bug: members who had
+ *    switched programmes were shown whichever study came back first.
+ *
+ * Note the join to `study_program`. Filtering on `group.type = 'STUDY'` alone is
+ * not enough — the group `fondsforvalter` carries that type in production
+ * without being a study at all, and would otherwise read as someone's degree.
+ * See https://github.com/TIHLDE/Photon/issues/621.
+ */
+export async function listMemberStudyPrograms(
+    ctx: AppContext,
+    userId: string,
+): Promise<MemberStudyProgram[]> {
+    const rows = await ctx.db
+        .select({
+            id: schema.studyProgram.id,
+            slug: schema.studyProgram.slug,
+            displayName: schema.studyProgram.displayName,
+            type: schema.studyProgram.type,
+            startYear: schema.studyProgramMembership.startYear,
+            feideActive: schema.studyProgramMembership.feideActive,
+            groupSlug: schema.groupMembership.groupSlug,
+        })
+        .from(schema.studyProgram)
+        .leftJoin(
+            schema.studyProgramMembership,
+            and(
+                eq(
+                    schema.studyProgramMembership.studyProgramId,
+                    schema.studyProgram.id,
+                ),
+                eq(schema.studyProgramMembership.userId, userId),
+            ),
+        )
+        .leftJoin(
+            schema.groupMembership,
+            and(
+                eq(schema.groupMembership.groupSlug, schema.studyProgram.slug),
+                eq(schema.groupMembership.userId, userId),
+            ),
+        );
+
+    return rows
+        .filter(
+            (row) =>
+                row.groupSlug !== null ||
+                row.feideActive !== null ||
+                row.startYear !== null,
+        )
+        .map((row) => ({
+            id: row.id,
+            slug: row.slug,
+            displayName: row.displayName,
+            isMaster: row.type === "master",
+            startYear: row.startYear,
+            feideActive: row.feideActive === true,
+        }))
+        .sort((a, b) => {
+            if (a.feideActive !== b.feideActive) return a.feideActive ? -1 : 1;
+            if (a.startYear !== b.startYear) {
+                if (a.startYear === null) return 1;
+                if (b.startYear === null) return -1;
+                return b.startYear - a.startYear;
+            }
+            if (a.isMaster !== b.isMaster) return a.isMaster ? -1 : 1;
+            return a.slug.localeCompare(b.slug);
+        });
+}
+
+/**
+ * The programme a member is on *now*, or null when we have no tie to any.
+ *
+ * Thin wrapper over {@link listMemberStudyPrograms} so callers that want the
+ * single answer do not re-implement the ordering — which is the whole point of
+ * having it in one place.
+ */
+export async function getCurrentStudyProgram(
+    ctx: AppContext,
+    userId: string,
+): Promise<MemberStudyProgram | null> {
+    const [current] = await listMemberStudyPrograms(ctx, userId);
+    return current ?? null;
+}

--- a/apps/api/src/routes/form/submission/download.ts
+++ b/apps/api/src/routes/form/submission/download.ts
@@ -5,7 +5,7 @@ import { HTTPException } from "hono/http-exception";
 import { canManageForm } from "~/lib/form/service";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { STUDY_GROUP_TYPES, deriveStudyFromGroups } from "~/lib/user/study";
+import { deriveStudyFromGroups, loadStudyGroupRows } from "~/lib/user/study";
 import { requireAuth } from "~/middleware/auth";
 
 export const downloadSubmissionsRoute = route().get(
@@ -130,44 +130,10 @@ export const downloadSubmissionsRoute = route().get(
          * shared one. These two columns shipped empty until now.
          */
         const submitterIds = [...new Set(submissions.map((s) => s.userId))];
-        const studyRows =
-            submitterIds.length === 0
-                ? []
-                : await db
-                      .select({
-                          userId: schema.groupMembership.userId,
-                          name: schema.group.name,
-                          type: schema.group.type,
-                      })
-                      .from(schema.groupMembership)
-                      .innerJoin(
-                          schema.group,
-                          eq(
-                              schema.group.slug,
-                              schema.groupMembership.groupSlug,
-                          ),
-                      )
-                      .where(
-                          and(
-                              inArray(
-                                  schema.groupMembership.userId,
-                                  submitterIds,
-                              ),
-                              inArray(sql`lower(${schema.group.type})`, [
-                                  ...STUDY_GROUP_TYPES,
-                              ]),
-                          ),
-                      );
-
-        const groupsByUser = new Map<
-            string,
-            { name: string; type: string }[]
-        >();
-        for (const row of studyRows) {
-            const entry = groupsByUser.get(row.userId) ?? [];
-            entry.push({ name: row.name, type: row.type });
-            groupsByUser.set(row.userId, entry);
-        }
+        const groupsByUser = await loadStudyGroupRows(
+            { db, ...ctx },
+            submitterIds,
+        );
 
         // Build CSV header
         const headers = [

--- a/apps/api/src/routes/groups/members/list.ts
+++ b/apps/api/src/routes/groups/members/list.ts
@@ -5,9 +5,9 @@ import { assertGroupVisible } from "~/lib/group";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import {
-    STUDY_GROUP_TYPES,
     type UserStudy,
     deriveStudyFromGroups,
+    loadStudyGroupRows,
 } from "~/lib/user/study";
 import { captureAuth } from "~/middleware/auth";
 import { memberListSchema } from "../schema";
@@ -74,41 +74,7 @@ export const listMembersRoute = route().get(
          * the derivation itself stays the shared one.
          */
         const userIds = members.map((m) => m.userId);
-        const studyRows =
-            userIds.length === 0
-                ? []
-                : await db
-                      .select({
-                          userId: schema.groupMembership.userId,
-                          name: schema.group.name,
-                          type: schema.group.type,
-                      })
-                      .from(schema.groupMembership)
-                      .innerJoin(
-                          schema.group,
-                          eq(
-                              schema.groupMembership.groupSlug,
-                              schema.group.slug,
-                          ),
-                      )
-                      .where(
-                          and(
-                              inArray(schema.groupMembership.userId, userIds),
-                              inArray(sql`lower(${schema.group.type})`, [
-                                  ...STUDY_GROUP_TYPES,
-                              ]),
-                          ),
-                      );
-
-        const groupsByUser = new Map<
-            string,
-            { name: string; type: string }[]
-        >();
-        for (const row of studyRows) {
-            const entry = groupsByUser.get(row.userId) ?? [];
-            entry.push({ name: row.name, type: row.type });
-            groupsByUser.set(row.userId, entry);
-        }
+        const groupsByUser = await loadStudyGroupRows(c.get("ctx"), userIds);
 
         const studyByUser = new Map<string, UserStudy>();
         for (const [userId, groups] of groupsByUser) {

--- a/apps/api/src/routes/user/get.ts
+++ b/apps/api/src/routes/user/get.ts
@@ -4,7 +4,7 @@ import { isMemberAudience } from "~/lib/auth";
 import { HTTPAppException } from "~/lib/errors";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { deriveStudyFromGroups } from "~/lib/user/study";
+import { getUserStudy } from "~/lib/user/study";
 import { requireAuthAllowPending } from "~/middleware/auth";
 import { userProfileSchema } from "./schema";
 
@@ -106,11 +106,17 @@ export const getUserRoute = route().get(
             }),
         ]);
 
-        // Derived from the group projection, not `studyProgramMembership`;
-        // see `deriveStudyFromGroups` for why. The memberships are already
-        // loaded above, so this is the pure form rather than a second query.
-        const { studyProgram, studyStartYear } = deriveStudyFromGroups(
-            memberships.map((m) => m.group),
+        /**
+         * A second query rather than reusing the memberships loaded above.
+         * Ranking a member's studies needs their programme rows — which
+         * programme Feide still reports as active, and what year each started
+         * — and the relational query above loads groups alone. Reading the
+         * group list by itself is exactly what showed a member who had
+         * switched studies whichever one came back first.
+         */
+        const { studyProgram, studyStartYear } = await getUserStudy(
+            c.get("ctx"),
+            user.id,
         );
 
         /**

--- a/apps/api/src/routes/user/list.ts
+++ b/apps/api/src/routes/user/list.ts
@@ -49,29 +49,86 @@ export const listUsersRoute = route().get(
         } = c.req.valid("query");
 
         /**
-         * Study programme and cohort mirror the group-member list: they are a
-         * projection of Feide onto ordinary groups (types STUDY/STUDYYEAR),
-         * not `studyProgramMembership` — that table only gets rows from a
-         * Feide login, so everyone migrated from Lepton is missing there. The
-         * type is stored in UPPERCASE from Lepton, hence the lower() compare.
+         * The member's *current* study programme, one row each.
+         *
+         * `DISTINCT ON` keeps the first row per member, so the ordering below
+         * is the whole decision. It used to be `order by user_id, group.slug`,
+         * which is deterministic and wrong: for a member who took Digital
+         * forretningsutvikling and went on to the master, the alphabetically
+         * first slug is the bachelor they left, so the list showed the old
+         * study. That is the bug this endpoint was reported for.
+         *
+         * The order matches {@link deriveStudyFromGroups}, and has to: the
+         * profile and this list showing different studies for the same person
+         * is its own kind of wrong.
+         *
+         * The join to `study_program` is not decoration. `type = 'STUDY'` is
+         * not proof of a study — `fondsforvalter` carries that type in
+         * production without being one — and ranking on the join is what keeps
+         * it from reading as somebody's degree. See
+         * https://github.com/TIHLDE/Photon/issues/621.
          */
         const studyProgram = db
             .selectDistinctOn([schema.groupMembership.userId], {
                 userId: schema.groupMembership.userId,
                 slug: schema.group.slug,
                 name: schema.group.name,
+                // Named apart from the cohort subquery's `start_year`: both
+                // are joined into the same select, and an unqualified
+                // reference to a name they share is ambiguous in Postgres.
+                programmeStartYear: sql<
+                    number | null
+                >`${schema.studyProgramMembership.startYear}`.as(
+                    "programme_start_year",
+                ),
             })
             .from(schema.groupMembership)
             .innerJoin(
                 schema.group,
                 eq(schema.group.slug, schema.groupMembership.groupSlug),
             )
+            .leftJoin(
+                schema.studyProgram,
+                eq(schema.studyProgram.slug, schema.group.slug),
+            )
+            .leftJoin(
+                schema.studyProgramMembership,
+                and(
+                    eq(
+                        schema.studyProgramMembership.userId,
+                        schema.groupMembership.userId,
+                    ),
+                    eq(
+                        schema.studyProgramMembership.studyProgramId,
+                        schema.studyProgram.id,
+                    ),
+                ),
+            )
             .where(sql`lower(${schema.group.type}) = 'study'`)
-            .orderBy(schema.groupMembership.userId, schema.group.slug)
+            .orderBy(
+                schema.groupMembership.userId,
+                // A group backed by a real study programme beats one that is
+                // not — `fondsforvalter` must never read as someone's degree,
+                // but a study group added before its programme row exists
+                // should still show rather than leaving the member blank.
+                sql`(${schema.studyProgram.id} is not null) desc`,
+                // Feide saying "enrolled" wins; "no answer" beats "not
+                // enrolled", which is the only one of the three that is
+                // evidence against.
+                sql`(case when ${schema.studyProgramMembership.feideActive} then 2
+                          when ${schema.studyProgramMembership.feideActive} is null then 1
+                          else 0 end) desc`,
+                sql`${schema.studyProgramMembership.startYear} desc nulls last`,
+                sql`(${schema.studyProgram.type} = 'master') desc`,
+                schema.studyProgram.slug,
+            )
             .as("study_program");
 
-        // Several cohorts can linger on one account (a bachelor who continued
-        // into a master). The most recent one is the useful one.
+        /**
+         * The cohort year, used only when the current programme has no start
+         * year of its own — which is the 1423 members who carry groups from
+         * the Lepton migration and have no programme row at all.
+         */
         const cohort = db
             .select({
                 userId: schema.groupMembership.userId,
@@ -129,7 +186,11 @@ export const listUsersRoute = route().get(
                 banned: schema.user.banned,
                 createdAt: schema.user.createdAt,
                 studyProgram: studyProgram.name,
-                studyStartYear: cohort.startYear,
+                // The current programme's own year, falling back to the cohort
+                // group for the members who have no programme row at all.
+                studyStartYear: sql<
+                    number | null
+                >`coalesce(${studyProgram.programmeStartYear}, ${cohort.startYear})`,
                 approvalStatus: schema.user.approvalStatus,
                 email: schema.user.email,
             })

--- a/apps/api/src/routes/user/schema.ts
+++ b/apps/api/src/routes/user/schema.ts
@@ -160,6 +160,10 @@ export const updateStudyYearInputSchema = Schema(
                 description:
                     "Cohort start year, e.g. 2026. Null clears the cohort and removes the member's STUDYYEAR group.",
             }),
+        studyProgramSlug: z.string().trim().min(1).max(64).nullish().meta({
+            description:
+                "Which study programme the year applies to, e.g. 'digital-samhandling'. Omit to correct the member's current programme, which is what the admin list shows. Only members who have switched studies have more than one.",
+        }),
     }),
 );
 

--- a/apps/api/src/routes/user/study-year/update.ts
+++ b/apps/api/src/routes/user/study-year/update.ts
@@ -4,6 +4,7 @@ import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
+import { listMemberStudyPrograms } from "~/lib/user/study";
 import { requireAccess } from "~/middleware/access";
 import { requireAuth } from "~/middleware/auth";
 import {
@@ -21,11 +22,19 @@ import {
  * for the first time — they lose priority on their own graduation ball, notice,
  * and ask us to fix it.
  *
- * Writing `manual` is the point: it outranks Feide in the sync's conflict
- * guard, so the correction survives every later login instead of being quietly
- * reverted. The three group-membership routes still refuse to touch STUDYYEAR
- * groups directly — this is the only sanctioned way in, and it keeps the
- * cohort group and the study-programme row from drifting apart.
+ * Writing `manual` is the point: it outranks every other source in the sync's
+ * conflict guard, so the correction survives every later login instead of being
+ * quietly reverted. The three group-membership routes still refuse to touch
+ * STUDYYEAR groups directly — this is the only sanctioned way in, and it keeps
+ * the cohort group and the study-programme row from drifting apart.
+ *
+ * Scoped to one programme. It used to write the year onto *every* row the
+ * member had, which quietly destroys the one thing this whole model exists to
+ * express: a member who took a bachelor from 2023 and started a master in 2026
+ * has two programmes with two different intakes, and flattening them is exactly
+ * the confusion that left first-year masters indistinguishable from
+ * third-year bachelors. Without an explicit programme the correction lands on
+ * the member's *current* one — the study the admin sees in the row they clicked.
  */
 export const updateStudyYearRoute = route().patch(
     "/:id/study-year",
@@ -48,9 +57,10 @@ export const updateStudyYearRoute = route().patch(
     requireAccess({ permission: "users:manage" }),
     validator("json", updateStudyYearInputSchema),
     async (c) => {
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const userId = c.req.param("id");
-        const { startYear } = c.req.valid("json");
+        const { startYear, studyProgramSlug } = c.req.valid("json");
 
         const user = await db.query.user.findFirst({
             where: eq(schema.user.id, userId),
@@ -63,62 +73,60 @@ export const updateStudyYearRoute = route().patch(
             });
         }
 
-        await db.transaction(async (tx) => {
-            /**
-             * Every programme row, not just one. A member who transferred has
-             * a row per programme, and leaving one behind would let the sync
-             * keep deriving the old cohort group from it on the next login.
-             */
-            const updated = await tx
-                .update(schema.studyProgramMembership)
-                .set({
-                    startYear,
-                    startYearSource: "manual",
-                    updatedAt: new Date(),
-                })
-                .where(eq(schema.studyProgramMembership.userId, userId))
-                .returning({
-                    userId: schema.studyProgramMembership.userId,
-                });
+        const programmes = await listMemberStudyPrograms(ctx, userId);
 
-            /**
-             * Members migrated from Lepton have no programme row — 1699 of
-             * 1707 in production — because the table is only ever written by a
-             * Feide login. Without one there is nowhere to record that the
-             * cohort was set by hand, and the next login that *does* bring a
-             * year from Feide would quietly win.
-             *
-             * So create the row from the member's STUDY group, which carries
-             * the same slug as its study programme by the convention the seed
-             * establishes and `syncDerivedStudyGroups` relies on.
-             */
-            if (updated.length === 0 && startYear !== null) {
-                const [programme] = await tx
-                    .select({ id: schema.studyProgram.id })
-                    .from(schema.groupMembership)
-                    .innerJoin(
-                        schema.group,
-                        eq(schema.group.slug, schema.groupMembership.groupSlug),
-                    )
-                    .innerJoin(
-                        schema.studyProgram,
-                        eq(schema.studyProgram.slug, schema.group.slug),
-                    )
+        /**
+         * Without an explicit programme the correction lands on the member's
+         * current one, which is the study the admin was looking at when they
+         * opened the dialog. Passing the slug is for the rarer case of
+         * correcting the programme they are *not* on any more.
+         */
+        const target = studyProgramSlug
+            ? programmes.find((p) => p.slug === studyProgramSlug)
+            : programmes[0];
+
+        if (studyProgramSlug && !target) {
+            throw new HTTPException(400, {
+                message:
+                    `User "${userId}" has no tie to study programme ` +
+                    `"${studyProgramSlug}". They belong to: ` +
+                    (programmes.map((p) => p.slug).join(", ") || "none"),
+            });
+        }
+
+        await db.transaction(async (tx) => {
+            if (target) {
+                const [updated] = await tx
+                    .update(schema.studyProgramMembership)
+                    .set({
+                        startYear,
+                        startYearSource: "manual",
+                        updatedAt: new Date(),
+                    })
                     .where(
                         and(
-                            eq(schema.groupMembership.userId, userId),
-                            sql`upper(${schema.group.type}) = 'STUDY'`,
+                            eq(schema.studyProgramMembership.userId, userId),
+                            eq(
+                                schema.studyProgramMembership.studyProgramId,
+                                target.id,
+                            ),
                         ),
                     )
-                    .limit(1);
+                    .returning({
+                        userId: schema.studyProgramMembership.userId,
+                    });
 
-                // No study group either (honorary members, long-gone alumni).
-                // The cohort group below is then the only record, which is
-                // what every read uses anyway.
-                if (programme) {
+                /**
+                 * Members migrated from Lepton have no programme row — the
+                 * table is only ever written by a Feide login — so there is
+                 * nowhere to record that the cohort was set by hand, and the
+                 * next login that *does* bring a year would quietly win.
+                 * Create it from the programme we just resolved.
+                 */
+                if (!updated && startYear !== null) {
                     await tx.insert(schema.studyProgramMembership).values({
                         userId,
-                        studyProgramId: programme.id,
+                        studyProgramId: target.id,
                         startYear,
                         startYearSource: "manual",
                     });
@@ -126,27 +134,49 @@ export const updateStudyYearRoute = route().patch(
             }
 
             /**
-             * Clear every cohort group before adding the new one. Members
-             * migrated from Lepton can carry more than one — a bachelor who
-             * continued into a master — and both `deriveStudy` and the profile
-             * endpoint take `Math.max()`, so a leftover higher year would beat
-             * the correction we were just asked to make.
+             * A master owns no cohort group — its intake lives on the
+             * programme row alone, because a cohort group is slugged as a bare
+             * year and would mix master students into the inherited pools
+             * aimed at that year's bachelor intake. So correcting a master's
+             * year must leave the member's groups exactly as they are: the
+             * only group carrying a year is their bachelor's, and it is not
+             * ours to move.
              */
-            const cohortSlugs = await tx
-                .select({ slug: schema.group.slug })
-                .from(schema.group)
-                .where(sql`upper(${schema.group.type}) = 'STUDYYEAR'`);
+            if (target?.isMaster) return;
 
-            if (cohortSlugs.length > 0) {
-                await tx.delete(schema.groupMembership).where(
-                    and(
-                        eq(schema.groupMembership.userId, userId),
-                        inArray(
-                            schema.groupMembership.groupSlug,
-                            cohortSlugs.map((g) => g.slug),
+            /**
+             * Clear the cohort group the correction replaces, then add the new
+             * one. Only the year this programme used to hold: a member who
+             * transferred carries a group per intake, and the blanket delete
+             * this once did took their history with it.
+             *
+             * With no previous year on record there is nothing to aim at, so
+             * every cohort group goes — the member has no per-programme
+             * history for us to preserve, and leaving a stale year behind
+             * would beat the correction, since `deriveStudyFromGroups` takes
+             * `Math.max()` over the groups.
+             */
+            const doomed =
+                target?.startYear !== null && target?.startYear !== undefined
+                    ? [String(target.startYear)]
+                    : (
+                          await tx
+                              .select({ slug: schema.group.slug })
+                              .from(schema.group)
+                              .where(
+                                  sql`upper(${schema.group.type}) = 'STUDYYEAR'`,
+                              )
+                      ).map((g) => g.slug);
+
+            if (doomed.length > 0) {
+                await tx
+                    .delete(schema.groupMembership)
+                    .where(
+                        and(
+                            eq(schema.groupMembership.userId, userId),
+                            inArray(schema.groupMembership.groupSlug, doomed),
                         ),
-                    ),
-                );
+                    );
             }
 
             if (startYear === null) return;

--- a/apps/api/src/test/event/priority-matching.test.ts
+++ b/apps/api/src/test/event/priority-matching.test.ts
@@ -61,6 +61,53 @@ describe("computeUserClassYear", () => {
         ).toBeNull();
     });
 
+    it("stops counting a bachelor at three years, not five", () => {
+        /**
+         * The ceiling used to be a flat five for everyone, so a finished
+         * three-year bachelor kept counting: the 2023 intake read as 4. klasse
+         * and the 2022 intake as 5., and 398 members in production sat in that
+         * state. Any pool asking for 4. or 5. klasse without naming a study
+         * would have pulled them in ahead of the master students it was for.
+         */
+        expect(
+            computeUserClassYear([BACHELOR, cohort(2023)], AUTUMN_2026),
+        ).toBeNull();
+        expect(
+            computeUserClassYear([BACHELOR, cohort(2022)], AUTUMN_2026),
+        ).toBeNull();
+
+        // The last year that is still a real class level.
+        expect(
+            computeUserClassYear([BACHELOR, cohort(2024)], AUTUMN_2026),
+        ).toBe(3);
+    });
+
+    it("uses the master's own intake when we have it", () => {
+        /**
+         * With the programme's own start year there is nothing to infer: year
+         * one of a master is 4. klasse. The cohort group here says 2023, the
+         * year their *bachelor* began — reading that instead is the confusion
+         * the programme row exists to end.
+         */
+        const master = { ...MASTER, isMaster: true, startYear: 2026 };
+        expect(computeUserClassYear([master, cohort(2023)], AUTUMN_2026)).toBe(
+            4,
+        );
+
+        const secondYear = { ...MASTER, isMaster: true, startYear: 2025 };
+        expect(
+            computeUserClassYear([secondYear, cohort(2022)], AUTUMN_2026),
+        ).toBe(5);
+    });
+
+    it("still reads the cohort group when the master has no year of its own", () => {
+        // The 1423 members migrated from Lepton have groups and no programme
+        // row, so this path has to keep working.
+        expect(computeUserClassYear([MASTER, cohort(2023)], AUTUMN_2026)).toBe(
+            4,
+        );
+    });
+
     it("puts a master's first year on 4. klasse, not 1.", () => {
         // Someone who came to the master from another school has only the
         // master's own intake year. Read naively that is "1. klasse", which

--- a/apps/api/src/test/feide/derived-cohort.test.ts
+++ b/apps/api/src/test/feide/derived-cohort.test.ts
@@ -14,17 +14,17 @@ import { integrationTest } from "~/test/config/integration";
 /**
  * What happens to a member whose programme Feide gives no cohort for.
  *
- * NTNU issues no `fc:fs:kull` for ITBAITBEDR — every one of the four such
- * logins in a month of production logs came back with `Cohort ids: (none)` or a
- * cohort belonging to a programme the member had left, and all five ITBAITBEDR
- * rows in production have a null start year. Because 172 of the 258 priority
- * pools select on a cohort group, a member without one loses priority on
- * everything aimed at their own intake.
+ * NTNU issues no `fc:fs:kull` for ITBAITBEDR, and none for the master either —
+ * 0 of 217 rows in production between them. Because the inherited priority
+ * pools select on cohort groups and class level, a member without a year loses
+ * priority on everything aimed at their own intake.
  *
- * So we assume the current intake, and record that it was a guess. These tests
- * pin down the three rules that make the guess safe: only for active students,
- * only when we do not already know a cohort, and only until Feide tells us
- * otherwise.
+ * So we work the year out ourselves and record it as `derived`, the lowest
+ * rank, which anything better may overwrite. These tests pin down the rules
+ * that make that safe: the member's own cohort group is preferred over any
+ * inference, the current intake is a last resort reserved for active
+ * memberships, and the result never depends on the order Feide listed the
+ * programmes in.
  */
 
 const kull = (code: string, year: string) => ({
@@ -193,9 +193,9 @@ describe("currentAcademicYear", () => {
     });
 });
 
-describe("assuming a cohort", () => {
+describe("deriving a cohort", () => {
     integrationTest(
-        "does not overwrite a cohort the member already has",
+        "takes the year from the cohort the member already has",
         async ({ ctx }) => {
             await seedProgrammes(ctx.db);
             const user = await ctx.utils.createTestUser();
@@ -203,9 +203,15 @@ describe("assuming a cohort", () => {
             /**
              * The production case that makes this rule non-negotiable: every
              * ITBAITBEDR member carries a correct cohort from Lepton and gets
-             * none from Feide. Guessing on top would add a second, higher year,
-             * and `Math.max()` in `deriveStudyFromGroups` would pick it — the
-             * whole cohort demoted to first-years on their next login.
+             * none from Feide. Inventing this year's intake on top would add a
+             * second, higher year, and `Math.max()` in `deriveStudyFromGroups`
+             * would pick it — the whole cohort demoted to first-years on their
+             * next login.
+             *
+             * The cohort group is not merely a veto, it is the answer: it holds
+             * the member's real intake, so the programme row is filled from it
+             * rather than left empty. That is what the older `assumed` rule got
+             * wrong, and why 118 ITBAITBEDR rows sat permanently without a year.
              */
             await ctx.db
                 .insert(schema.group)
@@ -226,6 +232,7 @@ describe("assuming a cohort", () => {
                 ...trondheimCourses.map(emne),
             ]);
 
+            // Still exactly one intake — no second cohort group invented.
             expect(await cohortGroupsOf(ctx.db, user.id)).toEqual(["2025"]);
 
             const membership = await membershipFor(
@@ -233,8 +240,8 @@ describe("assuming a cohort", () => {
                 user.id,
                 "ITBAITBEDR",
             );
-            expect(membership?.startYear).toBeNull();
-            expect(membership?.source).toBeNull();
+            expect(membership?.startYear).toBe(2025);
+            expect(membership?.source).toBe("derived");
         },
     );
 
@@ -378,6 +385,48 @@ describe("assuming a cohort", () => {
 
             // Still a first-year: they started the previous August.
             expect(await cohortGroupsOf(ctx.db, user.id)).toEqual(["2026"]);
+        },
+    );
+
+    integrationTest(
+        "fills a row that already exists without a year",
+        async ({ ctx }) => {
+            await seedProgrammes(ctx.db);
+            const user = await ctx.utils.createTestUser();
+
+            /**
+             * The shape 153 rows in production were stuck in: the membership
+             * exists, but both the year and its source are NULL. The old guard
+             * only ever let `feide` replace `assumed`, so such a row could
+             * never be filled no matter what a later login learned — including
+             * both rows belonging to every member who had gone on to the
+             * master.
+             */
+            const [programme] = await ctx.db
+                .select({ id: schema.studyProgram.id })
+                .from(schema.studyProgram)
+                .where(eq(schema.studyProgram.feideCode, "ITBAITBEDR"))
+                .limit(1);
+
+            await ctx.db.insert(schema.studyProgramMembership).values({
+                userId: user.id,
+                studyProgramId: programme?.id as number,
+                startYear: null,
+                startYearSource: null,
+            });
+
+            await signInWithFeide(ctx.db, user.id, [
+                prg("ITBAITBEDR"),
+                ...trondheimCourses.map(emne),
+            ]);
+
+            const membership = await membershipFor(
+                ctx.db,
+                user.id,
+                "ITBAITBEDR",
+            );
+            expect(membership?.startYear).toBe(2026);
+            expect(membership?.source).toBe("derived");
         },
     );
 });

--- a/apps/api/src/test/feide/master-cohort-group.test.ts
+++ b/apps/api/src/test/feide/master-cohort-group.test.ts
@@ -1,0 +1,258 @@
+import {
+    applyFeideStudyPrograms,
+    parseValidStudyPrograms,
+    partitionByCampus,
+    resolveCampus,
+} from "@photon/auth/feide";
+import { type DbSchema, schema } from "@photon/db";
+import { and, eq } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * A master's intake never becomes a cohort group.
+ *
+ * Cohort groups are programme-less: they are slugged as a bare year and say
+ * nothing about which studies started then, and 167 of the inherited priority
+ * pools select on them. Putting a master's intake in one therefore mixes
+ * master students into the pools aimed at that year's *bachelor* intake.
+ *
+ * The master's start year lives on the programme row instead. These tests pin
+ * both halves of that: the year is still recorded, and the bachelor cohort the
+ * member already carries is left standing as history.
+ */
+
+const kull = (code: string, year: string) => ({
+    id: `fc:fs:fs:kull:ntnu.no:${code}:${year}`,
+    type: "fc:fs:kull",
+    displayName: `Kull for Høst ${year.slice(0, 4)} ${code}`,
+    membership: { active: true },
+});
+
+const prg = (code: string) => ({
+    id: `fc:fs:fs:prg:ntnu.no:${code}`,
+    type: "fc:fs:prg",
+    displayName: code,
+    membership: { active: true },
+});
+
+const emne = (code: string) => ({
+    id: `fc:fs:fs:emne:ntnu.no:${code}:1`,
+    type: "fc:fs:emne",
+    displayName: code,
+    membership: { active: true },
+});
+
+/** Trondheim course codes, so the campus gate lets the member through. */
+const trondheimCourses = ["INGT1002", "IMAT1002", "IDATT1003"];
+
+const DURING_INTAKE = new Date("2026-08-15T12:00:00Z");
+
+type FeideGroups = Parameters<typeof parseValidStudyPrograms>[0];
+
+const seedProgrammes = async (db: NodePgDatabase<DbSchema>) => {
+    await db
+        .insert(schema.group)
+        .values([
+            {
+                slug: "dataingenior",
+                name: "Dataingeniør",
+                type: "STUDY",
+                finesInfo: "",
+                finesActivated: false,
+            },
+            {
+                slug: "digital-samhandling",
+                name: "Digital transformasjon",
+                type: "STUDY",
+                finesInfo: "",
+                finesActivated: false,
+            },
+        ])
+        .onConflictDoNothing();
+
+    await db
+        .insert(schema.studyProgram)
+        .values([
+            {
+                slug: "dataingenior",
+                feideCode: "BIDATA",
+                displayName: "Dataingeniør",
+                type: "bachelor",
+            },
+            {
+                slug: "digital-samhandling",
+                feideCode: "ITMAIKTSA",
+                displayName: "Digital Samhandling",
+                type: "master",
+            },
+        ])
+        .onConflictDoNothing();
+
+    await db
+        .insert(schema.role)
+        .values([{ name: "member" }, { name: "alumni" }])
+        .onConflictDoNothing();
+};
+
+const signInWithFeide = async (
+    db: NodePgDatabase<DbSchema>,
+    userId: string,
+    groups: FeideGroups,
+    now = DURING_INTAKE,
+) => {
+    const campus = resolveCampus(groups);
+    const { allowed, campusRejected } = partitionByCampus(
+        parseValidStudyPrograms(groups),
+        campus,
+    );
+
+    await applyFeideStudyPrograms(
+        db,
+        userId,
+        allowed,
+        campusRejected,
+        campus,
+        null,
+        now,
+    );
+};
+
+const cohortGroupsOf = async (db: NodePgDatabase<DbSchema>, userId: string) => {
+    const rows = await db
+        .select({ slug: schema.groupMembership.groupSlug })
+        .from(schema.groupMembership)
+        .where(eq(schema.groupMembership.userId, userId));
+
+    return rows
+        .map((r) => r.slug)
+        .filter((slug) => /^\d{4}$/.test(slug))
+        .sort();
+};
+
+const studyGroupsOf = async (db: NodePgDatabase<DbSchema>, userId: string) => {
+    const rows = await db
+        .select({ slug: schema.groupMembership.groupSlug })
+        .from(schema.groupMembership)
+        .innerJoin(
+            schema.group,
+            eq(schema.group.slug, schema.groupMembership.groupSlug),
+        )
+        .where(
+            and(
+                eq(schema.groupMembership.userId, userId),
+                eq(schema.group.type, "STUDY"),
+            ),
+        );
+
+    return rows.map((r) => r.slug).sort();
+};
+
+const membershipFor = async (
+    db: NodePgDatabase<DbSchema>,
+    userId: string,
+    feideCode: string,
+) => {
+    const [row] = await db
+        .select({
+            startYear: schema.studyProgramMembership.startYear,
+            source: schema.studyProgramMembership.startYearSource,
+        })
+        .from(schema.studyProgramMembership)
+        .innerJoin(
+            schema.studyProgram,
+            eq(
+                schema.studyProgram.id,
+                schema.studyProgramMembership.studyProgramId,
+            ),
+        )
+        .where(
+            and(
+                eq(schema.studyProgramMembership.userId, userId),
+                eq(schema.studyProgram.feideCode, feideCode),
+            ),
+        )
+        .limit(1);
+
+    return row;
+};
+
+describe("a master's intake", () => {
+    integrationTest(
+        "is recorded on the programme row, never as a cohort group",
+        async ({ ctx }) => {
+            await seedProgrammes(ctx.db);
+            const user = await ctx.utils.createTestUser();
+
+            /**
+             * NTNU has never handed this service a `fc:fs:kull` for
+             * ITMAIKTSA — 0 of 37 rows in production — but the rule must not
+             * depend on that. Supply one, so the test pins "no cohort group
+             * for a master" rather than "no year for a master".
+             */
+            await signInWithFeide(ctx.db, user.id, [
+                prg("ITMAIKTSA"),
+                kull("ITMAIKTSA", "2026H"),
+                ...trondheimCourses.map(emne),
+            ]);
+
+            expect(await membershipFor(ctx.db, user.id, "ITMAIKTSA")).toEqual({
+                startYear: 2026,
+                source: "feide",
+            });
+
+            // The study group is still mirrored — only the cohort is withheld.
+            expect(await studyGroupsOf(ctx.db, user.id)).toEqual([
+                "digital-samhandling",
+            ]);
+            expect(await cohortGroupsOf(ctx.db, user.id)).toEqual([]);
+        },
+    );
+
+    integrationTest(
+        "leaves the bachelor cohort standing when a member continues onto a master",
+        async ({ ctx }) => {
+            await seedProgrammes(ctx.db);
+            const user = await ctx.utils.createTestUser();
+
+            // Third year of the bachelor: cohort 2023, group created as usual.
+            await signInWithFeide(
+                ctx.db,
+                user.id,
+                [
+                    prg("BIDATA"),
+                    kull("BIDATA", "2023H"),
+                    ...trondheimCourses.map(emne),
+                ],
+                new Date("2025-09-01T12:00:00Z"),
+            );
+
+            expect(await cohortGroupsOf(ctx.db, user.id)).toEqual(["2023"]);
+
+            /**
+             * Continues onto the master. Its own cohort is supplied here on
+             * purpose: without it the master's year would be null anyway, and
+             * the assertion below would hold whether or not the rule exists.
+             */
+            await signInWithFeide(ctx.db, user.id, [
+                prg("BIDATA"),
+                kull("BIDATA", "2023H"),
+                prg("ITMAIKTSA"),
+                kull("ITMAIKTSA", "2026H"),
+                ...trondheimCourses.map(emne),
+            ]);
+
+            /**
+             * The bachelor cohort is the member's real intake and the only
+             * thing standing between them and every pool aimed at 2023. A
+             * master row must never take it with it.
+             */
+            expect(await cohortGroupsOf(ctx.db, user.id)).toEqual(["2023"]);
+            expect(await studyGroupsOf(ctx.db, user.id)).toEqual([
+                "dataingenior",
+                "digital-samhandling",
+            ]);
+        },
+    );
+});

--- a/apps/api/src/test/feide/new-student.test.ts
+++ b/apps/api/src/test/feide/new-student.test.ts
@@ -198,7 +198,7 @@ describe("a student with no prior TIHLDE account", () => {
     );
 
     integrationTest(
-        "is assumed into the current intake when Feide omits the kull",
+        "falls back to the current intake when Feide omits the kull",
         async ({ ctx }) => {
             await seedProgramme(ctx.db);
             const user = await ctx.utils.createTestUser();
@@ -237,14 +237,14 @@ describe("a student with no prior TIHLDE account", () => {
                 .where(eq(schema.studyProgramMembership.userId, user.id));
 
             expect(membership?.startYear).toBe(2026);
-            // Recorded as a guess, so a real year from Feide can replace it
-            // later and a manual correction can outrank it.
-            expect(membership?.source).toBe("assumed");
+            // Recorded as derived, the lowest rank, so a real year from Feide
+            // can replace it later and a manual correction outranks both.
+            expect(membership?.source).toBe("derived");
         },
     );
 
     integrationTest(
-        "is not assumed into an intake when the membership has lapsed",
+        "is given no intake at all when the membership has lapsed",
         async ({ ctx }) => {
             await seedProgramme(ctx.db);
             const user = await ctx.utils.createTestUser();

--- a/apps/api/src/test/user-list.test.ts
+++ b/apps/api/src/test/user-list.test.ts
@@ -97,4 +97,169 @@ describe("user list", () => {
         },
         500_000,
     );
+
+    integrationTest(
+        "shows the study a member switched to, not the one they left",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["users:view"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            /**
+             * The bug this whole change was reported for. A member took
+             * Digital forretningsutvikling from 2023 and went on to the master
+             * in 2026, and the list showed the bachelor — because it kept the
+             * alphabetically first slug per member, and
+             * `digital-forretningsutvikling` sorts before `digital-samhandling`.
+             *
+             * Note the cohort group: it holds 2023, the year the *bachelor*
+             * started. Reading it for the master is the same confusion in the
+             * other column, so the year has to follow the programme that wins.
+             */
+            await ctx.utils.createTestGroup({
+                slug: "digital-forretningsutvikling",
+                name: "Digital forretningsutvikling",
+                type: "STUDY",
+            });
+            await ctx.utils.createTestGroup({
+                slug: "digital-samhandling",
+                name: "Digital transformasjon",
+                type: "STUDY",
+            });
+            await ctx.utils.createTestGroup({
+                slug: "2023",
+                name: "2023",
+                type: "STUDYYEAR",
+            });
+
+            const [bachelor] = await ctx.db
+                .insert(schema.studyProgram)
+                .values({
+                    slug: "digital-forretningsutvikling",
+                    feideCode: "ITBAITBEDR",
+                    displayName: "Digital Forretningsutvikling",
+                    type: "bachelor",
+                })
+                .returning({ id: schema.studyProgram.id });
+            const [master] = await ctx.db
+                .insert(schema.studyProgram)
+                .values({
+                    slug: "digital-samhandling",
+                    feideCode: "ITMAIKTSA",
+                    displayName: "Digital Samhandling",
+                    type: "master",
+                })
+                .returning({ id: schema.studyProgram.id });
+
+            const switcher = await ctx.auth.api.createUser({
+                body: {
+                    email: "byttet@test.com",
+                    name: "Bytte Studentsen",
+                    password: "test123!",
+                    data: { username: "byttet" },
+                },
+            });
+
+            await ctx.db.insert(schema.groupMembership).values([
+                {
+                    userId: switcher.user.id,
+                    groupSlug: "digital-forretningsutvikling",
+                    role: "member",
+                },
+                {
+                    userId: switcher.user.id,
+                    groupSlug: "digital-samhandling",
+                    role: "member",
+                },
+                { userId: switcher.user.id, groupSlug: "2023", role: "member" },
+            ]);
+            await ctx.db.insert(schema.studyProgramMembership).values([
+                {
+                    userId: switcher.user.id,
+                    studyProgramId: bachelor?.id as number,
+                    startYear: 2023,
+                    startYearSource: "derived",
+                    feideActive: false,
+                },
+                {
+                    userId: switcher.user.id,
+                    studyProgramId: master?.id as number,
+                    startYear: 2026,
+                    startYearSource: "derived",
+                    feideActive: true,
+                },
+            ]);
+
+            const res = await client.api.user.$get({ query: {} });
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            const listed = body.items.find((u) => u.id === switcher.user.id);
+
+            expect(listed?.studyProgram).toBe("Digital transformasjon");
+            // The master's own intake, not the bachelor cohort group's 2023.
+            expect(listed?.studyStartYear).toBe(2026);
+        },
+    );
+
+    integrationTest(
+        "does not read a non-study group as someone's degree",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["users:view"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            /**
+             * `fondsforvalter` carries `type = 'STUDY'` in production without
+             * being a study, and the member holding it joined it more recently
+             * than their actual degree. Filtering on the group type alone
+             * would report it as what they study. See
+             * https://github.com/TIHLDE/Photon/issues/621.
+             */
+            await ctx.utils.createTestGroup({
+                slug: "digital-infrastruktur-og-cybersikkerhet",
+                name: "Digital infrastruktur og cybersikkerhet",
+                type: "STUDY",
+            });
+            await ctx.utils.createTestGroup({
+                slug: "fondsforvalter",
+                name: "Fondsforvalter",
+                type: "STUDY",
+            });
+            await ctx.db.insert(schema.studyProgram).values({
+                slug: "digital-infrastruktur-og-cybersikkerhet",
+                feideCode: "BDIGSEC",
+                displayName: "Digital Infrastruktur og Cybersikkerhet",
+                type: "bachelor",
+            });
+
+            const member = await ctx.auth.api.createUser({
+                body: {
+                    email: "fond@test.com",
+                    name: "Fond Forvaltersen",
+                    password: "test123!",
+                    data: { username: "fondf" },
+                },
+            });
+            await ctx.db.insert(schema.groupMembership).values([
+                {
+                    userId: member.user.id,
+                    groupSlug: "digital-infrastruktur-og-cybersikkerhet",
+                    role: "member",
+                },
+                {
+                    userId: member.user.id,
+                    groupSlug: "fondsforvalter",
+                    role: "member",
+                },
+            ]);
+
+            const res = await client.api.user.$get({ query: {} });
+            const body = await res.json();
+            const listed = body.items.find((u) => u.id === member.user.id);
+
+            expect(listed?.studyProgram).toBe(
+                "Digital infrastruktur og cybersikkerhet",
+            );
+        },
+    );
 });

--- a/apps/api/src/test/user-study-year.test.ts
+++ b/apps/api/src/test/user-study-year.test.ts
@@ -193,4 +193,260 @@ describe("PATCH /api/user/:id/study-year", () => {
 
         expect(res.status).toBe(404);
     });
+
+    integrationTest(
+        "corrects only the programme the member is on now",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["users:manage"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            /**
+             * The case the whole per-programme model exists for: a bachelor
+             * from 2023 who started the master in 2026. Writing the year onto
+             * every row — what this route used to do — collapses those two
+             * intakes into one, which is precisely what made a first-year
+             * master indistinguishable from a third-year bachelor.
+             */
+            await ctx.utils.createTestGroup({
+                slug: "dataingenior",
+                name: "Dataingeniør",
+                type: "STUDY",
+            });
+            await ctx.utils.createTestGroup({
+                slug: "digital-samhandling",
+                name: "Digital transformasjon",
+                type: "STUDY",
+            });
+            await ctx.utils.createTestGroup({
+                slug: "2023",
+                name: "2023",
+                type: "STUDYYEAR",
+            });
+
+            const [bachelor] = await ctx.db
+                .insert(schema.studyProgram)
+                .values({
+                    slug: "dataingenior",
+                    feideCode: "BIDATA",
+                    displayName: "Dataingeniør",
+                    type: "bachelor",
+                })
+                .returning({ id: schema.studyProgram.id });
+            const [master] = await ctx.db
+                .insert(schema.studyProgram)
+                .values({
+                    slug: "digital-samhandling",
+                    feideCode: "ITMAIKTSA",
+                    displayName: "Digital Samhandling",
+                    type: "master",
+                })
+                .returning({ id: schema.studyProgram.id });
+
+            const target = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.groupMembership).values([
+                {
+                    userId: target.id,
+                    groupSlug: "dataingenior",
+                    role: "member",
+                },
+                {
+                    userId: target.id,
+                    groupSlug: "digital-samhandling",
+                    role: "member",
+                },
+                { userId: target.id, groupSlug: "2023", role: "member" },
+            ]);
+            await ctx.db.insert(schema.studyProgramMembership).values([
+                {
+                    userId: target.id,
+                    studyProgramId: bachelor?.id as number,
+                    startYear: 2023,
+                    startYearSource: "derived",
+                    feideActive: false,
+                },
+                {
+                    userId: target.id,
+                    studyProgramId: master?.id as number,
+                    startYear: 2026,
+                    startYearSource: "derived",
+                    feideActive: true,
+                },
+            ]);
+
+            const res = await client.api.user[":id"]["study-year"].$patch({
+                param: { id: target.id },
+                json: { startYear: 2025 },
+            });
+            expect(res.status).toBe(200);
+
+            const rows = await ctx.db
+                .select({
+                    programme: schema.studyProgram.slug,
+                    startYear: schema.studyProgramMembership.startYear,
+                    source: schema.studyProgramMembership.startYearSource,
+                })
+                .from(schema.studyProgramMembership)
+                .innerJoin(
+                    schema.studyProgram,
+                    eq(
+                        schema.studyProgram.id,
+                        schema.studyProgramMembership.studyProgramId,
+                    ),
+                )
+                .where(eq(schema.studyProgramMembership.userId, target.id));
+
+            // The master is the current programme, so it is what was corrected.
+            expect(
+                rows.find((r) => r.programme === "digital-samhandling"),
+            ).toEqual({
+                programme: "digital-samhandling",
+                startYear: 2025,
+                source: "manual",
+            });
+
+            // The bachelor's own intake is untouched.
+            expect(rows.find((r) => r.programme === "dataingenior")).toEqual({
+                programme: "dataingenior",
+                startYear: 2023,
+                source: "derived",
+            });
+
+            /**
+             * And no group moved. A master owns no cohort group, so the only
+             * group carrying a year here belongs to the bachelor — moving it
+             * would take the member's real intake with it.
+             */
+            expect(await cohortGroupsOf(ctx.db, target.id)).toEqual(["2023"]);
+        },
+    );
+
+    integrationTest(
+        "can be aimed at a programme the member has left",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["users:manage"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            await ctx.utils.createTestGroup({
+                slug: "dataingenior",
+                name: "Dataingeniør",
+                type: "STUDY",
+            });
+            await ctx.utils.createTestGroup({
+                slug: "digital-samhandling",
+                name: "Digital transformasjon",
+                type: "STUDY",
+            });
+            await ctx.utils.createTestGroup({
+                slug: "2023",
+                name: "2023",
+                type: "STUDYYEAR",
+            });
+
+            const [bachelor] = await ctx.db
+                .insert(schema.studyProgram)
+                .values({
+                    slug: "dataingenior",
+                    feideCode: "BIDATA",
+                    displayName: "Dataingeniør",
+                    type: "bachelor",
+                })
+                .returning({ id: schema.studyProgram.id });
+            const [master] = await ctx.db
+                .insert(schema.studyProgram)
+                .values({
+                    slug: "digital-samhandling",
+                    feideCode: "ITMAIKTSA",
+                    displayName: "Digital Samhandling",
+                    type: "master",
+                })
+                .returning({ id: schema.studyProgram.id });
+
+            const target = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.groupMembership).values([
+                {
+                    userId: target.id,
+                    groupSlug: "dataingenior",
+                    role: "member",
+                },
+                {
+                    userId: target.id,
+                    groupSlug: "digital-samhandling",
+                    role: "member",
+                },
+                { userId: target.id, groupSlug: "2023", role: "member" },
+            ]);
+            await ctx.db.insert(schema.studyProgramMembership).values([
+                {
+                    userId: target.id,
+                    studyProgramId: bachelor?.id as number,
+                    startYear: 2023,
+                    startYearSource: "derived",
+                    feideActive: false,
+                },
+                {
+                    userId: target.id,
+                    studyProgramId: master?.id as number,
+                    startYear: 2026,
+                    startYearSource: "derived",
+                    feideActive: true,
+                },
+            ]);
+
+            const res = await client.api.user[":id"]["study-year"].$patch({
+                param: { id: target.id },
+                json: { startYear: 2022, studyProgramSlug: "dataingenior" },
+            });
+            expect(res.status).toBe(200);
+
+            const rows = await ctx.db
+                .select({
+                    programme: schema.studyProgram.slug,
+                    startYear: schema.studyProgramMembership.startYear,
+                })
+                .from(schema.studyProgramMembership)
+                .innerJoin(
+                    schema.studyProgram,
+                    eq(
+                        schema.studyProgram.id,
+                        schema.studyProgramMembership.studyProgramId,
+                    ),
+                )
+                .where(eq(schema.studyProgramMembership.userId, target.id));
+
+            expect(
+                rows.find((r) => r.programme === "dataingenior")?.startYear,
+            ).toBe(2022);
+            // The master, which was current, is left alone.
+            expect(
+                rows.find((r) => r.programme === "digital-samhandling")
+                    ?.startYear,
+            ).toBe(2026);
+
+            // The bachelor's cohort group followed its own correction.
+            expect(await cohortGroupsOf(ctx.db, target.id)).toEqual(["2022"]);
+        },
+    );
+
+    integrationTest(
+        "rejects a programme the member has no tie to",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["users:manage"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            const target = await ctx.utils.createTestUser();
+
+            const res = await client.api.user[":id"]["study-year"].$patch({
+                param: { id: target.id },
+                json: {
+                    startYear: 2024,
+                    studyProgramSlug: "digital-samhandling",
+                },
+            });
+
+            expect(res.status).toBe(400);
+        },
+    );
 });

--- a/apps/kvark/src/api/queries/user.ts
+++ b/apps/kvark/src/api/queries/user.ts
@@ -266,21 +266,28 @@ export const updateUserStudyMutation = mutationOptions({
 /**
  * Rett kullet til et medlem for hånd.
  *
- * Feide gir ikke kull for alle studier, så nye medlemmer antas å være
- * 1. klassinger. Denne overstyrer den antakelsen permanent — synken rører
- * aldri et kull som er satt manuelt.
+ * Feide gir ikke kull for alle studier, så året utledes for digfor og
+ * masteren. Denne overstyrer utledningen permanent — synken rører aldri et
+ * kull som er satt manuelt — og treffer bare ett studie om gangen.
  */
 export const updateUserStudyYearMutation = mutationOptions({
     mutationFn: ({
         userId,
         startYear,
+        studyProgramSlug,
     }: {
         userId: string;
         startYear: number | null;
+        /**
+         * Hvilket studie året gjelder. Utelates normalt — da treffer
+         * rettingen studiet medlemmet går på nå. Bare de som har byttet
+         * studium har mer enn ett.
+         */
+        studyProgramSlug?: string | null;
     }) =>
         apiClient.patch("/api/user/{id}/study-year", {
             params: { id: userId },
-            json: { startYear },
+            json: { startYear, studyProgramSlug },
         }),
     onSuccess(_, __, ___, ctx) {
         // Kullet vises både i admin-lista og på profilen.

--- a/apps/kvark/src/routes/admin/brukere.tsx
+++ b/apps/kvark/src/routes/admin/brukere.tsx
@@ -233,6 +233,8 @@ function AllUsersTable({
         id: string;
         name: string;
         studyStartYear: number | null;
+        /** Navnet på studiet rettingen gjelder, som er alt lista kjenner til. */
+        studyProgram: string | null;
     } | null>(null);
     const [editingStudy, setEditingStudy] = useState<{
         id: string;
@@ -510,6 +512,8 @@ function AllUsersTable({
                                                                                 name: user.name,
                                                                                 studyStartYear:
                                                                                     user.studyStartYear,
+                                                                                studyProgram:
+                                                                                    user.studyProgram,
                                                                             },
                                                                         )
                                                                     }
@@ -1449,17 +1453,26 @@ function FilterSelect({
 /**
  * Rett kullet til ett medlem.
  *
- * Feide gir ikke kull for alle studier, så nye medlemmer antas å være
- * 1. klassinger. Den antakelsen er riktig for høstopptaket og for alle som
- * bytter studium, men feil for en som melder seg inn senere i løpet — og de
- * merker det selv, fordi de mister prioritet på sitt eget kulls arrangementer.
+ * Feide gir ikke kull for alle studier — digfor og masteren får det aldri — så
+ * året utledes, og utledningen bommer av og til. Da er dette veien inn.
+ *
+ * Rettingen treffer studiet medlemmet går på nå, det samme som står i raden du
+ * klikket på. Det er med vilje: et medlem som har tatt en bachelor og gått
+ * videre på master har to studier med hvert sitt kull, og å skrive samme år på
+ * begge var nettopp feilen som gjorde en førsteårs master umulig å skille fra
+ * en tredjeårs bachelor.
  */
 function EditCohortDialog({
     user,
     open,
     onOpenChange,
 }: {
-    user: { id: string; name: string; studyStartYear: number | null } | null;
+    user: {
+        id: string;
+        name: string;
+        studyStartYear: number | null;
+        studyProgram: string | null;
+    } | null;
     open: boolean;
     onOpenChange: (open: boolean) => void;
 }) {
@@ -1521,10 +1534,11 @@ function EditCohortDialog({
                                 placeholder="2026"
                             />
                             <FieldDescription>
-                                Overstyrer Feide permanent. Medlemmet flyttes
-                                til kullgruppa med en gang, og senere
-                                innlogginger endrer den ikke tilbake. Tomt felt
-                                fjerner kullet.
+                                {user?.studyProgram
+                                    ? `Gjelder ${user.studyProgram}. Har medlemmet studert noe annet før, står det kullet urørt.`
+                                    : "Overstyrer Feide permanent."}{" "}
+                                Senere innlogginger endrer den ikke tilbake.
+                                Tomt felt fjerner kullet.
                             </FieldDescription>
                         </Field>
                     </FieldGroup>

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -6,7 +6,8 @@ import type {
     OAuth2UserInfo,
 } from "better-auth";
 import { genericOAuth } from "better-auth/plugins";
-import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import type { AnyColumn, SQL } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { DbSchema } from "@photon/db";
 import type { Campus, StudyYearSource } from "@photon/db/schema";
@@ -425,13 +426,14 @@ export async function applyFeideStudyPrograms(
         ];
 
         /**
-         * Resolved once, before the loop, and deliberately not re-read inside
-         * it. A member can arrive with one programme that carries a cohort and
-         * another that does not — a transfer from Bygg into Digital
-         * forretningsutvikling is the real case — and re-checking per programme
-         * would make the outcome depend on which order Feide listed them in.
+         * Read once, before the loop, and deliberately not re-read inside it.
+         * The loop creates cohort groups as it goes, so a per-programme lookup
+         * would see a different set depending on which order Feide happened to
+         * list the programmes in — a transfer from Dataingeniør into Digital
+         * forretningsutvikling would land in one intake or two purely by
+         * accident of ordering. There is a regression test for exactly this.
          */
-        const knownCohort = await hasKnownCohort(tx, userId);
+        const existingCohortYears = await readCohortYears(tx, userId);
 
         for (const feideGroup of groups) {
             const sp = await tx
@@ -450,28 +452,32 @@ export async function applyFeideStudyPrograms(
             const { id: studyProgramId, slug: programSlug } = sp[0];
 
             /**
-             * NTNU does not issue `fc:fs:kull` for every programme —
-             * ITBAITBEDR never gets one, confirmed across every such login
-             * in production — so an active student can arrive with a
-             * programme and no intake. 172 of the 258 priority pools select
-             * on the cohort group, so leaving the year empty costs them
-             * priority on everything aimed at their own intake, including
-             * the matriculation ball.
-             *
-             * Assume the current intake instead, and record that it was a
-             * guess. Only for active memberships: an alumnus whose groups
-             * are all lapsed would otherwise be stamped a fresh first-year.
+             * NTNU does not issue `fc:fs:kull` for every programme. Neither
+             * ITBAITBEDR nor the master ever gets one — 0 of 217 rows in
+             * production between them — so for those two a year we work out
+             * ourselves is not a stopgap until FS improves, it is the only
+             * source there will ever be. Leaving it empty costs the member
+             * priority on everything aimed at their own intake.
              */
-            const assumed =
-                feideGroup.startYear === null &&
-                feideGroup.active &&
-                !knownCohort;
+            const derivedStartYear =
+                feideGroup.startYear === null
+                    ? await deriveStartYear(
+                          tx,
+                          userId,
+                          programSlug,
+                          existingCohortYears,
+                          feideGroup.active,
+                          now,
+                      )
+                    : null;
+
+            const startYear = feideGroup.startYear ?? derivedStartYear;
 
             const startYearSource: StudyYearSource | null =
                 feideGroup.startYear !== null
                     ? "feide"
-                    : assumed
-                      ? "assumed"
+                    : derivedStartYear !== null
+                      ? "derived"
                       : null;
 
             const [before] = await tx
@@ -492,21 +498,28 @@ export async function applyFeideStudyPrograms(
                 .limit(1);
 
             /**
-             * Still additive for everything except a guess Feide has now
-             * answered. `setWhere` is what enforces that, in SQL rather than
-             * here, so no future caller can update a year it should not:
-             * `manual` is a deliberate correction that outranks Feide,
-             * `migrated` is the real year Lepton carried over, and `feide`
-             * is already the truth.
+             * A stored year is replaced only by one from a source that
+             * outranks it, and the comparison lives in SQL rather than here so
+             * no future caller can update a year it should not.
+             *
+             * This replaced a hand-written special case that only ever let
+             * `feide` overwrite `assumed`. That phrasing had a hole: a row
+             * that already existed with a NULL source could never be filled,
+             * whatever we learned later, which is how 153 rows in production —
+             * both of them on every member who had continued onto the master —
+             * ended up permanently without a year.
+             *
+             * Equal ranks do not overwrite, so the first answer of a given
+             * quality stands. That is what keeps a login from re-deriving over
+             * the more accurate year the backfill worked out from a member's
+             * cohort group.
              */
             const [written] = await tx
                 .insert(studyProgramMembership)
                 .values({
                     userId,
                     studyProgramId,
-                    startYear:
-                        feideGroup.startYear ??
-                        (assumed ? currentAcademicYear(now) : null),
+                    startYear,
                     startYearSource,
                     confirmedCampus: campus,
                 })
@@ -519,7 +532,11 @@ export async function applyFeideStudyPrograms(
                         startYear: sql`excluded.start_year`,
                         startYearSource: sql`excluded.start_year_source`,
                     },
-                    setWhere: sql`${studyProgramMembership.startYearSource} = 'assumed' AND excluded.start_year_source = 'feide'`,
+                    setWhere: sql`
+                        excluded.start_year IS NOT NULL
+                        AND ${startYearSourceRank(sql`excluded.start_year_source`)}
+                          > ${startYearSourceRank(studyProgramMembership.startYearSource)}
+                    `,
                 })
                 .returning({
                     startYear: studyProgramMembership.startYear,
@@ -541,7 +558,7 @@ export async function applyFeideStudyPrograms(
              * and deleting it would take their real intake with it.
              */
             if (
-                before?.startYearSource === "assumed" &&
+                before?.startYearSource === "derived" &&
                 before.startYear !== null &&
                 before.startYear !== effectiveStartYear &&
                 !isMasterStudySlug(programSlug)
@@ -787,24 +804,55 @@ type Transaction = Parameters<
 >[0];
 
 /**
- * Whether we already know which intake this member belongs to.
+ * Rank of a cohort year's source, as SQL. Higher wins; NULL ranks lowest.
  *
- * Guards the assumption in {@link syncFeideForUser}. Guessing on top of a
- * cohort we already have would put the member in two intakes at once, and both
- * `deriveStudy` and the profile endpoint take `Math.max()` over the cohort
- * groups — so the guess, always the current year, would beat the truth. That is
- * not hypothetical: every ITBAITBEDR member in production carries a correct
- * cohort from Lepton and gets no `fc:fs:kull` from Feide, so an unguarded
- * assumption would demote all of them to first-years.
- *
- * Both sources are checked because they disagree by design: members migrated
- * from Lepton have a cohort group and no study-programme row at all.
+ * `manual` is a deliberate correction by the board and outranks everything,
+ * `feide` is what NTNU says, `migrated` is the real year Lepton carried over,
+ * and `derived` is the one we worked out ourselves. A NULL source means a row
+ * that never resolved a year at all, so anything beats it.
  */
-async function hasKnownCohort(
+function startYearSourceRank(source: SQL | AnyColumn): SQL<number> {
+    return sql<number>`(CASE ${source}
+        WHEN 'manual' THEN 4
+        WHEN 'feide' THEN 3
+        WHEN 'migrated' THEN 2
+        WHEN 'derived' THEN 1
+        ELSE 0
+    END)`;
+}
+
+/**
+ * The intake year we believe a member started a programme in, when Feide will
+ * not tell us.
+ *
+ * Two signals, in order of how much they are worth:
+ *
+ * 1. **The member's cohort group.** Migrated from Lepton, it holds the real
+ *    intake, and it is exact rather than inferred. Only when there is exactly
+ *    one: a member who transferred carries two, and picking between them here
+ *    would be a guess dressed up as a lookup. Never for a master — the cohort
+ *    group belongs to the member's *bachelor*, and reading it here is precisely
+ *    the confusion that made a first-year master indistinguishable from a
+ *    third-year bachelor.
+ * 2. **When we first saw them on the programme**, from the study group's
+ *    `created_at`. Checked against the 314 rows where Feide did supply a year:
+ *    282 exact, 21 out by a year, 7 by more. Good enough to be the only source
+ *    two programmes will ever have, not good enough to override signal 1.
+ *
+ * Falls back to the current intake when neither exists, which is the right
+ * answer for the case that produces it: a member appearing on a programme for
+ * the first time, in the middle of the admission they were just admitted in.
+ *
+ * That last fallback is withheld from an inactive membership. With
+ * `showAll=true` an alumnus still arrives with their old groups, and stamping
+ * them with this year's intake would file someone who finished long ago as a
+ * fresh first-year.
+ */
+async function readCohortYears(
     tx: Transaction,
     userId: string,
-): Promise<boolean> {
-    const [fromGroups] = await tx
+): Promise<number[]> {
+    const rows = await tx
         .select({ slug: groupMembership.groupSlug })
         .from(groupMembership)
         .innerJoin(group, eq(group.slug, groupMembership.groupSlug))
@@ -815,23 +863,44 @@ async function hasKnownCohort(
                 // the `groupType` enum; compare case-insensitively.
                 sql`upper(${group.type}) = 'STUDYYEAR'`,
             ),
-        )
-        .limit(1);
+        );
 
-    if (fromGroups) return true;
+    return rows
+        .map((row) => Number.parseInt(row.slug, 10))
+        .filter((year) => Number.isFinite(year));
+}
 
-    const [fromTable] = await tx
-        .select({ userId: studyProgramMembership.userId })
-        .from(studyProgramMembership)
+async function deriveStartYear(
+    tx: Transaction,
+    userId: string,
+    programSlug: string,
+    cohortYears: readonly number[],
+    active: boolean,
+    now: Date,
+): Promise<number | null> {
+    if (!isMasterStudySlug(programSlug) && cohortYears.length === 1) {
+        return cohortYears[0] as number;
+    }
+
+    const [membership] = await tx
+        .select({ createdAt: groupMembership.createdAt })
+        .from(groupMembership)
         .where(
             and(
-                eq(studyProgramMembership.userId, userId),
-                isNotNull(studyProgramMembership.startYear),
+                eq(groupMembership.userId, userId),
+                eq(groupMembership.groupSlug, programSlug),
             ),
         )
         .limit(1);
 
-    return Boolean(fromTable);
+    /**
+     * The study group is created later in this same transaction, by
+     * {@link syncDerivedStudyGroups}, so on a member's first login with this
+     * programme there is deliberately nothing to read here yet.
+     */
+    if (membership) return currentAcademicYear(membership.createdAt);
+
+    return active ? currentAcademicYear(now) : null;
 }
 
 /**

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -22,7 +22,7 @@ import {
     userRole,
 } from "@photon/db/schema";
 import { env } from "@photon/core/env";
-import { currentAcademicYear } from "./academic-year";
+import { currentAcademicYear, isMasterStudySlug } from "./academic-year";
 
 /**
  * Database access required by the Feide sync hook.
@@ -535,10 +535,16 @@ export async function applyFeideStudyPrograms(
             const stored = written ?? before;
             const effectiveStartYear = stored?.startYear ?? null;
 
+            /**
+             * Never for a master: masters own no cohort group, so the only
+             * group slugged with that year belongs to the member's bachelor,
+             * and deleting it would take their real intake with it.
+             */
             if (
                 before?.startYearSource === "assumed" &&
                 before.startYear !== null &&
-                before.startYear !== effectiveStartYear
+                before.startYear !== effectiveStartYear &&
+                !isMasterStudySlug(programSlug)
             ) {
                 await removeCohortMembership(tx, userId, before.startYear);
             }
@@ -883,8 +889,20 @@ export async function syncDerivedStudyGroups(
      * `fc:fs:kull`, and a member can have the programme without ever having
      * had a cohort — inventing a year would put them in the wrong intake, and
      * the cohort groups are what the inherited priority pools select on.
+     *
+     * And none for a master either, whatever year we hold. A cohort group is
+     * programme-less — it is slugged as a bare year and says nothing about
+     * *which* studies started then — so putting a master's intake in one mixes
+     * master students into the inherited pools aimed at that year's bachelor
+     * intake. The master's own start year lives on the programme row instead,
+     * which is where {@link computeUserClassYear} now reads it, and the
+     * bachelor cohort group the member already carries stays untouched as
+     * history.
      */
-    const studyYearSlug = startYear === null ? null : String(startYear);
+    const studyYearSlug =
+        startYear === null || isMasterStudySlug(programSlug)
+            ? null
+            : String(startYear);
 
     if (studyYearSlug !== null) {
         /**

--- a/packages/db/drizzle/0067_useful_bug.sql
+++ b/packages/db/drizzle/0067_useful_bug.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "org_study_program_membership" ALTER COLUMN "start_year_source" SET DATA TYPE text;--> statement-breakpoint
+--
+-- `assumed` becomes `derived`. Must run while the column is still text: the
+-- cast back at the bottom rejects any value the new enum does not list, so
+-- without this the migration fails outright on the 64 rows holding it.
+--
+-- The two are the same claim about the same rows — "a year we worked out
+-- ourselves, which anything better may overwrite" — so this is a rename, not a
+-- reinterpretation.
+--
+UPDATE "org_study_program_membership" SET "start_year_source" = 'derived' WHERE "start_year_source" = 'assumed';--> statement-breakpoint
+DROP TYPE "public"."org_study_year_source";--> statement-breakpoint
+CREATE TYPE "public"."org_study_year_source" AS ENUM('feide', 'derived', 'manual', 'migrated');--> statement-breakpoint
+ALTER TABLE "org_study_program_membership" ALTER COLUMN "start_year_source" SET DATA TYPE "public"."org_study_year_source" USING "start_year_source"::"public"."org_study_year_source";

--- a/packages/db/drizzle/meta/0067_snapshot.json
+++ b/packages/db/drizzle/meta/0067_snapshot.json
@@ -1,0 +1,7500 @@
+{
+  "id": "fa42a79d-23d9-4229-9955-70e4a4a90277",
+  "prevId": "33f0dcb9-7c10-47a3-b41c-cfac15b97464",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apikey_api_key": {
+      "name": "apikey_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_api_key_created_by_user_id_auth_user_id_fk": {
+          "name": "apikey_api_key_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "apikey_api_key",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "apikey_api_key_key_hash_unique": {
+          "name": "apikey_api_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "application_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "submitted_by_id": {
+          "name": "submitted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_asset_key": {
+          "name": "pdf_asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_comment": {
+          "name": "internal_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled_by_id": {
+          "name": "handled_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled_at": {
+          "name": "handled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_submitted_by_id_created_at_index": {
+          "name": "application_submitted_by_id_created_at_index",
+          "columns": [
+            {
+              "expression": "submitted_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_type_status_created_at_index": {
+          "name": "application_type_status_created_at_index",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_submitted_by_id_auth_user_id_fk": {
+          "name": "application_submitted_by_id_auth_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "submitted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_handled_by_id_auth_user_id_fk": {
+          "name": "application_handled_by_id_auth_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "handled_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_attachment": {
+      "name": "application_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "application_attachment_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_attachment_application_id_index": {
+          "name": "application_attachment_application_id_index",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_attachment_application_id_application_id_fk": {
+          "name": "application_attachment_application_id_application_id_fk",
+          "tableFrom": "application_attachment",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_company_contact": {
+      "name": "application_company_contact",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semesters": {
+          "name": "semesters",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_company_contact_application_id_application_id_fk": {
+          "name": "application_company_contact_application_id_application_id_fk",
+          "tableFrom": "application_company_contact",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_expense": {
+      "name": "application_expense",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cc_email": {
+          "name": "cc_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_nok": {
+          "name": "amount_nok",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expense_date": {
+          "name": "expense_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_type": {
+          "name": "budget_type",
+          "type": "application_budget_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_expense_application_id_application_id_fk": {
+          "name": "application_expense_application_id_application_id_fk",
+          "tableFrom": "application_expense",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_expense_group_slug_org_group_slug_fk": {
+          "name": "application_expense_group_slug_org_group_slug_fk",
+          "tableFrom": "application_expense",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_hs_case": {
+      "name": "application_hs_case",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_name": {
+          "name": "case_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_type": {
+          "name": "case_type",
+          "type": "application_case_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_hs_case_application_id_application_id_fk": {
+          "name": "application_hs_case_application_id_application_id_fk",
+          "tableFrom": "application_hs_case",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_support": {
+      "name": "application_support",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_description": {
+          "name": "event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_nok": {
+          "name": "total_amount_nok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_link": {
+          "name": "budget_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_support_application_id_application_id_fk": {
+          "name": "application_support_application_id_application_id_fk",
+          "tableFrom": "application_support",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_support_group_slug_org_group_slug_fk": {
+          "name": "application_support_group_slug_org_group_slug_fk",
+          "tableFrom": "application_support",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_file": {
+      "name": "asset_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "asset_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_file_uploaded_by_id_auth_user_id_fk": {
+          "name": "asset_file_uploaded_by_id_auth_user_id_fk",
+          "tableFrom": "asset_file",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_file_key_unique": {
+          "name": "asset_file_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_source": {
+          "name": "password_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_session_id_auth_session_id_fk": {
+          "name": "auth_oauth_access_token_session_id_auth_session_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_refresh_id_auth_oauth_refresh_token_id_fk": {
+          "name": "auth_oauth_access_token_refresh_id_auth_oauth_refresh_token_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_token_unique": {
+          "name": "auth_oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_client": {
+      "name": "auth_oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_client_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_client_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_client",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_client_client_id_unique": {
+          "name": "auth_oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_refresh_token": {
+      "name": "auth_oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_refresh_token_client_id_auth_oauth_client_client_id_fk": {
+          "name": "auth_oauth_refresh_token_client_id_auth_oauth_client_client_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_refresh_token_session_id_auth_session_id_fk": {
+          "name": "auth_oauth_refresh_token_session_id_auth_session_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_refresh_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_refresh_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_refresh_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_refresh_token_token_unique": {
+          "name": "auth_oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_session_token_unique": {
+          "name": "auth_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_approvalStatus_idx": {
+          "name": "user_approvalStatus_idx",
+          "columns": [
+            {
+              "expression": "approval_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_user_email_unique": {
+          "name": "auth_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "auth_user_username_unique": {
+          "name": "auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banner_banner": {
+      "name": "banner_banner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_text": {
+          "name": "link_text",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_from": {
+          "name": "visible_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visible_until": {
+          "name": "visible_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banner_banner_created_by_user_id_auth_user_id_fk": {
+          "name": "banner_banner_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "banner_banner",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_event": {
+      "name": "event_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lat": {
+          "name": "location_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lng": {
+          "name": "location_lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_waitlist": {
+          "name": "allow_waitlist",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "contact_person_id": {
+          "name": "contact_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_by_user_id": {
+          "name": "update_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_start": {
+          "name": "registration_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_end": {
+          "name": "registration_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_deadline": {
+          "name": "cancellation_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_registration_closed": {
+          "name": "is_registration_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_paid_event": {
+          "name": "is_paid_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_signing_up": {
+          "name": "requires_signing_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions_allowed": {
+          "name": "reactions_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizer_group_slug": {
+          "name": "organizer_group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforces_previous_strikes": {
+          "name": "enforces_previous_strikes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_cause_strikes": {
+          "name": "can_cause_strikes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "no_show_processed_at": {
+          "name": "no_show_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_reminder_sent_at": {
+          "name": "registration_reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_review_notified_at": {
+          "name": "payment_review_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_allow_prioritized": {
+          "name": "only_allow_prioritized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restricted_to_institute_id": {
+          "name": "restricted_to_institute_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "event_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_event_category_slug_event_category_slug_fk": {
+          "name": "event_event_category_slug_event_category_slug_fk",
+          "tableFrom": "event_event",
+          "tableTo": "event_category",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_event_contact_person_id_auth_user_id_fk": {
+          "name": "event_event_contact_person_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "contact_person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_created_by_user_id_auth_user_id_fk": {
+          "name": "event_event_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_update_by_user_id_auth_user_id_fk": {
+          "name": "event_event_update_by_user_id_auth_user_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "update_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_organizer_group_slug_org_group_slug_fk": {
+          "name": "event_event_organizer_group_slug_org_group_slug_fk",
+          "tableFrom": "event_event",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "organizer_group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_event_restricted_to_institute_id_org_institute_id_fk": {
+          "name": "event_event_restricted_to_institute_id_org_institute_id_fk",
+          "tableFrom": "event_event",
+          "tableTo": "org_institute",
+          "columnsFrom": [
+            "restricted_to_institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_event_slug_unique": {
+          "name": "event_event_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_category": {
+      "name": "event_category",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_favorite": {
+      "name": "event_favorite",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_favorite_user_id_auth_user_id_fk": {
+          "name": "event_favorite_user_id_auth_user_id_fk",
+          "tableFrom": "event_favorite",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_favorite_event_id_event_event_id_fk": {
+          "name": "event_favorite_event_id_event_event_id_fk",
+          "tableFrom": "event_favorite",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_favorite_user_id_event_id_pk": {
+          "name": "event_favorite_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_feedback": {
+      "name": "event_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_feedback_event_id_event_event_id_fk": {
+          "name": "event_feedback_event_id_event_event_id_fk",
+          "tableFrom": "event_feedback",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_feedback_user_id_auth_user_id_fk": {
+          "name": "event_feedback_user_id_auth_user_id_fk",
+          "tableFrom": "event_feedback",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_payment": {
+      "name": "event_payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOK'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_payment_id": {
+          "name": "provider_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "received_payment_at": {
+          "name": "received_payment_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_extended_at": {
+          "name": "deadline_extended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flag": {
+          "name": "flag",
+          "type": "event_payment_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagged_at": {
+          "name": "flagged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_event_id_user_id_idx": {
+          "name": "payment_event_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_payment_event_id_event_event_id_fk": {
+          "name": "event_payment_event_id_event_event_id_fk",
+          "tableFrom": "event_payment",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_payment_user_id_auth_user_id_fk": {
+          "name": "event_payment_user_id_auth_user_id_fk",
+          "tableFrom": "event_payment",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_pool": {
+      "name": "event_priority_pool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_year": {
+          "name": "class_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "priority_pool_event_id_idx": {
+          "name": "priority_pool_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_priority_pool_event_id_event_event_id_fk": {
+          "name": "event_priority_pool_event_id_event_event_id_fk",
+          "tableFrom": "event_priority_pool",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_priority_pool_group_slug_org_group_slug_fk": {
+          "name": "event_priority_pool_group_slug_org_group_slug_fk",
+          "tableFrom": "event_priority_pool",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "priority_pool_not_empty": {
+          "name": "priority_pool_not_empty",
+          "value": "\"event_priority_pool\".\"group_slug\" is not null or \"event_priority_pool\".\"class_year\" is not null"
+        },
+        "priority_pool_class_year_range": {
+          "name": "priority_pool_class_year_range",
+          "value": "\"event_priority_pool\".\"class_year\" is null or \"event_priority_pool\".\"class_year\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_priority_pool_group": {
+      "name": "event_priority_pool_group",
+      "schema": "",
+      "columns": {
+        "priority_pool_id": {
+          "name": "priority_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_pool_group_priority_pool_id_event_priority_pool_id_fk": {
+          "name": "event_priority_pool_group_priority_pool_id_event_priority_pool_id_fk",
+          "tableFrom": "event_priority_pool_group",
+          "tableTo": "event_priority_pool",
+          "columnsFrom": [
+            "priority_pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_priority_pool_group_group_slug_org_group_slug_fk": {
+          "name": "event_priority_pool_group_group_slug_org_group_slug_fk",
+          "tableFrom": "event_priority_pool_group",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_priority_pool_group_priority_pool_id_group_slug_pk": {
+          "name": "event_priority_pool_group_priority_pool_id_group_slug_pk",
+          "columns": [
+            "priority_pool_id",
+            "group_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_priority_user": {
+      "name": "event_priority_user",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_priority_user_event_id_event_event_id_fk": {
+          "name": "event_priority_user_event_id_event_event_id_fk",
+          "tableFrom": "event_priority_user",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_priority_user_user_id_auth_user_id_fk": {
+          "name": "event_priority_user_user_id_auth_user_id_fk",
+          "tableFrom": "event_priority_user",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_priority_user_event_id_user_id_pk": {
+          "name": "event_priority_user_event_id_user_id_pk",
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reaction": {
+      "name": "event_reaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reaction_event_id_idx": {
+          "name": "reaction_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_reaction_user_id_auth_user_id_fk": {
+          "name": "event_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "event_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reaction_event_id_event_event_id_fk": {
+          "name": "event_reaction_event_id_event_event_id_fk",
+          "tableFrom": "event_reaction",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_reaction_user_id_event_id_pk": {
+          "name": "event_reaction_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_registration": {
+      "name": "event_registration",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "waitlist_position": {
+          "name": "waitlist_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended_at": {
+          "name": "attended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_photo": {
+          "name": "allow_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "registration_event_id_status_idx": {
+          "name": "registration_event_id_status_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "registration_pending_idx": {
+          "name": "registration_pending_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"event_registration\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_registration_event_id_event_event_id_fk": {
+          "name": "event_registration_event_id_event_event_id_fk",
+          "tableFrom": "event_registration",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_registration_user_id_auth_user_id_fk": {
+          "name": "event_registration_user_id_auth_user_id_fk",
+          "tableFrom": "event_registration",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_registration_user_id_event_id_pk": {
+          "name": "event_registration_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_strike": {
+      "name": "event_strike",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_strike_event_id_event_event_id_fk": {
+          "name": "event_strike_event_id_event_event_id_fk",
+          "tableFrom": "event_strike",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_strike_user_id_auth_user_id_fk": {
+          "name": "event_strike_user_id_auth_user_id_fk",
+          "tableFrom": "event_strike",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_item": {
+      "name": "feedback_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "feedback_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_item_created_at_idx": {
+          "name": "feedback_item_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_item_author_id_auth_user_id_fk": {
+          "name": "feedback_item_author_id_auth_user_id_fk",
+          "tableFrom": "feedback_item",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_vote": {
+      "name": "feedback_vote",
+      "schema": "",
+      "columns": {
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "feedback_vote_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_vote_feedback_id_feedback_item_id_fk": {
+          "name": "feedback_vote_feedback_id_feedback_item_id_fk",
+          "tableFrom": "feedback_vote",
+          "tableTo": "feedback_item",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_vote_user_id_auth_user_id_fk": {
+          "name": "feedback_vote_user_id_auth_user_id_fk",
+          "tableFrom": "feedback_vote",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_vote_feedback_id_user_id_pk": {
+          "name": "feedback_vote_feedback_id_user_id_pk",
+          "columns": [
+            "feedback_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_form": {
+      "name": "form_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_answer": {
+      "name": "form_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_text": {
+          "name": "answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_answer_submission_id_form_submission_id_fk": {
+          "name": "form_answer_submission_id_form_submission_id_fk",
+          "tableFrom": "form_answer",
+          "tableTo": "form_submission",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_answer_field_id_form_field_id_fk": {
+          "name": "form_answer_field_id_form_field_id_fk",
+          "tableFrom": "form_answer",
+          "tableTo": "form_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_answer_option": {
+      "name": "form_answer_option",
+      "schema": "",
+      "columns": {
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "answer_option_answer_id_idx": {
+          "name": "answer_option_answer_id_idx",
+          "columns": [
+            {
+              "expression": "answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_answer_option_answer_id_form_answer_id_fk": {
+          "name": "form_answer_option_answer_id_form_answer_id_fk",
+          "tableFrom": "form_answer_option",
+          "tableTo": "form_answer",
+          "columnsFrom": [
+            "answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_answer_option_option_id_form_option_id_fk": {
+          "name": "form_answer_option_option_id_form_option_id_fk",
+          "tableFrom": "form_answer_option",
+          "tableTo": "form_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_event_form": {
+      "name": "form_event_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_event_form_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_event_form_form_id_form_form_id_fk": {
+          "name": "form_event_form_form_id_form_form_id_fk",
+          "tableFrom": "form_event_form",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_event_form_event_id_event_event_id_fk": {
+          "name": "form_event_form_event_id_event_event_id_fk",
+          "tableFrom": "form_event_form",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_type": {
+          "name": "unique_event_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_field": {
+      "name": "form_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_field_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_field_form_id_form_form_id_fk": {
+          "name": "form_field_form_id_form_form_id_fk",
+          "tableFrom": "form_field",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_group_form": {
+      "name": "form_group_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_receiver_on_submit": {
+          "name": "email_receiver_on_submit",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_submit_multiple": {
+          "name": "can_submit_multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_open_for_submissions": {
+          "name": "is_open_for_submissions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "opens_at": {
+          "name": "opens_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_for_group_members": {
+          "name": "only_for_group_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_group_form_form_id_form_form_id_fk": {
+          "name": "form_group_form_form_id_form_form_id_fk",
+          "tableFrom": "form_group_form",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_group_form_group_slug_org_group_slug_fk": {
+          "name": "form_group_form_group_slug_org_group_slug_fk",
+          "tableFrom": "form_group_form",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_form": {
+          "name": "unique_group_form",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "group_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_option": {
+      "name": "form_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_option_field_id_form_field_id_fk": {
+          "name": "form_option_field_id_form_field_id_fk",
+          "tableFrom": "form_option",
+          "tableTo": "form_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_submission": {
+      "name": "form_submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_submission_form_id_form_form_id_fk": {
+          "name": "form_submission_form_id_form_form_id_fk",
+          "tableFrom": "form_submission",
+          "tableTo": "form_form",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_submission_user_id_auth_user_id_fk": {
+          "name": "form_submission_user_id_auth_user_id_fk",
+          "tableFrom": "form_submission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gallery_album": {
+      "name": "gallery_album",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gallery_album_event_id_event_event_id_fk": {
+          "name": "gallery_album_event_id_event_event_id_fk",
+          "tableFrom": "gallery_album",
+          "tableTo": "event_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gallery_album_created_by_user_id_auth_user_id_fk": {
+          "name": "gallery_album_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "gallery_album",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gallery_album_slug_unique": {
+          "name": "gallery_album_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gallery_picture": {
+      "name": "gallery_picture",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gallery_picture_album_id_idx": {
+          "name": "gallery_picture_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gallery_picture_album_id_gallery_album_id_fk": {
+          "name": "gallery_picture_album_id_gallery_album_id_fk",
+          "tableFrom": "gallery_picture",
+          "tableTo": "gallery_album",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_contract": {
+      "name": "org_contract",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signature_placement": {
+          "name": "signature_placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_placement": {
+          "name": "name_placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_contract_created_by_user_id_auth_user_id_fk": {
+          "name": "org_contract_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_contract",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_contract_signature": {
+      "name": "org_contract_signature",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signed_name": {
+          "name": "signed_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_pdf_key": {
+          "name": "signed_pdf_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_pdf_hash": {
+          "name": "signed_pdf_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_file_key": {
+          "name": "signature_file_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signer_ip": {
+          "name": "signer_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer_ua": {
+          "name": "signer_ua",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contract_signature_unique_idx": {
+          "name": "contract_signature_unique_idx",
+          "columns": [
+            {
+              "expression": "contract_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_contract_signature_contract_id_org_contract_id_fk": {
+          "name": "org_contract_signature_contract_id_org_contract_id_fk",
+          "tableFrom": "org_contract_signature",
+          "tableTo": "org_contract",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_contract_signature_user_id_auth_user_id_fk": {
+          "name": "org_contract_signature_user_id_auth_user_id_fk",
+          "tableFrom": "org_contract_signature",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_fine": {
+      "name": "org_fine",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "law_id": {
+          "name": "law_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defense": {
+          "name": "defense",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "org_fine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fine_group_slug_user_id_idx": {
+          "name": "fine_group_slug_user_id_idx",
+          "columns": [
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_fine_user_id_auth_user_id_fk": {
+          "name": "org_fine_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_fine_group_slug_org_group_slug_fk": {
+          "name": "org_fine_group_slug_org_group_slug_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_fine_law_id_org_group_law_id_fk": {
+          "name": "org_fine_law_id_org_group_law_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "org_group_law",
+          "columnsFrom": [
+            "law_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_fine_created_by_user_id_auth_user_id_fk": {
+          "name": "org_fine_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_fine_approved_by_user_id_auth_user_id_fk": {
+          "name": "org_fine_approved_by_user_id_auth_user_id_fk",
+          "tableFrom": "org_fine",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group": {
+      "name": "org_group",
+      "schema": "",
+      "columns": {
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fine_info": {
+          "name": "fine_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fines_activated": {
+          "name": "fines_activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fines_admin_id": {
+          "name": "fines_admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leader_permissions": {
+          "name": "leader_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "leader_global_permissions": {
+          "name": "leader_global_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "leader_title": {
+          "name": "leader_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_permissions": {
+          "name": "member_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "member_global_permissions": {
+          "name": "member_global_permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "contract_signing_required": {
+          "name": "contract_signing_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "institute_id": {
+          "name": "institute_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_fines_admin_id_auth_user_id_fk": {
+          "name": "org_group_fines_admin_id_auth_user_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "fines_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_group_institute_id_org_institute_id_fk": {
+          "name": "org_group_institute_id_org_institute_id_fk",
+          "tableFrom": "org_group",
+          "tableTo": "org_institute",
+          "columnsFrom": [
+            "institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_law": {
+      "name": "org_group_law",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paragraph": {
+          "name": "paragraph",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_law_group_slug_org_group_slug_fk": {
+          "name": "org_group_law_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_law",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_membership": {
+      "name": "org_group_membership",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_group_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_membership_group_slug_idx": {
+          "name": "group_membership_group_slug_idx",
+          "columns": [
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_group_membership_user_id_auth_user_id_fk": {
+          "name": "org_group_membership_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_membership_group_slug_org_group_slug_fk": {
+          "name": "org_group_membership_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_membership",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_group_membership_user_id_group_slug_pk": {
+          "name": "org_group_membership_user_id_group_slug_pk",
+          "columns": [
+            "user_id",
+            "group_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_membership_history": {
+      "name": "org_group_membership_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_membership_history_group_slug_idx": {
+          "name": "group_membership_history_group_slug_idx",
+          "columns": [
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_membership_history_user_id_idx": {
+          "name": "group_membership_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_membership_history_stint_idx": {
+          "name": "group_membership_history_stint_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_group_membership_history_user_id_auth_user_id_fk": {
+          "name": "org_group_membership_history_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_membership_history",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_membership_history_group_slug_org_group_slug_fk": {
+          "name": "org_group_membership_history_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_membership_history",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_position": {
+      "name": "org_group_position",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_slug": {
+          "name": "group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "org_group_position_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'group'"
+        },
+        "linked_group_slug": {
+          "name": "linked_group_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_position_group_slug_org_group_slug_fk": {
+          "name": "org_group_position_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_position",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_linked_group_slug_org_group_slug_fk": {
+          "name": "org_group_position_linked_group_slug_org_group_slug_fk",
+          "tableFrom": "org_group_position",
+          "tableTo": "org_group",
+          "columnsFrom": [
+            "linked_group_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_group_position_holder": {
+      "name": "org_group_position_holder",
+      "schema": "",
+      "columns": {
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_group_position_holder_position_id_org_group_position_id_fk": {
+          "name": "org_group_position_holder_position_id_org_group_position_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "org_group_position",
+          "columnsFrom": [
+            "position_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_holder_user_id_auth_user_id_fk": {
+          "name": "org_group_position_holder_user_id_auth_user_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_group_position_holder_granted_by_auth_user_id_fk": {
+          "name": "org_group_position_holder_granted_by_auth_user_id_fk",
+          "tableFrom": "org_group_position_holder",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_institute": {
+      "name": "org_institute",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_institute_slug_unique": {
+          "name": "org_institute_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_study_program": {
+      "name": "org_study_program",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feide_code": {
+          "name": "feide_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "org_study_program_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_study_program_slug_unique": {
+          "name": "org_study_program_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "org_study_program_feide_code_unique": {
+          "name": "org_study_program_feide_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feide_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_study_program_membership": {
+      "name": "org_study_program_membership",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_program_id": {
+          "name": "study_program_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_year_source": {
+          "name": "start_year_source",
+          "type": "org_study_year_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_campus": {
+          "name": "confirmed_campus",
+          "type": "org_campus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feide_active": {
+          "name": "feide_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feide_checked_at": {
+          "name": "feide_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_study_program_membership_user_id_auth_user_id_fk": {
+          "name": "org_study_program_membership_user_id_auth_user_id_fk",
+          "tableFrom": "org_study_program_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_study_program_membership_study_program_id_org_study_program_id_fk": {
+          "name": "org_study_program_membership_study_program_id_org_study_program_id_fk",
+          "tableFrom": "org_study_program_membership",
+          "tableTo": "org_study_program",
+          "columnsFrom": [
+            "study_program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_study_program_membership_user_id_study_program_id_pk": {
+          "name": "org_study_program_membership_user_id_study_program_id_pk",
+          "columns": [
+            "user_id",
+            "study_program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_role": {
+      "name": "rbac_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rbac_role_name_unique": {
+          "name": "rbac_role_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_user_permission": {
+      "name": "rbac_user_permission",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'*'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rbac_user_permission_user_id_auth_user_id_fk": {
+          "name": "rbac_user_permission_user_id_auth_user_id_fk",
+          "tableFrom": "rbac_user_permission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_user_permission_granted_by_auth_user_id_fk": {
+          "name": "rbac_user_permission_granted_by_auth_user_id_fk",
+          "tableFrom": "rbac_user_permission",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rbac_user_permission_user_id_permission_scope_pk": {
+          "name": "rbac_user_permission_user_id_permission_scope_pk",
+          "columns": [
+            "user_id",
+            "permission",
+            "scope"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_user_role": {
+      "name": "rbac_user_role",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rbac_user_role_user_id_auth_user_id_fk": {
+          "name": "rbac_user_role_user_id_auth_user_id_fk",
+          "tableFrom": "rbac_user_role",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_user_role_role_id_rbac_role_id_fk": {
+          "name": "rbac_user_role_role_id_rbac_role_id_fk",
+          "tableFrom": "rbac_user_role",
+          "tableTo": "rbac_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rbac_user_role_user_id_role_id_pk": {
+          "name": "rbac_user_role_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_notification": {
+      "name": "notification_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_id_created_at_idx": {
+          "name": "notification_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_notification_user_id_auth_user_id_fk": {
+          "name": "notification_notification_user_id_auth_user_id_fk",
+          "tableFrom": "notification_notification",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_device": {
+      "name": "notification_device",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_device_userId_idx": {
+          "name": "notification_device_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_device_user_id_auth_user_id_fk": {
+          "name": "notification_device_user_id_auth_user_id_fk",
+          "tableFrom": "notification_device",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_device_token_unique": {
+          "name": "notification_device_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_news": {
+      "name": "news_news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emojis_allowed": {
+          "name": "emojis_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_news_created_by_user_id_auth_user_id_fk": {
+          "name": "news_news_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "news_news",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_reaction": {
+      "name": "news_reaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "news_id": {
+          "name": "news_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_reaction_user_id_auth_user_id_fk": {
+          "name": "news_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "news_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "news_reaction_news_id_news_news_id_fk": {
+          "name": "news_reaction_news_id_news_news_id_fk",
+          "tableFrom": "news_reaction",
+          "tableTo": "news_news",
+          "columnsFrom": [
+            "news_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "news_reaction_user_id_news_id_pk": {
+          "name": "news_reaction_user_id_news_id_pk",
+          "columns": [
+            "user_id",
+            "news_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_job_post": {
+      "name": "job_job_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingress": {
+          "name": "ingress",
+          "type": "varchar(800)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_continuously_hiring": {
+          "name": "is_continuously_hiring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_start": {
+          "name": "class_start",
+          "type": "user_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'first'"
+        },
+        "class_end": {
+          "name": "class_end",
+          "type": "user_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fifth'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_job_post_created_by_user_id_auth_user_id_fk": {
+          "name": "job_job_post_created_by_user_id_auth_user_id_fk",
+          "tableFrom": "job_job_post",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_allergy": {
+      "name": "user_allergy",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_user_setting_allergy": {
+      "name": "user_user_setting_allergy",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergy_slug": {
+          "name": "allergy_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_user_setting_allergy_user_id_user_settings_user_id_fk": {
+          "name": "user_user_setting_allergy_user_id_user_settings_user_id_fk",
+          "tableFrom": "user_user_setting_allergy",
+          "tableTo": "user_settings",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_user_setting_allergy_allergy_slug_user_allergy_slug_fk": {
+          "name": "user_user_setting_allergy_allergy_slug_user_allergy_slug_fk",
+          "tableFrom": "user_user_setting_allergy",
+          "tableTo": "user_allergy",
+          "columnsFrom": [
+            "allergy_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_user_setting_allergy_user_id_allergy_slug_pk": {
+          "name": "user_user_setting_allergy_user_id_allergy_slug_pk",
+          "columns": [
+            "user_id",
+            "allergy_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_calendar_token": {
+      "name": "user_calendar_token",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_calendar_token_user_id_auth_user_id_fk": {
+          "name": "user_calendar_token_user_id_auth_user_id_fk",
+          "tableFrom": "user_calendar_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_calendar_token_token_unique": {
+          "name": "user_calendar_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "user_gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allows_photos_by_default": {
+          "name": "allows_photos_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_event_rules": {
+          "name": "accepts_event_rules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_description": {
+          "name": "bio_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_mail_communication": {
+          "name": "receive_mail_communication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_event_registrations": {
+          "name": "public_event_registrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_onboarded": {
+          "name": "is_onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_auth_user_id_fk": {
+          "name": "user_settings_user_id_auth_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.toddel_issue": {
+      "name": "toddel_issue",
+      "schema": "",
+      "columns": {
+        "edition": {
+          "name": "edition",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qrcode_qr_code": {
+      "name": "qrcode_qr_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "qrcode_qr_code_user_id_auth_user_id_fk": {
+          "name": "qrcode_qr_code_user_id_auth_user_id_fk",
+          "tableFrom": "qrcode_qr_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_event": {
+      "name": "motetid_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_mode": {
+          "name": "date_mode",
+          "type": "motetid_date_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DATES'"
+        },
+        "dates": {
+          "name": "dates",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_duration": {
+          "name": "slot_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "motetid_event_created_by_id_index": {
+          "name": "motetid_event_created_by_id_index",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_event_created_by_id_auth_user_id_fk": {
+          "name": "motetid_event_created_by_id_auth_user_id_fk",
+          "tableFrom": "motetid_event",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "motetid_event_slug_unique": {
+          "name": "motetid_event_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_google_credential": {
+      "name": "motetid_google_credential",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "motetid_google_credential_user_id_auth_user_id_fk": {
+          "name": "motetid_google_credential_user_id_auth_user_id_fk",
+          "tableFrom": "motetid_google_credential",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_participant": {
+      "name": "motetid_participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "motetid_participant_event_id_user_id_index": {
+          "name": "motetid_participant_event_id_user_id_index",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "motetid_participant_user_id_index": {
+          "name": "motetid_participant_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_participant_event_id_motetid_event_id_fk": {
+          "name": "motetid_participant_event_id_motetid_event_id_fk",
+          "tableFrom": "motetid_participant",
+          "tableTo": "motetid_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "motetid_participant_user_id_auth_user_id_fk": {
+          "name": "motetid_participant_user_id_auth_user_id_fk",
+          "tableFrom": "motetid_participant",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motetid_slot": {
+      "name": "motetid_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "motetid_slot_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "motetid_slot_participant_id_date_time_index": {
+          "name": "motetid_slot_participant_id_date_time_index",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "motetid_slot_event_id_date_time_index": {
+          "name": "motetid_slot_event_id_date_time_index",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motetid_slot_participant_id_motetid_participant_id_fk": {
+          "name": "motetid_slot_participant_id_motetid_participant_id_fk",
+          "tableFrom": "motetid_slot",
+          "tableTo": "motetid_participant",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "motetid_slot_event_id_motetid_event_id_fk": {
+          "name": "motetid_slot_event_id_motetid_event_id_fk",
+          "tableFrom": "motetid_slot",
+          "tableTo": "motetid_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.application_attachment_kind": {
+      "name": "application_attachment_kind",
+      "schema": "public",
+      "values": [
+        "receipt",
+        "budget",
+        "attachment"
+      ]
+    },
+    "public.application_budget_type": {
+      "name": "application_budget_type",
+      "schema": "public",
+      "values": [
+        "social_budget",
+        "group_budget",
+        "approved_hs_application",
+        "approved_idkom_application"
+      ]
+    },
+    "public.application_case_type": {
+      "name": "application_case_type",
+      "schema": "public",
+      "values": [
+        "discussion",
+        "decision",
+        "orientation"
+      ]
+    },
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "in_progress",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.application_type": {
+      "name": "application_type",
+      "schema": "public",
+      "values": [
+        "expense",
+        "support",
+        "sports_support",
+        "hs_case",
+        "company_contact"
+      ]
+    },
+    "public.asset_status": {
+      "name": "asset_status",
+      "schema": "public",
+      "values": [
+        "staged",
+        "ready"
+      ]
+    },
+    "public.asset_visibility": {
+      "name": "asset_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "private"
+      ]
+    },
+    "public.event_visibility": {
+      "name": "event_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "members"
+      ]
+    },
+    "public.event_payment_flag": {
+      "name": "event_payment_flag",
+      "schema": "public",
+      "values": [
+        "provider_unreachable",
+        "paid_without_spot"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "refunded",
+        "failed"
+      ]
+    },
+    "public.event_registration_status": {
+      "name": "event_registration_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "waitlisted",
+        "cancelled",
+        "attended",
+        "no_show",
+        "pending"
+      ]
+    },
+    "public.feedback_status": {
+      "name": "feedback_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "in_progress",
+        "closed",
+        "rejected"
+      ]
+    },
+    "public.feedback_type": {
+      "name": "feedback_type",
+      "schema": "public",
+      "values": [
+        "idea",
+        "bug"
+      ]
+    },
+    "public.feedback_vote_value": {
+      "name": "feedback_vote_value",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    },
+    "public.form_event_form_type": {
+      "name": "form_event_form_type",
+      "schema": "public",
+      "values": [
+        "survey",
+        "evaluation"
+      ]
+    },
+    "public.form_field_type": {
+      "name": "form_field_type",
+      "schema": "public",
+      "values": [
+        "text_answer",
+        "multiple_select",
+        "single_select"
+      ]
+    },
+    "public.org_campus": {
+      "name": "org_campus",
+      "schema": "public",
+      "values": [
+        "trondheim",
+        "gjovik",
+        "alesund"
+      ]
+    },
+    "public.org_fine_status": {
+      "name": "org_fine_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "paid",
+        "rejected"
+      ]
+    },
+    "public.org_group_membership_role": {
+      "name": "org_group_membership_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "leader"
+      ]
+    },
+    "public.org_group_position_scope": {
+      "name": "org_group_position_scope",
+      "schema": "public",
+      "values": [
+        "group",
+        "global"
+      ]
+    },
+    "public.org_group_type": {
+      "name": "org_group_type",
+      "schema": "public",
+      "values": [
+        "studyyear",
+        "interestgroup",
+        "committee",
+        "study",
+        "private",
+        "board",
+        "subgroup",
+        "tihlde"
+      ]
+    },
+    "public.org_study_program_type": {
+      "name": "org_study_program_type",
+      "schema": "public",
+      "values": [
+        "bachelor",
+        "master"
+      ]
+    },
+    "public.org_study_year_source": {
+      "name": "org_study_year_source",
+      "schema": "public",
+      "values": [
+        "feide",
+        "derived",
+        "manual",
+        "migrated"
+      ]
+    },
+    "public.job_type": {
+      "name": "job_type",
+      "schema": "public",
+      "values": [
+        "full_time",
+        "part_time",
+        "summer_job",
+        "other"
+      ]
+    },
+    "public.user_class": {
+      "name": "user_class",
+      "schema": "public",
+      "values": [
+        "first",
+        "second",
+        "third",
+        "fourth",
+        "fifth",
+        "alumni"
+      ]
+    },
+    "public.user_gender": {
+      "name": "user_gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other"
+      ]
+    },
+    "public.motetid_date_mode": {
+      "name": "motetid_date_mode",
+      "schema": "public",
+      "values": [
+        "DATES",
+        "WEEKDAYS"
+      ]
+    },
+    "public.motetid_slot_status": {
+      "name": "motetid_slot_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "IF_NEEDED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -470,6 +470,13 @@
       "when": 1787087389422,
       "tag": "0066_powerful_firestar",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1787145564257,
+      "tag": "0067_useful_bug",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/org.ts
+++ b/packages/db/src/schema/org.ts
@@ -63,20 +63,28 @@ export type Campus = (typeof campus)["enumValues"][number];
 /**
  * Where a cohort start year came from, which decides who may overwrite it.
  *
- * NTNU does not hand out `fc:fs:kull` for every programme — ITBAITBEDR
- * (Digital forretningsutvikling) never gets one — so a member who registers
- * from scratch would otherwise land with no cohort at all, and 172 of the 258
- * priority pools select on the cohort group. We therefore assume the current
- * intake for active students we have no year for, and record that it was a
- * guess rather than something Feide told us.
+ * NTNU does not hand out `fc:fs:kull` for every programme. Neither ITBAITBEDR
+ * (Digital forretningsutvikling) nor ITMAIKTSA (the master) ever gets one — 0
+ * of 217 rows in production between them — so for those two a year we work out
+ * ourselves is not a stopgap until FS improves, it is the only source there
+ * will ever be. Without one the member loses priority on everything aimed at
+ * their own intake.
  *
- * Only `assumed` may be overwritten, and only by `feide`. `manual` is a
- * deliberate correction by the board and outranks Feide; `migrated` is the
- * year Lepton carried over, which is real data we have no better source for.
+ * Ranked, highest first: `manual` is a deliberate correction by the board;
+ * `feide` is what NTNU says; `migrated` is the year Lepton carried over, real
+ * data we have no better source for; `derived` is the one we worked out
+ * ourselves. A higher rank overwrites a lower one and nothing else — equal
+ * ranks leave the stored value alone, so the first answer of a given quality
+ * stands.
+ *
+ * `derived` replaced an older `assumed`, which meant "this year's intake,
+ * because you are active now". It answered the same question worse: it was
+ * right only for someone who had just started, and said nothing for the far
+ * larger group whose real intake was sitting in their cohort group all along.
  */
 export const studyYearSource = pgEnum("org_study_year_source", [
     "feide",
-    "assumed",
+    "derived",
     "manual",
     "migrated",
 ]);

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -6226,6 +6226,8 @@ export interface components {
         UpdateStudyYearInput: {
             /** @description Cohort start year, e.g. 2026. Null clears the cohort and removes the member's STUDYYEAR group. */
             startYear: number | null;
+            /** @description Which study programme the year applies to, e.g. 'digital-samhandling'. Omit to correct the member's current programme, which is what the admin list shows. Only members who have switched studies have more than one. */
+            studyProgramSlug?: string | null;
         };
         UpdateStudy: {
             message: string;


### PR DESCRIPTION
André Karsten har kull 2023, har begynt på digtrans, men står fortsatt som digfor. Han har begge studiegruppene — dataene er der. Feilen er at fire kodesteder plukket en tilfeldig rad når et medlem har mer enn ett studie, og at klassetrinn ble regnet med et tak som bare stemmer for master.

## Hva som faktisk var galt

**Tilfeldig valgt studie.** `deriveStudyFromGroups` tok første rad Postgres returnerte. Adminlista brukte `distinct on` sortert på slug, altså alfabetisk — og `digital-forretningsutvikling` kommer før `digital-samhandling`. Det er hele forklaringen på det rapporterte symptomet. 36 medlemmer i prod har to eller flere studiegrupper.

**Flatt klassetak på fem.** Ingenting kappet en bachelor ved tre, så 401 medlemmer som er ferdige med en treårig bachelor telte fortsatt som 4. og 5. klasse. `programmeLength()` kodet allerede riktig svar og ble allerede brukt i kvark — frontend kalte dem alumni mens backend ga dem prioritet.

**Rader som aldri kunne fylles.** Vakten på upserten var skrevet som ett spesialtilfelle: bare `feide` fikk overskrive `assumed`. En rad som alt fantes med NULL kilde var dermed låst for godt. 154 rader i prod sitter slik, deriblant begge radene til hvert medlem som har gått videre på master.

## Seks endringer, i deploy-rekkefølge

1. **Masterkull blir aldri en kullgruppe.** En kullgruppe er programløs, så et masterkull i en slik gruppe blander masterstudenter inn i de arvede poolene rettet mot bachelorkullet det året.
2. **Kilderangering i SQL** — `manual > feide > migrated > derived`, NULL nederst. Lik rang overskriver ikke. `derived` erstatter `assumed`, som svarte på samme spørsmål dårligere: den sa «årets opptak fordi du er aktiv nå», mens det ekte kullet lå i kullgruppa hele tiden.
3. **Manuell retting per studieprogram.** Ruta skrev året til hver eneste programrad og slettet alle kullgruppene. Uten et eksplisitt studie lander rettingen nå på medlemmets nåværende.
4. **Backfill av 152 rader** — bachelorrader fra kullgruppa (eksakt), masterrader fra `created_at` (eneste kilde). To med flere kullgrupper står igjen med vilje.
5. **Én rangering, fire steder.** Feide sier innskrevet → seneste startår, ukjent sist → master før bachelor → slug. Siste ledd avgjør aldri en ekte sak, men gjør at ingen kodesti kan avhenge av radrekkefølgen i databasen igjen.
6. **Programlengden avgjør taket.** Bachelor 3, master 5.

## Verifisering

- Hele API-suiten grønn: 104 filer, 699 tester. 12 nye tester, alle mutasjonssjekket — snur jeg endringen de dekker, faller de.
- **Migrasjon 0067 prøvekjørt begge veier.** Den genererte migrasjonen ville feilet i prod: de 64 `assumed`-radene overlever castingen til tekst, og castingen tilbake avviser en verdi det nye enumet ikke har. `UPDATE`-steget mellom castingene er lagt inn og verifisert — uten det får man `invalid input value for enum`.
- **Backfillen prøvekjørt mot en full kopi av prod** med migrasjonen påført: 154 rader uten år ble til 2, `feide` (314) og `migrated` (6) urørt, ny kjøring skriver null.
- **Før/etter-telling av klassetrinn mot prod, med den faktiske koden:** 415 av 1927 skifter. 401 er ferdige bachelorer som blir alumni.

## Krever oppmerksomhet før deploy

**Rekkefølgen er ikke valgfri.** Migrasjon 0067 må deployes før backfillen kjøres — skriptet skriver `derived`, og prod-enumet kjenner ikke verdien ennå. Lesekjeden rangerer på `start_year`, som er NULL på 154 rader til backfillen har kjørt.

**14 medlemmer flytter seg av en annen grunn enn de 401.** De har to kullgrupper og et Feide-år som peker på den eldste. 11 går opp et trinn — Feides eget år slår nå en foreldet kullgruppe, altså en retting. Men tre går fra 3. klasse til alumni:

| Navn | Kullgrupper | Feide sier |
|---|---|---|
| Anna Legankova | 2023, 2024 | digsec fra 2023 |
| Elias André Willumsen | 2020, 2024 | dataing fra 2020 |
| Eric Segura Hernandez | 2023, 2024 | digsec fra 2023 |

Alle tre har `feide_active = NULL`, så vi vet ikke om de fortsatt studerer. Regelen er konsistent, men de bør vurderes for hånd før eller rett etter deploy — `PATCH /api/user/:id/study-year` med riktig `studyProgramSlug` setter `manual`, som slår alt annet.

**Immeballet påvirkes ikke.** 11. september har pools `hs`, klasse 1 og `digital-samhandling`+4. Alle 22 aktive masterstudenter får samme klassetrinn før og etter, og André matcher allerede. De 401 mangler mastergruppa og treffer ingen av poolene.

Relatert: #621 (`fondsforvalter` er typet STUDY uten å være et studie — lesestien er herdet her, dataene er ikke rettet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)