### PR TITLE
docs: rett to påstander om release-flyten

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -20,7 +20,14 @@ Kjør skriptet — ikke lag taggen for hånd:
 bun run cut-release
 ```
 
-Det gjør alle sjekkene selv: at du står på `main`, at treet er rent, at `main` er i synk med `origin/main`, og at CI faktisk er grønn på commiten som tagges. Det regner ut neste nummer for dagen, viser hvilke commits som slippes siden forrige release, og spør før det pusher.
+Det sjekker at du står på `main`, at treet er rent, og at `main` er i synk med `origin/main`. Det regner ut neste nummer for dagen, viser hvilke commits som slippes siden forrige release, og spør før det pusher.
+
+**Skriptet sjekker ikke CI.** Det må du gjøre selv før du tagger. Merge-commiten på `main` har typisk fortsatt testene kjørende i flere minutter etter at PR-en gikk inn, og det er den commiten taggen peker på:
+
+```bash
+gh api "repos/TIHLDE/Photon/commits/<sha>/check-runs" \
+  --jq '[.check_runs[] | "\(.name): \(.conclusion // .status)"] | join("\n")'
+```
 
 For å se hva som ville skjedd uten å slippe noe:
 
@@ -34,9 +41,21 @@ Etterpå: følg kjøringen og **rapporter faktisk status**, ikke bare «deployet
 gh run list --limit 3
 ```
 
+### «Deploy: success» betyr ikke at migrasjonen har kjørt
+
+`deploy.yml` har tre jobber — `build`, `release_notes`, `notify` — og ingen av dem rører databasen. Migrasjonen ligger i containerens entrypoint:
+
+```
+ENTRYPOINT ["sh", "-c", "bun run ./apps/api/dist/migrate.js && bun run ./apps/api/dist/index.js"]
+```
+
+Skjemaet endrer seg altså først når Drift har byttet container, som er minutter etter at workflowen melder `success`. Venter du på en migrasjon, poll databasen — ikke workflowen. Og `drizzle-kit migrate` velger på journal-tidsstempel, ikke på hash — den kan melde «applied successfully» uten å ha kjørt noe. Verifiser mot databasen, ikke mot loggen.
+
+Rekkefølgen i entrypointet er det som gjør skjemaendringer trygge: migrasjonen er ferdig før ny kode svarer på en eneste forespørsel. Et skript som må kjøre *etter* en migrasjon — en backfill som skriver en ny enum-verdi, for eksempel — kan derfor ikke kjøres før ny container faktisk har startet.
+
 ## Ting å ikke gjøre
 
-- **Ikke lag taggen manuelt** med `git tag`. Skriptet finnes fordi sjekkene (CI grønn, i synk med origin, riktig nummer) er lette å glemme, og en feil tag deployer rett i prod.
+- **Ikke lag taggen manuelt** med `git tag`. Skriptet finnes fordi sjekkene (i synk med origin, rent tre, riktig nummer for dagen) er lette å glemme, og en feil tag deployer rett i prod.
 - **Ikke gjenbruk eller flytt en tag.** En release-tag er en uforanderlig markør — Drift peker på den. Trenger du å fikse noe, lag en ny tag.
 - **Ikke gjenopprett en `dev`-branch.** Den ble bevisst fjernet: dobbel CI-venting (~20 min i stedet for ~10) og en merge-strategi nye i Index måtte lære. Kommer det en «vi burde ha en staging-branch»-diskusjon, er det en egen avgjørelse — ikke noe man gjør i forbifarten.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,9 @@ The repo has **one long-lived branch: `main`**. There is no `dev` branch.
 
 - All work: feature branch → PR → `main`. CI runs on the PR.
 - A release is a **tag**, not a merge: `<YYYY-MM-DD>.release-<n>` (e.g. `2026-08-08.release-1`).
-- Cut a release with `bun run cut-release` — never `git tag` by hand. The script verifies you're on an up-to-date `main`, that the tree is clean, and that CI is green on the commit being tagged.
+- Cut a release with `bun run cut-release` — never `git tag` by hand. The script verifies you're on `main`, that the tree is clean, and that `main` is in sync with `origin/main`. It does **not** check CI — verify that yourself before tagging, because the merge commit on `main` usually still has tests running for several minutes after the PR went in.
 - The tag triggers `deploy.yml`: build → push to GHCR → notify Drift → publish a GitHub Release with a generated changelog. The release tag is also applied to the docker image so Drift can use it as a deploy marker.
+- **The deploy runs no migrations.** The container's entrypoint is `migrate.js && index.js`, so the schema changes when the new container boots — which is minutes after the workflow reports success. "Deploy: success" is not evidence that a migration ran; check the database. The ordering is what makes enum changes safe: the migration finishes before the new code serves a request.
 - `bun run release` is something else — changesets' npm publish of `@tihlde/sdk`. Don't confuse the two.
 
 ### Commit Message Convention


### PR DESCRIPTION
To ting står feil i dokumentasjonen av release-flyten, og begge kan lure noen til å tro at en sjekk skjer automatisk. Begge ble avdekket under release-3 og release-4 i dag.

## `cut-release` sjekker ikke CI

`CLAUDE.md` og `.claude/skills/release/SKILL.md` sier begge at skriptet verifiserer «at CI faktisk er grønn på commiten som tagges».

Det gjør det ikke. `scripts/cut-release.ts` sjekker tre ting — at du står på `main`, at treet er rent, og at `HEAD` er lik `origin/main` — og eneste bruk av `gh` er `gh release list`, for å regne ut neste nummer for dagen.

Det er ikke akademisk: merge-commiten på `main` har typisk API-testene kjørende i flere minutter etter at PR-en gikk inn, og det er den commiten taggen peker på. Den som stoler på dokumentasjonen tagger en commit ingen har sett grønn.

Begge filene sier nå hva skriptet faktisk gjør, og skillen viser kommandoen for å sjekke CI selv.

## Deployen migrerer ikke — containeren gjør det

Ingen av dem nevner det. `deploy.yml` har tre jobber — `build`, `release_notes`, `notify` — og ingen rører databasen. Migrasjonen ligger i containerens entrypoint:

```
ENTRYPOINT ["sh", "-c", "bun run ./apps/api/dist/migrate.js && bun run ./apps/api/dist/index.js"]
```

Så «Deploy: success» betyr at imaget er bygget og Drift varslet — ikke at skjemaet er oppdatert. Det kostet tid i dag: etter release-3 sto enumet uendret i flere minutter mens Drift ennå ikke hadde byttet container, og et backfill-skript som skriver en ny enum-verdi kunne ikke kjøre før den faktisk hadde startet.

Rekkefølgen i entrypointet er samtidig det som gjør slike endringer trygge, og det er verdt å ha skrevet ned: migrasjonen er ferdig før ny kode svarer på en eneste forespørsel.

Dokumentasjonsendring, ingen kode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)