### PR TITLE
fix(bøter): la ubetalt-summen følge dagens medlemmer

### DIFF
--- a/apps/api/src/routes/groups/fines/get.ts
+++ b/apps/api/src/routes/groups/fines/get.ts
@@ -16,7 +16,7 @@ export const getFineRoute = route().get(
         summary: "Get fine by ID",
         operationId: "getFine",
         description:
-            "Retrieve detailed information about a specific fine. Group members can view every fine in their own group, users can always view their own, and the fines admin and root can view any.",
+            "Retrieve detailed information about a specific fine. Group members can view every fine in their own group, and the fines admin and root can view any. Anyone party to a fine — the member who received it and the one who handed it out — can always view it, membership or not.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -83,11 +83,18 @@ export const getFineRoute = route().get(
             });
         }
 
-        // Check authorization: own fine, membership in the group (Lepton
-        // parity), the fines admin, or root.
-        const isOwner = fine.userId === user.id;
+        /**
+         * Check authorization: a fine you are party to, membership in the
+         * group (Lepton parity), the fines admin, or root.
+         *
+         * Party is both ends of the bot — the member who got it and the one
+         * who wrote it. Neither loses sight of it by leaving the group: the
+         * receiver still owes it, and the giver still has to answer for it.
+         */
+        const isParty =
+            fine.userId === user.id || fine.createdByUserId === user.id;
 
-        if (!isOwner && !(await canViewFines(ctx, user.id, group))) {
+        if (!isParty && !(await canViewFines(ctx, user.id, group))) {
             throw new HTTPException(403, {
                 message: "Not authorized to view this fine",
             });

--- a/apps/api/src/routes/groups/fines/list.ts
+++ b/apps/api/src/routes/groups/fines/list.ts
@@ -1,7 +1,6 @@
 import { schema } from "@photon/db";
-import { and, desc, eq } from "drizzle-orm";
+import { type SQL, and, desc, eq, or } from "drizzle-orm";
 import { validator } from "hono-openapi";
-import { HTTPException } from "hono/http-exception";
 import z from "zod";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -23,15 +22,12 @@ export const listFinesRoute = route().get(
         summary: "List fines for a group",
         operationId: "listFines",
         description:
-            "Retrieve a paginated list of fines for a group, newest first. Group members can view all fines in their own group (Lepton parity), as can the fines admin and root. Filter with 'status' and 'userId'.",
+            "Retrieve a paginated list of fines for a group, newest first. Group members can view all fines in their own group (Lepton parity), as can the fines admin and root. Everyone else sees only the fines they are party to: the ones they received and the ones they handed out. Filter with 'status' and 'userId'.",
     })
         .schemaResponse({
             statusCode: 200,
             schema: fineListResponseSchema,
             description: "List of fines retrieved successfully",
-        })
-        .forbidden({
-            description: "Not authorized to view fines for this group",
         })
         .notFound({
             description: "Group not found, or fines not activated for it",
@@ -59,13 +55,31 @@ export const listFinesRoute = route().get(
 
         const group = await requireFinesGroup(ctx, groupSlug);
 
-        if (!(await canViewFines(ctx, user.id, group))) {
-            throw new HTTPException(403, {
-                message: "Not authorized to view fines for this group",
-            });
-        }
+        const conditions: (SQL | undefined)[] = [
+            eq(schema.fine.groupSlug, groupSlug),
+        ];
 
-        const conditions = [eq(schema.fine.groupSlug, groupSlug)];
+        /**
+         * Reading the group's whole botliste is for the group: members, the
+         * botsjef, root. Everyone else is narrowed to the fines they are party
+         * to rather than turned away.
+         *
+         * That narrowing is what a removed member is left with, and they need
+         * it. Leaving the group ends their bøter there — the unpaid total
+         * stops counting them — but the ones already handed out stay theirs to
+         * look up: what they were fined for and still owe, and what they
+         * handed out to others while they were in the group. Being removed
+         * should not black out your own record, and a botsjef fielding "hva
+         * var det jeg fikk bot for?" should not be the only way to read it.
+         */
+        if (!(await canViewFines(ctx, user.id, group))) {
+            conditions.push(
+                or(
+                    eq(schema.fine.userId, user.id),
+                    eq(schema.fine.createdByUserId, user.id),
+                ),
+            );
+        }
 
         if (userId) {
             conditions.push(eq(schema.fine.userId, userId));

--- a/apps/api/src/routes/groups/fines/list.ts
+++ b/apps/api/src/routes/groups/fines/list.ts
@@ -1,6 +1,7 @@
 import { schema } from "@photon/db";
 import { type SQL, and, desc, eq, or } from "drizzle-orm";
 import { validator } from "hono-openapi";
+import { HTTPException } from "hono/http-exception";
 import z from "zod";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -11,7 +12,11 @@ import {
     getPageOffset,
     getTotalPages,
 } from "~/middleware/pagination";
-import { canViewFines, requireFinesGroup } from "./permissions";
+import {
+    canViewFines,
+    requireFinesGroup,
+    wasEverGroupMember,
+} from "./permissions";
 import { fineListResponseSchema, fineStatusSchema } from "./schema";
 import { serializeFineLaw } from "./serialize";
 
@@ -22,12 +27,15 @@ export const listFinesRoute = route().get(
         summary: "List fines for a group",
         operationId: "listFines",
         description:
-            "Retrieve a paginated list of fines for a group, newest first. Group members can view all fines in their own group (Lepton parity), as can the fines admin and root. Everyone else sees only the fines they are party to: the ones they received and the ones they handed out. Filter with 'status' and 'userId'.",
+            "Retrieve a paginated list of fines for a group, newest first. Group members can view all fines in their own group (Lepton parity), as can the fines admin and root. A former member sees only the fines they are party to: the ones they received and the ones they handed out. Anyone who never belonged to the group is refused. Filter with 'status' and 'userId'.",
     })
         .schemaResponse({
             statusCode: 200,
             schema: fineListResponseSchema,
             description: "List of fines retrieved successfully",
+        })
+        .forbidden({
+            description: "Never belonged to this group",
         })
         .notFound({
             description: "Group not found, or fines not activated for it",
@@ -61,18 +69,28 @@ export const listFinesRoute = route().get(
 
         /**
          * Reading the group's whole botliste is for the group: members, the
-         * botsjef, root. Everyone else is narrowed to the fines they are party
-         * to rather than turned away.
+         * botsjef, root. A former member is narrowed to the fines they are
+         * party to rather than turned away.
          *
-         * That narrowing is what a removed member is left with, and they need
+         * That narrowing is what being removed leaves them with, and they need
          * it. Leaving the group ends their bøter there — the unpaid total
          * stops counting them — but the ones already handed out stay theirs to
          * look up: what they were fined for and still owe, and what they
          * handed out to others while they were in the group. Being removed
          * should not black out your own record, and a botsjef fielding "hva
          * var det jeg fikk bot for?" should not be the only way to read it.
+         *
+         * Having belonged to the group is the price of entry, though. Bøter
+         * are internal, so someone who never was a member is refused outright
+         * rather than handed an empty list.
          */
         if (!(await canViewFines(ctx, user.id, group))) {
+            if (!(await wasEverGroupMember(ctx, user.id, groupSlug))) {
+                throw new HTTPException(403, {
+                    message: "Not authorized to view fines for this group",
+                });
+            }
+
             conditions.push(
                 or(
                     eq(schema.fine.userId, user.id),

--- a/apps/api/src/routes/groups/fines/permissions.ts
+++ b/apps/api/src/routes/groups/fines/permissions.ts
@@ -1,6 +1,6 @@
 import { hasPermission } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import type { AppContext } from "~/lib/ctx";
 import { isDerivedGroupType, isGroupLeader, isGroupMember } from "~/lib/group";
@@ -112,6 +112,48 @@ export async function canViewFines(
     }
 
     return await hasPermission(ctx, userId, "root");
+}
+
+/**
+ * Whether a user ever belonged to the group — currently, or in a stint the
+ * membership history recorded.
+ *
+ * This is what separates "may read my own bøter here" from "is a stranger to
+ * this group". Bøter are internal to a group, so the door only opens for
+ * someone who was on the inside; an outsider who never was gets nothing,
+ * whatever the fine table happens to say.
+ *
+ * A study group's alumni pass on the current membership alone: the Feide
+ * projection never removes anyone, so their row is still there even though
+ * {@link isFinesEligibleMember} stopped counting them once they graduated.
+ * That is the intended reading — they were members, and their bøter from
+ * those years stay theirs.
+ *
+ * Note the history table only knows removals it has seen: a stint that ended
+ * before Photon started recording them leaves no row, and that person reads
+ * as a stranger here.
+ */
+export async function wasEverGroupMember(
+    ctx: AppContext,
+    userId: string,
+    groupSlug: string,
+): Promise<boolean> {
+    if (await isGroupMember(ctx, userId, groupSlug)) {
+        return true;
+    }
+
+    const stint = await ctx.db
+        .select({ id: schema.groupMembershipHistory.id })
+        .from(schema.groupMembershipHistory)
+        .where(
+            and(
+                eq(schema.groupMembershipHistory.userId, userId),
+                eq(schema.groupMembershipHistory.groupSlug, groupSlug),
+            ),
+        )
+        .limit(1);
+
+    return stint.length > 0;
 }
 
 /**

--- a/apps/api/src/routes/groups/fines/statistics.ts
+++ b/apps/api/src/routes/groups/fines/statistics.ts
@@ -1,5 +1,5 @@
 import { schema } from "@photon/db";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -14,7 +14,7 @@ export const fineStatisticsRoute = route().get(
         summary: "Fine totals for a group",
         operationId: "getFineStatistics",
         description:
-            "Sum of fine amounts per settlement stage for a group: awaiting approval, approved but unpaid, and paid. Rejected fines are excluded. Same audience as the fine list.",
+            "Sum of fine amounts per settlement stage for a group: awaiting approval, approved but unpaid, and paid. Rejected fines are excluded. The unpaid totals only count the group's current members — a fine follows the person out of the group, but the debt does not. 'paid' is history and counts everyone. Same audience as the fine list.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -43,14 +43,35 @@ export const fineStatisticsRoute = route().get(
             });
         }
 
+        /**
+         * The unpaid totals are the group's outstanding debt right now, and
+         * that has to be the same number the per-member list adds up to. That
+         * list is driven by the membership table, so someone removed from the
+         * group drops out of it — leaving the group ends their bøter there.
+         * Summing the fine table alone kept counting them and made the two
+         * views disagree, so the membership row gates the unpaid sums here as
+         * well.
+         *
+         * 'paid' is left alone: it is history, and a settled fine stays part
+         * of what the group has collected no matter who has left since.
+         */
+        const isMember = sql`${schema.groupMembership.userId} is not null`;
+
         // One pass over the group's fines rather than three counting queries.
         const [totals] = await db
             .select({
-                notApproved: sql<number>`coalesce(sum(case when ${schema.fine.status} = 'pending' then ${schema.fine.amount} else 0 end), 0)::int`,
-                approvedNotPaid: sql<number>`coalesce(sum(case when ${schema.fine.status} = 'approved' then ${schema.fine.amount} else 0 end), 0)::int`,
+                notApproved: sql<number>`coalesce(sum(case when ${schema.fine.status} = 'pending' and ${isMember} then ${schema.fine.amount} else 0 end), 0)::int`,
+                approvedNotPaid: sql<number>`coalesce(sum(case when ${schema.fine.status} = 'approved' and ${isMember} then ${schema.fine.amount} else 0 end), 0)::int`,
                 paid: sql<number>`coalesce(sum(case when ${schema.fine.status} = 'paid' then ${schema.fine.amount} else 0 end), 0)::int`,
             })
             .from(schema.fine)
+            .leftJoin(
+                schema.groupMembership,
+                and(
+                    eq(schema.groupMembership.userId, schema.fine.userId),
+                    eq(schema.groupMembership.groupSlug, schema.fine.groupSlug),
+                ),
+            )
             .where(eq(schema.fine.groupSlug, groupSlug));
 
         return c.json({

--- a/apps/api/src/routes/groups/fines/update.ts
+++ b/apps/api/src/routes/groups/fines/update.ts
@@ -6,7 +6,7 @@ import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { isValidUUID } from "~/lib/validation/uuid";
 import { requireAuth } from "~/middleware/auth";
-import { canUpdateFines, requireFinesGroup } from "./permissions";
+import { canUpdateFines, canViewFines, requireFinesGroup } from "./permissions";
 import { updateFineResponseSchema, updateFineSchema } from "./schema";
 
 export const updateFineRoute = route().patch(
@@ -16,7 +16,7 @@ export const updateFineRoute = route().patch(
         summary: "Partially update fine",
         operationId: "updateFine",
         description:
-            "Partially update a fine. Only provided fields will be updated. Users can add defense to their own fines. Fines admins can update status and approve/reject fines.",
+            "Partially update a fine. Only provided fields will be updated. Current members can add a defense to their own fines; someone who has left the group can read their fines but no longer write to them. Fines admins can update status and approve/reject fines.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -86,6 +86,19 @@ export const updateFineRoute = route().patch(
             if (!isOwner) {
                 throw new HTTPException(403, {
                     message: "Only the fine recipient can add a defense",
+                });
+            }
+
+            /**
+             * A defense is an argument put to the group, and it only means
+             * something while you are in it. Someone who has left keeps
+             * reading their old bøter, but the record closes: they cannot
+             * write into a case the group is still settling among itself.
+             */
+            if (!(await canViewFines(ctx, user.id, group))) {
+                throw new HTTPException(403, {
+                    message:
+                        "Only a current member can write a defense for their fine",
                 });
             }
         }

--- a/apps/api/src/routes/groups/get.ts
+++ b/apps/api/src/routes/groups/get.ts
@@ -3,7 +3,7 @@ import { assertGroupVisible } from "~/lib/group";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { captureAuth } from "~/middleware/auth";
-import { isFinesEligibleMember } from "./fines/permissions";
+import { isFinesEligibleMember, wasEverGroupMember } from "./fines/permissions";
 import { groupDetailSchema } from "./schema";
 
 export const getRoute = route().get(
@@ -59,6 +59,20 @@ export const getRoute = route().get(
                 (await isFinesEligibleMember(ctx, userId, group))),
         );
 
-        return c.json({ ...group, viewerCanUseFines });
+        /**
+         * The read-only half of the same question, for someone who has left:
+         * they no longer take part in the group's bøter, but the ones already
+         * in their name — given and received — stay theirs to look up. Without
+         * this the client has nothing to hang that view on, since every other
+         * field here says "not a member".
+         */
+        const viewerCanSeeOwnFines = Boolean(
+            group.finesActivated &&
+            userId &&
+            !viewerCanUseFines &&
+            (await wasEverGroupMember(ctx, userId, group.slug)),
+        );
+
+        return c.json({ ...group, viewerCanUseFines, viewerCanSeeOwnFines });
     },
 );

--- a/apps/api/src/routes/groups/schema.ts
+++ b/apps/api/src/routes/groups/schema.ts
@@ -188,6 +188,10 @@ export const groupDetailSchema = Schema(
             description:
                 "Whether the authenticated caller may see and give fines in this group. False when fines are off, when signed out, or when the caller is a study-group member who is no longer an enrolled student.",
         }),
+        viewerCanSeeOwnFines: z.boolean().meta({
+            description:
+                "Whether the caller may read the fines they are party to here without taking part in the group's fine system: true for someone who has left the group but was once a member. Never true together with 'viewerCanUseFines'.",
+        }),
     }),
 );
 

--- a/apps/api/src/test/groups/fines-study-group.test.ts
+++ b/apps/api/src/test/groups/fines-study-group.test.ts
@@ -133,7 +133,13 @@ describe("fines in a study group", () => {
             const alumnus = await ctx.utils.createTestUser();
             const member = await ctx.utils.createTestUser();
             // Ferdig med studiet, men fortsatt med i komiteen.
-            await enrol(ctx, alumnus.id, "digtrans-ordinary", program.id, false);
+            await enrol(
+                ctx,
+                alumnus.id,
+                "digtrans-ordinary",
+                program.id,
+                false,
+            );
             await ctx.db.insert(schema.groupMembership).values([
                 { userId: alumnus.id, groupSlug: committee.slug },
                 { userId: member.id, groupSlug: committee.slug },

--- a/apps/api/src/test/groups/fines-study-group.test.ts
+++ b/apps/api/src/test/groups/fines-study-group.test.ts
@@ -114,6 +114,64 @@ describe("fines in a study group", () => {
     );
 
     integrationTest(
+        "an alumnus in an ordinary group is a member like any other",
+        async ({ ctx }) => {
+            // Poenget: Feide-sperren gjelder studiegruppene, ikke gruppene folk
+            // faktisk melder seg inn i. En ferdig utdannet som fortsatt sitter
+            // i en undergruppe eller interessegruppe er medlem der på ordinært
+            // vis, og botsystemet skal behandle hen som det.
+            const { program } = await createStudyProgramGroup(
+                ctx,
+                "digtrans-ordinary",
+            );
+            const committee = await ctx.utils.createTestGroup({
+                slug: "alumni-i-komiteen",
+                type: "COMMITTEE",
+                finesActivated: true,
+            });
+
+            const alumnus = await ctx.utils.createTestUser();
+            const member = await ctx.utils.createTestUser();
+            // Ferdig med studiet, men fortsatt med i komiteen.
+            await enrol(ctx, alumnus.id, "digtrans-ordinary", program.id, false);
+            await ctx.db.insert(schema.groupMembership).values([
+                { userId: alumnus.id, groupSlug: committee.slug },
+                { userId: member.id, groupSlug: committee.slug },
+            ]);
+
+            const client = await ctx.utils.clientForUser(alumnus);
+
+            const given = await client.api.groups[":groupSlug"].fines.$post({
+                param: { groupSlug: committee.slug },
+                json: {
+                    userId: member.id,
+                    groupSlug: committee.slug,
+                    reason: "Møtte ikke opp",
+                    amount: 1,
+                },
+            });
+            expect(given.status).toBe(201);
+
+            // Og hele komiteens botliste, ikke bare sine egne.
+            await ctx.db.insert(schema.fine).values({
+                userId: member.id,
+                groupSlug: committee.slug,
+                reason: "Bot mellom to andre",
+                amount: 1,
+                createdByUserId: member.id,
+            });
+            const listed = await client.api.groups[":groupSlug"].fines.$get({
+                param: { groupSlug: committee.slug },
+                query: {},
+            });
+
+            expect(listed.status).toBe(200);
+            expect((await listed.json()).fines).toHaveLength(2);
+        },
+        500_000,
+    );
+
+    integrationTest(
         "an alumnus in the group may not give fines",
         async ({ ctx }) => {
             const { group, program } = await createStudyProgramGroup(

--- a/apps/api/src/test/groups/fines-study-group.test.ts
+++ b/apps/api/src/test/groups/fines-study-group.test.ts
@@ -144,7 +144,7 @@ describe("fines in a study group", () => {
     );
 
     integrationTest(
-        "an alumnus in the group may not read the group's fines",
+        "an alumnus in the group reads their own fines, not the students'",
         async ({ ctx }) => {
             const { group, program } = await createStudyProgramGroup(
                 ctx,
@@ -152,7 +152,27 @@ describe("fines in a study group", () => {
             );
 
             const alumnus = await ctx.utils.createTestUser();
+            const student = await ctx.utils.createTestUser();
             await enrol(ctx, alumnus.id, group.slug, program.id, false);
+            await enrol(ctx, student.id, group.slug, program.id, true);
+
+            // En bot fra studietiden, og en som gjelder dagens studenter.
+            await ctx.db.insert(schema.fine).values([
+                {
+                    userId: alumnus.id,
+                    groupSlug: group.slug,
+                    reason: "Fra studietiden",
+                    amount: 1,
+                    createdByUserId: student.id,
+                },
+                {
+                    userId: student.id,
+                    groupSlug: group.slug,
+                    reason: "Dagens kull",
+                    amount: 1,
+                    createdByUserId: student.id,
+                },
+            ]);
 
             const client = await ctx.utils.clientForUser(alumnus);
 
@@ -161,7 +181,11 @@ describe("fines in a study group", () => {
                 query: {},
             });
 
-            expect(response.status).toBe(403);
+            // Kullets botliste er ikke lenger deres, men egen bot består.
+            expect(response.status).toBe(200);
+            const json = await response.json();
+            expect(json.fines).toHaveLength(1);
+            expect(json.fines[0]?.reason).toBe("Fra studietiden");
         },
         500_000,
     );

--- a/apps/api/src/test/groups/fines.test.ts
+++ b/apps/api/src/test/groups/fines.test.ts
@@ -1,6 +1,7 @@
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { describe, expect } from "vitest";
+import { removeUserFromGroup } from "~/lib/group";
 import { integrationTest } from "~/test/config/integration";
 
 /**
@@ -1435,6 +1436,10 @@ describe("fines", () => {
                         password: "test123!",
                     },
                 });
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: target.user.id,
+                    groupSlug: group.slug,
+                });
 
                 await ctx.db.insert(schema.fine).values([
                     {
@@ -1478,6 +1483,74 @@ describe("fines", () => {
                 expect(json.notApproved).toBe(3);
                 expect(json.approvedNotPaid).toBe(4);
                 expect(json.paid).toBe(5);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "leaves a removed member's unpaid fines out, but keeps their paid ones",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "fine-stats-removed",
+                    finesActivated: true,
+                });
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: user.id,
+                    groupSlug: group.slug,
+                });
+
+                const former = await ctx.auth.api.createUser({
+                    body: {
+                        email: "stats-former@test.com",
+                        name: "Stats Former",
+                        password: "test123!",
+                    },
+                });
+
+                // Ble med, fikk bøter, og ble så fjernet fra gruppen.
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: former.user.id,
+                    groupSlug: group.slug,
+                });
+                await ctx.db.insert(schema.fine).values([
+                    {
+                        userId: former.user.id,
+                        groupSlug: group.slug,
+                        reason: "ubetalt ved exit",
+                        amount: 7,
+                        status: "pending",
+                    },
+                    {
+                        userId: former.user.id,
+                        groupSlug: group.slug,
+                        reason: "godkjent, men ubetalt",
+                        amount: 11,
+                        status: "approved",
+                    },
+                    {
+                        userId: former.user.id,
+                        groupSlug: group.slug,
+                        reason: "gjort opp for",
+                        amount: 13,
+                        status: "paid",
+                    },
+                ]);
+                await removeUserFromGroup(ctx, former.user.id, group.slug);
+
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].fines.statistics.$get({
+                    param: { groupSlug: group.slug },
+                });
+
+                expect(response.status).toBe(200);
+                const json = await response.json();
+                expect(json.notApproved).toBe(0);
+                expect(json.approvedNotPaid).toBe(0);
+                expect(json.paid).toBe(13);
             },
             500_000,
         );

--- a/apps/api/src/test/groups/fines.test.ts
+++ b/apps/api/src/test/groups/fines.test.ts
@@ -995,32 +995,73 @@ describe("fines", () => {
         );
 
         integrationTest(
-            "hides the group's fines from a non-member with none of their own",
+            "refuses a removed member's defense, and flags the read-only view",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "fines-removed-readonly",
+                    finesActivated: true,
+                });
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: user.id,
+                    groupSlug: group.slug,
+                });
+
+                const [fine] = await ctx.db
+                    .insert(schema.fine)
+                    .values({
+                        userId: user.id,
+                        groupSlug: group.slug,
+                        reason: "Sak til forsvar",
+                        amount: 50,
+                    })
+                    .returning();
+                if (!fine) {
+                    throw new Error("Failed to create fine");
+                }
+
+                // Som medlem står saken åpen.
+                const asMember = await client.api.groups[":groupSlug"].fines[
+                    ":fineId"
+                ].$patch({
+                    param: { groupSlug: group.slug, fineId: fine.id },
+                    json: { defense: "Jeg var syk" },
+                });
+                expect(asMember.status).toBe(200);
+
+                await removeUserFromGroup(ctx, user.id, group.slug);
+
+                // Etterpå er den bare til å lese.
+                const afterRemoval = await client.api.groups[
+                    ":groupSlug"
+                ].fines[":fineId"].$patch({
+                    param: { groupSlug: group.slug, fineId: fine.id },
+                    json: { defense: "Ny forklaring" },
+                });
+                expect(afterRemoval.status).toBe(403);
+
+                // Og gruppesiden sier at visningen er lesevisningen.
+                const detail = await client.api.groups[":slug"].$get({
+                    param: { slug: group.slug },
+                });
+                expect(detail.status).toBe(200);
+                const json = await detail.json();
+                expect(json.viewerCanUseFines).toBe(false);
+                expect(json.viewerCanSeeOwnFines).toBe(true);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "fails to list fines as someone who never belonged to the group",
             async ({ ctx }) => {
                 const user = await ctx.utils.createTestUser();
                 const client = await ctx.utils.clientForUser(user);
 
                 const group = await ctx.utils.createTestGroup({
                     finesActivated: true,
-                });
-
-                const member = await ctx.auth.api.createUser({
-                    body: {
-                        email: "list-outsider-member@test.com",
-                        name: "List Outsider Member",
-                        password: "test123!",
-                    },
-                });
-                await ctx.db.insert(schema.groupMembership).values({
-                    userId: member.user.id,
-                    groupSlug: group.slug,
-                });
-                await ctx.db.insert(schema.fine).values({
-                    userId: member.user.id,
-                    groupSlug: group.slug,
-                    reason: "Ikke utenforståendes bord",
-                    amount: 50,
-                    createdByUserId: member.user.id,
                 });
 
                 const response = await client.api.groups[
@@ -1030,12 +1071,9 @@ describe("fines", () => {
                     query: {},
                 });
 
-                // Botlista er gruppens; den som står utenfor ser bare sine
-                // egne bøter, og har ingen her.
-                expect(response.status).toBe(200);
-                const json = await response.json();
-                expect(json.fines).toHaveLength(0);
-                expect(json.totalCount).toBe(0);
+                // Bøter er gruppens indre anliggende: har du aldri vært med,
+                // får du ikke engang en tom liste å lese av.
+                expect(response.status).toBe(403);
             },
             500_000,
         );

--- a/apps/api/src/test/groups/fines.test.ts
+++ b/apps/api/src/test/groups/fines.test.ts
@@ -659,7 +659,7 @@ describe("fines", () => {
         );
 
         integrationTest(
-            "fails to get fine as a non-member",
+            "fails to get fine as a non-member with no part in it",
             async ({ ctx }) => {
                 const user = await ctx.utils.createTestUser();
                 const client = await ctx.utils.clientForUser(user);
@@ -675,6 +675,15 @@ describe("fines", () => {
                         password: "test123!",
                     },
                 });
+                // Boten er gitt av en annen: leseren er verken den bøtelagte
+                // eller den som ga boten, og har da ikke noe der å gjøre.
+                const giver = await ctx.auth.api.createUser({
+                    body: {
+                        email: "giver2@test.com",
+                        name: "Giver User 2",
+                        password: "test123!",
+                    },
+                });
 
                 const [fine] = await ctx.db
                     .insert(schema.fine)
@@ -683,7 +692,7 @@ describe("fines", () => {
                         groupSlug: group.slug,
                         reason: "No view permission",
                         amount: 50,
-                        createdByUserId: user.id,
+                        createdByUserId: giver.user.id,
                         status: "pending",
                     })
                     .returning();
@@ -898,13 +907,120 @@ describe("fines", () => {
         );
 
         integrationTest(
-            "fails to list fines as a non-member",
+            "keeps a removed member's own fines readable, given and received",
+            async ({ ctx }) => {
+                const user = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(user);
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "fines-removed-member",
+                    finesActivated: true,
+                });
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: user.id,
+                    groupSlug: group.slug,
+                });
+
+                const other = await ctx.auth.api.createUser({
+                    body: {
+                        email: "removed-other@test.com",
+                        name: "Removed Other",
+                        password: "test123!",
+                    },
+                });
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: other.user.id,
+                    groupSlug: group.slug,
+                });
+
+                const [received] = await ctx.db
+                    .insert(schema.fine)
+                    .values({
+                        userId: user.id,
+                        groupSlug: group.slug,
+                        reason: "Boten jeg fikk",
+                        amount: 50,
+                        createdByUserId: other.user.id,
+                    })
+                    .returning();
+                await ctx.db.insert(schema.fine).values([
+                    {
+                        userId: other.user.id,
+                        groupSlug: group.slug,
+                        reason: "Boten jeg ga",
+                        amount: 60,
+                        createdByUserId: user.id,
+                    },
+                    // Denne har hen ingen del i, og skal ikke følge med ut.
+                    {
+                        userId: other.user.id,
+                        groupSlug: group.slug,
+                        reason: "Gruppens egen sak",
+                        amount: 70,
+                        createdByUserId: other.user.id,
+                    },
+                ]);
+
+                await removeUserFromGroup(ctx, user.id, group.slug);
+
+                const response = await client.api.groups[
+                    ":groupSlug"
+                ].fines.$get({
+                    param: { groupSlug: group.slug },
+                    query: {},
+                });
+
+                expect(response.status).toBe(200);
+                const json = await response.json();
+                expect(json.totalCount).toBe(2);
+                expect(json.fines.map((f) => f.reason).sort()).toEqual([
+                    "Boten jeg fikk",
+                    "Boten jeg ga",
+                ]);
+
+                // Og den enkelte boten er fortsatt mulig å slå opp.
+                if (!received) {
+                    throw new Error("Failed to create fine");
+                }
+                const single = await client.api.groups[":groupSlug"].fines[
+                    ":fineId"
+                ].$get({
+                    param: { groupSlug: group.slug, fineId: received.id },
+                });
+
+                expect(single.status).toBe(200);
+                expect((await single.json()).reason).toBe("Boten jeg fikk");
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "hides the group's fines from a non-member with none of their own",
             async ({ ctx }) => {
                 const user = await ctx.utils.createTestUser();
                 const client = await ctx.utils.clientForUser(user);
 
                 const group = await ctx.utils.createTestGroup({
                     finesActivated: true,
+                });
+
+                const member = await ctx.auth.api.createUser({
+                    body: {
+                        email: "list-outsider-member@test.com",
+                        name: "List Outsider Member",
+                        password: "test123!",
+                    },
+                });
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: member.user.id,
+                    groupSlug: group.slug,
+                });
+                await ctx.db.insert(schema.fine).values({
+                    userId: member.user.id,
+                    groupSlug: group.slug,
+                    reason: "Ikke utenforståendes bord",
+                    amount: 50,
+                    createdByUserId: member.user.id,
                 });
 
                 const response = await client.api.groups[
@@ -914,7 +1030,12 @@ describe("fines", () => {
                     query: {},
                 });
 
-                expect(response.status).toBe(403);
+                // Botlista er gruppens; den som står utenfor ser bare sine
+                // egne bøter, og har ingen her.
+                expect(response.status).toBe(200);
+                const json = await response.json();
+                expect(json.fines).toHaveLength(0);
+                expect(json.totalCount).toBe(0);
             },
             500_000,
         );

--- a/apps/kvark/src/components/group-fine-dialog.tsx
+++ b/apps/kvark/src/components/group-fine-dialog.tsx
@@ -43,6 +43,11 @@ type GroupFineDialogProps = {
      * dette vet dialogen ikke om feltet skal vises eller bare leses.
      */
     currentUserId?: string;
+    /**
+     * Satt for den som har forlatt gruppen: boten er fortsatt deres å lese,
+     * men saken er ute av hendene deres, så forsvaret vises som tekst.
+     */
+    readOnly?: boolean;
     onApprove: (fine: Fine) => void;
     onMarkPaid: (fine: Fine) => void;
     onDelete: (fine: Fine) => void;
@@ -55,6 +60,7 @@ export function GroupFineDialog({
     onOpenChange,
     canManage,
     currentUserId,
+    readOnly = false,
     onApprove,
     onMarkPaid,
     onDelete,
@@ -74,6 +80,7 @@ export function GroupFineDialog({
     const isOwnFine = Boolean(
         fine && currentUserId && fine.userId === currentUserId,
     );
+    const canWriteDefense = isOwnFine && !readOnly;
     const defenseValue = defenseDraft ?? fine?.defense ?? "";
     const defenseChanged =
         defenseDraft !== null && defenseDraft !== fine?.defense;
@@ -197,7 +204,7 @@ export function GroupFineDialog({
                                         className="max-h-80 w-full rounded-md object-contain"
                                     />
                                 ) : null}
-                                {isOwnFine ? (
+                                {canWriteDefense ? (
                                     <div className="flex flex-col gap-2">
                                         <Label htmlFor="fine-defense">
                                             Ditt forsvar

--- a/apps/kvark/src/components/group-fines-tab.tsx
+++ b/apps/kvark/src/components/group-fines-tab.tsx
@@ -65,6 +65,12 @@ type GroupFinesTabProps = {
     onLoadMore: () => void;
     /** Whether the viewer may approve, settle or delete the group's fines. */
     canManage: boolean;
+    /**
+     * Satt for den som har forlatt gruppen. Da er dette ikke gruppens botliste
+     * lenger, men et oppslag i egne bøter: gruppens summer og medlemsoversikt
+     * hører ikke hjemme her, og ingenting kan endres.
+     */
+    ownFinesOnly?: boolean;
     /** Den innloggede brukeren, som er den eneste som kan skrive forsvar. */
     currentUserId?: string;
     onApprove: (fine: Fine) => void;
@@ -111,6 +117,7 @@ export function GroupFinesTab({
     isLoadingMore,
     onLoadMore,
     canManage,
+    ownFinesOnly = false,
     currentUserId,
     onApprove,
     onMarkPaid,
@@ -126,33 +133,45 @@ export function GroupFinesTab({
 
     return (
         <div className="flex flex-col gap-6">
-            <GroupPageHeader title="Bøter" />
+            <GroupPageHeader title={ownFinesOnly ? "Mine bøter" : "Bøter"} />
 
-            {finesInfo ? (
+            {ownFinesOnly ? (
+                <p className="text-sm text-muted-foreground">
+                    Du er ikke lenger medlem av gruppen. Her står bøtene du fikk
+                    og ga mens du var med.
+                </p>
+            ) : null}
+
+            {/* Botreglene gjelder dem som er med. Har du gått ut, er de ikke
+                lenger dine å følge. */}
+            {finesInfo && !ownFinesOnly ? (
                 <Card size="sm" className="p-4">
                     <MarkdownView registry={richRegistry} source={finesInfo} />
                 </Card>
             ) : null}
 
             {/* Summene gjelder hele gruppa, ikke det som er filtrert fram —
-                ellers ville «Betalt» falt til 0 så snart du så på ubetalte. */}
-            <div className="grid gap-4 md:grid-cols-3">
-                <GroupFineStatCard
-                    label="Ikke godkjent"
-                    value={notApproved}
-                    perMember={perMember(notApproved, memberCount)}
-                />
-                <GroupFineStatCard
-                    label="Godkjent, ikke betalt"
-                    value={approvedNotPaid}
-                    perMember={perMember(approvedNotPaid, memberCount)}
-                />
-                <GroupFineStatCard
-                    label="Betalt"
-                    value={paid}
-                    perMember={perMember(paid, memberCount)}
-                />
-            </div>
+                ellers ville «Betalt» falt til 0 så snart du så på ubetalte.
+                De er gruppens regnskap, og vises ikke for den som har gått ut. */}
+            {ownFinesOnly ? null : (
+                <div className="grid gap-4 md:grid-cols-3">
+                    <GroupFineStatCard
+                        label="Ikke godkjent"
+                        value={notApproved}
+                        perMember={perMember(notApproved, memberCount)}
+                    />
+                    <GroupFineStatCard
+                        label="Godkjent, ikke betalt"
+                        value={approvedNotPaid}
+                        perMember={perMember(approvedNotPaid, memberCount)}
+                    />
+                    <GroupFineStatCard
+                        label="Betalt"
+                        value={paid}
+                        perMember={perMember(paid, memberCount)}
+                    />
+                </div>
+            )}
 
             <div className="flex flex-col gap-3">
                 <Tabs
@@ -160,12 +179,18 @@ export function GroupFinesTab({
                     onValueChange={(v) => onGroupingChange(v as FineGrouping)}
                 >
                     <div className="flex flex-wrap items-center gap-3">
-                        <TabsList>
-                            <TabsTrigger value="alle">Alle bøter</TabsTrigger>
-                            <TabsTrigger value="per-medlem">
-                                Per medlem
-                            </TabsTrigger>
-                        </TabsList>
+                        {/* «Per medlem» er gruppens medlemsliste, og den står
+                            ikke åpen for en som har gått ut. */}
+                        {ownFinesOnly ? null : (
+                            <TabsList>
+                                <TabsTrigger value="alle">
+                                    Alle bøter
+                                </TabsTrigger>
+                                <TabsTrigger value="per-medlem">
+                                    Per medlem
+                                </TabsTrigger>
+                            </TabsList>
+                        )}
                         <div className="ml-auto flex flex-wrap items-center gap-2">
                             <Select
                                 value={status}
@@ -232,7 +257,8 @@ export function GroupFinesTab({
                 fines={fines}
                 openIndex={openIndex}
                 onOpenChange={setOpenIndex}
-                canManage={canManage}
+                canManage={canManage && !ownFinesOnly}
+                readOnly={ownFinesOnly}
                 currentUserId={currentUserId}
                 onApprove={onApprove}
                 onMarkPaid={onMarkPaid}

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -255,6 +255,13 @@ function GroupDetail() {
     // dagens studenter. Root er ikke med i serverens svar (den gjelder én
     // gruppe, ikke tilgang på tvers), så den legges på her.
     const canViewFines = Boolean(apiGroup.viewerCanUseFines) || isRoot;
+    // Den som har gått ut av gruppen tar ikke lenger del i botsystemet, men
+    // bøtene i eget navn — gitt og mottatt — er fortsatt deres å slå opp.
+    // Serveren snevrer botlista til dem av seg selv; her styrer flagget bare
+    // hva som vises, og at ingenting kan endres.
+    const canSeeOwnFines =
+        !canViewFines && Boolean(apiGroup.viewerCanSeeOwnFines);
+    const finesTabVisible = canViewFines || canSeeOwnFines;
 
     // Filtrene går til serveren, ikke gjennom en ferdiglastet liste: en gruppe
     // med noen tusen bøter skal ikke lastes ned i sin helhet for å vise 25.
@@ -273,7 +280,9 @@ function GroupDetail() {
         fetchNextPage: fetchMoreFines,
     } = useInfiniteQuery({
         ...getGroupFinesInfiniteQuery(slug, fineFilters),
-        enabled: canViewFines && botVisning === "alle",
+        // Egen-visningen har bare den flate lista, så den henter uansett hva
+        // `botVisning` skulle stå til fra en gammel URL.
+        enabled: canSeeOwnFines || (canViewFines && botVisning === "alle"),
     });
 
     const {
@@ -432,16 +441,17 @@ function GroupDetail() {
     const navItems = useMemo(
         () =>
             GROUP_NAV_ITEMS.filter((item) => {
-                if (item.key === "boter" || item.key === "lovverk") {
-                    return canViewFines;
-                }
+                if (item.key === "boter") return finesTabVisible;
+                // Lovverket er gruppens regelverk, ikke en del av ens egen
+                // botlogg: det følger medlemskapet.
+                if (item.key === "lovverk") return canViewFines;
                 // Spørreskjemaene ligger bak innlogging i API-et, så en
                 // utlogget besøkende skal ikke se fanen i det hele tatt — den
                 // ville uansett bare stått tom.
                 if (item.key === "sporreskjema") return isLoggedIn;
                 return true;
             }),
-        [canViewFines, isLoggedIn],
+        [canViewFines, finesTabVisible, isLoggedIn],
     );
     // ?tab=boter kan stå i URL-en fra før rettighetene ble sjekket, så en fane
     // som ikke lenger finnes faller tilbake til «Om».
@@ -768,7 +778,7 @@ function GroupDetail() {
                             statistics={apiFineStatistics}
                             memberCount={members.length}
                             finesInfo={group.finesInfo}
-                            grouping={botVisning}
+                            grouping={canSeeOwnFines ? "alle" : botVisning}
                             onGroupingChange={(botVisning) =>
                                 navigate({
                                     search: (prev) => ({
@@ -825,6 +835,7 @@ function GroupDetail() {
                                 }
                             }}
                             canManage={canManageFines}
+                            ownFinesOnly={canSeeOwnFines}
                             currentUserId={session?.user?.id}
                             onApprove={(fine) =>
                                 updateFine.mutate({

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1495,7 +1495,7 @@ export interface paths {
         };
         /**
          * List fines for a group
-         * @description Retrieve a paginated list of fines for a group, newest first. Group members can view all fines in their own group (Lepton parity), as can the fines admin and root. Filter with 'status' and 'userId'.
+         * @description Retrieve a paginated list of fines for a group, newest first. Group members can view all fines in their own group (Lepton parity), as can the fines admin and root. Everyone else sees only the fines they are party to: the ones they received and the ones they handed out. Filter with 'status' and 'userId'.
          */
         get: operations["listFines"];
         put?: never;
@@ -1599,7 +1599,7 @@ export interface paths {
         };
         /**
          * Get fine by ID
-         * @description Retrieve detailed information about a specific fine. Group members can view every fine in their own group, users can always view their own, and the fines admin and root can view any.
+         * @description Retrieve detailed information about a specific fine. Group members can view every fine in their own group, and the fines admin and root can view any. Anyone party to a fine — the member who received it and the one who handed it out — can always view it, membership or not.
          */
         get: operations["getFine"];
         put?: never;

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1495,7 +1495,7 @@ export interface paths {
         };
         /**
          * List fines for a group
-         * @description Retrieve a paginated list of fines for a group, newest first. Group members can view all fines in their own group (Lepton parity), as can the fines admin and root. Everyone else sees only the fines they are party to: the ones they received and the ones they handed out. Filter with 'status' and 'userId'.
+         * @description Retrieve a paginated list of fines for a group, newest first. Group members can view all fines in their own group (Lepton parity), as can the fines admin and root. A former member sees only the fines they are party to: the ones they received and the ones they handed out. Anyone who never belonged to the group is refused. Filter with 'status' and 'userId'.
          */
         get: operations["listFines"];
         put?: never;
@@ -1613,7 +1613,7 @@ export interface paths {
         head?: never;
         /**
          * Partially update fine
-         * @description Partially update a fine. Only provided fields will be updated. Users can add defense to their own fines. Fines admins can update status and approve/reject fines.
+         * @description Partially update a fine. Only provided fields will be updated. Current members can add a defense to their own fines; someone who has left the group can read their fines but no longer write to them. Fines admins can update status and approve/reject fines.
          */
         patch: operations["updateFine"];
         trace?: never;
@@ -4934,6 +4934,8 @@ export interface components {
             updatedAt: string;
             /** @description Whether the authenticated caller may see and give fines in this group. False when fines are off, when signed out, or when the caller is a study-group member who is no longer an enrolled student. */
             viewerCanUseFines: boolean;
+            /** @description Whether the caller may read the fines they are party to here without taking part in the group's fine system: true for someone who has left the group but was once a member. Never true together with 'viewerCanUseFines'. */
+            viewerCanSeeOwnFines: boolean;
         };
         Fine: {
             /** @description Fine ID */

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1519,7 +1519,7 @@ export interface paths {
         };
         /**
          * Fine totals for a group
-         * @description Sum of fine amounts per settlement stage for a group: awaiting approval, approved but unpaid, and paid. Rejected fines are excluded. Same audience as the fine list.
+         * @description Sum of fine amounts per settlement stage for a group: awaiting approval, approved but unpaid, and paid. Rejected fines are excluded. The unpaid totals only count the group's current members — a fine follows the person out of the group, but the debt does not. 'paid' is history and counts everyone. Same audience as the fine list.
          */
         get: operations["getFineStatistics"];
         put?: never;


### PR DESCRIPTION
## Hva

Tre ting rundt bøter når noen fjernes fra en gruppe.

### 1. Ubetalt-summen følger dagens medlemmer

Botstatistikken (`GET /:groupSlug/fines/statistics`) summerte hele bot-tabellen for gruppen, mens «per medlem»-lista bygges på medlemskapstabellen. Fjernet man noen fra gruppen forsvant de fra lista, men bøtene deres ble liggende i totalen — så de to tallene botsjefen leser side om side sa ikke det samme.

Å forlate gruppen avslutter bøtene der, så **ubetalt** (`pending` + `approved`) teller nå bare dem som fortsatt er medlemmer. `paid` er urørt: det er historikk over hva gruppen faktisk har krevd inn, og skal ikke krympe fordi noen har sluttet.

### 2. Egne bøter følger deg ut av gruppen

At bøtene ikke lenger teller for gruppen betyr ikke at de ikke angår personen. Før endte fjerning tilgangen helt — botlista svarte 403, og den fjernede kunne verken se hva hen står til rest med eller hva hen selv har delt ut.

Nå snevres botlista inn for den som har gått ut, til bøtene hen er part i: **dem hen har fått og dem hen har gitt**. Gruppens øvrige bøter er fortsatt bare for medlemmene, botsjefen og root, og det samme gjelder statistikken og «per medlem».

Å ha vært medlem er prisen for å komme inn: den som aldri har vært med, avvises som før. Studiegruppenes alumni beholder rekkevidden — Feide-projeksjonen fjerner aldri medlemskapsraden, så de har vært medlemmer selv om `isFinesEligibleMember` sluttet å telle dem da de var ferdige.

### 3. Lesevisning i Kvark

Botfanen gates på `viewerCanUseFines`, som er false for den som har gått ut, så fanen forsvant helt og punkt 2 var ikke nåbart i UI-et. Gruppedetaljen svarer derfor også `viewerCanSeeOwnFines`, og fanen viser da **«Mine bøter»**: egne bøter gitt og mottatt, uten gruppens summer, «Per medlem», lovverk, «Gi bot» eller botreglene som ikke lenger angår en.

Visningen er kun til å lese. Forsvaret er et innlegg i en sak gruppen fortsatt behandler seg imellom, så det er stengt både i dialogen og i `PATCH`-en bak den.

## Hva som ikke endres

Bøter slettes ikke ved fjerning av medlem, og gruppens fulle botliste viser dem fortsatt.

## Implementasjon

- **statistics**: `leftJoin` mot `group_membership` på `(user_id, group_slug)`; ubetalt-summene teller bare rader med medlemskap. Fortsatt én spørring, og sammensatt primærnøkkel gjør joinen 1:1.
- **list**: mangler man leserett, kreves `wasEverGroupMember` (medlemskap nå eller en avsluttet periode i historikken), og filteret snevres til `user_id = meg OR created_by_user_id = meg`. Ellers 403 som før.
- **get**: «eier» er utvidet til begge ender av boten.
- **Kvark**: `ownFinesOnly` på botfanen og `readOnly` på bot-dialogen.

## Testing

- Statistikk: fjernet person med `pending` 7, `approved` 11, `paid` 13 → 0 / 0 / 13.
- Liste: fjernet medlem ser nøyaktig sine to bøter (fått + gitt) av gruppens tre, og kan åpne den enkelte boten; den som aldri var medlem får 403.
- Forsvar: godtas som medlem (200), avvises etter fjerning (403), og `viewerCanSeeOwnFines` slår om.
- Oppdaterte tre tester som kodet den gamle regelen (statistikk-testen bøtela en som aldri var medlem; get-testen lot leseren være den som ga boten; alumnus-testen ventet 403 og sjekker nå at hen ser sin egen bot, men ikke kullets).
- `bun run typecheck` 9/9, `vitest run src/test/groups` 157/157, lint/format uten nye funn.
- Verifisert i nettleseren mot lokal dev: som medlem full botliste, etter fjerning «Mine bøter» med de to riktige bøtene og uten summer, faner, knapper eller forsvarsfelt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)