### PR TITLE
fix(profil): vis studiet medlemmet går på nå

### DIFF
--- a/apps/api/src/routes/user/get.ts
+++ b/apps/api/src/routes/user/get.ts
@@ -4,7 +4,8 @@ import { isMemberAudience } from "~/lib/auth";
 import { HTTPAppException } from "~/lib/errors";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { getUserStudy } from "~/lib/user/study";
+import { computeUserClassYear } from "~/lib/event/priority";
+import { deriveStudyFromGroups, loadStudyGroupRows } from "~/lib/user/study";
 import { requireAuthAllowPending } from "~/middleware/auth";
 import { userProfileSchema } from "./schema";
 
@@ -114,10 +115,21 @@ export const getUserRoute = route().get(
          * group list by itself is exactly what showed a member who had
          * switched studies whichever one came back first.
          */
-        const { studyProgram, studyStartYear } = await getUserStudy(
-            c.get("ctx"),
-            user.id,
-        );
+        const studyRows =
+            (await loadStudyGroupRows(c.get("ctx"), [user.id])).get(user.id) ??
+            [];
+        const { studyProgram, studyStartYear } =
+            deriveStudyFromGroups(studyRows);
+
+        /**
+         * Served rather than left to the client. A master's first year is 4.
+         * klasse, and the offset that encodes only holds if you know the year
+         * belongs to the master and not the bachelor it followed — which is
+         * exactly what the client cannot see. kvark used to work it out from
+         * the group list and got the programme itself wrong for anyone who had
+         * switched studies.
+         */
+        const classYear = computeUserClassYear(studyRows);
 
         /**
          * Ended memberships — the same rule the group page's "tidligere
@@ -154,6 +166,7 @@ export const getUserRoute = route().get(
             linkedinUrl: settings?.linkedinUrl ?? null,
             studyProgram,
             studyStartYear,
+            classYear,
             groups: memberships.map((m) => ({
                 slug: m.groupSlug,
                 name: m.group.name,

--- a/apps/api/src/routes/user/schema.ts
+++ b/apps/api/src/routes/user/schema.ts
@@ -359,7 +359,11 @@ export const userProfileSchema = Schema(
         }),
         studyStartYear: z.number().int().nullable().meta({
             description:
-                "The year the user started studying (kull), derived from their STUDYYEAR group membership. Null when unknown.",
+                "The year the user started their current study programme. Falls back to their STUDYYEAR group when we have no year for the programme itself. Null when unknown.",
+        }),
+        classYear: z.number().int().nullable().meta({
+            description:
+                "Class level 1-5, computed from the current programme and its length. A master's first year is 4. Null for alumni and for anyone we cannot place — served by the API so the rule lives in one place rather than being recomputed per client.",
         }),
         groups: z
             .array(

--- a/apps/api/src/test/user-profile-study.test.ts
+++ b/apps/api/src/test/user-profile-study.test.ts
@@ -1,0 +1,154 @@
+import { schema } from "@photon/db";
+import { describe, expect } from "vitest";
+import type { IntegrationTestContext } from "~/test/config/integration";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * GET /api/user/:id — the study a profile shows.
+ *
+ * The profile page used to work this out in the browser, from the group list
+ * the endpoint happened to return: it took the first STUDY group in whatever
+ * order Postgres produced, and computed the class level without the master
+ * offset. Both are rules the server already owns, so the profile serves them
+ * and the client renders what it is given.
+ */
+
+const seedProgrammes = async (ctx: IntegrationTestContext) => {
+    await ctx.utils.createTestGroup({
+        slug: "digital-forretningsutvikling",
+        name: "Digital forretningsutvikling",
+        type: "STUDY",
+    });
+    await ctx.utils.createTestGroup({
+        slug: "digital-samhandling",
+        name: "Digital transformasjon",
+        type: "STUDY",
+    });
+    await ctx.utils.createTestGroup({
+        slug: "2023",
+        name: "2023",
+        type: "STUDYYEAR",
+    });
+
+    const [bachelor] = await ctx.db
+        .insert(schema.studyProgram)
+        .values({
+            slug: "digital-forretningsutvikling",
+            feideCode: "ITBAITBEDR",
+            displayName: "Digital Forretningsutvikling",
+            type: "bachelor",
+        })
+        .returning({ id: schema.studyProgram.id });
+    const [master] = await ctx.db
+        .insert(schema.studyProgram)
+        .values({
+            slug: "digital-samhandling",
+            feideCode: "ITMAIKTSA",
+            displayName: "Digital Samhandling",
+            type: "master",
+        })
+        .returning({ id: schema.studyProgram.id });
+
+    return {
+        bachelorId: bachelor?.id as number,
+        masterId: master?.id as number,
+    };
+};
+
+describe("GET /api/user/:id — study on the profile", () => {
+    integrationTest(
+        "shows the programme the member is on now, with its own class level",
+        async ({ ctx }) => {
+            const viewer = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(viewer);
+
+            const { bachelorId, masterId } = await seedProgrammes(ctx);
+
+            const target = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.groupMembership).values([
+                {
+                    userId: target.id,
+                    groupSlug: "digital-forretningsutvikling",
+                    role: "member",
+                },
+                {
+                    userId: target.id,
+                    groupSlug: "digital-samhandling",
+                    role: "member",
+                },
+                { userId: target.id, groupSlug: "2023", role: "member" },
+            ]);
+            await ctx.db.insert(schema.studyProgramMembership).values([
+                {
+                    userId: target.id,
+                    studyProgramId: bachelorId,
+                    startYear: 2023,
+                    startYearSource: "derived",
+                    feideActive: false,
+                },
+                {
+                    userId: target.id,
+                    studyProgramId: masterId,
+                    startYear: 2026,
+                    startYearSource: "derived",
+                    feideActive: true,
+                },
+            ]);
+
+            const res = await client.api.user[":id"].$get({
+                param: { id: target.id },
+            });
+            expect(res.status).toBe(200);
+            const body = await res.json();
+
+            expect(body.studyProgram).toBe("Digital transformasjon");
+            // The master's own intake, not the 2023 cohort group.
+            expect(body.studyStartYear).toBe(2026);
+            /**
+             * Year one of a master is 4. klasse. Computed in the browser from
+             * the start year alone it would have read as 1., and computed from
+             * the cohort group it happened to be right only because the master
+             * followed the bachelor after exactly three years.
+             */
+            expect(body.classYear).toBe(4);
+        },
+    );
+
+    integrationTest(
+        "gives a finished bachelor no class level",
+        async ({ ctx }) => {
+            const viewer = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(viewer);
+
+            const { bachelorId } = await seedProgrammes(ctx);
+
+            const target = await ctx.utils.createTestUser();
+            await ctx.db.insert(schema.groupMembership).values([
+                {
+                    userId: target.id,
+                    groupSlug: "digital-forretningsutvikling",
+                    role: "member",
+                },
+                { userId: target.id, groupSlug: "2023", role: "member" },
+            ]);
+            await ctx.db.insert(schema.studyProgramMembership).values({
+                userId: target.id,
+                studyProgramId: bachelorId,
+                startYear: 2023,
+                startYearSource: "derived",
+                feideActive: false,
+            });
+
+            const res = await client.api.user[":id"].$get({
+                param: { id: target.id },
+            });
+            const body = await res.json();
+
+            // Three years from 2023 is done, so the profile shows the cohort
+            // rather than a class level they are no longer on.
+            expect(body.studyProgram).toBe("Digital forretningsutvikling");
+            expect(body.studyStartYear).toBe(2023);
+            expect(body.classYear).toBeNull();
+        },
+    );
+});

--- a/apps/kvark/src/lib/utils.ts
+++ b/apps/kvark/src/lib/utils.ts
@@ -1,4 +1,3 @@
-import { computeClassYear } from "@photon/auth/academic-year";
 import type { ClassValue } from "clsx";
 import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
@@ -38,8 +37,6 @@ export {
     currentAcademicYear,
 } from "@photon/auth/academic-year";
 
-type StudyGroupLike = { name: string; type: string };
-
 /**
  * Masterprogrammene ved TIHLDE. Alt annet (Dataingeniør, Digital
  * forretningsutvikling, Digital infrastruktur og cybersikkerhet, Drift,
@@ -58,49 +55,21 @@ export function programmeLength(programme: string | undefined): number {
 }
 
 /**
- * Avled studieprogram, klassetrinn og kull fra brukerens gruppemedlemskap.
- * `study`- og `studyyear`-gruppene er en projeksjon av Feide-dataene; typen
- * lagres i UPPERCASE i databasen, så sammenlign case-insensitivt.
- *
- * Klassetrinn vises kun så lenge man faktisk går på studiet — til og med 3.
- * klasse på bachelor, 5. på master. Er man forbi det, er man alumni, og da er
- * kullet (oppstartsåret) det riktige å vise. Tidligere ble klassetrinnet vist
- * så lenge det lå mellom 1 og 5, så en som startet i 2022 og var ferdig i 2025
- * sto oppført som «4. klasse».
- */
-export function deriveStudy(
-    groups: readonly StudyGroupLike[],
-    now = new Date(),
-): { programme?: string; classYear?: number; startYear?: number } {
-    const programme = groups.find(
-        (g) => g.type.toLowerCase() === "study",
-    )?.name;
-
-    const startYears = groups
-        .filter((g) => g.type.toLowerCase() === "studyyear")
-        .map((g) => Number.parseInt(g.name, 10))
-        .filter((year) => Number.isFinite(year));
-
-    if (startYears.length === 0) return { programme };
-
-    const startYear = Math.max(...startYears);
-    const computed = computeClassYear(startYear, now);
-    const isStudying = computed >= 1 && computed <= programmeLength(programme);
-
-    return {
-        programme,
-        classYear: isStudying ? computed : undefined,
-        startYear,
-    };
-}
-
-/**
  * «Dataingeniør · 3. klasse» mens man studerer, «Dataingeniør · kull 2022»
  * etterpå. Returnerer undefined når vi ikke vet noe om studiet.
+ *
+ * Tar verdiene som de kommer fra API-et. Siden brukes til å utlede dem selv fra
+ * gruppelista, og det gikk galt på to måter samtidig: den plukket den første
+ * studiegruppa i den rekkefølgen serveren tilfeldigvis sendte dem, så et medlem
+ * som hadde byttet studium fikk vist det gamle — og klassetrinnet manglet
+ * master-offsetten, så første år på master ville lest som 1. klasse i stedet for
+ * 4. Begge deler er regler serveren allerede kan, og de hører hjemme ett sted.
  */
-export function formatStudyLabel(
-    study: ReturnType<typeof deriveStudy>,
-): string | undefined {
+export function formatStudyLabel(study: {
+    programme?: string | null;
+    classYear?: number | null;
+    startYear?: number | null;
+}): string | undefined {
     const detail = study.classYear
         ? `${study.classYear}. klasse`
         : study.startYear

--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -44,7 +44,7 @@ import {
     type ProfileHeaderUser,
     type ProfileLink,
 } from "#/components/profile-header";
-import { deriveStudy, formatStudyLabel } from "#/lib/utils";
+import { formatStudyLabel } from "#/lib/utils";
 
 export const Route = createFileRoute("/_app/profil/$id")({
     component: RouteComponent,
@@ -107,7 +107,13 @@ function RouteComponent() {
     const [bioOpen, setBioOpen] = useState(false);
 
     const settings = session?.user.settings;
-    const studyLabel = formatStudyLabel(deriveStudy(profile.groups));
+    // Fra API-et, ikke utledet her: hvilket studie som er det gjeldende, og
+    // hvilket klassetrinn det gir, er regler serveren allerede eier.
+    const studyLabel = formatStudyLabel({
+        programme: profile.studyProgram,
+        classYear: profile.classYear,
+        startYear: profile.studyStartYear,
+    });
     const user: ProfileHeaderUser = {
         name: profile.name,
         // E-post er ikke en del av den offentlige profilen. Din egen ligger i

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -6310,8 +6310,10 @@ export interface components {
             linkedinUrl: string | null;
             /** @description Name of the user's study programme, derived from their STUDY group membership. Null when they have none. */
             studyProgram: string | null;
-            /** @description The year the user started studying (kull), derived from their STUDYYEAR group membership. Null when unknown. */
+            /** @description The year the user started their current study programme. Falls back to their STUDYYEAR group when we have no year for the programme itself. Null when unknown. */
             studyStartYear: number | null;
+            /** @description Class level 1-5, computed from the current programme and its length. A master's first year is 4. Null for alumni and for anyone we cannot place — served by the API so the rule lives in one place rather than being recomputed per client. */
+            classYear: number | null;
             /** @description Every group the user belongs to, including the derived STUDY/STUDYYEAR groups */
             groups: {
                 slug: string;


### PR DESCRIPTION
Etter #622 viste adminlista, brukeroppslaget, gruppemedlemslista og skjemaeksporten riktig studie — men profilsiden gjorde det fortsatt ikke. Den utledet studiet selv i nettleseren:

```ts
const programme = groups.find((g) => g.type.toLowerCase() === "study")?.name;
```

Første STUDY-gruppe i den rekkefølgen Postgres tilfeldigvis returnerte dem. Samme feil som ble rettet på serversiden, bare flyttet til klienten — og derfor sto André Karsten fortsatt som «Digital forretningsutvikling · kull 2023» på profilen sin etter at alt annet var rettet.

## Endringen

Profilsiden bruker nå `studyProgram` og `studyStartYear` fra API-et, som allerede går gjennom den delte rangeringen.

**Klassetrinnet serveres også av API-et,** som et nytt `classYear` på profilsvaret. Det måtte det: første år på master er 4. klasse, og offsetten som koder det holder bare hvis man vet at året tilhører masteren og ikke bacheloren den fulgte — nettopp det klienten ikke kan se. Matet med masterens eget startår ville nettleserversjonen lest «1. klasse». At den til nå viste riktig tall for førsteårs mastere skyldtes at den regnet fra bachelorkullet, og at masteren tilfeldigvis starter tre år etter.

`deriveStudy` i kvark er fjernet. Den hadde ingen andre kallere.

## Verifisering

- Full API-suite grønn: 108 filer, 712 tester.
- To nye integrasjonstester på profil-endepunktet, begge mutasjonssjekket: bytter jeg ut kilden til `classYear`, faller begge.
  - En master med eget startår 2026 og bachelorkullgruppe 2023 → «Digital transformasjon», kull 2026, 4. klasse.
  - En ferdig treårig bachelor fra 2023 → studiet vises, `classYear` er null.
- Typecheck, lint og build grønt.

Ikke verifisert i nettleser: endringen er et felt-bytte dekket av API-testene, og en full lokal stack ville kollidert med en dev-server en annen økt kjører i samme mappe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)