### PR TITLE
fix(tilganger): la gruppas «Spørreskjema» virke, og ta lederraden ut av lederens egne hender

### DIFF
--- a/apps/api/src/lib/form/service.ts
+++ b/apps/api/src/lib/form/service.ts
@@ -1,3 +1,4 @@
+import { hasPermission, hasScopedPermission } from "@photon/auth/rbac";
 import type { DbSchema } from "@photon/db";
 import { schema } from "@photon/db";
 import { and, count, eq, inArray } from "drizzle-orm";
@@ -17,6 +18,9 @@ import {
 } from "./exceptions";
 
 type Database = NodePgDatabase<DbSchema>;
+
+/** Anything carrying a database handle — the Hono app context satisfies it. */
+type DbCtx = { db: Database };
 
 // ===== FORM HELPERS =====
 
@@ -764,60 +768,75 @@ export async function calculateFormStatistics(db: Database, formId: string) {
 // ===== PERMISSIONS =====
 
 /**
- * Check if user can manage a form (edit, delete, view submissions)
+ * Check if user can manage a form (edit, delete, view submissions).
+ *
+ * A form belongs to the group that owns it — the group for a group form, the
+ * organizer for an event form — and a grant scoped to that group is enough.
+ * That is what "Spørreskjema" ticked on a group's member permissions or on a
+ * verv hands out, and it is already what creating the form asks for; without
+ * the same check here, the group could make a form it could never read the
+ * answers to. A global grant still satisfies the scoped check, so `root` and
+ * org-wide `forms:manage` are unaffected.
+ *
+ * The group's leader passes regardless of any permission list, unchanged.
+ *
+ * A form owned by no group — a standalone or template form — has no scope to
+ * check against, so it stays global-only.
  */
 export async function canManageForm(
-    db: Database,
+    ctx: DbCtx,
     formId: string,
     userId: string,
-    hasAdminPermission: boolean,
 ): Promise<boolean> {
-    if (hasAdminPermission) {
+    const { db } = ctx;
+
+    const ownerGroupSlug = await formOwnerGroupSlug(db, formId);
+
+    if (!ownerGroupSlug) {
+        return await hasPermission(ctx, userId, "forms:manage");
+    }
+
+    if (
+        await hasScopedPermission(
+            ctx,
+            userId,
+            ["forms:manage", "forms:update"],
+            `group:${ownerGroupSlug}`,
+        )
+    ) {
         return true;
     }
 
-    // Check if it's an event form
+    const membership = await db.query.groupMembership.findFirst({
+        where: and(
+            eq(schema.groupMembership.groupSlug, ownerGroupSlug),
+            eq(schema.groupMembership.userId, userId),
+            eq(schema.groupMembership.role, "leader"),
+        ),
+    });
+
+    return !!membership;
+}
+
+/**
+ * The slug of the group a form belongs to, or null for a form owned by none.
+ */
+async function formOwnerGroupSlug(
+    db: Database,
+    formId: string,
+): Promise<string | null> {
     const eventForm = await db.query.formEventForm.findFirst({
         where: eq(schema.formEventForm.formId, formId),
-        with: {
-            event: {
-                with: {
-                    organizer: true,
-                },
-            },
-        },
+        with: { event: true },
     });
 
     if (eventForm) {
-        // Check if user is event organizer or has group leadership
-        const organizerSlug = eventForm.event.organizerGroupSlug;
-        if (organizerSlug) {
-            const membership = await db.query.groupMembership.findFirst({
-                where: and(
-                    eq(schema.groupMembership.groupSlug, organizerSlug),
-                    eq(schema.groupMembership.userId, userId),
-                    eq(schema.groupMembership.role, "leader"),
-                ),
-            });
-            return !!membership;
-        }
+        return eventForm.event.organizerGroupSlug ?? null;
     }
 
-    // Check if it's a group form
     const groupForm = await db.query.formGroupForm.findFirst({
         where: eq(schema.formGroupForm.formId, formId),
     });
 
-    if (groupForm) {
-        const membership = await db.query.groupMembership.findFirst({
-            where: and(
-                eq(schema.groupMembership.groupSlug, groupForm.groupSlug),
-                eq(schema.groupMembership.userId, userId),
-                eq(schema.groupMembership.role, "leader"),
-            ),
-        });
-        return !!membership;
-    }
-
-    return false;
+    return groupForm?.groupSlug ?? null;
 }

--- a/apps/api/src/lib/group/positions.ts
+++ b/apps/api/src/lib/group/positions.ts
@@ -78,6 +78,39 @@ export async function canManagePositions(
 }
 
 /**
+ * Can the user edit the group leader's own permission set?
+ *
+ * Stricter than {@link canManagePositions} on purpose: being the leader is not
+ * enough. A leader manages their group — its verv and what every member holds
+ * — but their own access is not theirs to change, and is only moved by someone
+ * holding "Tilganger" ("roles:create"/"groups:manage", for this group or
+ * org-wide).
+ *
+ * The reason is a trap that cost a leader their access mid-opptak. The leader
+ * row and the member list are separate grants, but a leader whose row is empty
+ * holds everything through membership — so trimming what the group gives every
+ * member silently trimmed the leader too. Worse, it was a one-way door: the
+ * escalation guard ("you may only grant what you hold") then refused to let
+ * them put it back. Taking the row out of the leader's hands makes the two
+ * lists independent in practice and not just in the schema.
+ *
+ * Reading stays open to anyone who may manage the group's verv — a leader
+ * should be able to see what they hold, they just cannot edit it.
+ */
+export async function canManageLeaderPermissions(
+    ctx: AppContext,
+    userId: string,
+    groupSlug: string,
+): Promise<boolean> {
+    return await hasScopedPermission(
+        ctx,
+        userId,
+        ["root", "groups:manage", "roles:create"],
+        `group:${groupSlug}`,
+    );
+}
+
+/**
  * Guardrail: does the user hold every permission in the list at the
  * position's effective scope?
  *

--- a/apps/api/src/routes/event/form/get.ts
+++ b/apps/api/src/routes/event/form/get.ts
@@ -1,6 +1,6 @@
-import { hasPermission } from "@photon/auth/rbac";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
+import { canActOnEvent } from "~/lib/event/access";
 import { getEventFormWithDetails, userHasSubmitted } from "~/lib/form/service";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
@@ -50,12 +50,19 @@ export const getEventFormRoute = route().get(
             });
         }
 
-        // For evaluation forms, check if user attended or is organizer
+        // For evaluation forms, check if user attended or is organizer.
+        //
+        // Asked for the arranging group, not org-wide: a group that holds
+        // "Arrangementer" for itself arranges the event, and could otherwise
+        // not open the evaluation of its own arrangement. A global grant still
+        // satisfies the scoped check, and an event with no organiser group
+        // falls back to it.
         if (formType === "evaluation") {
-            const hasEventsManage = await hasPermission(
+            const mayManageEvent = await canActOnEvent(
                 { db, ...ctx },
                 user.id,
-                "events:manage",
+                eventId,
+                ["events:update", "events:manage"],
             );
 
             const registration = await db.query.eventRegistration.findFirst({
@@ -65,7 +72,7 @@ export const getEventFormRoute = route().get(
 
             const isAttendee = registration?.status === "attended";
 
-            if (!hasEventsManage && !isAttendee) {
+            if (!mayManageEvent && !isAttendee) {
                 throw new HTTPException(403, {
                     message:
                         "You must have attended the event to access the evaluation",

--- a/apps/api/src/routes/form/delete.ts
+++ b/apps/api/src/routes/form/delete.ts
@@ -1,4 +1,3 @@
-import { hasPermission } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
@@ -49,17 +48,7 @@ export const deleteRoute = route().delete(
         }
 
         // Check permissions
-        const hasAdminPermission = await hasPermission(
-            { db, ...ctx },
-            user.id,
-            "forms:manage",
-        );
-        const canManage = await canManageForm(
-            db,
-            formId,
-            user.id,
-            hasAdminPermission,
-        );
+        const canManage = await canManageForm({ db, ...ctx }, formId, user.id);
 
         if (!canManage) {
             throw new HTTPException(403, {

--- a/apps/api/src/routes/form/statistics.ts
+++ b/apps/api/src/routes/form/statistics.ts
@@ -1,4 +1,3 @@
-import { hasPermission } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
@@ -49,17 +48,7 @@ export const statisticsRoute = route().get(
         }
 
         // Check permissions
-        const hasAdminPermission = await hasPermission(
-            { db, ...ctx },
-            user.id,
-            "forms:manage",
-        );
-        const canManage = await canManageForm(
-            db,
-            formId,
-            user.id,
-            hasAdminPermission,
-        );
+        const canManage = await canManageForm({ db, ...ctx }, formId, user.id);
 
         if (!canManage) {
             throw new HTTPException(403, {

--- a/apps/api/src/routes/form/submission/delete.ts
+++ b/apps/api/src/routes/form/submission/delete.ts
@@ -3,9 +3,9 @@ import { and, eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { env } from "~/lib/env";
+import { canManageForm } from "~/lib/form/service";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
-import { requireAccess } from "~/middleware/access";
 import { requireAuth } from "~/middleware/auth";
 import {
     deleteSubmissionResponseSchema,
@@ -19,23 +19,41 @@ export const deleteSubmissionWithReasonRoute = route().delete(
         summary: "Delete submission with reason",
         operationId: "deleteFormSubmission",
         description:
-            "Delete a submission and notify the user with a reason. Admin only.",
+            "Delete a submission and notify the user with a reason. Requires permission to manage the form.",
     })
         .schemaResponse({
             statusCode: 200,
             schema: deleteSubmissionResponseSchema,
             description: "Success",
         })
+        .forbidden({ description: "Insufficient permissions" })
         .notFound({ description: "Submission not found" })
         .build(),
     requireAuth,
-    requireAccess({ permission: "forms:manage" }),
     validator("json", deleteSubmissionWithReasonSchema),
     async (c) => {
         const body = c.req.valid("json");
         const { db, ...ctx } = c.get("ctx");
+        const user = c.get("user");
         const formId = c.req.param("formId");
         const submissionId = c.req.param("id");
+
+        if (!user) {
+            throw new HTTPException(401, {
+                message: "Authentication required",
+            });
+        }
+
+        // Deleting someone's answer is a managing action on the form, so it
+        // follows the same rule as reading them: the owning group's grant, or
+        // an org-wide one. It used to demand the org-wide one alone, which
+        // left the group that owns the form unable to clean up its own.
+        if (!(await canManageForm({ db, ...ctx }, formId, user.id))) {
+            throw new HTTPException(403, {
+                message:
+                    "You do not have permission to delete submissions for this form",
+            });
+        }
 
         // Get submission with form and user details
         const submission = await db.query.formSubmission.findFirst({

--- a/apps/api/src/routes/form/submission/download.ts
+++ b/apps/api/src/routes/form/submission/download.ts
@@ -1,4 +1,3 @@
-import { hasPermission } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
@@ -60,17 +59,7 @@ export const downloadSubmissionsRoute = route().get(
         }
 
         // Check permissions
-        const hasAdminPermission = await hasPermission(
-            { db, ...ctx },
-            user.id,
-            "forms:manage",
-        );
-        const canManage = await canManageForm(
-            db,
-            formId,
-            user.id,
-            hasAdminPermission,
-        );
+        const canManage = await canManageForm({ db, ...ctx }, formId, user.id);
 
         if (!canManage) {
             throw new HTTPException(403, {

--- a/apps/api/src/routes/form/submission/get.ts
+++ b/apps/api/src/routes/form/submission/get.ts
@@ -1,4 +1,3 @@
-import { hasPermission } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
@@ -66,17 +65,7 @@ export const getSubmissionRoute = route().get(
 
         // Check permissions: own submission OR can manage form
         const isOwnSubmission = submission.userId === user.id;
-        const hasAdminPermission = await hasPermission(
-            { db, ...ctx },
-            user.id,
-            "forms:manage",
-        );
-        const canManage = await canManageForm(
-            db,
-            formId,
-            user.id,
-            hasAdminPermission,
-        );
+        const canManage = await canManageForm({ db, ...ctx }, formId, user.id);
 
         if (!isOwnSubmission && !canManage) {
             throw new HTTPException(403, {

--- a/apps/api/src/routes/form/submission/list.ts
+++ b/apps/api/src/routes/form/submission/list.ts
@@ -1,4 +1,3 @@
-import { hasPermission } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
@@ -49,17 +48,7 @@ export const listSubmissionsRoute = route().get(
         }
 
         // Check permissions
-        const hasAdminPermission = await hasPermission(
-            { db, ...ctx },
-            user.id,
-            "forms:manage",
-        );
-        const canManage = await canManageForm(
-            db,
-            formId,
-            user.id,
-            hasAdminPermission,
-        );
+        const canManage = await canManageForm({ db, ...ctx }, formId, user.id);
 
         if (!canManage) {
             throw new HTTPException(403, {

--- a/apps/api/src/routes/form/update.ts
+++ b/apps/api/src/routes/form/update.ts
@@ -1,4 +1,3 @@
-import { hasPermission } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { validator } from "hono-openapi";
@@ -57,17 +56,7 @@ export const updateRoute = route().patch(
         }
 
         // Check permissions
-        const hasAdminPermission = await hasPermission(
-            { db, ...ctx },
-            user.id,
-            "forms:manage",
-        );
-        const canManage = await canManageForm(
-            db,
-            formId,
-            user.id,
-            hasAdminPermission,
-        );
+        const canManage = await canManageForm({ db, ...ctx }, formId, user.id);
 
         if (!canManage) {
             throw new HTTPException(403, {

--- a/apps/api/src/routes/groups/positions/leader-permissions.ts
+++ b/apps/api/src/routes/groups/positions/leader-permissions.ts
@@ -12,10 +12,12 @@
  * each group's `leaderPermissions` and removed, so what the admin UI shows is
  * now the whole truth.
  *
- * Guardrails are the position ones, deliberately: managing this is managing a
- * verv, and you still cannot hand out what you do not hold — the group list is
- * checked for this group, the org-wide one globally, so a group leader (who
- * holds nothing globally) can never write the second.
+ * Writing requires "Tilganger" for the group, which the leader themselves does
+ * not hold by virtue of leading it: their own access is set for them, not by
+ * them. Reading is open to anyone who may manage the group's verv, so a leader
+ * can still see what they hold. On top of that sits the usual escalation
+ * guard — you cannot hand out what you do not hold — with the group list
+ * checked for this group and the org-wide one globally.
  *
  * The group's name for the role travels with the permissions here: a group
  * that calls its leader "President" should not have to keep a second, manually
@@ -36,6 +38,7 @@ import {
 } from "~/lib/group/linked-leader";
 import {
     canGrantPositionPermissions,
+    canManageLeaderPermissions,
     canManagePositions,
     knownPermissions,
 } from "~/lib/group/positions";
@@ -123,7 +126,7 @@ export const updateLeaderPermissionsRoute = route().patch(
         summary: "Set the group leader's permissions",
         operationId: "updateGroupLeaderPermissions",
         description:
-            "Replace the permissions held by the group's leader. Granted scoped to this group, so they never reach another group's resources. You can only grant permissions you hold yourself for this group.",
+            "Replace the permissions held by the group's leader. Granted scoped to this group, so they never reach another group's resources. Requires \"Tilganger\" (roles:create/groups:manage) for this group — the group's own leader may not edit their own access. You can only grant permissions you hold yourself for this group.",
     })
         .schemaResponse({
             statusCode: 200,
@@ -132,7 +135,8 @@ export const updateLeaderPermissionsRoute = route().patch(
         })
         .badRequest({ description: "Unknown permission" })
         .forbidden({
-            description: "Not authorized, or granting permissions you lack",
+            description:
+                "Not authorized (the group's own leader may not edit this), or granting permissions you lack",
         })
         .notFound({ description: "Group not found" })
         .build(),
@@ -156,14 +160,17 @@ export const updateLeaderPermissionsRoute = route().patch(
             });
         }
 
-        if (!(await canManagePositions(ctx, user.id, groupSlug, "group"))) {
+        // Not canManagePositions: the group's own leader may manage its verv
+        // and its member permissions, but not the row describing their own
+        // access. See canManageLeaderPermissions.
+        if (!(await canManageLeaderPermissions(ctx, user.id, groupSlug))) {
             throw new HTTPException(403, {
-                message: "Not authorized to manage this group's permissions",
+                message: "Not authorized to change this group's leader access",
             });
         }
 
-        // Same escalation guard as verv: a leader editing their own group
-        // cannot grant themselves anything they do not already hold here.
+        // Escalation guard, unchanged: you cannot hand out what you do not
+        // already hold for this group.
         if (
             !(await canGrantPositionPermissions(
                 ctx,

--- a/apps/api/src/test/form/group-scoped-access.test.ts
+++ b/apps/api/src/test/form/group-scoped-access.test.ts
@@ -1,0 +1,111 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * "Spørreskjema" handed to a group, rather than to a person org-wide.
+ *
+ * The checkbox has always been group-scopable, and creating a group's form
+ * honoured that — but everything downstream asked for the org-wide grant or
+ * for being the group's leader. A group could therefore make a form it could
+ * never read the answers to, which is exactly what happened to a group during
+ * opptak: the leader handed a member "Spørreskjema", the member made the form,
+ * and then nobody but the leader could open the søknader.
+ */
+describe("group-scoped forms access", () => {
+    integrationTest(
+        "a member holding the group's «Spørreskjema» can read and manage its form",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            const helper = await ctx.utils.createTestUser();
+            const outsider = await ctx.utils.createTestUser();
+
+            const group = await ctx.utils.createTestGroup();
+            const otherGroup = await ctx.utils.createTestGroup();
+
+            // The group gives every member the forms domain, scoped to itself.
+            await ctx.db
+                .update(schema.group)
+                .set({ memberPermissions: ["forms:create", "forms:manage"] })
+                .where(eq(schema.group.slug, group.slug));
+
+            await ctx.db.insert(schema.groupMembership).values([
+                { userId: leader.id, groupSlug: group.slug, role: "leader" },
+                { userId: helper.id, groupSlug: group.slug, role: "member" },
+                {
+                    userId: outsider.id,
+                    groupSlug: otherGroup.slug,
+                    role: "leader",
+                },
+            ]);
+
+            const helperClient = await ctx.utils.clientForUser(helper);
+            const outsiderClient = await ctx.utils.clientForUser(outsider);
+
+            const created = await helperClient.api.groups[":slug"].forms.$post({
+                param: { slug: group.slug },
+                json: {
+                    title: "Opptak",
+                    description: "Søknad",
+                    template: false,
+                    group: group.slug,
+                    can_submit_multiple: false,
+                    is_open_for_submissions: true,
+                    only_for_group_members: false,
+                    fields: [
+                        {
+                            title: "Hvorfor søker du?",
+                            type: "text_answer",
+                            required: true,
+                            order: 0,
+                        },
+                    ],
+                },
+            });
+            expect(created.status).toBe(201);
+            const form = await created.json();
+            const formId = form.id!;
+            const fieldId = form.fields?.[0]?.id!;
+
+            // Someone applies.
+            const applicant = await ctx.utils.createTestUser();
+            const applicantClient = await ctx.utils.clientForUser(applicant);
+            const submitted = await applicantClient.api.forms[
+                ":formId"
+            ].submissions.$post({
+                param: { formId },
+                json: {
+                    answers: [
+                        {
+                            field: { id: fieldId },
+                            answer_text: "Fordi jeg vil",
+                        },
+                    ],
+                },
+            });
+            expect(submitted.status).toBe(201);
+
+            // The whole point: the member who made the form can read the
+            // answers to it, without a global grant and without leading.
+            const listed = await helperClient.api.forms[
+                ":formId"
+            ].submissions.$get({ param: { formId } });
+            expect(listed.status).toBe(200);
+            expect(await listed.json()).toHaveLength(1);
+
+            const stats = await helperClient.api.forms[":id"].statistics.$get({
+                param: { id: formId },
+            });
+            expect(stats.status).toBe(200);
+
+            // …and the grant stops at the group's own forms. The other
+            // group's leader holds "Spørreskjema" nowhere near this one.
+            const denied = await outsiderClient.api.forms[
+                ":formId"
+            ].submissions.$get({ param: { formId } });
+            expect(denied.status).toBe(403);
+        },
+        500_000,
+    );
+});

--- a/apps/api/src/test/form/group-scoped-access.test.ts
+++ b/apps/api/src/test/form/group-scoped-access.test.ts
@@ -21,8 +21,14 @@ describe("group-scoped forms access", () => {
             const helper = await ctx.utils.createTestUser();
             const outsider = await ctx.utils.createTestUser();
 
-            const group = await ctx.utils.createTestGroup();
-            const otherGroup = await ctx.utils.createTestGroup();
+            // Eksplisitte slugs: createTestGroup lager sin egen av
+            // Date.now(), og to grupper på rad lander i samme millisekund.
+            const group = await ctx.utils.createTestGroup({
+                slug: "forms-scope-eier",
+            });
+            const otherGroup = await ctx.utils.createTestGroup({
+                slug: "forms-scope-andre",
+            });
 
             // The group gives every member the forms domain, scoped to itself.
             await ctx.db
@@ -104,6 +110,89 @@ describe("group-scoped forms access", () => {
             const denied = await outsiderClient.api.forms[
                 ":formId"
             ].submissions.$get({ param: { formId } });
+            expect(denied.status).toBe(403);
+        },
+        500_000,
+    );
+
+    /**
+     * Evalueringsskjemaet spurte etter `events:manage` org-vidt, så gruppa som
+     * faktisk arrangerte kunne ikke åpne evalueringen av sitt eget
+     * arrangement — samme form som feilen over, i arrangementsdomenet.
+     */
+    integrationTest(
+        "the arranging group can open the evaluation of its own event",
+        async ({ ctx }) => {
+            const arranger = await ctx.utils.createTestUser();
+            const outsider = await ctx.utils.createTestUser();
+
+            const group = await ctx.utils.createTestGroup({
+                slug: "eval-scope-arrangor",
+            });
+            const otherGroup = await ctx.utils.createTestGroup({
+                slug: "eval-scope-andre",
+            });
+
+            // «Arrangementer» for gruppa, scopet til gruppa selv.
+            await ctx.db
+                .update(schema.group)
+                .set({ memberPermissions: ["events:update", "events:manage"] })
+                .where(eq(schema.group.slug, group.slug));
+            await ctx.db
+                .update(schema.group)
+                .set({ memberPermissions: ["events:update", "events:manage"] })
+                .where(eq(schema.group.slug, otherGroup.slug));
+
+            await ctx.db.insert(schema.groupMembership).values([
+                { userId: arranger.id, groupSlug: group.slug, role: "member" },
+                {
+                    userId: outsider.id,
+                    groupSlug: otherGroup.slug,
+                    role: "member",
+                },
+            ]);
+
+            await ctx.utils.setupEventCategories();
+            const event = await ctx.utils.createTestEvent({
+                organizerGroupSlug: group.slug,
+            });
+
+            const arrangerClient = await ctx.utils.clientForUser(arranger);
+            const outsiderClient = await ctx.utils.clientForUser(outsider);
+
+            const created = await arrangerClient.api.event[
+                ":eventId"
+            ].forms.$post({
+                param: { eventId: event.id },
+                json: {
+                    title: "Evaluering",
+                    description: "Etter arrangementet",
+                    type: "evaluation",
+                    event: event.id,
+                    template: false,
+                    fields: [
+                        {
+                            title: "Hvordan var det?",
+                            type: "text_answer",
+                            required: true,
+                            order: 0,
+                        },
+                    ],
+                },
+            });
+            expect(created.status).toBe(201);
+
+            // Arrangøren har aldri deltatt på sitt eget arrangement, så dette
+            // er tilgangen — ikke oppmøtet — som åpner skjemaet.
+            const opened = await arrangerClient.api.event[":eventId"].forms[
+                ":type"
+            ].$get({ param: { eventId: event.id, type: "evaluation" } });
+            expect(opened.status).toBe(200);
+
+            // Og «Arrangementer» for en annen gruppe når ikke hit.
+            const denied = await outsiderClient.api.event[":eventId"].forms[
+                ":type"
+            ].$get({ param: { eventId: event.id, type: "evaluation" } });
             expect(denied.status).toBe(403);
         },
         500_000,

--- a/apps/api/src/test/groups/leader-permissions.test.ts
+++ b/apps/api/src/test/groups/leader-permissions.test.ts
@@ -79,18 +79,16 @@ describe("group leader permissions", () => {
 
     describe("editing", () => {
         integrationTest(
-            "a leader can set permissions they hold for the group",
+            "a «Tilganger» holder sets them, and can read them back",
             async ({ ctx }) => {
-                const leader = await ctx.utils.createTestUser();
-                const client = await ctx.utils.clientForUser(leader);
+                const admin = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(admin);
                 const group = await ctx.utils.createTestGroup();
 
-                await ctx.db.insert(schema.groupMembership).values({
-                    userId: leader.id,
-                    groupSlug: group.slug,
-                    role: "leader",
-                });
-                await ctx.utils.giveUserPermissions(leader, ["news:manage"]);
+                await ctx.utils.giveUserPermissions(admin, [
+                    "roles:create",
+                    "news:manage",
+                ]);
 
                 const response = await client.api.groups[":groupSlug"][
                     "leader-permissions"
@@ -106,8 +104,17 @@ describe("group leader permissions", () => {
             500_000,
         );
 
+        /**
+         * Leading a group does not put your own access in your own hands.
+         *
+         * A leader whose row is empty holds everything through membership, so
+         * when the row was theirs to edit, trimming what the group gave every
+         * member trimmed the leader too — and the escalation guard then
+         * refused to let them put it back. Reading stays open: they can see
+         * what they hold, they just cannot move it.
+         */
         integrationTest(
-            "a leader cannot hand out permissions they do not hold",
+            "the group's own leader may read their row but not write it",
             async ({ ctx }) => {
                 const leader = await ctx.utils.createTestUser();
                 const client = await ctx.utils.clientForUser(leader);
@@ -118,6 +125,32 @@ describe("group leader permissions", () => {
                     groupSlug: group.slug,
                     role: "leader",
                 });
+                await ctx.utils.giveUserPermissions(leader, ["news:manage"]);
+
+                const read = await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$get({ param: { groupSlug: group.slug } });
+                expect(read.status).toBe(200);
+
+                const write = await client.api.groups[":groupSlug"][
+                    "leader-permissions"
+                ].$patch({
+                    param: { groupSlug: group.slug },
+                    json: { permissions: ["news:manage"] },
+                });
+                expect(write.status).toBe(403);
+            },
+            500_000,
+        );
+
+        integrationTest(
+            "an editor cannot hand out permissions they do not hold",
+            async ({ ctx }) => {
+                const admin = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(admin);
+                const group = await ctx.utils.createTestGroup();
+
+                await ctx.utils.giveUserPermissions(admin, ["roles:create"]);
 
                 const response = await client.api.groups[":groupSlug"][
                     "leader-permissions"
@@ -196,20 +229,23 @@ describe("group leader permissions", () => {
         );
 
         integrationTest(
-            "a group leader cannot grant them from a right they only hold for their group",
+            "an editor cannot grant them from a right they only hold for the group",
             async ({ ctx }) => {
-                const leader = await ctx.utils.createTestUser();
-                const client = await ctx.utils.clientForUser(leader);
+                const editor = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(editor);
                 const group = await ctx.utils.createTestGroup();
 
+                // May edit the row, but holds news:manage only for this group
+                // — through the group's own member permissions.
+                await ctx.utils.giveUserPermissions(editor, ["roles:create"]);
                 await ctx.db
                     .update(schema.group)
-                    .set({ leaderPermissions: ["news:manage"] })
+                    .set({ memberPermissions: ["news:manage"] })
                     .where(eq(schema.group.slug, group.slug));
                 await ctx.db.insert(schema.groupMembership).values({
-                    userId: leader.id,
+                    userId: editor.id,
                     groupSlug: group.slug,
-                    role: "leader",
+                    role: "member",
                 });
 
                 // Holds news:manage@group:<slug>, so the group list is fine…
@@ -282,17 +318,15 @@ describe("group leader permissions", () => {
      */
     describe("title", () => {
         integrationTest(
-            "a leader can name the role, clear it, and leave it untouched",
+            "it can be named, cleared, and left untouched",
             async ({ ctx }) => {
-                const leader = await ctx.utils.createTestUser();
-                const client = await ctx.utils.clientForUser(leader);
+                const admin = await ctx.utils.createTestUser();
+                const client = await ctx.utils.clientForUser(admin);
                 const group = await ctx.utils.createTestGroup();
 
-                await ctx.db.insert(schema.groupMembership).values({
-                    userId: leader.id,
-                    groupSlug: group.slug,
-                    role: "leader",
-                });
+                // The title rides on the leader row, so it follows the row's
+                // rule: set by «Tilganger», not by the leader themselves.
+                await ctx.utils.giveUserPermissions(admin, ["roles:create"]);
 
                 const patch = (json: {
                     permissions: string[];

--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -390,9 +390,9 @@ function paymentDeadlineText(props: EventRegistrationCardProps): string | null {
         return "Betalingsfristen er gått ut. Plassen kan ha gått videre til neste på ventelista.";
     }
     if (!props.paymentExpiresInLabel) {
-        return `Betal innen ${props.paymentDeadline.day} kl. ${props.paymentDeadline.time}, ellers gis plassen videre.`;
+        return `Betal innen ${props.paymentDeadline.day} kl. ${props.paymentDeadline.time}.`;
     }
-    return `${props.paymentExpiresInLabel} igjen å betale (innen kl. ${props.paymentDeadline.time}), ellers gis plassen videre.`;
+    return `${props.paymentExpiresInLabel} igjen å betale (innen kl. ${props.paymentDeadline.time}).`;
 }
 
 type TimelinePoint = {

--- a/apps/kvark/src/routes/admin/roller.tsx
+++ b/apps/kvark/src/routes/admin/roller.tsx
@@ -121,6 +121,24 @@ function useCanGrantGlobally(): boolean {
     return usePermission(["root", "roles:create"]);
 }
 
+/**
+ * Whether the viewer may change the group leader's own permissions.
+ *
+ * Mirrors `canManageLeaderPermissions` server-side, and is deliberately
+ * stricter than {@link useCanManagePositions}: leading a group does not put
+ * your own access in your own hands. A leader manages the group's verv and
+ * what every member holds; the leader row is moved for them by someone holding
+ * «Tilganger». That is what keeps the two lists independent — trimming what
+ * members get can no longer trim the leader, and no leader can lock themselves
+ * out of their own group mid-opptak.
+ */
+function useCanManageLeaderPermissions(groupSlug: string): boolean {
+    return useScopedPermission(
+        ["groups:manage", "roles:create"],
+        `group:${groupSlug}`,
+    );
+}
+
 function RolesAdminPage() {
     return (
         <Stagger
@@ -141,6 +159,9 @@ function RolesAdminPage() {
 // =============================================================================
 // Shared: domain-level permission checkboxes
 // =============================================================================
+
+/** No domains covered — the leader row subtracts nothing. */
+const EMPTY_DOMAINS: Set<string> = new Set();
 
 function PermissionDomainCheckboxes({
     value,
@@ -425,8 +446,6 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                     <LeaderRow
                         groupSlug={groupSlug}
                         canManage={canManage}
-                        covered={coveredForGroupScope}
-                        coveredGlobally={coveredForGlobalScope}
                         leaders={leaders.map((leader) => ({
                             userId: leader.userId,
                             name: leader.user?.name ?? leader.userId,
@@ -857,21 +876,14 @@ function useGroupCoveredDomains(
 function LeaderRow({
     groupSlug,
     canManage,
-    covered,
-    coveredGlobally,
     leaders,
 }: {
     groupSlug: string;
     canManage: boolean;
-    /** Domains the group already gives every member, and which the leader
-     *  therefore does not get listed for a second time. */
-    covered: Set<string>;
-    /** The same, but only what the group gives org-wide — the org-wide half of
-     *  the leader's set is not covered by a group-scoped member grant. */
-    coveredGlobally: Set<string>;
     leaders: { userId: string; name: string; image: string | null }[];
 }) {
     const [editing, setEditing] = useState(false);
+    const canEdit = useCanManageLeaderPermissions(groupSlug);
     // Only managers may read this — asking as anyone else is a guaranteed 403.
     const { data } = useQuery({
         ...getLeaderPermissionsQuery(groupSlug),
@@ -915,17 +927,21 @@ function LeaderRow({
             </TableCell>
             <TableCell className="max-w-72 truncate text-sm text-muted-foreground">
                 {canManage
-                    ? summarizeExtraPermissionsByScope([
-                          { permissions, covered },
+                    ? // Nothing subtracted for what the group also gives every
+                      // member: the leader's set stands on its own now, and
+                      // «Ingen egne tilganger» is exactly the warning that was
+                      // missing when a leader's access rode on the member list.
+                      summarizeExtraPermissionsByScope([
+                          { permissions, covered: EMPTY_DOMAINS },
                           {
                               permissions: globalPermissions,
-                              covered: coveredGlobally,
+                              covered: EMPTY_DOMAINS,
                           },
                       ])
                     : "Gruppens ledertilganger"}
             </TableCell>
             <TableCell>
-                {canManage ? (
+                {canEdit ? (
                     <DropdownMenu>
                         <DropdownMenuTrigger
                             aria-label="Handlinger"
@@ -978,14 +994,16 @@ function LeaderPermissionsDialog({
     const [global, setGlobal] = useState<string[]>(initialGlobal);
     const [title, setTitle] = useState(initialTitle ?? "");
     const [error, setError] = useState<string | null>(null);
-    // The group-scoped list is covered both by what the group gives every
-    // member and by anything the leader already holds org-wide.
-    const coveredByGroup = useGroupCoveredDomains(groupSlug, true, "group");
-    const covered = useMemo(() => {
-        const all = new Set(coveredByGroup);
-        for (const domain of domainsOf(global)) all.add(domain);
-        return all;
-    }, [coveredByGroup, global]);
+    // Only the leader's own org-wide list locks a box here: ticking a domain
+    // for all of TIHLDE already covers this group, so two switches for it
+    // could only disagree.
+    //
+    // What the group gives every member deliberately does NOT lock anything.
+    // It used to, and that is how a leader ended up with an empty row that
+    // looked full: the access was real but rode on the member list, and
+    // trimming that list took it away. Giving the leader their own copy has to
+    // be possible even when members happen to hold the same thing.
+    const covered = useMemo(() => domainsOf(global), [global]);
 
     async function handleSubmit() {
         setError(null);
@@ -1036,11 +1054,13 @@ function LeaderPermissionsDialog({
                                 value={permissions}
                                 onChange={setPermissions}
                                 lockedDomains={covered}
-                                lockedHint="Avhukede felt er allerede gitt til alle medlemmer, eller for hele TIHLDE nedenfor."
+                                lockedHint="Avhukede felt er allerede gitt for hele TIHLDE nedenfor."
                             />
                             <p className="text-sm text-muted-foreground">
                                 Gjelder bare gruppens eget innhold, og følger
-                                den som til enhver tid er leder.
+                                den som til enhver tid er leder. Står for seg
+                                selv: lederen beholder dette selv om gruppen
+                                endrer hva alle medlemmer får.
                             </p>
                         </Field>
 

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1242,7 +1242,7 @@ export interface paths {
         post?: never;
         /**
          * Delete submission with reason
-         * @description Delete a submission and notify the user with a reason. Admin only.
+         * @description Delete a submission and notify the user with a reason. Requires permission to manage the form.
          */
         delete: operations["deleteFormSubmission"];
         options?: never;
@@ -1861,7 +1861,7 @@ export interface paths {
         head?: never;
         /**
          * Set the group leader's permissions
-         * @description Replace the permissions held by the group's leader. Granted scoped to this group, so they never reach another group's resources. You can only grant permissions you hold yourself for this group.
+         * @description Replace the permissions held by the group's leader. Granted scoped to this group, so they never reach another group's resources. Requires "Tilganger" (roles:create/groups:manage) for this group — the group's own leader may not edit their own access. You can only grant permissions you hold yourself for this group.
          */
         patch: operations["updateGroupLeaderPermissions"];
         trace?: never;


### PR DESCRIPTION
To feil med samme rot: en tilgang delt ut i adminpanelet gjør ikke det den lover.

## Gruppas «Spørreskjema» ga bare retten til å lage skjemaet

Sosialminister Elliot ga en i gruppa «Spørreskjema» under opptaket. Vedkommende kunne lage skjemaet, men ikke se en eneste søknad.

Bare `POST /groups/:slug/forms` var scope-bevisst. Alt nedstrøms — innsendinger, statistikk, redigering, sletting — spurte etter `forms:manage` **globalt**, eller etter at du var gruppas leder. Gruppa kunne altså lage et opptaksskjema den aldri fikk lese søknadene til.

`canManageForm` slår nå opp hvilken gruppe skjemaet tilhører (gruppa for et gruppeskjema, arrangøren for et arrangementsskjema) og godtar et grant scopet dit. Global tilgang og lederskap virker som før, og grantet stopper ved gruppas egne skjema. `destroy_with_reason` er tatt med — ellers ble det den ene handlingen eieren av skjemaet ikke kunne gjøre.

## Lederraden var lederens egen å skrive

Samme hendelse, tidligere ledd: Elliot fjernet «Spørreskjema» fra alle medlemmer av Sosialen og mistet det selv.

En tom lederrad betyr at lederen holder alt gjennom medlemskapet. Å trimme hva gruppa gir alle medlemmer trimmet derfor lederen også — og eskaleringsvakta («du kan bare gi bort det du selv har») nektet dem så å legge det tilbake. En enveisdør midt i opptaket.

Raden endres nå bare av noen som holder «Tilganger» for gruppa. Lesing er fortsatt åpen for den som kan styre gruppas verv, så lederen ser hva hen har — hen kan bare ikke flytte det.

To ting i UI-et måtte følge med:

- Lederboksene låses ikke lenger av det medlemmene har. Det var derfor raden så full ut mens den var tom, og uten opplåsing er det umulig å gi lederen sin egen kopi av noe medlemmene også har.
- Tilgangskolonnen trekker ikke fra medlemslista. «Ingen egne tilganger» er advarselen som manglet.

**Bivirkning:** tittelen («President») bor på lederraden og følger samme regel, så lederen kan ikke lenger døpe om sin egen rolle. Å skille de to krever et eget felt og en egen dialog.

Ingen backfill: eksisterende lederrader står som de er.

## Testing

`typecheck`, `build`, `lint` og `format` er grønt. 244 tester i `form`/`groups`/`rbac` passerer.

Den nye testen i `apps/api/src/test/form/group-scoped-access.test.ts` er kjørt mot koden før fiksen først — den feilet med 403 på innsendings-lista, så den dekker den ekte feilen og ikke bare seg selv.

Siste commit er urelatert: «ellers gis plassen videre» er kuttet fra betalingsfristen på arrangementer.