### PR TITLE
fix(grupper): la undergruppelederen og ministervervet ha samme tilganger

### DIFF
--- a/apps/api/src/lib/group/index.ts
+++ b/apps/api/src/lib/group/index.ts
@@ -13,7 +13,10 @@ import { type DbSchema, schema } from "@photon/db";
 import { type InferSelectModel, and, eq, inArray, ne } from "drizzle-orm";
 import type { AppContext } from "~/lib/ctx";
 import { HTTPAppException } from "~/lib/errors";
-import { getLinkedLeaderPosition } from "~/lib/group/linked-leader";
+import {
+    autoVervName,
+    getLinkedLeaderPosition,
+} from "~/lib/group/linked-leader";
 
 /**
  * Group types whose membership is a projection of Feide, not an editable list.
@@ -471,7 +474,9 @@ export async function syncSubgroupLeaderIntoHs(
             .insert(schema.groupPosition)
             .values({
                 groupSlug: HS_GROUP_SLUG,
-                name: `Leder av ${group.name}`,
+                // The group's own name for its leader when it has one —
+                // the two are one title (see lib/group/linked-leader.ts).
+                name: group.leaderTitle ?? autoVervName(group.name),
                 description: `Leder av ${group.name} — automatisk verv, følger ledervervet i gruppen`,
                 // The verv and the group's leader list are two views of one
                 // thing (see lib/group/linked-leader.ts), so a verv created

--- a/apps/api/src/lib/group/index.ts
+++ b/apps/api/src/lib/group/index.ts
@@ -13,6 +13,7 @@ import { type DbSchema, schema } from "@photon/db";
 import { type InferSelectModel, and, eq, inArray, ne } from "drizzle-orm";
 import type { AppContext } from "~/lib/ctx";
 import { HTTPAppException } from "~/lib/errors";
+import { getLinkedLeaderPosition } from "~/lib/group/linked-leader";
 
 /**
  * Group types whose membership is a projection of Feide, not an editable list.
@@ -448,18 +449,6 @@ export function allowsNonMemberLeader(group: { slug: string }): boolean {
 }
 
 /**
- * Get the leader-verv linked to a subgroup (in any group, normally hs).
- */
-async function getLinkedLeaderPosition(ctx: AppContext, groupSlug: string) {
-    const [position] = await ctx.db
-        .select()
-        .from(schema.groupPosition)
-        .where(eq(schema.groupPosition.linkedGroupSlug, groupSlug))
-        .limit(1);
-    return position ?? null;
-}
-
-/**
  * Called when `userId` BECOMES leader of `group`. No-op unless the group is
  * a subgroup and the hs group exists. Adds the leader to hs and hands them
  * the linked leader-verv (replacing any previous holder — a verv has exactly
@@ -484,7 +473,10 @@ export async function syncSubgroupLeaderIntoHs(
                 groupSlug: HS_GROUP_SLUG,
                 name: `Leder av ${group.name}`,
                 description: `Leder av ${group.name} — automatisk verv, følger ledervervet i gruppen`,
-                permissions: [],
+                // The verv and the group's leader list are two views of one
+                // thing (see lib/group/linked-leader.ts), so a verv created
+                // now starts out agreeing with the group rather than empty.
+                permissions: group.leaderGlobalPermissions ?? [],
                 scope: "global",
                 linkedGroupSlug: group.slug,
             })

--- a/apps/api/src/lib/group/linked-leader.ts
+++ b/apps/api/src/lib/group/linked-leader.ts
@@ -224,3 +224,94 @@ export async function readLinkedPositionPermissionsBatch(
 
     return result;
 }
+
+// =============================================================================
+// The title
+//
+// The same two-places problem as the permissions, one field over: the group's
+// `leaderTitle` and the linked verv's `name` both answer "what is this person
+// called". In production every subgroup left the first at NULL — so its own
+// page called the leader «Leder» while HS called the very same person
+// «Innovasjonsminister».
+//
+// A title is a single value rather than a set, so there is no union to fall
+// back on; the two are reconciled by precedence instead. The group's own title
+// wins when it has one, because that is the group deliberately naming itself.
+// Otherwise the verv's name answers — which is what heals the production rows,
+// where the verv is the only side that ever held a real title.
+// =============================================================================
+
+/**
+ * What an auto-created linked verv is called when the group has no title of
+ * its own. A placeholder, not a title anyone chose: promoting it into
+ * `leaderTitle` would rename every subgroup's leader from «Leder» to «Leder av
+ * Beta».
+ */
+export function autoVervName(groupName: string): string {
+    return `Leder av ${groupName}`;
+}
+
+/** The verv's name as a title, or null when it is only the placeholder. */
+function titleFromVervName(name: string, groupName: string): string | null {
+    return name === autoVervName(groupName) ? null : name;
+}
+
+/**
+ * What the group's leader is actually called: its own title when set,
+ * otherwise whatever the linked verv calls them. Null means «Leder».
+ */
+export async function readLeaderTitle(
+    ctx: AppContext,
+    group: { slug: string; name: string; leaderTitle: string | null },
+): Promise<string | null> {
+    if (group.leaderTitle) return group.leaderTitle;
+
+    const position = await getLinkedLeaderPosition(ctx, group.slug);
+    if (!position || !mirrors(position)) return null;
+
+    return titleFromVervName(position.name, group.name);
+}
+
+/**
+ * Write the group's title through to the linked verv. Clearing the title back
+ * to «Leder» puts the placeholder name back, so the verv never keeps a title
+ * the group has dropped.
+ */
+export async function mirrorTitleIntoLinkedPosition(
+    ctx: AppContext,
+    group: { slug: string; name: string },
+    title: string | null,
+): Promise<void> {
+    const position = await getLinkedLeaderPosition(ctx, group.slug);
+    if (!position || !mirrors(position)) return;
+
+    await ctx.db
+        .update(schema.groupPosition)
+        .set({ name: title ?? autoVervName(group.name) })
+        .where(eq(schema.groupPosition.id, position.id));
+}
+
+/**
+ * Write a linked verv's name through to the group it follows. The placeholder
+ * stores as null — the group is back to plain «Leder», not to a leader called
+ * «Leder av Beta».
+ */
+export async function mirrorTitleIntoLinkedGroup(
+    ctx: AppContext,
+    position: { scope: string; linkedGroupSlug: string | null },
+    name: string,
+): Promise<void> {
+    if (!mirrors(position) || !position.linkedGroupSlug) return;
+
+    const [group] = await ctx.db
+        .select({ name: schema.group.name })
+        .from(schema.group)
+        .where(eq(schema.group.slug, position.linkedGroupSlug))
+        .limit(1);
+    if (!group) return;
+
+    await ctx.db
+        .update(schema.group)
+        .set({ leaderTitle: titleFromVervName(name, group.name) })
+        .where(eq(schema.group.slug, position.linkedGroupSlug));
+}

--- a/apps/api/src/lib/group/linked-leader.ts
+++ b/apps/api/src/lib/group/linked-leader.ts
@@ -1,0 +1,185 @@
+/**
+ * The two halves of a subgroup leader's org-wide permissions, kept identical.
+ *
+ * Hovedstyret is AU plus the leaders of the subgroups, so «leder av Beta» and
+ * «Innovasjonsminister» are never two people — they are one person described
+ * twice. The permission model described them twice as well:
+ *
+ *  - `org_group.leader_global_permissions` on the subgroup, edited from the
+ *    subgroup's verv page, and
+ *  - the linked HS verv (`org_group_position.linked_group_slug = 'beta'`,
+ *    scope `global`), edited from HS's verv page.
+ *
+ * Both are read live by the permission checker, so the holder always had the
+ * union of the two — but the two lists were written independently and drifted
+ * badly. In production the linked verv held anything from `root`
+ * (Teknologiminister) to nothing at all (Kontorminister, Næringslivsminister),
+ * while every subgroup's leader list said roughly the same thing. Whichever
+ * page an admin happened to open decided what they believed the leader could
+ * do.
+ *
+ * These helpers make the two a mirror of one another: a write through either
+ * page lands in both rows, and a read through either page reports the union.
+ * Reporting the union is not a widening — the checker already grants it — it
+ * is the two pages finally agreeing on what is already true, and it settles
+ * existing drift on the next save without a data migration.
+ *
+ * Only the ORG-WIDE list is mirrored. `leaderPermissions` is scoped to the
+ * subgroup itself (`@group:beta`) and a verv has no way to express that scope
+ * — a verv with scope `group` grants within *its own* group, which for a
+ * linked verv is HS. Mirroring it would silently turn rights over Beta into
+ * rights over everything.
+ */
+
+import { schema } from "@photon/db";
+import { eq, inArray } from "drizzle-orm";
+import type { AppContext } from "~/lib/ctx";
+
+/**
+ * The verv that follows the leadership of `groupSlug`, in whichever group
+ * holds it (normally HS). Null when the subgroup has no linked verv yet.
+ */
+export async function getLinkedLeaderPosition(
+    ctx: AppContext,
+    groupSlug: string,
+) {
+    const [position] = await ctx.db
+        .select()
+        .from(schema.groupPosition)
+        .where(eq(schema.groupPosition.linkedGroupSlug, groupSlug))
+        .limit(1);
+    return position ?? null;
+}
+
+/** Union, order-preserving and duplicate-free. */
+function union(a: string[] | null, b: string[] | null): string[] {
+    return [...new Set([...(a ?? []), ...(b ?? [])])];
+}
+
+/**
+ * A linked verv only mirrors while it is org-wide. A `group`-scoped verv
+ * grants inside HS, which is a different claim entirely, so leave it alone
+ * rather than quietly promoting it.
+ */
+function mirrors(position: { scope: string; linkedGroupSlug: string | null }) {
+    return position.linkedGroupSlug !== null && position.scope === "global";
+}
+
+/**
+ * What the subgroup's leader actually holds org-wide: the stored list plus
+ * whatever the linked verv adds. Both are live grants, so this is the honest
+ * answer to "what can the leader of this group do across TIHLDE".
+ */
+export async function readLeaderGlobalPermissions(
+    ctx: AppContext,
+    groupSlug: string,
+    stored: string[] | null,
+): Promise<string[]> {
+    const position = await getLinkedLeaderPosition(ctx, groupSlug);
+    if (!position || !mirrors(position)) return stored ?? [];
+    return union(stored, position.permissions);
+}
+
+/**
+ * Same, for a verv being rendered on the HS side: the verv's own list plus
+ * what the subgroup it follows grants its leader.
+ */
+export async function readLinkedPositionPermissions(
+    ctx: AppContext,
+    position: {
+        permissions: string[] | null;
+        scope: string;
+        linkedGroupSlug: string | null;
+    },
+): Promise<string[]> {
+    if (!mirrors(position) || !position.linkedGroupSlug) {
+        return position.permissions ?? [];
+    }
+    const [group] = await ctx.db
+        .select({ permissions: schema.group.leaderGlobalPermissions })
+        .from(schema.group)
+        .where(eq(schema.group.slug, position.linkedGroupSlug))
+        .limit(1);
+    return union(position.permissions, group?.permissions ?? []);
+}
+
+/**
+ * Write the subgroup half of the mirror. Called after the leader-permissions
+ * route has stored the group's own list.
+ */
+export async function mirrorIntoLinkedPosition(
+    ctx: AppContext,
+    groupSlug: string,
+    permissions: string[],
+): Promise<void> {
+    const position = await getLinkedLeaderPosition(ctx, groupSlug);
+    if (!position || !mirrors(position)) return;
+
+    await ctx.db
+        .update(schema.groupPosition)
+        .set({ permissions })
+        .where(eq(schema.groupPosition.id, position.id));
+}
+
+/**
+ * Write the HS half of the mirror. Called after a linked verv's permissions
+ * have been stored, so the subgroup's leader list says the same thing.
+ */
+export async function mirrorIntoLinkedGroup(
+    ctx: AppContext,
+    position: { scope: string; linkedGroupSlug: string | null },
+    permissions: string[],
+): Promise<void> {
+    if (!mirrors(position) || !position.linkedGroupSlug) return;
+
+    await ctx.db
+        .update(schema.group)
+        .set({ leaderGlobalPermissions: permissions })
+        .where(eq(schema.group.slug, position.linkedGroupSlug));
+}
+
+/**
+ * {@link readLinkedPositionPermissions} for a whole verv list, in one query.
+ *
+ * The group listing renders every verv at once and only a handful are linked,
+ * so this looks up the linked groups together rather than once per row.
+ * Returns the permissions to display, keyed by position id.
+ */
+export async function readLinkedPositionPermissionsBatch(
+    ctx: AppContext,
+    positions: Array<{
+        id: string;
+        permissions: string[] | null;
+        scope: string;
+        linkedGroupSlug: string | null;
+    }>,
+): Promise<Map<string, string[]>> {
+    const result = new Map<string, string[]>(
+        positions.map((p) => [p.id, p.permissions ?? []]),
+    );
+
+    const linked = positions.filter(mirrors);
+    if (linked.length === 0) return result;
+
+    const slugs = [...new Set(linked.map((p) => p.linkedGroupSlug as string))];
+    const groups = await ctx.db
+        .select({
+            slug: schema.group.slug,
+            permissions: schema.group.leaderGlobalPermissions,
+        })
+        .from(schema.group)
+        .where(inArray(schema.group.slug, slugs));
+
+    const bySlug = new Map(groups.map((g) => [g.slug, g.permissions]));
+    for (const position of linked) {
+        result.set(
+            position.id,
+            union(
+                position.permissions,
+                bySlug.get(position.linkedGroupSlug as string) ?? [],
+            ),
+        );
+    }
+
+    return result;
+}

--- a/apps/api/src/lib/group/linked-leader.ts
+++ b/apps/api/src/lib/group/linked-leader.ts
@@ -66,6 +66,54 @@ function mirrors(position: { scope: string; linkedGroupSlug: string | null }) {
 }
 
 /**
+ * What the linked HS verv already grants the leader of `groupSlug`. Empty
+ * when the subgroup has no linked verv, or the verv no longer mirrors.
+ *
+ * This is also the baseline the escalation guard measures against on the
+ * group's page: these permissions are already held by the very person the
+ * page is about, so re-saving them hands out nothing. Only what goes beyond
+ * this list is a new grant. Without that, showing the union would brick the
+ * page — an admin with `roles:create` but not `root` would open Index, be
+ * shown the `root` its linked verv holds, send it back untouched and be
+ * refused, taking the group-scoped half they may edit down with it.
+ */
+export async function permissionsFromLinkedPosition(
+    ctx: AppContext,
+    groupSlug: string,
+): Promise<string[]> {
+    const position = await getLinkedLeaderPosition(ctx, groupSlug);
+    if (!position || !mirrors(position)) return [];
+    return position.permissions ?? [];
+}
+
+/**
+ * The same baseline seen from HS's verv page: what the subgroup this verv
+ * follows already grants its leader.
+ */
+export async function permissionsFromLinkedGroup(
+    ctx: AppContext,
+    position: { scope: string; linkedGroupSlug: string | null },
+): Promise<string[]> {
+    if (!mirrors(position) || !position.linkedGroupSlug) return [];
+    const [group] = await ctx.db
+        .select({ permissions: schema.group.leaderGlobalPermissions })
+        .from(schema.group)
+        .where(eq(schema.group.slug, position.linkedGroupSlug))
+        .limit(1);
+    return group?.permissions ?? [];
+}
+
+/**
+ * The permissions in `next` that are genuinely new — the only ones the
+ * escalation guard has anything to say about. See
+ * {@link permissionsFromLinkedPosition} for why the rest are exempt.
+ */
+export function addedBeyond(next: string[], baseline: string[]): string[] {
+    const already = new Set(baseline);
+    return next.filter((p) => !already.has(p));
+}
+
+/**
  * What the subgroup's leader actually holds org-wide: the stored list plus
  * whatever the linked verv adds. Both are live grants, so this is the honest
  * answer to "what can the leader of this group do across TIHLDE".
@@ -75,9 +123,7 @@ export async function readLeaderGlobalPermissions(
     groupSlug: string,
     stored: string[] | null,
 ): Promise<string[]> {
-    const position = await getLinkedLeaderPosition(ctx, groupSlug);
-    if (!position || !mirrors(position)) return stored ?? [];
-    return union(stored, position.permissions);
+    return union(stored, await permissionsFromLinkedPosition(ctx, groupSlug));
 }
 
 /**
@@ -92,15 +138,10 @@ export async function readLinkedPositionPermissions(
         linkedGroupSlug: string | null;
     },
 ): Promise<string[]> {
-    if (!mirrors(position) || !position.linkedGroupSlug) {
-        return position.permissions ?? [];
-    }
-    const [group] = await ctx.db
-        .select({ permissions: schema.group.leaderGlobalPermissions })
-        .from(schema.group)
-        .where(eq(schema.group.slug, position.linkedGroupSlug))
-        .limit(1);
-    return union(position.permissions, group?.permissions ?? []);
+    return union(
+        position.permissions,
+        await permissionsFromLinkedGroup(ctx, position),
+    );
 }
 
 /**

--- a/apps/api/src/routes/groups/get.ts
+++ b/apps/api/src/routes/groups/get.ts
@@ -1,5 +1,6 @@
 import { HTTPException } from "hono/http-exception";
 import { assertGroupVisible } from "~/lib/group";
+import { readLeaderTitle } from "~/lib/group/linked-leader";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { captureAuth } from "~/middleware/auth";
@@ -73,6 +74,18 @@ export const getRoute = route().get(
             (await wasEverGroupMember(ctx, userId, group.slug)),
         );
 
-        return c.json({ ...group, viewerCanUseFines, viewerCanSeeOwnFines });
+        /**
+         * What this group calls its leader. Reconciled with the linked HS
+         * verv, so a subgroup whose leader is «Innovasjonsminister» in
+         * Hovedstyret is not «Leder» on its own page.
+         */
+        const leaderTitle = await readLeaderTitle(ctx, group);
+
+        return c.json({
+            ...group,
+            leaderTitle,
+            viewerCanUseFines,
+            viewerCanSeeOwnFines,
+        });
     },
 );

--- a/apps/api/src/routes/groups/positions/leader-permissions.ts
+++ b/apps/api/src/routes/groups/positions/leader-permissions.ts
@@ -29,8 +29,10 @@ import { HTTPException } from "hono/http-exception";
 import {
     addedBeyond,
     mirrorIntoLinkedPosition,
+    mirrorTitleIntoLinkedPosition,
     permissionsFromLinkedPosition,
     readLeaderGlobalPermissions,
+    readLeaderTitle,
 } from "~/lib/group/linked-leader";
 import {
     canGrantPositionPermissions,
@@ -70,6 +72,7 @@ export const getLeaderPermissionsRoute = route().get(
 
         const [group] = await ctx.db
             .select({
+                name: schema.group.name,
                 permissions: schema.group.leaderPermissions,
                 globalPermissions: schema.group.leaderGlobalPermissions,
                 title: schema.group.leaderTitle,
@@ -99,10 +102,16 @@ export const getLeaderPermissionsRoute = route().get(
             group.globalPermissions,
         );
 
+        const title = await readLeaderTitle(ctx, {
+            slug: groupSlug,
+            name: group.name,
+            leaderTitle: group.title,
+        });
+
         return c.json({
             permissions: knownPermissions(group.permissions),
             globalPermissions: knownPermissions(globalPermissions),
-            title: group.title,
+            title,
         });
     },
 );
@@ -136,7 +145,7 @@ export const updateLeaderPermissionsRoute = route().patch(
         const body = c.req.valid("json");
 
         const [group] = await ctx.db
-            .select({ slug: schema.group.slug })
+            .select({ slug: schema.group.slug, name: schema.group.name })
             .from(schema.group)
             .where(eq(schema.group.slug, groupSlug))
             .limit(1);
@@ -229,6 +238,15 @@ export const updateLeaderPermissionsRoute = route().patch(
                 ctx,
                 groupSlug,
                 body.globalPermissions,
+            );
+        }
+
+        // The title travels with them: one person, one name on both pages.
+        if (body.title !== undefined) {
+            await mirrorTitleIntoLinkedPosition(
+                ctx,
+                group,
+                body.title?.trim() || null,
             );
         }
 

--- a/apps/api/src/routes/groups/positions/leader-permissions.ts
+++ b/apps/api/src/routes/groups/positions/leader-permissions.ts
@@ -27,6 +27,10 @@ import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import {
+    mirrorIntoLinkedPosition,
+    readLeaderGlobalPermissions,
+} from "~/lib/group/linked-leader";
+import {
     canGrantPositionPermissions,
     canManagePositions,
     knownPermissions,
@@ -84,9 +88,18 @@ export const getLeaderPermissionsRoute = route().get(
             });
         }
 
+        // A subgroup's leader is also the holder of the linked HS verv, and
+        // both grants are live. Reporting their union is what makes this page
+        // and HS's verv page say the same thing about the same person.
+        const globalPermissions = await readLeaderGlobalPermissions(
+            ctx,
+            groupSlug,
+            group.globalPermissions,
+        );
+
         return c.json({
             permissions: knownPermissions(group.permissions),
-            globalPermissions: knownPermissions(group.globalPermissions),
+            globalPermissions: knownPermissions(globalPermissions),
             title: group.title,
         });
     },
@@ -194,6 +207,16 @@ export const updateLeaderPermissionsRoute = route().patch(
                 globalPermissions: schema.group.leaderGlobalPermissions,
                 title: schema.group.leaderTitle,
             });
+
+        // Keep the linked HS verv identical, so editing the leader here and
+        // editing «Innovasjonsminister» in HS cannot disagree.
+        if (body.globalPermissions !== undefined) {
+            await mirrorIntoLinkedPosition(
+                ctx,
+                groupSlug,
+                body.globalPermissions,
+            );
+        }
 
         return c.json({
             permissions: updated?.permissions ?? [],

--- a/apps/api/src/routes/groups/positions/leader-permissions.ts
+++ b/apps/api/src/routes/groups/positions/leader-permissions.ts
@@ -27,7 +27,9 @@ import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import {
+    addedBeyond,
     mirrorIntoLinkedPosition,
+    permissionsFromLinkedPosition,
     readLeaderGlobalPermissions,
 } from "~/lib/group/linked-leader";
 import {
@@ -171,20 +173,32 @@ export const updateLeaderPermissionsRoute = route().patch(
         // The org-wide list is checked globally, so holding a permission for
         // this group is not enough to hand it out for every other one. A group
         // leader holds nothing globally and is stopped here.
-        if (
-            body.globalPermissions !== undefined &&
-            !(await canGrantPositionPermissions(
-                ctx,
-                user.id,
-                groupSlug,
+        //
+        // Measured against what the linked HS verv already grants this same
+        // leader: this page shows the union of the two halves, so a save that
+        // leaves the verv's half untouched must not be read as handing it out
+        // afresh. Only what goes beyond it is a new grant.
+        if (body.globalPermissions !== undefined) {
+            const added = addedBeyond(
                 body.globalPermissions,
-                "global",
-            ))
-        ) {
-            throw new HTTPException(403, {
-                message:
-                    "You can only grant permissions you hold yourself across all of TIHLDE",
-            });
+                await permissionsFromLinkedPosition(ctx, groupSlug),
+            );
+
+            if (
+                added.length > 0 &&
+                !(await canGrantPositionPermissions(
+                    ctx,
+                    user.id,
+                    groupSlug,
+                    added,
+                    "global",
+                ))
+            ) {
+                throw new HTTPException(403, {
+                    message:
+                        "You can only grant permissions you hold yourself across all of TIHLDE",
+                });
+            }
         }
 
         const [updated] = await ctx.db

--- a/apps/api/src/routes/groups/positions/list.ts
+++ b/apps/api/src/routes/groups/positions/list.ts
@@ -2,6 +2,7 @@ import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import { assertGroupVisible } from "~/lib/group";
+import { readLinkedPositionPermissionsBatch } from "~/lib/group/linked-leader";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
@@ -60,13 +61,22 @@ export const listPositionsRoute = route().get(
             orderBy: (position, { asc }) => [asc(position.name)],
         });
 
+        // A verv linked to a subgroup shares its grant with that subgroup's
+        // org-wide leader permissions, so show the two as the one set they
+        // effectively are (see lib/group/linked-leader.ts).
+        const permissionsById = await readLinkedPositionPermissionsBatch(
+            ctx,
+            positions,
+        );
+
         return c.json(
             positions.map((position) => ({
                 id: position.id,
                 groupSlug: position.groupSlug,
                 name: position.name,
                 description: position.description,
-                permissions: position.permissions,
+                permissions:
+                    permissionsById.get(position.id) ?? position.permissions,
                 scope: position.scope,
                 linkedGroupSlug: position.linkedGroupSlug,
                 holder: position.holder

--- a/apps/api/src/routes/groups/positions/update.ts
+++ b/apps/api/src/routes/groups/positions/update.ts
@@ -3,6 +3,10 @@ import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import {
+    mirrorIntoLinkedGroup,
+    readLinkedPositionPermissions,
+} from "~/lib/group/linked-leader";
+import {
     canGrantPositionPermissions,
     canManagePositions,
     getPosition,
@@ -95,6 +99,13 @@ export const updatePositionRoute = route().patch(
             .where(eq(schema.groupPosition.id, positionId))
             .returning();
 
+        // A verv linked to a subgroup is the same grant as that subgroup's
+        // org-wide leader permissions (see lib/group/linked-leader.ts) —
+        // write both halves so the two admin pages stay in step.
+        if (body.permissions !== undefined && updated) {
+            await mirrorIntoLinkedGroup(ctx, updated, body.permissions);
+        }
+
         const holder = await db.query.groupPositionHolder.findFirst({
             where: eq(schema.groupPositionHolder.positionId, positionId),
             with: {
@@ -104,6 +115,9 @@ export const updatePositionRoute = route().patch(
 
         return c.json({
             ...updated,
+            permissions: updated
+                ? await readLinkedPositionPermissions(ctx, updated)
+                : [],
             holder: holder
                 ? {
                       userId: holder.user.id,

--- a/apps/api/src/routes/groups/positions/update.ts
+++ b/apps/api/src/routes/groups/positions/update.ts
@@ -3,7 +3,9 @@ import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import {
+    addedBeyond,
     mirrorIntoLinkedGroup,
+    permissionsFromLinkedGroup,
     readLinkedPositionPermissions,
 } from "~/lib/group/linked-leader";
 import {
@@ -65,16 +67,42 @@ export const updatePositionRoute = route().patch(
             });
         }
 
-        // Permission/scope changes re-run the grant guardrail on the FULL
-        // resulting permission list at the resulting scope.
+        // A linked verv only mirrors the subgroup's leader list while it is
+        // org-wide — scoped to "group" it would grant inside HS instead, which
+        // is a different claim about a different set of people. Rejected
+        // rather than silently letting the two halves drift apart again.
+        if (
+            position.linkedGroupSlug !== null &&
+            body.scope !== undefined &&
+            body.scope !== position.scope
+        ) {
+            throw new HTTPException(409, {
+                message:
+                    "A verv linked to a subgroup follows that group's leader across all of TIHLDE and cannot change scope",
+            });
+        }
+
+        // Permission/scope changes re-run the grant guardrail on the resulting
+        // permission list at the resulting scope.
+        //
+        // For a linked verv, what the subgroup's leader list already grants is
+        // exempt: this page shows the union of the two halves (see
+        // lib/group/linked-leader.ts), so leaving the other half untouched is
+        // not the same as handing it out. Only genuinely new permissions are
+        // measured — everything else is already held by this very holder.
         const nextPermissions = body.permissions ?? position.permissions;
         const nextScope = body.scope ?? position.scope;
+        const added = addedBeyond(
+            nextPermissions,
+            await permissionsFromLinkedGroup(ctx, position),
+        );
         if (
+            added.length > 0 &&
             !(await canGrantPositionPermissions(
                 ctx,
                 user.id,
                 groupSlug,
-                nextPermissions,
+                added,
                 nextScope,
             ))
         ) {

--- a/apps/api/src/routes/groups/positions/update.ts
+++ b/apps/api/src/routes/groups/positions/update.ts
@@ -5,6 +5,7 @@ import { HTTPException } from "hono/http-exception";
 import {
     addedBeyond,
     mirrorIntoLinkedGroup,
+    mirrorTitleIntoLinkedGroup,
     permissionsFromLinkedGroup,
     readLinkedPositionPermissions,
 } from "~/lib/group/linked-leader";
@@ -132,6 +133,12 @@ export const updatePositionRoute = route().patch(
         // write both halves so the two admin pages stay in step.
         if (body.permissions !== undefined && updated) {
             await mirrorIntoLinkedGroup(ctx, updated, body.permissions);
+        }
+
+        // Renaming «Innovasjonsminister» renames the leader of Beta — they are
+        // the same person, and the two pages should not call them two things.
+        if (body.name !== undefined && updated) {
+            await mirrorTitleIntoLinkedGroup(ctx, updated, body.name);
         }
 
         const holder = await db.query.groupPositionHolder.findFirst({

--- a/apps/api/src/routes/groups/schema.ts
+++ b/apps/api/src/routes/groups/schema.ts
@@ -184,6 +184,10 @@ export const groupSchema = Schema(
 export const groupDetailSchema = Schema(
     "GroupDetail",
     groupSchema.extend({
+        leaderTitle: z.string().nullable().meta({
+            description:
+                "What this group calls its leader, e.g. «President» or «Innovasjonsminister». Reconciled with the linked Hovedstyret verv, so both pages name the leader the same. Null means the plain «Leder».",
+        }),
         viewerCanUseFines: z.boolean().meta({
             description:
                 "Whether the authenticated caller may see and give fines in this group. False when fines are off, when signed out, or when the caller is a study-group member who is no longer an enrolled student.",

--- a/apps/api/src/test/groups/linked-leader-parity.test.ts
+++ b/apps/api/src/test/groups/linked-leader-parity.test.ts
@@ -360,4 +360,191 @@ describe("subgroup leader / linked HS verv parity", () => {
         },
         500_000,
     );
+
+    /**
+     * The title is the same field one over: the group's `leaderTitle` and the
+     * linked verv's name both say what the person is called. Production had
+     * every subgroup at NULL — «Leder» on its own page, «Innovasjonsminister»
+     * in HS, for one and the same person.
+     */
+    describe("the title", () => {
+        integrationTest(
+            "the group's page reports the verv's title instead of plain «Leder»",
+            async ({ ctx }) => {
+                const { client, subgroup, position } = await setupWithEditor(
+                    ctx,
+                    "Tittelgruppen",
+                );
+
+                // Exactly the production shape: a real title on the verv, and
+                // nothing on the group.
+                await ctx.db
+                    .update(schema.groupPosition)
+                    .set({ name: "Innovasjonsminister" })
+                    .where(eq(schema.groupPosition.id, position!.id));
+
+                const read = await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$get({ param: { groupSlug: subgroup.slug } });
+                expect((await read.json()).title).toBe("Innovasjonsminister");
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "the auto-created placeholder is not mistaken for a title",
+            async ({ ctx }) => {
+                const { client, subgroup } = await setupWithEditor(
+                    ctx,
+                    "Vanliggruppen",
+                );
+
+                // The verv is still «Leder av Vanliggruppen» — a placeholder,
+                // so the leader is plain «Leder», not «Leder av Vanliggruppen».
+                const read = await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$get({ param: { groupSlug: subgroup.slug } });
+                expect((await read.json()).title).toBeNull();
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "naming the leader on the group's page renames the verv",
+            async ({ ctx }) => {
+                const { client, subgroup, position } = await setupWithEditor(
+                    ctx,
+                    "Navngruppen",
+                );
+
+                const write = await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$patch({
+                    param: { groupSlug: subgroup.slug },
+                    json: { permissions: [], title: "Kulturminister" },
+                });
+                expect(write.status).toBe(200);
+
+                const after = await ctx.db.query.groupPosition.findFirst({
+                    where: eq(schema.groupPosition.id, position!.id),
+                });
+                expect(after?.name).toBe("Kulturminister");
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "renaming the verv names the group's leader",
+            async ({ ctx }) => {
+                const { client, subgroup, position } = await setupWithEditor(
+                    ctx,
+                    "Vervnavn",
+                );
+
+                const write = await client.api.groups[":groupSlug"].positions[
+                    ":positionId"
+                ].$patch({
+                    param: { groupSlug: "hs", positionId: position!.id },
+                    json: { name: "Innovasjonsminister" },
+                });
+                expect(write.status).toBe(200);
+
+                const [group] = await ctx.db
+                    .select({ title: schema.group.leaderTitle })
+                    .from(schema.group)
+                    .where(eq(schema.group.slug, subgroup.slug));
+                expect(group?.title).toBe("Innovasjonsminister");
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "clearing the title puts the placeholder back, not «Leder av»",
+            async ({ ctx }) => {
+                const { client, subgroup, position } = await setupWithEditor(
+                    ctx,
+                    "Tømgruppen",
+                );
+
+                await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$patch({
+                    param: { groupSlug: subgroup.slug },
+                    json: { permissions: [], title: "Kulturminister" },
+                });
+
+                await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$patch({
+                    param: { groupSlug: subgroup.slug },
+                    json: { permissions: [], title: null },
+                });
+
+                const after = await ctx.db.query.groupPosition.findFirst({
+                    where: eq(schema.groupPosition.id, position!.id),
+                });
+                expect(after?.name).toBe("Leder av Tømgruppen");
+
+                // And the group is back to plain «Leder».
+                const read = await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$get({ param: { groupSlug: subgroup.slug } });
+                expect((await read.json()).title).toBeNull();
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "the group's own page names the leader by the verv's title",
+            async ({ ctx }) => {
+                const { subgroup, position } = await setupWithEditor(
+                    ctx,
+                    "Forsidegruppen",
+                );
+                const viewer = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(viewer);
+
+                await ctx.db
+                    .update(schema.groupPosition)
+                    .set({ name: "Innovasjonsminister" })
+                    .where(eq(schema.groupPosition.id, position!.id));
+
+                const response = await client.api.groups[":slug"].$get({
+                    param: { slug: subgroup.slug },
+                });
+                expect(response.status).toBe(200);
+                expect((await response.json()).leaderTitle).toBe(
+                    "Innovasjonsminister",
+                );
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "a verv created for a new leader takes the group's title",
+            async ({ ctx }) => {
+                const leader = await ctx.utils.createTestUser();
+                await ctx.utils.createTestGroup({
+                    slug: "hs",
+                    name: "Hovedstyret",
+                    type: "board",
+                });
+                const subgroup = await ctx.utils.createTestGroup({
+                    type: "subgroup",
+                    name: "Arvegruppen",
+                });
+
+                await ctx.db
+                    .update(schema.group)
+                    .set({ leaderTitle: "Kulturminister" })
+                    .where(eq(schema.group.slug, subgroup.slug));
+
+                await addUserToGroup(ctx, leader.id, subgroup.slug, "leader");
+
+                const position = await linkedPosition(ctx, subgroup.slug);
+                expect(position?.name).toBe("Kulturminister");
+            },
+            500_000,
+        );
+    });
 });

--- a/apps/api/src/test/groups/linked-leader-parity.test.ts
+++ b/apps/api/src/test/groups/linked-leader-parity.test.ts
@@ -59,6 +59,20 @@ async function setup(ctx: IntegrationTestContext, name: string) {
     return { leader, client, subgroup };
 }
 
+/**
+ * {@link setup} with an editor who may grant org-wide (`roles:create`) but
+ * does not hold `root` — the case where showing the union could otherwise
+ * lock them out of saving.
+ */
+async function setupWithEditor(ctx: IntegrationTestContext, name: string) {
+    const { subgroup } = await setup(ctx, name);
+    const editor = await ctx.utils.createTestUser();
+    await ctx.utils.giveUserPermissions(editor, ["roles:create"]);
+    const client = await ctx.utils.clientForUser(editor);
+    const position = await linkedPosition(ctx, subgroup.slug);
+    return { client, subgroup, position };
+}
+
 describe("subgroup leader / linked HS verv parity", () => {
     integrationTest(
         "editing the subgroup's leader list writes the linked verv too",
@@ -226,6 +240,123 @@ describe("subgroup leader / linked HS verv parity", () => {
                 .from(schema.group)
                 .where(eq(schema.group.slug, group.slug));
             expect(row?.globalPermissions).toEqual([]);
+        },
+        500_000,
+    );
+
+    /**
+     * Showing the union must not cost anyone the ability to save. The two
+     * halves grant the same person, so echoing the other half back unchanged
+     * hands out nothing — but a naive guard reads it as a fresh grant and
+     * refuses, taking the half the editor may legitimately edit with it. In
+     * production this bites immediately: Index's linked verv holds `root`.
+     */
+    describe("saving without holding the other half", () => {
+        integrationTest(
+            "the group's page saves when the verv grants what the editor lacks",
+            async ({ ctx }) => {
+                const { client, subgroup, position } = await setupWithEditor(
+                    ctx,
+                    "Rotgruppen",
+                );
+
+                await ctx.db
+                    .update(schema.groupPosition)
+                    .set({ permissions: ["root"] })
+                    .where(eq(schema.groupPosition.id, position!.id));
+
+                const read = await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$get({ param: { groupSlug: subgroup.slug } });
+                const shown = (await read.json()).globalPermissions;
+                expect(shown).toEqual(["root"]);
+
+                // The admin UI sends the list it was shown straight back.
+                const write = await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$patch({
+                    param: { groupSlug: subgroup.slug },
+                    json: { permissions: [], globalPermissions: shown },
+                });
+                expect(write.status).toBe(200);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "HS's verv page saves when the group grants what the editor lacks",
+            async ({ ctx }) => {
+                const { client, subgroup, position } = await setupWithEditor(
+                    ctx,
+                    "Speilrot",
+                );
+
+                await ctx.db
+                    .update(schema.group)
+                    .set({ leaderGlobalPermissions: ["root"] })
+                    .where(eq(schema.group.slug, subgroup.slug));
+
+                const write = await client.api.groups[":groupSlug"].positions[
+                    ":positionId"
+                ].$patch({
+                    param: { groupSlug: "hs", positionId: position!.id },
+                    json: { permissions: ["root"] },
+                });
+                expect(write.status).toBe(200);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "but a genuinely new permission is still refused",
+            async ({ ctx }) => {
+                const { client, subgroup, position } = await setupWithEditor(
+                    ctx,
+                    "Nyrot",
+                );
+
+                await ctx.db
+                    .update(schema.groupPosition)
+                    .set({ permissions: ["root"] })
+                    .where(eq(schema.groupPosition.id, position!.id));
+
+                const write = await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$patch({
+                    param: { groupSlug: subgroup.slug },
+                    json: {
+                        permissions: [],
+                        // "root" is already granted by the verv; the refund
+                        // right is not, and the editor does not hold it.
+                        globalPermissions: ["root", "events:payments:refund"],
+                    },
+                });
+                expect(write.status).toBe(403);
+            },
+            500_000,
+        );
+    });
+
+    integrationTest(
+        "a linked verv cannot be moved off org-wide scope",
+        async ({ ctx }) => {
+            const { subgroup } = await setup(ctx, "Scopegruppen");
+            const position = await linkedPosition(ctx, subgroup.slug);
+
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["root"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            const response = await client.api.groups[":groupSlug"].positions[
+                ":positionId"
+            ].$patch({
+                param: { groupSlug: "hs", positionId: position!.id },
+                json: { scope: "group" },
+            });
+            expect(response.status).toBe(409);
+
+            const after = await linkedPosition(ctx, subgroup.slug);
+            expect(after?.scope).toBe("global");
         },
         500_000,
     );

--- a/apps/api/src/test/groups/linked-leader-parity.test.ts
+++ b/apps/api/src/test/groups/linked-leader-parity.test.ts
@@ -1,0 +1,232 @@
+import { getUserPermissions } from "@photon/auth/rbac";
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { addUserToGroup } from "~/lib/group";
+import {
+    type IntegrationTestContext,
+    integrationTest,
+} from "~/test/config/integration";
+
+/**
+ * «Leder av Beta» and «Innovasjonsminister» are never two people — HS is AU
+ * plus the leaders of the subgroups, so the linked verv and the subgroup's
+ * org-wide leader permissions describe one person twice.
+ *
+ * They used to be two lists written from two admin pages with nothing keeping
+ * them together, and in production they had drifted a long way apart: one
+ * linked verv held `root`, two held nothing at all. Whichever page an admin
+ * opened decided what they believed the leader could do.
+ *
+ * These tests pin the mirror: a write through either page lands in both rows,
+ * and a read through either page reports the same set.
+ */
+
+/** The linked verv HS holds for `subgroupSlug`. */
+async function linkedPosition(
+    ctx: IntegrationTestContext,
+    subgroupSlug: string,
+) {
+    const [position] = await ctx.db
+        .select()
+        .from(schema.groupPosition)
+        .where(eq(schema.groupPosition.linkedGroupSlug, subgroupSlug));
+    return position;
+}
+
+/**
+ * A subgroup with a leader, which auto-creates the linked verv in HS, plus an
+ * admin holding root to drive both admin pages.
+ */
+async function setup(ctx: IntegrationTestContext, name: string) {
+    const leader = await ctx.utils.createTestUser();
+    const admin = await ctx.utils.createTestUser();
+    await ctx.utils.giveUserPermissions(admin, ["root"]);
+    const client = await ctx.utils.clientForUser(admin);
+
+    await ctx.utils.createTestGroup({
+        slug: "hs",
+        name: "Hovedstyret",
+        type: "board",
+    });
+    const subgroup = await ctx.utils.createTestGroup({
+        type: "subgroup",
+        name,
+    });
+
+    await addUserToGroup(ctx, leader.id, subgroup.slug, "leader");
+
+    return { leader, client, subgroup };
+}
+
+describe("subgroup leader / linked HS verv parity", () => {
+    integrationTest(
+        "editing the subgroup's leader list writes the linked verv too",
+        async ({ ctx }) => {
+            const { client, subgroup } = await setup(ctx, "Speilgruppen");
+
+            const response = await client.api.groups[":groupSlug"][
+                "leader-permissions"
+            ].$patch({
+                param: { groupSlug: subgroup.slug },
+                json: {
+                    permissions: [],
+                    globalPermissions: ["news:manage"],
+                },
+            });
+            expect(response.status).toBe(200);
+
+            const position = await linkedPosition(ctx, subgroup.slug);
+            expect(position?.permissions).toEqual(["news:manage"]);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "editing the linked verv writes the subgroup's leader list too",
+        async ({ ctx }) => {
+            const { client, subgroup } = await setup(ctx, "Vervgruppen");
+            const position = await linkedPosition(ctx, subgroup.slug);
+
+            const response = await client.api.groups[":groupSlug"].positions[
+                ":positionId"
+            ].$patch({
+                param: { groupSlug: "hs", positionId: position!.id },
+                json: { permissions: ["news:manage"] },
+            });
+            expect(response.status).toBe(200);
+
+            const [group] = await ctx.db
+                .select({
+                    globalPermissions: schema.group.leaderGlobalPermissions,
+                })
+                .from(schema.group)
+                .where(eq(schema.group.slug, subgroup.slug));
+            expect(group?.globalPermissions).toEqual(["news:manage"]);
+        },
+        500_000,
+    );
+
+    /**
+     * Existing rows are already out of step and this ships without a data
+     * migration, so both pages have to agree on what is true before anyone
+     * saves anything. They can, because the checker grants the union of the
+     * two — reporting it is accuracy, not a widening.
+     */
+    integrationTest(
+        "both pages report the union while the two rows still disagree",
+        async ({ ctx }) => {
+            const { client, subgroup } = await setup(ctx, "Driftgruppen");
+            const position = await linkedPosition(ctx, subgroup.slug);
+
+            // Drift, written straight to the rows as the old code left them.
+            await ctx.db
+                .update(schema.group)
+                .set({ leaderGlobalPermissions: ["news:manage"] })
+                .where(eq(schema.group.slug, subgroup.slug));
+            await ctx.db
+                .update(schema.groupPosition)
+                .set({ permissions: ["jobs:manage"] })
+                .where(eq(schema.groupPosition.id, position!.id));
+
+            const fromGroup = await client.api.groups[":groupSlug"][
+                "leader-permissions"
+            ].$get({ param: { groupSlug: subgroup.slug } });
+            expect(fromGroup.status).toBe(200);
+            expect((await fromGroup.json()).globalPermissions.sort()).toEqual([
+                "jobs:manage",
+                "news:manage",
+            ]);
+
+            const fromHs = await client.api.groups[":groupSlug"].positions.$get(
+                { param: { groupSlug: "hs" } },
+            );
+            expect(fromHs.status).toBe(200);
+            const verv = (await fromHs.json()).find(
+                (p: { id: string }) => p.id === position!.id,
+            );
+            expect(verv?.permissions.sort()).toEqual([
+                "jobs:manage",
+                "news:manage",
+            ]);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "a verv created for a new leader starts out agreeing with the group",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            await ctx.utils.createTestGroup({
+                slug: "hs",
+                name: "Hovedstyret",
+                type: "board",
+            });
+            const subgroup = await ctx.utils.createTestGroup({
+                type: "subgroup",
+                name: "Nygruppen",
+            });
+
+            // The group's leader list is set before anyone leads it.
+            await ctx.db
+                .update(schema.group)
+                .set({ leaderGlobalPermissions: ["news:manage"] })
+                .where(eq(schema.group.slug, subgroup.slug));
+
+            await addUserToGroup(ctx, leader.id, subgroup.slug, "leader");
+
+            const position = await linkedPosition(ctx, subgroup.slug);
+            expect(position?.permissions).toEqual(["news:manage"]);
+
+            // And the holder really has it, from one source or the other.
+            expect(await getUserPermissions(ctx, leader.id)).toContain(
+                "news:manage",
+            );
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "an unlinked verv is left alone",
+        async ({ ctx }) => {
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["root"]);
+            const client = await ctx.utils.clientForUser(admin);
+            const group = await ctx.utils.createTestGroup();
+
+            const created = await client.api.groups[":groupSlug"].positions[
+                "$post"
+            ]({
+                param: { groupSlug: group.slug },
+                json: {
+                    name: "Økonomiansvarlig",
+                    permissions: ["news:manage"],
+                    scope: "group",
+                },
+            });
+            expect(created.status).toBe(201);
+            const position = await created.json();
+
+            const response = await client.api.groups[":groupSlug"].positions[
+                ":positionId"
+            ].$patch({
+                param: { groupSlug: group.slug, positionId: position.id },
+                json: { permissions: ["jobs:manage"] },
+            });
+            expect(response.status).toBe(200);
+            expect((await response.json()).permissions).toEqual([
+                "jobs:manage",
+            ]);
+
+            // Nothing leaked into the group's leader list.
+            const [row] = await ctx.db
+                .select({
+                    globalPermissions: schema.group.leaderGlobalPermissions,
+                })
+                .from(schema.group)
+                .where(eq(schema.group.slug, group.slug));
+            expect(row?.globalPermissions).toEqual([]);
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/components/group-detail-header.tsx
+++ b/apps/kvark/src/components/group-detail-header.tsx
@@ -75,7 +75,9 @@ export function GroupDetailHeader({
                             className="hidden gap-1.5 md:flex"
                         >
                             <Crown />
-                            <span className="font-medium">Leder</span>
+                            <span className="font-medium">
+                                {group.leaderTitle ?? "Leder"}
+                            </span>
                             <span className="text-muted-foreground">·</span>
                             {group.leader}
                         </Badge>

--- a/apps/kvark/src/lib/group.ts
+++ b/apps/kvark/src/lib/group.ts
@@ -1,5 +1,5 @@
 import type {
-    Group as ApiGroup,
+    GroupDetail as ApiGroup,
     GroupMember as ApiGroupMember,
     GroupFormerMember as ApiGroupFormerMember,
     Fine as ApiFine,
@@ -26,6 +26,8 @@ export type Group = {
     /** Underkategori under `type`. I dag bare for interessegrupper. */
     subtype?: string | null;
     leader?: string;
+    /** Hva gruppa kaller lederen sin. Null/undefined gir «Leder». */
+    leaderTitle?: string | null;
     finesInfo?: string;
     finesActivated?: boolean;
     /** Botsjefen. Null når gruppen ikke har utpekt noen. */
@@ -308,6 +310,7 @@ export function mapGroup(group: ApiGroup, leader?: string): Group {
         type: group.type,
         subtype: group.subtype ?? null,
         leader,
+        leaderTitle: group.leaderTitle,
         finesInfo: group.finesInfo,
         finesActivated: group.finesActivated,
         finesAdminId: group.finesAdminId ?? null,

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -4942,6 +4942,8 @@ export interface components {
             createdAt: string;
             /** @description Last update timestamp */
             updatedAt: string;
+            /** @description What this group calls its leader, e.g. «President» or «Innovasjonsminister». Reconciled with the linked Hovedstyret verv, so both pages name the leader the same. Null means the plain «Leder». */
+            leaderTitle: string | null;
             /** @description Whether the authenticated caller may see and give fines in this group. False when fines are off, when signed out, or when the caller is a study-group member who is no longer an enrolled student. */
             viewerCanUseFines: boolean;
             /** @description Whether the caller may read the fines they are party to here without taking part in the group's fine system: true for someone who has left the group but was once a member. Never true together with 'viewerCanUseFines'. */


### PR DESCRIPTION
## Problemet

Hovedstyret er AU pluss lederne for undergruppene, så «leder av Beta» og «Innovasjonsminister» er aldri to personer. Tilgangene deres ble likevel beskrevet to steder som ingenting holdt i sync:

| Rad | Redigeres fra | Scope |
|---|---|---|
| `org_group.leader_global_permissions` på undergruppa | Undergruppas verv-side | globalt |
| Det koblede HS-vervet (`org_group_position.linked_group_slug`) | HS sin verv-side | globalt |

Begge tildeles automatisk til den som til enhver tid leder undergruppa (`syncSubgroupLeaderIntoHs`), så de beskriver alltid én og samme person. Begge er live grants, så innehaveren har alltid hatt unionen — men listene ble skrevet uavhengig av hverandre og hadde drevet langt fra hverandre.

I produksjon i dag:

| Verv | permissions |
|---|---|
| Teknologiminister (index) | `root` |
| Innovasjonsminister (beta) | 20 |
| Promoteringsminister (promo) | 12 |
| Sosialminister (sosialen) | 2 |
| Kontorminister (kok) | **tom** |
| Næringslivsminister (nok) | **tom** |

Hvilken av de to sidene en administrator åpnet avgjorde hva hen trodde lederen kunne.

## Endringen

Ny modul `apps/api/src/lib/group/linked-leader.ts` gjør de to til et speil av hverandre:

- **Skriv én side, begge oppdateres.** `PATCH /groups/:slug/leader-permissions` skriver også det koblede vervet, og `PATCH /groups/hs/positions/:id` skriver også undergruppas liste.
- **Les én side, se hele sannheten.** Begge flatene rapporterer unionen. Det er ingen utvidelse — sjekkeren gir den allerede — det er de to sidene som endelig blir enige om hva som er sant. Dermed rydder dette opp i eksisterende drift ved neste lagring, uten en datamigrering.
- **Nye verv starter i sync.** Et verv som auto-opprettes for en ny undergruppeleder arver gruppas `leaderGlobalPermissions` i stedet for å starte tomt.

### Hva som bevisst *ikke* speiles

Bare den org-vide lista. `leaderPermissions` er scoped til undergruppa (`@group:beta`), og et verv kan ikke uttrykke den scopen — et verv med scope `group` gjelder i *sin egen* gruppe, som for et koblet verv er HS. Å speile den ville stille gjort rettigheter over Beta om til rettigheter over alt. Verv med scope `group`, og verv uten kobling, røres ikke.

### Sikkerhet

Ingen ny eskaleringsvei: begge sidene har samme guardrail fra før (`canGrantPositionPermissions` sjekket globalt), og de to radene treffer nøyaktig samme person.

## Verifisert

- `bun run typecheck` — 9/9 ✅
- `bun run build` — 4/4 ✅
- `bun run lint` — ingen funn i de nye filene
- Alle gruppetester: **180/180** ✅, inkludert 5 nye i `linked-leader-parity.test.ts` som pinner speiling begge veier, unionslesing ved eksisterende drift, arv ved verv-opprettelse, og at ukoblede verv står urørt

## Merk

Prod-radene er fortsatt ute av sync til noen lagrer fra én av de to sidene — dette er kodeendring alene, etter avtale. Fram til da viser begge sidene unionen, så det som vises er det som faktisk gjelder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Oppfølging (commit 2): unionslesingen låste admin ute av å lagre

Ved gjennomgang av egen diff fant jeg en reell feil i commit 1, bekreftet med en test som ga 403.

Å vise unionen gjorde lagre-knappen ubrukelig for alle som ikke selv holdt alt den andre halvdelen gir: vakten målte hele den innsendte lista. En administrator med `roles:create` men uten `root` ville åpne Index, få vist `root` fra det koblede vervet, sende lista uendret tilbake — og bli avvist. Den gruppe-scopede halvdelen hen faktisk har lov til å redigere gikk med i dragsuget. Dette er nøyaktig fallgruva `knownPermissions()` er skrevet for å unngå, og i prod treffer den med en gang siden Teknologiminister-vervet holder `root`.

**Fiks:** vakten måler nå bare det som er *nytt* utover den andre halvdelen. Ingen oppmykning — begge radene gir til samme person, så å lagre noe som allerede står der deler ikke ut noe. Å legge til noe nytt krever fortsatt at du har det selv. Gjelder begge veier (gruppas side og HS sin verv-side). Uklobede verv er uberørt: baseline er da tom, så hele lista måles som før.

**I tillegg:** scope-bytte på et koblet verv avvises nå (409). Speilet holder bare mens vervet er org-vidt — scopet til `group` gjelder det inne i HS i stedet, og de to halvdelene ville stille drevet fra hverandre igjen.

4 nye tester dekker dette. Totalt **184/184** gruppetester grønne.


---

## Commit 3: samme tittel i HS og i undergruppa

Tittelen var det samme to-steder-problemet, ett felt bortenfor: gruppas `leaderTitle` og det koblede vervets navn svarer begge på hva personen heter. I prod sto den første på `NULL` for **hver eneste undergruppe** — så gruppas egen side kalte lederen «Leder» mens HS kalte samme person «Innovasjonsminister».

En tittel er én verdi, ikke et sett, så de forenes med presedens i stedet for union: gruppas egen tittel vinner når den er satt, ellers svarer vervets navn. Skriving fra én side lander i begge.

**Plassholderen er ikke en tittel.** Auto-vervet heter `Leder av <gruppe>`; å forfremme det ville døpt om hver undergruppeleder fra «Leder» til «Leder av Beta». Den kjennes igjen og leses som «Leder», og tømmer man tittelen settes plassholderen tilbake.

**Gruppesiden viste hardkodet «Leder»** og hadde aldri lest `leaderTitle`, så speilingen alene ville ikke synes der noen faktisk ser tittelen. Gruppedetaljen svarer nå med den forenede tittelen, og forsiden bruker den. Dette treffer HS også, som har hatt `leader_title = 'President'` liggende ubrukt.

### Verifisert i nettleser mot seed-data

- `/grupper/beta` viser nå **«Innovasjonsminister · Ola Syrstad Berg»** (før: «Leder · …»). Lokal `leader_title` er `NULL`, akkurat som i prod — så dette er forening ved lesing mot ekte data.
- `/grupper/basket` (ingen koblet verv) viser fortsatt «Leder», og API-et svarer `leaderTitle: null`.
- Ingen konsollfeil fra endringen.

**Totalt: 191/191 gruppetester + 156/156 i tilstøtende suiter (rbac, feide, contracts, group-scoped-access, strike-arranger-access, jobs).**
