### PR TITLE
feat(kontrakt): åpne kontrakt-PDF-en fra versjonstabellen

### DIFF
--- a/apps/kvark/src/routes/admin/opptak.tsx
+++ b/apps/kvark/src/routes/admin/opptak.tsx
@@ -11,6 +11,14 @@ import {
     CardTitle,
 } from "@tihlde/ui/ui/card";
 import { Field, FieldGroup, FieldLabel } from "@tihlde/ui/ui/field";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@tihlde/ui/ui/dialog";
 import { Input } from "@tihlde/ui/ui/input";
 import {
     Table,
@@ -29,6 +37,7 @@ import { Suspense, lazy, useEffect, useState } from "react";
 import { Stagger } from "@tihlde/ui/ui/motion";
 
 import { uploadAssetMutation } from "#/api/queries/assets";
+import { assetPublicUrl } from "#/lib/assets";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 import {
@@ -306,7 +315,9 @@ function ContractRow({
 }) {
     return (
         <TableRow>
-            <TableCell>{contract.title}</TableCell>
+            <TableCell>
+                <ContractPreviewDialog contract={contract} />
+            </TableCell>
             <TableCell>{contract.version}</TableCell>
             <TableCell>
                 {contract.isActive ? (
@@ -331,5 +342,37 @@ function ContractRow({
                 )}
             </TableCell>
         </TableRow>
+    );
+}
+
+/** Opens the uploaded PDF so an admin can read the contract before activating it. */
+function ContractPreviewDialog({ contract }: { contract: Contract }) {
+    return (
+        <Dialog>
+            <DialogTrigger
+                render={
+                    <Button
+                        variant="link"
+                        className="h-auto p-0 text-left font-normal text-foreground"
+                    >
+                        {contract.title}
+                    </Button>
+                }
+            />
+            <DialogContent className="flex max-w-[95vw] flex-col sm:max-w-4xl">
+                <DialogHeader>
+                    <DialogTitle>{contract.title}</DialogTitle>
+                    <DialogDescription>
+                        Versjon {contract.version}
+                    </DialogDescription>
+                </DialogHeader>
+                {/* Høy nok til at en A4-side er lesbar uten å zoome. */}
+                <iframe
+                    src={assetPublicUrl(contract.fileKey)}
+                    title={contract.title}
+                    className="h-[75vh] w-full rounded-md border"
+                />
+            </DialogContent>
+        </Dialog>
     );
 }


### PR DESCRIPTION
Tittelen i «Kontraktversjoner»-tabellen på `/admin/opptak` er nå en knapp som åpner selve PDF-en i en dialog, så en admin kan lese kontrakten før den aktiveres.

## Endring
- Ny `ContractPreviewDialog` i `apps/kvark/src/routes/admin/opptak.tsx` — dialog med tittel, versjon og PDF-en i en iframe (`h-[75vh]`).
- URL-en bygges med `assetPublicUrl(contract.fileKey)`, samme mekanisme som `downloadUrl` på den aktive kontrakten.
- Ingen backend-endring: `GET /api/contracts` returnerer allerede `fileKey`, og siden ligger bak `contracts:view`.

## Verifisert
Lokal API (4100) + kvark, innlogget som admin: klikk på tittelen åpner dialogen, og asset-kallet svarer `200 application/pdf` med `Content-Disposition: inline`. Typecheck og format er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)