### PR TITLE
fix(tilganger): la arrangøren håndtere prikkene på egne arrangementer

### DIFF
--- a/apps/api/src/lib/event/access.ts
+++ b/apps/api/src/lib/event/access.ts
@@ -28,6 +28,32 @@ type Variables = {
 };
 
 /**
+ * Permissions that make you the arrangør of a group's events.
+ *
+ * Whoever may edit a group's arrangementer runs them, and running an
+ * arrangement includes the prikker it produces: the no-shows belong to the
+ * event the same way the påmeldte do. Requiring a separate `events:strikes:*`
+ * on top meant the person who put the arrangement up could not deal with its
+ * prikker — every group's leader list carried the event permissions and none
+ * of them carried the strike ones, so the answer was always no.
+ *
+ * Held scoped to a group, this reaches that group's own events and nothing
+ * else, so it cannot become a way into another group's prikker.
+ */
+export const EVENT_ARRANGER_PERMISSIONS = [
+    "events:update",
+    "events:manage",
+] as const;
+
+/**
+ * Everything that lets you view, give or remove prikker on an event: the
+ * strike permission itself, or simply arranging the event.
+ */
+export function strikePermissions(action: "view" | "create" | "delete") {
+    return [`events:strikes:${action}`, ...EVENT_ARRANGER_PERMISSIONS];
+}
+
+/**
  * The slug of the group arranging `eventId`, or null when the event has no
  * organiser group (older events migrated from Lepton) or does not exist.
  */

--- a/apps/api/src/routes/event/strike/create.ts
+++ b/apps/api/src/routes/event/strike/create.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import type z from "zod";
-import { canActOnEvent } from "~/lib/event/access";
+import { canActOnEvent, strikePermissions } from "~/lib/event/access";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -17,7 +17,7 @@ export const createStrikeRoute = route().post(
         summary: "Create strike",
         operationId: "createStrike",
         description:
-            "Give a user a strike (prikk) connected to an event. Requires 'events:strikes:create' or 'events:manage', globally or for the group arranging the event.",
+            "Give a user a strike (prikk) connected to an event. Requires 'events:strikes:create', or the right to arrange the event ('events:update' / 'events:manage') — globally or for the group arranging it.",
     })
         .schemaResponse({
             statusCode: 201,
@@ -26,7 +26,7 @@ export const createStrikeRoute = route().post(
         })
         .forbidden({
             description:
-                "Requires events:strikes:create or events:manage permission",
+                "Requires events:strikes:create, or the right to arrange the event",
         })
         .notFound({ description: "User or event not found" })
         .build(),
@@ -34,7 +34,7 @@ export const createStrikeRoute = route().post(
     // Coarse gate: the event — and with it the scope — is named in the body,
     // so the group-level check happens in the handler once it is resolved.
     requireAccess({
-        permission: ["events:strikes:create", "events:manage"],
+        permission: strikePermissions("create"),
         anyGroupScope: true,
     }),
     validator("json", createStrikeSchema),
@@ -69,12 +69,12 @@ export const createStrikeRoute = route().post(
                 c.get("ctx"),
                 c.get("user").id,
                 body.eventId,
-                ["events:strikes:create", "events:manage"],
+                strikePermissions("create"),
             ))
         ) {
             throw new HTTPException(403, {
                 message:
-                    "Forbidden - requires events:strikes:create or events:manage for the group arranging this event",
+                    "Forbidden - requires events:strikes:create, or the right to arrange events for the group behind this event",
             });
         }
 

--- a/apps/api/src/routes/event/strike/delete.ts
+++ b/apps/api/src/routes/event/strike/delete.ts
@@ -1,7 +1,7 @@
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
-import { canActOnEvent } from "~/lib/event/access";
+import { canActOnEvent, strikePermissions } from "~/lib/event/access";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAccess } from "~/middleware/access";
@@ -15,7 +15,7 @@ export const deleteStrikeRoute = route().delete(
         summary: "Delete strike",
         operationId: "deleteStrike",
         description:
-            "Delete a strike (prikk) by its ID. Requires 'events:strikes:delete' or 'events:manage', globally or for the group arranging the strike's event.",
+            "Delete a strike (prikk) by its ID. Requires 'events:strikes:delete', or the right to arrange the event ('events:update' / 'events:manage') — globally or for the group arranging it.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -24,7 +24,7 @@ export const deleteStrikeRoute = route().delete(
         })
         .forbidden({
             description:
-                "Requires events:strikes:delete or events:manage permission",
+                "Requires events:strikes:delete, or the right to arrange the event",
         })
         .notFound({ description: "Strike not found" })
         .build(),
@@ -32,7 +32,7 @@ export const deleteStrikeRoute = route().delete(
     // Coarse gate: the strike's event decides the scope, so the group-level
     // check happens in the handler once the strike is loaded.
     requireAccess({
-        permission: ["events:strikes:delete", "events:manage"],
+        permission: strikePermissions("delete"),
         anyGroupScope: true,
     }),
     async (c) => {
@@ -52,12 +52,12 @@ export const deleteStrikeRoute = route().delete(
                 c.get("ctx"),
                 c.get("user").id,
                 strike.eventId,
-                ["events:strikes:delete", "events:manage"],
+                strikePermissions("delete"),
             ))
         ) {
             throw new HTTPException(403, {
                 message:
-                    "Forbidden - requires events:strikes:delete or events:manage for the group arranging this event",
+                    "Forbidden - requires events:strikes:delete, or the right to arrange events for the group behind this event",
             });
         }
 

--- a/apps/api/src/routes/event/strike/list.ts
+++ b/apps/api/src/routes/event/strike/list.ts
@@ -1,5 +1,6 @@
+import { getPermissionGroupScopes } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
-import { and, desc, eq, gte } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
 import { createMiddleware } from "hono/factory";
 import { validator } from "hono-openapi";
 import z from "zod";
@@ -13,18 +14,23 @@ import {
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
+import { strikePermissions } from "~/lib/event/access";
 import { getStrikeActiveCutoff } from "~/lib/event/strikes";
 import { strikeListResponseSchema } from "./schema";
 
 const requireStrikePermission = requireAccess({
-    permission: ["events:strikes:view", "events:manage"],
+    // Coarse gate only: a group-scoped grant is enough to have prikker to
+    // read, and the handler narrows the listing to exactly those groups.
+    permission: strikePermissions("view"),
+    anyGroupScope: true,
 });
 
 /**
  * Everyone may read their own prikker — `?userId=<seg selv>` needs no grant.
  * Anything wider (all strikes, or someone else's) still requires
- * `events:strikes:view` / `events:manage`. Without this, the "Prikker" page on
- * a member's own profile could never load anything.
+ * `events:strikes:view`, or the right to arrange the events they came from.
+ * Without this, the "Prikker" page on a member's own profile could never load
+ * anything.
  */
 const requireStrikeAccess = createMiddleware(async (c, next) => {
     const user = c.get("user");
@@ -63,19 +69,56 @@ export const listStrikesRoute = route().get(
         }),
     ),
     async (c) => {
-        const { db } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const { pageSize, page, userId } = c.req.valid("query");
+        const isOwnStrikes = userId === c.get("user").id;
 
         const pageOffset = getPageOffset(page, pageSize);
         // Only list strikes that are still active (not expired / not aged out
         // past the freeze-adjusted 20-day window).
         const activeCutoff = getStrikeActiveCutoff();
-        const filters = userId
-            ? and(
-                  eq(schema.eventStrike.userId, userId),
-                  gte(schema.eventStrike.createdAt, activeCutoff),
-              )
-            : gte(schema.eventStrike.createdAt, activeCutoff);
+
+        /**
+         * Narrow to the groups whose arrangementer the reader answers for.
+         *
+         * The gate above accepts a group-scoped grant, so without this a NoK
+         * verv would open every group's prikker at once. Reading your own is
+         * never narrowed — that branch skips the gate entirely.
+         */
+        const scopes = isOwnStrikes
+            ? "*"
+            : await getPermissionGroupScopes(
+                  ctx,
+                  c.get("user").id,
+                  strikePermissions("view"),
+              );
+
+        const groupFilter =
+            scopes === "*"
+                ? undefined
+                : inArray(
+                      schema.eventStrike.eventId,
+                      db
+                          .select({ id: schema.event.id })
+                          .from(schema.event)
+                          .where(
+                              scopes.length > 0
+                                  ? inArray(
+                                        schema.event.organizerGroupSlug,
+                                        scopes,
+                                    )
+                                  : // No group at all: match nothing rather
+                                    // than everything.
+                                    sql`false`,
+                          ),
+                  );
+
+        const filters = and(
+            gte(schema.eventStrike.createdAt, activeCutoff),
+            userId ? eq(schema.eventStrike.userId, userId) : undefined,
+            groupFilter,
+        );
 
         const totalCount = await db.$count(schema.eventStrike, filters);
 

--- a/apps/api/src/test/event/group-scoped-access.test.ts
+++ b/apps/api/src/test/event/group-scoped-access.test.ts
@@ -199,7 +199,7 @@ describe("group-scoped event access", () => {
      * quietly add them back.
      */
     integrationTest(
-        "a leader set with payments:view and check-in still cannot refund or strike",
+        "a leader set with payments:view and check-in may strike, but still cannot refund",
         async ({ ctx }) => {
             const leader = await ctx.utils.createTestUser();
             const client = await ctx.utils.clientForUser(leader);
@@ -267,6 +267,9 @@ describe("group-scoped event access", () => {
             });
             expect(refund.status).toBe(403);
 
+            // Prikker ride with the arrangement: `events:update` for the
+            // organiser group is the right to deal with its no-shows, so no
+            // separate `events:strikes:create` is needed.
             const strike = await client.api.event.strikes.$post({
                 json: {
                     userId: attendee.id,
@@ -275,7 +278,7 @@ describe("group-scoped event access", () => {
                     reason: "Møtte ikke opp",
                 },
             });
-            expect(strike.status).toBe(403);
+            expect(strike.status).toBe(201);
         },
         500_000,
     );

--- a/apps/api/src/test/event/strike-arranger-access.test.ts
+++ b/apps/api/src/test/event/strike-arranger-access.test.ts
@@ -1,0 +1,186 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * Prikker follow the arrangement.
+ *
+ * Whoever may edit a group's arrangementer handles the prikker they produce —
+ * no separate `events:strikes:*` needed. It stays narrow: the grant is scoped
+ * to a group, so it reaches that group's own events and nobody else's.
+ */
+describe("prikker follow the event's arrangør", () => {
+    integrationTest(
+        "a group leader without events:strikes:* may give and remove prikker on their own group's event",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            const target = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(leader);
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const group = await ctx.utils.createTestGroup({
+                slug: "arrangorgruppa",
+            });
+            // Exactly what NoK's leader holds in production: the event
+            // permissions, and no strike permission anywhere.
+            await ctx.db
+                .update(schema.group)
+                .set({ leaderPermissions: ["events:update", "events:create"] })
+                .where(eq(schema.group.slug, group.slug));
+            await ctx.db.insert(schema.groupMembership).values({
+                userId: leader.id,
+                groupSlug: group.slug,
+                role: "leader",
+            });
+
+            const event = await ctx.utils.createTestEvent({
+                organizerGroupSlug: group.slug,
+            });
+
+            const created = await client.api.event.strikes.$post({
+                json: {
+                    userId: target.id,
+                    eventId: event.id,
+                    count: 1,
+                    reason: "Møtte ikke opp",
+                },
+            });
+            expect(created.status).toBe(201);
+            const strike = await created.json();
+
+            const removed = await client.api.event.strikes[":strikeId"].$delete(
+                { param: { strikeId: strike.id } },
+            );
+            expect(removed.status).toBe(200);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "the same leader may not touch another group's event",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            const target = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(leader);
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const own = await ctx.utils.createTestGroup({
+                slug: "egen-gruppe",
+            });
+            const other = await ctx.utils.createTestGroup({
+                slug: "annen-gruppe",
+            });
+            await ctx.db
+                .update(schema.group)
+                .set({ leaderPermissions: ["events:update", "events:create"] })
+                .where(eq(schema.group.slug, own.slug));
+            await ctx.db.insert(schema.groupMembership).values({
+                userId: leader.id,
+                groupSlug: own.slug,
+                role: "leader",
+            });
+
+            const foreignEvent = await ctx.utils.createTestEvent({
+                organizerGroupSlug: other.slug,
+            });
+
+            const created = await client.api.event.strikes.$post({
+                json: {
+                    userId: target.id,
+                    eventId: foreignEvent.id,
+                    count: 1,
+                    reason: "Ikke min gruppe",
+                },
+            });
+            expect(created.status).toBe(403);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "the prikkeliste shows the arrangør only their own group's prikker",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            const target = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(leader);
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const own = await ctx.utils.createTestGroup({ slug: "min-gruppe" });
+            const other = await ctx.utils.createTestGroup({
+                slug: "andres-gruppe",
+            });
+            await ctx.db
+                .update(schema.group)
+                .set({ leaderPermissions: ["events:update"] })
+                .where(eq(schema.group.slug, own.slug));
+            await ctx.db.insert(schema.groupMembership).values({
+                userId: leader.id,
+                groupSlug: own.slug,
+                role: "leader",
+            });
+
+            const ownEvent = await ctx.utils.createTestEvent({
+                organizerGroupSlug: own.slug,
+            });
+            const otherEvent = await ctx.utils.createTestEvent({
+                slug: `annet-arrangement-${Date.now()}`,
+                organizerGroupSlug: other.slug,
+            });
+
+            await ctx.db.insert(schema.eventStrike).values([
+                { userId: target.id, eventId: ownEvent.id, count: 1 },
+                { userId: target.id, eventId: otherEvent.id, count: 1 },
+            ]);
+
+            const listed = await client.api.event.strikes.$get({ query: {} });
+            expect(listed.status).toBe(200);
+            const body = await listed.json();
+
+            expect(body.strikes.map((s) => s.eventId)).toEqual([ownEvent.id]);
+            expect(body.totalCount).toBe(1);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "a global events:strikes:view still sees every group's prikker (non-regression)",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            const target = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["events:strikes:view"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const one = await ctx.utils.createTestGroup({ slug: "gruppe-en" });
+            const two = await ctx.utils.createTestGroup({ slug: "gruppe-to" });
+
+            const eventOne = await ctx.utils.createTestEvent({
+                organizerGroupSlug: one.slug,
+            });
+            const eventTwo = await ctx.utils.createTestEvent({
+                slug: `arrangement-to-${Date.now()}`,
+                organizerGroupSlug: two.slug,
+            });
+
+            await ctx.db.insert(schema.eventStrike).values([
+                { userId: target.id, eventId: eventOne.id, count: 1 },
+                { userId: target.id, eventId: eventTwo.id, count: 1 },
+            ]);
+
+            const listed = await client.api.event.strikes.$get({ query: {} });
+            expect(listed.status).toBe(200);
+            const body = await listed.json();
+            expect(body.totalCount).toBe(2);
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/lib/admin-sections.ts
+++ b/apps/kvark/src/lib/admin-sections.ts
@@ -56,10 +56,13 @@ export const ADMIN_SECTION_PERMISSIONS = {
         "groups:update",
         "groups:manage",
     ],
+    // Arranging a group's events carries its prikker, so the section opens for
+    // the arrangør too — the list itself only shows their own groups' prikker.
     prikker: [
         "events:strikes:view",
         "events:strikes:create",
         "events:strikes:delete",
+        "events:update",
         "events:manage",
     ],
     roller: [

--- a/apps/kvark/src/lib/permission-domains.ts
+++ b/apps/kvark/src/lib/permission-domains.ts
@@ -41,17 +41,46 @@ function under(prefix: string): string[] {
 }
 
 /**
- * Arranging an event is one job, so registrations, feedback, payments and
- * prikker ride with it — whoever put the arrangement up handles who shows up,
- * who paid and who never turned up. Every one of those endpoints narrows to
- * the event's organiser group, so a group-scoped grant reaches that group's
- * own arrangementer and nobody else's.
+ * Arranging an event is one job, so registrations and the payment list ride
+ * with it — whoever put the arrangement up handles who shows up and who paid.
+ * Every one of those endpoints narrows to the event's organiser group, so a
+ * group-scoped grant reaches that group's own arrangementer and nobody else's.
+ *
+ * Prikker for the group's own arrangementer ride with it too, but not as
+ * checkboxes: the API reads `events:update` / `events:manage` for the
+ * organiser group as the right to handle that event's prikker. The boxes below
+ * therefore only have to say something about *other* groups' prikker, which is
+ * what the org-wide "Prikker" box is for.
  *
  * Refunds are the exception, and the only one: moving money back out is a
  * separate decision that stays with whoever holds it explicitly.
  */
 const EVENT_REFUND = "events:payments:refund";
-const EVENT_PERMISSIONS = under("events").filter((p) => p !== EVENT_REFUND);
+const EVENT_STRIKES = under("events:strikes");
+
+/**
+ * Listed one by one rather than derived from the namespace, because the
+ * namespace is wider than the API.
+ *
+ * `under("events")` handed out eighteen strings, and twelve of them are read
+ * by no route at all — `events:feedback:create`, `events:payments:update` and
+ * the rest are registry entries nobody ever wired up, while
+ * `events:registrations:checkin` and friends are covered by `events:update`.
+ * They granted nothing, but the box is atomic and you may only hand out what
+ * you hold, so those dead strings were enough to make the whole box
+ * unsaveable for every group leader whose list predates them. Only what the
+ * API actually checks belongs here; add a line when a route starts reading
+ * one.
+ */
+const EVENT_PERMISSIONS = [
+    "events:create",
+    "events:update",
+    "events:delete",
+    "events:manage",
+    "events:registrations:view",
+    "events:registrations:create",
+    "events:payments:view",
+];
 
 /**
  * Søknader land on four different desks — utlegg with the Finansminister,
@@ -65,6 +94,16 @@ export const PERMISSION_DOMAINS: PermissionDomain[] = [
         label: "Arrangementer",
         groupScopable: true,
         permissions: EVENT_PERMISSIONS,
+    },
+    {
+        slug: "events-strikes",
+        label: "Prikker",
+        // Prikker on your own group's arrangementer follow from arranging
+        // them, so a group-scoped box here would only repeat access the group
+        // already has. What is left is the cross-group job — the prikkeliste
+        // for all of TIHLDE — and that is global by nature.
+        groupScopable: false,
+        permissions: EVENT_STRIKES,
     },
     {
         slug: "events-refund",

--- a/apps/kvark/src/routes/admin/prikker.tsx
+++ b/apps/kvark/src/routes/admin/prikker.tsx
@@ -63,6 +63,7 @@ export const Route = createFileRoute("/admin/prikker")({
 function StrikesAdminPage() {
     const canCreate = useAnyScopePermission([
         "events:strikes:create",
+        "events:update",
         "events:manage",
     ]);
     const [createOpen, setCreateOpen] = useState(false);
@@ -100,8 +101,12 @@ function StrikesSection() {
     const [page, setPage] = useState(0);
     const { data, isPending } = useQuery(getStrikesQuery(page));
     const remove = useMutation(deleteStrikeMutation);
+    // Arranging a group's events carries its prikker, so the arrangør sees the
+    // delete button too. The API still answers per prikk: the button only
+    // works on prikker from their own groups' arrangementer.
     const canDelete = useAnyScopePermission([
         "events:strikes:delete",
+        "events:update",
         "events:manage",
     ]);
 

--- a/packages/auth/src/rbac/permissions/checker.ts
+++ b/packages/auth/src/rbac/permissions/checker.ts
@@ -338,6 +338,47 @@ export async function hasPermissionInAnyGroupScope(
     );
 }
 
+/**
+ * Which groups the user holds one of `permissionName` for.
+ *
+ * Answers "whose events may you touch?" in one go, for the listing endpoints
+ * that have no single resource to scope against and would otherwise have to
+ * ask per row. Returns `"*"` when the permission is held globally (or via
+ * root) — the caller then filters nothing, because a global grant reaches
+ * every group.
+ *
+ * Only `group:<slug>` grants are collected. A grant scoped to one specific
+ * resource says nothing about the group and must not widen a listing.
+ */
+export async function getPermissionGroupScopes(
+    ctx: DbCtx,
+    userId: string,
+    permissionName: string | string[],
+): Promise<string[] | "*"> {
+    const permissionNames = Array.isArray(permissionName)
+        ? permissionName
+        : [permissionName];
+
+    if (permissionNames.length === 0) return [];
+
+    const permissions = await getUserPermissions(ctx, userId);
+
+    if (hasRoot(permissions)) return "*";
+
+    const slugs = new Set<string>();
+
+    for (const granted of permissions) {
+        const parsed = parsePermission(granted);
+        if (!permissionNames.includes(parsed.permission)) continue;
+        if (parsed.scope === GLOBAL_SCOPE) return "*";
+        if (parsed.scope.startsWith("group:")) {
+            slugs.add(parsed.scope.slice("group:".length));
+        }
+    }
+
+    return [...slugs];
+}
+
 export async function hasScopedPermission(
     ctx: DbCtx,
     userId: string,

--- a/packages/auth/src/rbac/permissions/index.ts
+++ b/packages/auth/src/rbac/permissions/index.ts
@@ -24,6 +24,7 @@ export {
 
 // Permission checking
 export {
+    getPermissionGroupScopes,
     getUserPermissions,
     getUserPermissionsWithScope,
     hasPermission,

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -613,7 +613,7 @@ export interface paths {
         put?: never;
         /**
          * Create strike
-         * @description Give a user a strike (prikk) connected to an event. Requires 'events:strikes:create' or 'events:manage', globally or for the group arranging the event.
+         * @description Give a user a strike (prikk) connected to an event. Requires 'events:strikes:create', or the right to arrange the event ('events:update' / 'events:manage') — globally or for the group arranging it.
          */
         post: operations["createStrike"];
         delete?: never;
@@ -674,7 +674,7 @@ export interface paths {
         post?: never;
         /**
          * Delete strike
-         * @description Delete a strike (prikk) by its ID. Requires 'events:strikes:delete' or 'events:manage', globally or for the group arranging the strike's event.
+         * @description Delete a strike (prikk) by its ID. Requires 'events:strikes:delete', or the right to arrange the event ('events:update' / 'events:manage') — globally or for the group arranging it.
          */
         delete: operations["deleteStrike"];
         options?: never;


### PR DESCRIPTION
Jørgen Digre, leder for NoK, fikk ikke gitt arrangement-tilgang til et medlem av gruppa si. Det viste seg å ikke handle om lederstatusen hans i det hele tatt.

## Hva som var galt

Ett hakk i «Arrangementer» ekspanderte til **18 tilganger**, og garantien i `canGrantPositionPermissions` er at du bare kan gi bort det du selv holder — alle sammen. Én manglende streng avviser hele lagringen med 403.

**59 av 60 grupper** hadde en leder-liste som ikke dekket boksen. I praksis kunne bare HS-lederen og root bruke den.

To uavhengige årsaker:

**1. Prikker lå i boksen, men ingen gruppe hadde dem.** `events:strikes:*` fantes bare hos Sosialen og FadderKom (medlemmer) og HS-lederen. Alle andre traff dem og ble avvist.

**2. Tolv av strengene leses av ingen rute.** `events:feedback:create/update/delete`, `events:payments:create/update/delete`, `events:registrations:checkin/manage/delete`, `events:view` — registeroppføringer som aldri ble koblet opp. De ga null tilgang, men var nok til å blokkere lagringen.

## Hva som er endret

**Prikker følger arrangementet.** Den som kan redigere en gruppes arrangementer håndterer prikkene de gir: `events:update` / `events:manage` for arrangørgruppa er nå nok til å se, gi og slette prikker der. Grantet er scopet til gruppa, så det når den gruppas egne arrangementer og ingen andres.

Prikkelista (`GET /event/strikes`) godtar nå en gruppe-scopet tilgang, men **snevres inn** til gruppene leseren faktisk svarer for — uten det ville et NoK-verv åpnet alles prikker på én gang. En global tilgang ser fortsatt alt, og «mine prikker» er urørt.

**Boksen lister bare det som håndheves.** Sju tilganger i stedet for 18, skrevet ut linje for linje i stedet for å utledes fra navnerommet — det var `under("events")` som dro inn hva som helst noen registrerte. Prikker har fått sin egen org-vid boks, slik `events:payments:refund` allerede hadde.

## Datafiks kjørt mot prod

`events:manage` manglet i 59 gruppers `leader_permissions`. Den er lagt inn — **kun gruppe-scopet**; `leader_global_permissions` er ikke rørt (fortsatt nøyaktig én gruppe med global `events:manage`, som før). Scopet gir den ikke noe nytt: hvert scopede sjekkpunkt lister `events:manage` sammen med `events:update`, som lederne allerede hadde.

Sikkerhetskopi i `_backup_group_leader_perms_20260819`. Diff verifisert per gruppe: `lagt_til = {events:manage}`, `fjernet = {}`. Alle 60 gruppene dekker nå boksen.

## Verifisert

- 409 tester grønne (`event`, `rbac`, `groups`), inkludert fire nye i `strike-arranger-access.test.ts`: arrangøren uten `events:strikes:*` kan gi og slette prikker på egne arrangementer, men får 403 på andres; lista viser bare egen gruppes prikker; en global `events:strikes:view` ser fortsatt alt.
- `group-scoped-access.test.ts` snudd der den pinnet den gamle oppførselen — lederen kan nå prikke, men fortsatt ikke refundere.
- `typecheck`, `build` og `lint` passerer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)