### PR TITLE
fix(kvark): vis alle tidspunkt i norsk tid, og fiks utleggsskjemaet

### DIFF
--- a/apps/kvark/src/components/event-calendar.tsx
+++ b/apps/kvark/src/components/event-calendar.tsx
@@ -17,6 +17,7 @@ import { nb } from "date-fns/locale";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useMemo, useState } from "react";
 
+import { formatInOslo } from "#/lib/date";
 import { cn } from "#/lib/utils";
 
 export type CalendarEvent = {
@@ -50,7 +51,10 @@ export function EventCalendar({ events }: EventCalendarProps) {
     const eventsByDay = useMemo(() => {
         const map = new Map<string, CalendarEvent[]>();
         for (const event of events) {
-            const key = format(new Date(event.startTime), "yyyy-MM-dd");
+            // Datoen et arrangement havner på er den norske datoen. Rutenettet
+            // under bygges av lokale midnatter, som gir samme «yyyy-MM-dd»
+            // uansett tidssone, så de to nøklene møtes.
+            const key = formatInOslo(event.startTime, "yyyy-MM-dd");
             const list = map.get(key) ?? [];
             list.push(event);
             map.set(key, list);

--- a/apps/kvark/src/components/form/field/account-number.tsx
+++ b/apps/kvark/src/components/form/field/account-number.tsx
@@ -1,0 +1,129 @@
+import { useFieldContext } from "#/hooks/form";
+import { Input as InputPrimitive } from "@tihlde/ui/ui/input";
+import { useLayoutEffect, useRef } from "react";
+import { useField } from "./field";
+
+/** Et norsk kontonummer er elleve siffer, skrevet xxxx.xx.xxxxx. */
+const ACCOUNT_NUMBER_DIGITS = 11;
+const GROUPS = [4, 6] as const;
+
+function countDigits(value: string): number {
+    return value.replace(/\D/g, "").length;
+}
+
+/**
+ * Alt som ikke er siffer forkastes, og punktumene settes inn på nytt ut fra
+ * hvor mange siffer som faktisk er skrevet. Da spiller det ingen rolle om
+ * medlemmet skriver, limer inn «1234.56.78901», «1234 56 78901» eller bare
+ * elleve siffer — det som havner i skjemaet er alltid formatet API-et krever.
+ */
+export function formatAccountNumber(raw: string): string {
+    const digits = raw.replace(/\D/g, "").slice(0, ACCOUNT_NUMBER_DIGITS);
+    return [
+        digits.slice(0, GROUPS[0]),
+        digits.slice(GROUPS[0], GROUPS[1]),
+        digits.slice(GROUPS[1]),
+    ]
+        .filter((group) => group.length > 0)
+        .join(".");
+}
+
+/** Posisjonen rett etter siffer nummer `digits` i en ferdig formatert verdi. */
+function caretAfterDigit(value: string, digits: number): number {
+    if (digits <= 0) return 0;
+
+    let seen = 0;
+    for (let i = 0; i < value.length; i++) {
+        if (!/\d/.test(value[i] as string)) continue;
+        seen++;
+        if (seen === digits) return i + 1;
+    }
+    return value.length;
+}
+
+type AccountNumberProps = Omit<
+    React.ComponentProps<"input">,
+    "value" | "required" | "type"
+>;
+
+/**
+ * Kontonummer som formaterer seg selv mens man skriver: punktumene kommer av
+ * seg selv, og siffer nummer tolv kommer aldri inn. Skjemaverdien er hele
+ * tiden den formaterte teksten, siden det er den formen API-et validerer.
+ */
+export function AccountNumber({
+    onChange,
+    onKeyDown,
+    ...props
+}: AccountNumberProps) {
+    const field = useFieldContext<string>();
+    const ctx = useField();
+    const inputRef = useRef<HTMLInputElement>(null);
+    // React skriver den formaterte verdien tilbake i inputen først ved neste
+    // render. Uten at markøren flyttes etterpå hopper den til slutten hver
+    // gang et punktum settes inn — altså midt i et kontonummer.
+    const caretRef = useRef<number | null>(null);
+
+    useLayoutEffect(() => {
+        const caret = caretRef.current;
+        caretRef.current = null;
+        if (caret === null) return;
+        inputRef.current?.setSelectionRange(caret, caret);
+    });
+
+    function commit(next: string, digitsBeforeCaret: number) {
+        caretRef.current = caretAfterDigit(next, digitsBeforeCaret);
+        field.handleChange(next);
+    }
+
+    return (
+        <InputPrimitive
+            {...props}
+            ref={inputRef}
+            id={ctx.inputId}
+            name={field.name}
+            required={ctx.required}
+            type="text"
+            inputMode="numeric"
+            autoComplete="off"
+            value={field.state.value}
+            onChange={(e) => {
+                onChange?.(e);
+                if (e.defaultPrevented) return;
+
+                const caret = e.target.selectionStart ?? e.target.value.length;
+                commit(
+                    formatAccountNumber(e.target.value),
+                    countDigits(e.target.value.slice(0, caret)),
+                );
+            }}
+            onKeyDown={(e) => {
+                onKeyDown?.(e);
+                if (e.defaultPrevented) return;
+
+                // Backspace rett bak et punktum ville ellers slette skilletegnet
+                // og få det satt inn igjen med det samme — tastetrykket ser ut
+                // som om det ikke gjorde noe. Slett sifferet foran i stedet.
+                const el = e.currentTarget;
+                const caret = el.selectionStart ?? 0;
+                if (
+                    e.key !== "Backspace" ||
+                    caret !== el.selectionEnd ||
+                    caret < 2 ||
+                    el.value[caret - 1] !== "."
+                ) {
+                    return;
+                }
+
+                e.preventDefault();
+                const kept = el.value.slice(0, caret - 2);
+                commit(
+                    formatAccountNumber(kept + el.value.slice(caret)),
+                    countDigits(kept),
+                );
+            }}
+            onBlur={field.handleBlur}
+            aria-invalid={ctx.isInvalid}
+        />
+    );
+}

--- a/apps/kvark/src/components/form/field/index.ts
+++ b/apps/kvark/src/components/form/field/index.ts
@@ -1,6 +1,7 @@
 export { Field } from "./field";
 export { Label, Description, Error } from "./parts";
 export { Input, Password, Textarea } from "./input";
+export { AccountNumber } from "./account-number";
 export { Markdown } from "./markdown";
 export { Number } from "./number";
 export { Checkbox } from "./checkbox";

--- a/apps/kvark/src/components/soknader/admin-detail-dialog.tsx
+++ b/apps/kvark/src/components/soknader/admin-detail-dialog.tsx
@@ -27,6 +27,7 @@ import type {
 } from "#/api/queries/applications";
 import { formatIsoDate, formatNok } from "./format";
 import { ApplicationStatusBadge } from "./status-badge";
+import { OSLO_DATE_OPTIONS } from "#/lib/date";
 
 const STATUS_OPTIONS: { value: ApplicationStatus; label: string }[] = [
     { value: "new", label: "Ny" },
@@ -178,7 +179,10 @@ export function AdminDetailDialog({
                                 <span className="text-sm text-muted-foreground">
                                     {new Date(
                                         application.createdAt,
-                                    ).toLocaleString("nb-NO")}
+                                    ).toLocaleString(
+                                        "nb-NO",
+                                        OSLO_DATE_OPTIONS,
+                                    )}
                                 </span>
                                 {application.hasPdf && (
                                     <Button

--- a/apps/kvark/src/components/soknader/expense-form.tsx
+++ b/apps/kvark/src/components/soknader/expense-form.tsx
@@ -5,6 +5,8 @@ import { Spinner } from "@tihlde/ui/ui/spinner";
 import { z } from "zod";
 import type { ApplicationOptions } from "#/api/queries/applications";
 import { formHandlers, useAppForm } from "#/hooks/form";
+import { todayInOslo } from "#/lib/date";
+import { usePrefillContact } from "./shared";
 import type {
     CcOption,
     DefaultContact,
@@ -57,7 +59,7 @@ export function ExpenseForm({
             contactEmail: defaultContact.email,
             cc: null as CcOption | null,
             amountNok: null as unknown as number,
-            date: new Date(),
+            date: todayInOslo(),
             group: null as unknown as GroupOption,
             budgetType: "",
             description: "",
@@ -71,6 +73,8 @@ export function ExpenseForm({
             });
         },
     });
+
+    usePrefillContact(form, defaultContact);
 
     return (
         <Card>
@@ -136,7 +140,7 @@ export function ExpenseForm({
                             {(field) => (
                                 <field.Field required>
                                     <field.Label>Kontonummer</field.Label>
-                                    <field.Input placeholder="1234.56.78901" />
+                                    <field.AccountNumber placeholder="1234.56.78901" />
                                     <field.Description>
                                         Formatet er xxxx.xx.xxxxx
                                     </field.Description>

--- a/apps/kvark/src/components/soknader/hs-case-form.tsx
+++ b/apps/kvark/src/components/soknader/hs-case-form.tsx
@@ -11,6 +11,7 @@ import { useStore } from "@tanstack/react-form";
 import { z } from "zod";
 import type { ApplicationOptions } from "#/api/queries/applications";
 import { formHandlers, useAppForm } from "#/hooks/form";
+import { usePrefillContact } from "./shared";
 import type { DefaultContact, SubmitHelpers } from "./shared";
 
 const schema = z
@@ -76,6 +77,8 @@ export function HsCaseForm({
             });
         },
     });
+
+    usePrefillContact(form, defaultContact);
 
     const caseType = useStore(form.store, (state) => state.values.caseType);
     const isDecision = caseType === "decision";

--- a/apps/kvark/src/components/soknader/my-applications.tsx
+++ b/apps/kvark/src/components/soknader/my-applications.tsx
@@ -12,6 +12,7 @@ import { Download, ListChecks } from "lucide-react";
 import type { ApplicationSummary } from "#/api/queries/applications";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { ApplicationStatusBadge } from "./status-badge";
+import { OSLO_DATE_OPTIONS } from "#/lib/date";
 
 type MyApplicationsProps = {
     applications: ApplicationSummary[];
@@ -56,7 +57,10 @@ export function MyApplications({
                                 <TableCell>
                                     {new Date(
                                         application.createdAt,
-                                    ).toLocaleDateString("nb-NO")}
+                                    ).toLocaleDateString(
+                                        "nb-NO",
+                                        OSLO_DATE_OPTIONS,
+                                    )}
                                 </TableCell>
                                 <TableCell>
                                     <ApplicationStatusBadge

--- a/apps/kvark/src/components/soknader/shared.ts
+++ b/apps/kvark/src/components/soknader/shared.ts
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 import type { ApplicationOptions } from "#/api/queries/applications";
 
 export type GroupOption = ApplicationOptions["groups"][number];
@@ -13,6 +15,13 @@ export type SubmitHelpers = {
     reset: () => void;
 };
 
+/** Så lite av skjema-API-et som `usePrefillContact` faktisk trenger. */
+type ContactField = "contactName" | "contactEmail";
+type ContactFieldsForm = {
+    getFieldValue: (name: ContactField) => string;
+    setFieldValue: (name: ContactField, value: string) => void;
+};
+
 /**
  * Format a picked date as "YYYY-MM-DD" using local calendar fields.
  *
@@ -24,4 +33,27 @@ export function toIsoDate(date: Date): string {
     const month = String(date.getMonth() + 1).padStart(2, "0");
     const day = String(date.getDate()).padStart(2, "0");
     return `${year}-${month}-${day}`;
+}
+
+/**
+ * Fyll inn navn og e-post når sesjonen lander.
+ *
+ * Sesjonen hentes etter at siden er tegnet, så `defaultValues` rekker aldri å
+ * se den — uten dette blir kontaktfeltene stående tomme selv om vi vet hvem
+ * som er logget inn. Feltene fylles bare mens de fortsatt er tomme: en søknad
+ * kan sendes på vegne av noen andre, og da skal ikke det som er skrevet
+ * overskrives idet sesjonen kommer.
+ */
+export function usePrefillContact(
+    form: ContactFieldsForm,
+    contact: DefaultContact,
+): void {
+    useEffect(() => {
+        if (contact.name && !form.getFieldValue("contactName")) {
+            form.setFieldValue("contactName", contact.name);
+        }
+        if (contact.email && !form.getFieldValue("contactEmail")) {
+            form.setFieldValue("contactEmail", contact.email);
+        }
+    }, [contact.name, contact.email, form]);
 }

--- a/apps/kvark/src/components/soknader/support-form.tsx
+++ b/apps/kvark/src/components/soknader/support-form.tsx
@@ -10,6 +10,7 @@ import { Spinner } from "@tihlde/ui/ui/spinner";
 import { z } from "zod";
 import type { ApplicationOptions } from "#/api/queries/applications";
 import { formHandlers, useAppForm } from "#/hooks/form";
+import { usePrefillContact } from "./shared";
 import type { DefaultContact, GroupOption, SubmitHelpers } from "./shared";
 
 const schema = z.object({
@@ -96,6 +97,8 @@ export function SupportForm({
             });
         },
     });
+
+    usePrefillContact(form, defaultContact);
 
     return (
         <Card>

--- a/apps/kvark/src/hooks/form.ts
+++ b/apps/kvark/src/hooks/form.ts
@@ -5,6 +5,7 @@ import {
     useStore,
 } from "@tanstack/react-form";
 import {
+    AccountNumber,
     Checkbox,
     CheckboxGroup,
     Combobox,
@@ -102,6 +103,7 @@ const {
         Field,
         Label,
         Input,
+        AccountNumber,
         InputField,
         PasswordField,
         Password,

--- a/apps/kvark/src/lib/date.ts
+++ b/apps/kvark/src/lib/date.ts
@@ -1,4 +1,6 @@
 import { addHours, startOfHour } from "date-fns";
+import { nb } from "date-fns/locale";
+import { formatInTimeZone } from "date-fns-tz";
 
 /**
  * Neste hele time strengt etter `from` (f.eks. 14:23 -> 15:00, 15:00 -> 16:00).
@@ -6,4 +8,45 @@ import { addHours, startOfHour } from "date-fns";
  */
 export function nextWholeHour(from: Date = new Date()): Date {
     return startOfHour(addHours(from, 1));
+}
+
+/**
+ * Alt TIHLDE gjør skjer i norsk tid, så alle tidspunkt vises i norsk tid.
+ *
+ * Dette er ikke bare kosmetikk: `format()` og `toLocaleString()` bruker
+ * tidssonen til den som kjører koden. SSR-serveren står i UTC, nettleseren i
+ * Europe/Oslo, så uten en fast sone rendres hvert klokkeslett to timer feil i
+ * server-HTML-en og «hopper» ved hydrering — som React melder som en
+ * hydreringsfeil (#418) på hver eneste side med et tidspunkt.
+ */
+export const OSLO_TIME_ZONE = "Europe/Oslo";
+
+/** `Intl`-opsjoner for datoer som skrives ut med `toLocale*`. */
+export const OSLO_DATE_OPTIONS = { timeZone: OSLO_TIME_ZONE } as const;
+
+/**
+ * `format()` fra date-fns, men alltid i norsk tid og med norsk locale.
+ * Bruk denne i stedet for `format(new Date(iso), …)` for alt som skal vises.
+ */
+export function formatInOslo(
+    value: Date | string | number,
+    pattern: string,
+): string {
+    return formatInTimeZone(value, OSLO_TIME_ZONE, pattern, { locale: nb });
+}
+
+/**
+ * Dagens dato i Norge, som lokal midnatt.
+ *
+ * `new Date()` som standardverdi i en datovelger gir feil dag på en server i
+ * UTC de to første timene av det norske døgnet — og da står det én dato i
+ * server-HTML-en og en annen i nettleseren. Her plukkes datoen ut i norsk tid
+ * først, og settes så sammen igjen lokalt, slik at begge sider skriver samme
+ * dag.
+ */
+export function todayInOslo(): Date {
+    const [year, month, day] = formatInOslo(new Date(), "yyyy-MM-dd")
+        .split("-")
+        .map(Number) as [number, number, number];
+    return new Date(year, month - 1, day);
 }

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -1,6 +1,7 @@
-import { addMilliseconds, format, formatDistanceStrict, set } from "date-fns";
+import { addMilliseconds, formatDistanceStrict, set } from "date-fns";
 import { nb } from "date-fns/locale";
 import { MAX_CLASS_YEAR, computeClassYear } from "@photon/auth/academic-year";
+import { formatInOslo } from "#/lib/date";
 
 // -- Shared display types (previously in mock/events) --
 
@@ -236,14 +237,14 @@ export function formatEventPrice(
  * Format an ISO timestamp as a Norwegian long date, e.g. "tor. 30. apr. 2026".
  */
 export function formatEventDate(iso: string): string {
-    return format(new Date(iso), "EEE d. MMM yyyy", { locale: nb });
+    return formatInOslo(iso, "EEE d. MMM yyyy");
 }
 
 /**
  * Format an ISO timestamp as a time of day, e.g. "12:00".
  */
 export function formatEventTime(iso: string): string {
-    return format(new Date(iso), "HH:mm", { locale: nb });
+    return formatInOslo(iso, "HH:mm");
 }
 
 /**

--- a/apps/kvark/src/lib/form.ts
+++ b/apps/kvark/src/lib/form.ts
@@ -1,12 +1,10 @@
-import { format } from "date-fns";
-import { nb } from "date-fns/locale";
-
 import type {
     FormDetail,
     FormStatistics,
     SubmissionList,
     UpdateForm,
 } from "@tihlde/sdk";
+import { formatInOslo } from "#/lib/date";
 
 export type FormQuestionType =
     | "text_answer"
@@ -67,7 +65,7 @@ export function toFormFieldsPayload(
  * Tidspunktet et planlagt skjema åpner, f.eks. «tor. 30. apr. 2026 kl. 12:00».
  */
 export function formatFormOpensAt(iso: string): string {
-    return format(new Date(iso), "EEE d. MMM yyyy 'kl.' HH:mm", { locale: nb });
+    return formatInOslo(iso, "EEE d. MMM yyyy 'kl.' HH:mm");
 }
 
 // -- Svar --
@@ -94,9 +92,7 @@ export function mapSubmission(
         id: submission.id,
         userName: submission.user.name,
         userEmail: submission.user.email,
-        submittedAt: format(new Date(submission.created_at), "d. MMM yyyy", {
-            locale: nb,
-        }),
+        submittedAt: formatInOslo(submission.created_at, "d. MMM yyyy"),
         answers: submission.answers.map((answer) => ({
             fieldId: answer.field_id,
             text:

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -1,6 +1,3 @@
-import { format } from "date-fns";
-import { nb } from "date-fns/locale";
-
 import type {
     Group as ApiGroup,
     GroupMember as ApiGroupMember,
@@ -10,6 +7,7 @@ import type {
     Law as ApiLaw,
     GroupFormList,
 } from "@tihlde/sdk";
+import { formatInOslo } from "#/lib/date";
 
 type ApiFineUser = FineUserList["users"][number];
 
@@ -291,7 +289,7 @@ export function compareGroupHierarchy(
  * Format an ISO timestamp as a Norwegian long date, e.g. "tor. 30. apr. 2026".
  */
 export function formatGroupDate(iso: string): string {
-    return format(new Date(iso), "EEE d. MMM yyyy", { locale: nb });
+    return formatInOslo(iso, "EEE d. MMM yyyy");
 }
 
 /**

--- a/apps/kvark/src/lib/job.ts
+++ b/apps/kvark/src/lib/job.ts
@@ -1,5 +1,4 @@
-import { format } from "date-fns";
-import { nb } from "date-fns/locale";
+import { formatInOslo } from "#/lib/date";
 
 // -- Shared display types & helpers (previously in mock/jobs) --
 
@@ -61,12 +60,12 @@ export function formatJobDeadline(
     if (isContinuouslyHiring || !deadline) {
         return "Fortløpende";
     }
-    return format(new Date(deadline), "EEE d. MMM yyyy, HH:mm", { locale: nb });
+    return formatInOslo(deadline, "EEE d. MMM yyyy, HH:mm");
 }
 
 /**
  * Format an ISO timestamp as a Norwegian long date, e.g. "tor. 24. apr. 2026".
  */
 export function formatJobDate(iso: string): string {
-    return format(new Date(iso), "EEE d. MMM yyyy", { locale: nb });
+    return formatInOslo(iso, "EEE d. MMM yyyy");
 }

--- a/apps/kvark/src/lib/news.ts
+++ b/apps/kvark/src/lib/news.ts
@@ -1,5 +1,6 @@
-import { format, formatDistanceToNow } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 import { nb } from "date-fns/locale";
+import { formatInOslo } from "#/lib/date";
 
 // -- Shared display types (previously in mock/news) --
 
@@ -18,7 +19,7 @@ export type NewsItem = {
  * e.g. "tor. 24. apr. 2026, 14:30".
  */
 export function formatNewsDate(iso: string): string {
-    return format(new Date(iso), "EEE d. MMM yyyy, HH:mm", { locale: nb });
+    return formatInOslo(iso, "EEE d. MMM yyyy, HH:mm");
 }
 
 /**

--- a/apps/kvark/src/routes/_app/kontrakt.tsx
+++ b/apps/kvark/src/routes/_app/kontrakt.tsx
@@ -23,6 +23,7 @@ import {
     getMySignatureQuery,
     signContractMutation,
 } from "#/api/queries/contracts";
+import { OSLO_TIME_ZONE } from "#/lib/date";
 
 // The signed PDF is a private asset streamed by the API, so it is linked
 // directly rather than fetched through the SDK. A top-level navigation carries
@@ -95,6 +96,7 @@ function KontraktViewer({ contract }: { contract: ActiveContract }) {
     if (signature?.hasSigned) {
         const signedAt = signature.signedAt
             ? new Date(signature.signedAt).toLocaleDateString("nb-NO", {
+                  timeZone: OSLO_TIME_ZONE,
                   day: "numeric",
                   month: "long",
                   year: "numeric",

--- a/apps/kvark/src/routes/_app/motetid.index.tsx
+++ b/apps/kvark/src/routes/_app/motetid.index.tsx
@@ -20,6 +20,7 @@ import {
     deleteMotetidEventMutation,
     getMyMotetidEventsQuery,
 } from "#/api/queries/motetid";
+import { OSLO_DATE_OPTIONS } from "#/lib/date";
 
 export const Route = createFileRoute("/_app/motetid/")({
     component: MotetidPage,
@@ -72,6 +73,7 @@ function MotetidEventList() {
                                 Opprettet{" "}
                                 {new Date(event.createdAt).toLocaleDateString(
                                     "nb-NO",
+                                    OSLO_DATE_OPTIONS,
                                 )}
                                 {" · "}
                                 {event.participantCount}{" "}

--- a/apps/kvark/src/routes/_app/tilbakemelding.tsx
+++ b/apps/kvark/src/routes/_app/tilbakemelding.tsx
@@ -72,6 +72,7 @@ import {
 } from "#/api/queries/feedback";
 import { LoadMoreButton } from "#/components/load-more-button";
 import { useCanActOnResource, usePermission } from "#/hooks/use-permission";
+import { OSLO_TIME_ZONE } from "#/lib/date";
 
 export const Route = createFileRoute("/_app/tilbakemelding")({
     component: FeedbackPage,
@@ -119,6 +120,7 @@ const STATUS_VARIANTS: Record<
 
 function formatDate(value: string): string {
     return new Date(value).toLocaleDateString("nb-NO", {
+        timeZone: OSLO_TIME_ZONE,
         day: "2-digit",
         month: "2-digit",
         year: "numeric",

--- a/apps/kvark/src/routes/_app/toddel.tsx
+++ b/apps/kvark/src/routes/_app/toddel.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "@tihlde/ui/ui/skeleton";
 
 import { getToddelIssuesQuery } from "#/api/queries/toddel";
 import { IssueCard } from "#/components/issue-card";
+import { OSLO_TIME_ZONE } from "#/lib/date";
 
 export const Route = createFileRoute("/_app/toddel")({
     component: ToddelPage,
@@ -22,6 +23,7 @@ export const Route = createFileRoute("/_app/toddel")({
  */
 function publishedLabel(publishedAt: string): string {
     const label = new Date(publishedAt).toLocaleDateString("nb-NO", {
+        timeZone: OSLO_TIME_ZONE,
         month: "long",
         year: "numeric",
     });

--- a/apps/kvark/src/routes/admin/_super-admin/api-keys.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/api-keys.tsx
@@ -45,6 +45,7 @@ import { Stagger } from "@tihlde/ui/ui/motion";
 
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import { OSLO_DATE_OPTIONS } from "#/lib/date";
 
 export const Route = createFileRoute("/admin/_super-admin/api-keys")({
     component: ApiKeysPage,
@@ -207,7 +208,10 @@ function ApiKeysTable({
                                     {apiKey.lastUsedAt
                                         ? new Date(
                                               apiKey.lastUsedAt,
-                                          ).toLocaleDateString("nb-NO")
+                                          ).toLocaleDateString(
+                                              "nb-NO",
+                                              OSLO_DATE_OPTIONS,
+                                          )
                                         : "Aldri"}
                                 </TableCell>
                                 <TableCell>

--- a/apps/kvark/src/routes/admin/annonser.tsx
+++ b/apps/kvark/src/routes/admin/annonser.tsx
@@ -66,6 +66,7 @@ import {
     useCanActOnResource,
 } from "#/hooks/use-permission";
 import { nextWholeHour } from "#/lib/date";
+import { OSLO_DATE_OPTIONS } from "#/lib/date";
 
 const JOB_TYPES = ["full_time", "part_time", "summer_job", "other"] as const;
 type JobType = (typeof JOB_TYPES)[number];
@@ -761,7 +762,7 @@ function JobDialog({
 
 function formatDeadline(iso: string | null): string {
     if (!iso) return "—";
-    return new Date(iso).toLocaleDateString("nb-NO");
+    return new Date(iso).toLocaleDateString("nb-NO", OSLO_DATE_OPTIONS);
 }
 
 function TableSkeleton() {

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -11,8 +11,6 @@ import {
     useNavigate,
     useSearch,
 } from "@tanstack/react-router";
-import { format } from "date-fns";
-import { nb } from "date-fns/locale";
 import {
     BanknoteArrowDownIcon,
     BanknoteIcon,
@@ -103,6 +101,7 @@ import { cn } from "#/lib/utils";
 import { EVENT_FORM_ERRORS } from "#/lib/event";
 import { isCohortGroupType } from "#/lib/group";
 import { useDebounced } from "#/lib/use-debounced";
+import { formatInOslo } from "#/lib/date";
 
 const TABS = [
     "detaljer",
@@ -1693,7 +1692,7 @@ function matchesQuery(fields: (string | null | undefined)[], query: string) {
 }
 
 function formatDateTime(iso: string) {
-    return format(new Date(iso), "d. MMM yyyy 'kl.' HH:mm", { locale: nb });
+    return formatInOslo(iso, "d. MMM yyyy 'kl.' HH:mm");
 }
 
 /** Minor units (øre) -> "1 234 kr" */

--- a/apps/kvark/src/routes/admin/arrangementer.index.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.index.tsx
@@ -1,7 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
-import { format } from "date-fns";
-import { nb } from "date-fns/locale";
 import { CalendarDaysIcon, EyeIcon, PlusIcon } from "lucide-react";
 import { Suspense, startTransition, useState } from "react";
 
@@ -40,6 +38,7 @@ import {
     useAnyScopePermission,
     useCanActOnGroupResource,
 } from "#/hooks/use-permission";
+import { formatInOslo } from "#/lib/date";
 
 const PAGE_SIZE = 25;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -357,7 +356,7 @@ function EventStatusBadge({
 }
 
 function formatDateTime(iso: string) {
-    return format(new Date(iso), "d. MMM yyyy 'kl.' HH:mm", { locale: nb });
+    return formatInOslo(iso, "d. MMM yyyy 'kl.' HH:mm");
 }
 
 function TableSkeleton() {

--- a/apps/kvark/src/routes/admin/bannere.tsx
+++ b/apps/kvark/src/routes/admin/bannere.tsx
@@ -44,6 +44,7 @@ import { requireAdminSection } from "#/lib/admin-access";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { useAnyScopePermission } from "#/hooks/use-permission";
+import { OSLO_TIME_ZONE } from "#/lib/date";
 
 export const Route = createFileRoute("/admin/bannere")({
     component: BannersAdminPage,
@@ -435,6 +436,7 @@ function BannerDialog({
 
 function formatDateTime(iso: string): string {
     return new Date(iso).toLocaleString("nb-NO", {
+        timeZone: OSLO_TIME_ZONE,
         dateStyle: "short",
         timeStyle: "short",
     });

--- a/apps/kvark/src/routes/admin/grupper.tsx
+++ b/apps/kvark/src/routes/admin/grupper.tsx
@@ -98,6 +98,7 @@ import {
     groupTypeLabel,
     supportsGroupSubtype,
 } from "#/lib/group";
+import { OSLO_DATE_OPTIONS } from "#/lib/date";
 
 export const Route = createFileRoute("/admin/grupper")({
     component: GrupperAdminPage,
@@ -942,7 +943,10 @@ function MemberRow({
             </TableCell>
             <TableCell>
                 {member.signedAt
-                    ? new Date(member.signedAt).toLocaleDateString("nb-NO")
+                    ? new Date(member.signedAt).toLocaleDateString(
+                          "nb-NO",
+                          OSLO_DATE_OPTIONS,
+                      )
                     : "—"}
             </TableCell>
             <TableCell>

--- a/apps/kvark/src/routes/admin/index.tsx
+++ b/apps/kvark/src/routes/admin/index.tsx
@@ -1,7 +1,5 @@
 import { CatchBoundary, createFileRoute, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { format } from "date-fns";
-import { nb } from "date-fns/locale";
 import {
     BriefcaseBusinessIcon,
     CalendarIcon,
@@ -29,6 +27,7 @@ import { getNewsQuery } from "#/api/queries/news";
 import { SectionError } from "#/components/section-error";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 import { ADMIN_SECTION_PERMISSIONS } from "#/lib/admin-sections";
+import { formatInOslo } from "#/lib/date";
 
 export const Route = createFileRoute("/admin/")({
     component: DashboardPage,
@@ -356,7 +355,7 @@ function RecentNews() {
 }
 
 function formatDate(iso: string): string {
-    return format(new Date(iso), "d. MMM yyyy", { locale: nb });
+    return formatInOslo(iso, "d. MMM yyyy");
 }
 
 function StatsSkeleton() {

--- a/apps/kvark/src/routes/admin/kontaktskjema.tsx
+++ b/apps/kvark/src/routes/admin/kontaktskjema.tsx
@@ -28,6 +28,7 @@ import { AdminPageHeader } from "#/components/admin-page-header";
 import { AdminDetailDialog } from "#/components/soknader/admin-detail-dialog";
 import { ApplicationStatusBadge } from "#/components/soknader/status-badge";
 import { useAnyScopePermission } from "#/hooks/use-permission";
+import { OSLO_DATE_OPTIONS } from "#/lib/date";
 
 const searchSchema = z.object({
     /** Deep link from the notification email opens this henvendelse directly. */
@@ -184,7 +185,10 @@ function AdminCompanyContactPage() {
                                         <TableCell>
                                             {new Date(
                                                 application.createdAt,
-                                            ).toLocaleDateString("nb-NO")}
+                                            ).toLocaleDateString(
+                                                "nb-NO",
+                                                OSLO_DATE_OPTIONS,
+                                            )}
                                         </TableCell>
                                         <TableCell>
                                             <ApplicationStatusBadge

--- a/apps/kvark/src/routes/admin/nyheter.tsx
+++ b/apps/kvark/src/routes/admin/nyheter.tsx
@@ -1,7 +1,5 @@
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { format } from "date-fns";
-import { nb } from "date-fns/locale";
 import { NewspaperIcon, PencilIcon, PlusIcon, Trash2 } from "lucide-react";
 import { Suspense, useEffect, useState } from "react";
 
@@ -46,6 +44,7 @@ import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { richRegistry } from "#/components/markdown/directives/presets";
 import { useAnyScopePermission } from "#/hooks/use-permission";
+import { formatInOslo } from "#/lib/date";
 
 // `?rediger=<id>` gjør redigeringsdialogen adresserbar, slik at «Rediger
 // nyhet» på nyhetssiden kan lenke rett til riktig artikkel i stedet for å
@@ -400,7 +399,7 @@ function NewsDialog({
 }
 
 function formatDate(iso: string) {
-    return format(new Date(iso), "d. MMM yyyy", { locale: nb });
+    return formatInOslo(iso, "d. MMM yyyy");
 }
 
 function TableSkeleton() {

--- a/apps/kvark/src/routes/admin/opptak.tsx
+++ b/apps/kvark/src/routes/admin/opptak.tsx
@@ -46,6 +46,7 @@ import {
     createContractMutation,
     getContractListQuery,
 } from "#/api/queries/contracts";
+import { OSLO_DATE_OPTIONS } from "#/lib/date";
 
 // react-pdf needs canvas and a worker, so it must never load during SSR. It is
 // only rendered once a file is picked, which is necessarily client-side.
@@ -331,7 +332,10 @@ function ContractRow({
                 )}
             </TableCell>
             <TableCell>
-                {new Date(contract.createdAt).toLocaleDateString("nb-NO")}
+                {new Date(contract.createdAt).toLocaleDateString(
+                    "nb-NO",
+                    OSLO_DATE_OPTIONS,
+                )}
             </TableCell>
             <TableCell>
                 {!contract.isActive && onActivate && (

--- a/apps/kvark/src/routes/admin/prikker.tsx
+++ b/apps/kvark/src/routes/admin/prikker.tsx
@@ -55,6 +55,7 @@ import {
 import { initials } from "#/lib/utils";
 
 import { avatarImageUrl } from "#/lib/assets";
+import { OSLO_DATE_OPTIONS } from "#/lib/date";
 
 export const Route = createFileRoute("/admin/prikker")({
     component: StrikesAdminPage,
@@ -198,7 +199,10 @@ function StrikesSection() {
                                     <TableCell>
                                         {new Date(
                                             strike.createdAt,
-                                        ).toLocaleDateString("nb-NO")}
+                                        ).toLocaleDateString(
+                                            "nb-NO",
+                                            OSLO_DATE_OPTIONS,
+                                        )}
                                     </TableCell>
                                     <TableCell>
                                         <div className="flex justify-end">

--- a/apps/kvark/src/routes/admin/soknader.tsx
+++ b/apps/kvark/src/routes/admin/soknader.tsx
@@ -32,6 +32,7 @@ import { AdminPageHeader } from "#/components/admin-page-header";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 import { AdminDetailDialog } from "#/components/soknader/admin-detail-dialog";
 import { ApplicationStatusBadge } from "#/components/soknader/status-badge";
+import { OSLO_DATE_OPTIONS } from "#/lib/date";
 
 const searchSchema = z.object({
     /** Deep link from the notification email opens this søknad directly. */
@@ -249,7 +250,10 @@ function AdminApplicationsPage() {
                                         <TableCell>
                                             {new Date(
                                                 application.createdAt,
-                                            ).toLocaleDateString("nb-NO")}
+                                            ).toLocaleDateString(
+                                                "nb-NO",
+                                                OSLO_DATE_OPTIONS,
+                                            )}
                                         </TableCell>
                                         <TableCell>
                                             <ApplicationStatusBadge


### PR DESCRIPTION
## Hydreringsfeilen (React #418)

`Minified React error #418` ble meldt på ~alle sider på tihlde.org, ikke bare der man merket den. Årsaken er at SSR-serveren kjører i UTC mens nettleseren står i Europe/Oslo: `format()` fra date-fns og `toLocaleString()` bruker tidssonen til den som kjører koden, så hvert klokkeslett ble skrevet to timer feil i server-HTML-en og «hoppet» ved hydrering.

Reprodusert med prod-bygg lokalt under `TZ=UTC`, som er det Vercel gjør: tekstdiff SSR↔klient på `lør 22. aug. 2026, 01:00` mot `03:00`, `tor 3. sep. 2026, 14:15` mot `16:15`, osv.

**Fiks:** `lib/date.ts` er nå kilden til norsk tid — `formatInOslo()` (date-fns-tz), `OSLO_TIME_ZONE` / `OSLO_DATE_OPTIONS` og `todayInOslo()`. 13 `format(new Date(iso), …)` og 14 `toLocale*String("nb-NO")` går over på dem, og månedskalenderen grupperer arrangementer på norsk dato.

### Påvirker dette påmelding eller registrering? Nei

- Alle kallsteder for `formatEventDate`/`formatEventTime`/`formatEventDateTime`/`toEventDeadline` er ren visning (`value=`, `startsAt=`, JSX).
- `formatCountdown`/`formatTimeUntil` regner på `getTime()` — millisekunder, uten tidssone. Diffen i `lib/event.ts` er to linjer, begge inne i formateringsfunksjoner.
- `apps/api` er ikke rørt. Påmeldingsvinduer, avmeldingsfrister, betalingsfrister og prikker avgjøres server-side på absolutt tid.

For alle i Norge er teksten uendret. Et medlem i utlandet ser nå norske klokkeslett i stedet for sine egne — som er det riktige, siden alt TIHLDE gjør skjer i norsk tid.

## Søknadsskjemaene

- **Kontonummer formaterer seg selv** mens man skriver (`xxxx.xx.xxxxx`), tar maks elleve siffer, og håndterer innliming (`1234 56 78901`, rene siffer) og Backspace på et skilletegn. Punktum og ikke mellomrom, fordi API-et validerer `^\d{4}\.\d{2}\.\d{5}$` og kolonnen er `varchar(13)`.
- **Navn og e-post prefylles.** Sesjonen kom etter at skjemaet var satt opp, så `defaultValues` rakk aldri å se den. Fylles nå når sesjonen lander, men bare mens feltene er tomme — en søknad kan sendes på vegne av noen andre.
- **Standarddatoen for utlegg** er dagens norske dato, ikke serverens.

## Verifisert

Prod-bygg kjørt lokalt med `TZ=UTC`:

| Side | Før | Etter |
|---|---|---|
| `/arrangementer` | #418, tekstdiff på hvert klokkeslett | ingen feil, 0 tekstdiffer SSR↔klient |
| forsiden, `/nyheter`, `/annonser` | — | ingen #418 |
| `/soknader` (utlegg + mine) | — | ingen #418, dato lik i SSR og klient |
| `/admin/arrangementer` | — | ingen #418 |

Kontonummerfeltet er testet tegn for tegn med ekte input-hendelser: skilletegn kommer av seg selv, markøren blir stående riktig, siffer nummer tolv avvises, og Backspace bak et punktum sletter sifferet foran. Prefill er bekreftet på alle tre fanene, og et felt endret til «Noen Andre» overlevde en ny sesjonshenting.

`bun run typecheck`, `bun run build`, `bun run lint` og `bun run format` er grønne.

## Rester som står igjen

Relative tekster (`formatDistanceToNow`, «for 3 timer siden») og månedskalenderens startmåned følger fortsatt nettleseren. De avhenger av *når*, ikke *hvor*, og gir bare avvik i sjeldne kanttilfeller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)