### PR TITLE
fix(arrangementsregler): rett død wiki-lenke og la reglene godkjennes fra profilen

### DIFF
--- a/apps/kvark/src/components/event-rules-consent.tsx
+++ b/apps/kvark/src/components/event-rules-consent.tsx
@@ -4,7 +4,8 @@ import { Checkbox } from "@tihlde/ui/ui/checkbox";
 import { Label } from "@tihlde/ui/ui/label";
 import { ScrollText } from "lucide-react";
 
-export const EVENT_RULES_URL = "https://wiki.tihlde.org/arrangementer";
+export const EVENT_RULES_URL =
+    "https://wiki.tihlde.org/retningslinjer/arrangementer";
 
 type EventRulesConsentProps = {
     /** Kalles når medlemmet huker av. Én handling — det finnes ingen angre. */

--- a/apps/kvark/src/routes/_app/profil/$id/innstillinger.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/innstillinger.tsx
@@ -11,6 +11,7 @@ import {
     AllergyPicker,
     type AllergySelection,
 } from "#/components/allergy-picker";
+import { EVENT_RULES_URL } from "#/components/event-rules-consent";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
@@ -115,8 +116,84 @@ function RouteComponent() {
                     ) : null}
                 </CardContent>
             </Card>
+            <EventRulesCard />
             <AllergiesCard />
         </div>
+    );
+}
+
+/**
+ * Godkjenningen av arrangementsreglene — samme felt som varselet på
+ * arrangementssiden skriver til. Her kan medlemmet ta den unna i forkant, og
+ * også trekke den igjen; varselet dukker da opp neste gang de skal melde seg
+ * på. Egen mutasjon slik at en feil her ikke slår ut i Personvern-kortet.
+ */
+function EventRulesCard() {
+    const { data: session } = useQuery(authQueryOptions);
+    const updateSettings = useMutation(updateUserSettingsMutation);
+
+    const acceptsEventRules =
+        session?.user.settings?.acceptsEventRules ?? false;
+
+    async function handleChange(checked: boolean) {
+        await updateSettings.mutateAsync({
+            data: { acceptsEventRules: checked },
+        });
+        // Godkjenningen leses fra sesjonen, både her og på arrangementssiden.
+        await invalidateAuth();
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Arrangementer</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+                <Field orientation="horizontal">
+                    <FieldContent>
+                        <FieldLabel htmlFor="accepts-event-rules">
+                            Arrangementsreglene
+                        </FieldLabel>
+                        <FieldDescription>
+                            Må være godkjent før du kan melde deg på
+                            arrangementer. Gjør du det her, er du klar når
+                            påmeldingen åpner.
+                        </FieldDescription>
+                        <div>
+                            <Button
+                                size="sm"
+                                variant="link"
+                                render={
+                                    <a
+                                        href={EVENT_RULES_URL}
+                                        target="_blank"
+                                        rel="noreferrer noopener"
+                                    />
+                                }
+                            >
+                                Les reglene
+                            </Button>
+                        </div>
+                    </FieldContent>
+                    <Switch
+                        id="accepts-event-rules"
+                        checked={acceptsEventRules}
+                        disabled={updateSettings.isPending}
+                        onCheckedChange={handleChange}
+                    />
+                </Field>
+
+                {updateSettings.isError ? (
+                    <Alert variant="destructive">
+                        <AlertCircle className="size-4" />
+                        <AlertTitle>Innstillingen ble ikke lagret</AlertTitle>
+                        <AlertDescription>
+                            Prøv på nytt. Står det seg, gi beskjed til TIHLDE.
+                        </AlertDescription>
+                    </Alert>
+                ) : null}
+            </CardContent>
+        </Card>
     );
 }
 


### PR DESCRIPTION
## Hva

To ting rundt godkjenning av arrangementsreglene:

**1. Lenka «Les reglene» var død.** Den pekte på `wiki.tihlde.org/arrangementer`, som gir 404 — wikien er strukturert om, og siden ligger nå på `wiki.tihlde.org/retningslinjer/arrangementer`. Gamle Kvark hadde nøyaktig samme URL (`URLS.tsx` → `WIKI_URLS.EVENT_RULES`), så dette var ikke en feil ved portingen; lenka var allerede død der. Sjekket resten av appen: de to andre wiki-lenkene (`/` og `/ny-student`) svarer 200.

**2. Godkjenningen kunne bare gis fra arrangementssiden.** Profilbryteren fra gamle Kvark («Aksepterer arrangementreglene») forsvant i porten, så et medlem som ville ta dette unna i forkant — eller trekke godkjenningen — hadde ingen vei. Den er tilbake som et eget «Arrangementer»-kort i profilinnstillingene.

Bryteren skriver til samme felt som varselet på arrangementssiden, `settings.accepts_event_rules`. Egen mutasjon i kortet slik at en feil her ikke dukker opp som feilmelding i Personvern-kortet. Varselet på arrangementssiden er urørt.

## Verdt å merke seg

Bryteren går begge veier, som i gamle Kvark, mens varselet er enveis. Trekker medlemmet godkjenningen, får de varselet tilbake ved neste påmelding. Eksisterende påmeldinger røres ikke — API-et sjekker bare ved ny påmelding.

## Testet

Kjørt lokalt (kvark mot lokal API, innlogget som testbruker) og kryssjekket mot dev-databasen:

1. Bryteren står på når `accepts_event_rules = true`
2. Skrudd av på profilen → DB: `f`
3. `/arrangementer` → varselet «Du må godkjenne arrangementsreglene» dukker opp
4. Huket av i varselet → DB: `t`
5. Tilbake på profilen → bryteren står på igjen

`typecheck`, `lint`, `format` og `build` passerer. Begge URL-ene verifisert med curl: gammel → 404, ny → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)