### PR TITLE
feat(allergier): be om svar når plassen er betalt, og la det koste ett trykk

### DIFF
--- a/apps/kvark/src/components/allergy-nudge.tsx
+++ b/apps/kvark/src/components/allergy-nudge.tsx
@@ -1,0 +1,82 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+import { authQueryOptions } from "#/api/auth";
+import { getAllergiesQuery } from "#/api/queries/user";
+import type { AllergySelection } from "#/components/allergy-picker";
+import { AllergyPrompt } from "#/components/allergy-prompt";
+import { useAllergyPrompt } from "#/hooks/use-allergy-prompt";
+import { useSaveAllergies } from "#/hooks/use-save-allergies";
+
+type AllergyNudgeProps = {
+    eventId: string;
+    hasPaid: boolean;
+};
+
+const NO_ALLERGIES: AllergySelection = { allergies: [], customAllergies: [] };
+
+/**
+ * Oppfordringen om å oppgi allergier, med alt den trenger for å svare.
+ *
+ * En container framfor props hele veien opp i arrangementsruta: ruta har
+ * hverken katalogen eller lagringen fra før, og oppfordringen avgjør selv om
+ * den skal vises. Da holder det at ruta sier hvilket arrangement det gjelder
+ * og om plassen er betalt.
+ */
+export function AllergyNudge({ eventId, hasPaid }: AllergyNudgeProps) {
+    const { showAllergyPrompt, dismissAllergyPrompt } = useAllergyPrompt(
+        eventId,
+        hasPaid,
+    );
+    const { data: session } = useQuery(authQueryOptions);
+    const saveAllergies = useSaveAllergies();
+    const [isPickerOpen, setIsPickerOpen] = useState(false);
+
+    // Katalogen hentes først når noen faktisk folder ut velgeren. De aller
+    // fleste svarer «Jeg har ingen» eller lar være, og skal ikke betale for et
+    // kall de ikke bruker.
+    const { data: catalogue } = useQuery({
+        ...getAllergiesQuery({ curated: true }),
+        enabled: isPickerOpen,
+    });
+
+    const savedAllergies = session?.user.settings?.allergies ?? [];
+    const savedCustom = session?.user.settings?.customAllergies ?? [];
+
+    const [selection, setSelection] = useState<AllergySelection>(NO_ALLERGIES);
+
+    // Sesjonen kommer inn etter første render. Nøkkelen sammenligner innhold,
+    // ikke referanse — arrayene er nye objekter ved hver henting.
+    const savedKey = `${savedAllergies.join(",")}|${savedCustom.join(",")}`;
+    // biome-ignore lint/correctness/useExhaustiveDependencies: savedKey er
+    // innholdssammenligningen; å avhenge av arrayene ville løpt hver render.
+    useEffect(() => {
+        setSelection({
+            allergies: savedAllergies,
+            customAllergies: savedCustom,
+        });
+    }, [savedKey]);
+
+    if (!showAllergyPrompt) return null;
+
+    async function save(next: AllergySelection) {
+        await saveAllergies.save(next);
+        setIsPickerOpen(false);
+    }
+
+    return (
+        <AllergyPrompt
+            options={catalogue ?? []}
+            value={selection}
+            onChange={setSelection}
+            isPickerOpen={isPickerOpen}
+            onOpenPicker={() => setIsPickerOpen(true)}
+            onClosePicker={() => setIsPickerOpen(false)}
+            onSave={() => void save(selection)}
+            onSaveNone={() => void save(NO_ALLERGIES)}
+            onDismiss={dismissAllergyPrompt}
+            isSaving={saveAllergies.isPending}
+            isError={saveAllergies.isError}
+        />
+    );
+}

--- a/apps/kvark/src/components/allergy-nudge.tsx
+++ b/apps/kvark/src/components/allergy-nudge.tsx
@@ -60,8 +60,15 @@ export function AllergyNudge({ eventId, hasPaid }: AllergyNudgeProps) {
     if (!showAllergyPrompt) return null;
 
     async function save(next: AllergySelection) {
-        await saveAllergies.save(next);
-        setIsPickerOpen(false);
+        try {
+            await saveAllergies.save(next);
+            setIsPickerOpen(false);
+        } catch {
+            // Feilen vises fra `saveAllergies.isError`, så det er ingenting å
+            // gjøre her. Fanges likevel: `mutateAsync` kaster, og uten dette
+            // blir hvert mislykket forsøk en ubehandlet promise-rejection.
+            // Velgeren blir stående åpen, så svaret kan sendes på nytt.
+        }
     }
 
     return (

--- a/apps/kvark/src/components/allergy-prompt.tsx
+++ b/apps/kvark/src/components/allergy-prompt.tsx
@@ -1,46 +1,128 @@
 import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { Button } from "@tihlde/ui/ui/button";
-import { Link } from "@tanstack/react-router";
 import { UtensilsCrossed } from "lucide-react";
 
+import {
+    AllergyPicker,
+    type AllergyOption,
+    type AllergySelection,
+} from "#/components/allergy-picker";
+
 type AllergyPromptProps = {
+    /** Kun de kuraterte valgene — samme liste som innstillingene bruker. */
+    options: AllergyOption[];
+    value: AllergySelection;
+    onChange: (value: AllergySelection) => void;
+    /** Om velgeren er foldet ut. */
+    isPickerOpen: boolean;
+    onOpenPicker: () => void;
+    onClosePicker: () => void;
+    onSave: () => void;
+    /** Lagrer et tomt svar, uten å måtte tømme feltet først. */
+    onSaveNone: () => void;
     /** Kalles når medlemmet velger å skjule oppfordringen. */
     onDismiss: () => void;
+    isSaving?: boolean;
+    isError?: boolean;
 };
 
 /**
- * Ber medlemmet oppgi allergier når de nettopp har fått plass.
+ * Ber medlemmet oppgi allergier når plassen er betalt og sikret.
  *
  * Her, og ikke bare på profilen, fordi det er nå det er relevant: arrangøren
  * bestiller maten etter påmeldingslista, og folk går ikke innom innstillingene
- * uoppfordret. Vises kun til dem som aldri har svart — har man svart «ingen
- * allergier», er man ferdig med spørsmålet.
+ * uoppfordret.
+ *
+ * Velgeren folder seg ut i kortet framfor å åpne en dialog. En dialog klipper
+ * nedtrekkslista til sin egen høyde, så lista ble to rader høy — og flyttes
+ * lista ut av dialogen igjen, leser dialogen klikket i den som et klikk utenfor
+ * og lukker seg uten å ta valget. Inline har lista hele vinduet å vokse i.
  */
-export function AllergyPrompt({ onDismiss }: AllergyPromptProps) {
+export function AllergyPrompt({
+    options,
+    value,
+    onChange,
+    isPickerOpen,
+    onOpenPicker,
+    onClosePicker,
+    onSave,
+    onSaveNone,
+    onDismiss,
+    isSaving = false,
+    isError = false,
+}: AllergyPromptProps) {
     return (
         <Alert>
             <UtensilsCrossed className="size-4" />
-            <AlertTitle>Har du allergier?</AlertTitle>
+            <AlertTitle>Har du noen allergier?</AlertTitle>
             <AlertDescription className="flex flex-col gap-3">
                 <span>
-                    Arrangøren bruker dette når de bestiller mat. Har du ingen,
-                    sier du fra om det samme sted.
+                    Plassen din er betalt og klar. Si fra hva du ikke tåler, så
+                    vet de som bestiller maten det. Har du ingen, tar det ett
+                    trykk.
                 </span>
+
+                {isPickerOpen ? (
+                    <AllergyPicker
+                        options={options}
+                        value={value}
+                        onChange={onChange}
+                        disabled={isSaving}
+                    />
+                ) : null}
+
+                {isError ? (
+                    <span>
+                        Svaret ble ikke lagret. Prøv på nytt. Står det seg, gi
+                        beskjed til TIHLDE.
+                    </span>
+                ) : null}
+
                 <div className="flex flex-wrap gap-2">
-                    <Button
-                        size="sm"
-                        render={
-                            <Link
-                                to="/profil/$id/innstillinger"
-                                params={{ id: "me" }}
-                            />
-                        }
-                    >
-                        Legg inn allergier
-                    </Button>
-                    <Button size="sm" variant="ghost" onClick={onDismiss}>
-                        Ikke nå
-                    </Button>
+                    {isPickerOpen ? (
+                        <>
+                            <Button
+                                size="sm"
+                                disabled={isSaving}
+                                onClick={onSave}
+                            >
+                                Lagre
+                            </Button>
+                            <Button
+                                size="sm"
+                                variant="ghost"
+                                disabled={isSaving}
+                                onClick={onClosePicker}
+                            >
+                                Avbryt
+                            </Button>
+                        </>
+                    ) : (
+                        <>
+                            <Button
+                                size="sm"
+                                disabled={isSaving}
+                                onClick={onOpenPicker}
+                            >
+                                Legg inn allergier
+                            </Button>
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={isSaving}
+                                onClick={onSaveNone}
+                            >
+                                Jeg har ingen
+                            </Button>
+                            <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={onDismiss}
+                            >
+                                Ikke nå
+                            </Button>
+                        </>
+                    )}
                 </div>
             </AlertDescription>
         </Alert>

--- a/apps/kvark/src/components/site-bottom-bar.tsx
+++ b/apps/kvark/src/components/site-bottom-bar.tsx
@@ -5,6 +5,7 @@ import {
     AccordionItem,
     AccordionTrigger,
 } from "@tihlde/ui/ui/accordion";
+import { Badge } from "@tihlde/ui/ui/badge";
 import { BottomBar, BottomBarItem } from "@tihlde/ui/ui/bottom-bar";
 import {
     Drawer,
@@ -27,11 +28,18 @@ import type { NavItem, NavLink } from "./site-header";
 type SiteBottomBarProps = {
     navItems: NavItem[];
     isAuthenticated: boolean;
+    /**
+     * Setter en prikk på menyen og på «Min profil». Headeren merker avataren
+     * på samme grunnlag, men den er skjult under lg — uten dette ville
+     * påminnelsen forsvunnet for alle på mobil.
+     */
+    hasProfileTodo?: boolean;
 };
 
 export function SiteBottomBar({
     navItems,
     isAuthenticated,
+    hasProfileTodo = false,
 }: SiteBottomBarProps) {
     const [menuOpen, setMenuOpen] = useState(false);
     const closeMenu = () => setMenuOpen(false);
@@ -60,7 +68,16 @@ export function SiteBottomBar({
 
                 <Drawer open={menuOpen} onOpenChange={setMenuOpen}>
                     <DrawerTrigger asChild>
-                        <BottomBarItem aria-label="Åpne meny">
+                        <BottomBarItem
+                            aria-label="Åpne meny"
+                            className="relative"
+                        >
+                            {hasProfileTodo ? (
+                                <Badge
+                                    className="absolute top-1 right-2 size-2.5 p-0"
+                                    aria-hidden
+                                />
+                            ) : null}
                             <Menu />
                             Meny
                         </BottomBarItem>
@@ -121,6 +138,7 @@ export function SiteBottomBar({
                                         },
                                     }}
                                     onNavigate={closeMenu}
+                                    hasTodo={hasProfileTodo}
                                 />
                             ) : (
                                 <MenuLink
@@ -143,9 +161,11 @@ export function SiteBottomBar({
 function MenuLink({
     link,
     onNavigate,
+    hasTodo = false,
 }: {
     link: NavLink;
     onNavigate: () => void;
+    hasTodo?: boolean;
 }) {
     if (link.kind === "external") {
         return (
@@ -163,8 +183,13 @@ function MenuLink({
     }
 
     return (
-        <Link {...link.link} className="py-2" onClick={onNavigate}>
+        <Link
+            {...link.link}
+            className="flex items-center gap-2 py-2"
+            onClick={onNavigate}
+        >
             {link.label}
+            {hasTodo ? <Badge className="size-2.5 p-0" aria-hidden /> : null}
         </Link>
     );
 }

--- a/apps/kvark/src/components/site-header.tsx
+++ b/apps/kvark/src/components/site-header.tsx
@@ -1,5 +1,6 @@
 import { Link, type LinkOptions } from "@tanstack/react-router";
 import { Avatar, AvatarFallback, AvatarImage } from "@tihlde/ui/ui/avatar";
+import { Badge } from "@tihlde/ui/ui/badge";
 import {
     NavigationMenu,
     NavigationMenuContent,
@@ -49,9 +50,20 @@ type SiteHeaderProps = {
      * layout-ruten.
      */
     actions?: ReactNode;
+    /**
+     * Setter en prikk på avataren. Brukes til allergispørsmålet, som blir
+     * stående ubesvart til noen svarer — og et lite merke på profilen er den
+     * eneste påminnelsen som ikke krever at man er inne på et arrangement.
+     */
+    hasProfileTodo?: boolean;
 };
 
-export function SiteHeader({ navItems, user, actions }: SiteHeaderProps) {
+export function SiteHeader({
+    navItems,
+    user,
+    actions,
+    hasProfileTodo = false,
+}: SiteHeaderProps) {
     return (
         <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur">
             <div className="container mx-auto flex h-14 items-center justify-between gap-4 px-4">
@@ -132,8 +144,21 @@ export function SiteHeader({ navItems, user, actions }: SiteHeaderProps) {
                         {...(user
                             ? { to: "/profil/$id", params: { id: "me" } }
                             : { to: "/login" })}
-                        aria-label={user ? "Gå til profil" : "Logg inn"}
+                        aria-label={
+                            user
+                                ? hasProfileTodo
+                                    ? "Gå til profil. Du mangler å svare på om du har allergier."
+                                    : "Gå til profil"
+                                : "Logg inn"
+                        }
+                        className="relative flex items-center"
                     >
+                        {hasProfileTodo ? (
+                            <Badge
+                                className="absolute -top-0.5 -right-0.5 z-10 size-2.5 p-0"
+                                aria-hidden
+                            />
+                        ) : null}
                         <Avatar className="size-8">
                             {user?.avatarUrl ? (
                                 <AvatarImage

--- a/apps/kvark/src/hooks/use-allergy-prompt.ts
+++ b/apps/kvark/src/hooks/use-allergy-prompt.ts
@@ -8,14 +8,20 @@ const STORAGE_PREFIX = "allergy-prompt-dismissed:";
 /**
  * Om medlemmet skal oppfordres til å oppgi allergier på dette arrangementet.
  *
- * Kriteriet er at de aldri har svart — ikke at lista er tom. Har de svart
- * «ingen allergier», er de ferdige med spørsmålet og skal ikke få det igjen.
+ * To krav må være oppfylt. De må ha betalt og fått plassen sin — da er de
+ * ferdige med påmeldingen, og spørsmålet forstyrrer ingenting. Og de må aldri
+ * ha svart: har de svart «ingen allergier», er de ferdige med spørsmålet og
+ * skal ikke få det igjen.
+ *
+ * Betalingen er også det nærmeste vi kommer «her blir det mat». Det finnes
+ * ingen serveringsflagg på arrangementer, og de betalte er dem arrangøren
+ * faktisk bestiller mat til.
  *
  * Avvisningen huskes per arrangement i `localStorage`, ikke i databasen: å
  * ikke orke akkurat nå er ikke et svar, og det skal ikke se ut som ett for
  * arrangøren.
  */
-export function useAllergyPrompt(eventId: string) {
+export function useAllergyPrompt(eventId: string, hasPaid: boolean) {
     const { data: session } = useQuery(authQueryOptions);
     const hasAnswered = session?.user.settings?.allergiesConfirmedAt != null;
 
@@ -31,7 +37,8 @@ export function useAllergyPrompt(eventId: string) {
     }, [eventId]);
 
     return {
-        showAllergyPrompt: Boolean(session) && !hasAnswered && !isDismissed,
+        showAllergyPrompt:
+            Boolean(session) && hasPaid && !hasAnswered && !isDismissed,
         dismissAllergyPrompt() {
             window.localStorage.setItem(STORAGE_PREFIX + eventId, "true");
             setIsDismissed(true);

--- a/apps/kvark/src/hooks/use-save-allergies.ts
+++ b/apps/kvark/src/hooks/use-save-allergies.ts
@@ -1,0 +1,35 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { invalidateAuth } from "#/api/auth";
+import { updateUserSettingsMutation } from "#/api/queries/user";
+import type { AllergySelection } from "#/components/allergy-picker";
+
+/**
+ * Lagrer allergiene til medlemmet selv, uansett hvor i appen de svarer.
+ *
+ * Finnes som egen hook fordi svaret nå kan gis tre steder: i innstillingene, i
+ * dialogen på arrangementssiden, og med «Jeg har ingen» rett i oppfordringen.
+ * Alle tre må gjøre det samme etterpå — hente sesjonen på nytt, siden både
+ * allergiene og `allergiesConfirmedAt` leses derfra.
+ *
+ * Et tomt utvalg er et gyldig svar: API-et stempler bekreftelsen så lenge
+ * feltene er med, og det er nettopp slik «jeg har ingen allergier» skilles fra
+ * «har aldri sett spørsmålet».
+ */
+export function useSaveAllergies() {
+    const updateSettings = useMutation(updateUserSettingsMutation);
+
+    return {
+        isPending: updateSettings.isPending,
+        isError: updateSettings.isError,
+        async save(selection: AllergySelection) {
+            await updateSettings.mutateAsync({
+                data: {
+                    allergies: selection.allergies,
+                    customAllergies: selection.customAllergies,
+                },
+            });
+            await invalidateAuth();
+        },
+    };
+}

--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -38,6 +38,14 @@ function AppLayout() {
     // før noen har sagt ja. Det må stå et sted de faktisk ser det — og
     // medlemsmenyen skjules, siden hver side der svarer 403 for dem.
     const isPendingApproval = session?.user?.isPendingApproval === true;
+    // Allergispørsmålet er det eneste medlemmet kan bli sittende med ubesvart
+    // uten å merke det, og arrangørene bestiller mat etter svarene. Prikken
+    // blir stående til de har svart — også når svaret er «jeg har ingen».
+    // Ingen ekstra kall: bekreftelsen ligger i sesjonen fra før.
+    const hasProfileTodo =
+        isAuthenticated &&
+        !isPendingApproval &&
+        session?.user.settings?.allergiesConfirmedAt == null;
     const navItems = useSiteNavItems(isAuthenticated, !isPendingApproval);
 
     return (
@@ -47,6 +55,7 @@ function AppLayout() {
             <SiteHeader
                 navItems={navItems}
                 user={currentUser}
+                hasProfileTodo={hasProfileTodo}
                 // Bjella spør etter uleste varsler, så den vises bare for
                 // innloggede — ellers ville hver besøkende få en 401. Den som
                 // venter på godkjenning får 403 på samme kall, og har uansett
@@ -86,6 +95,7 @@ function AppLayout() {
             <SiteBottomBar
                 navItems={navItems}
                 isAuthenticated={isAuthenticated}
+                hasProfileTodo={hasProfileTodo}
             />
         </div>
     );

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -43,8 +43,7 @@ import { DetailPage } from "#/components/detail-page";
 import { DetailsCard } from "#/components/details-card";
 import { EventQrDialog } from "#/components/event-qr-dialog";
 import { EventRegistrantsDialog } from "#/components/event-registrants-dialog";
-import { useAllergyPrompt } from "#/hooks/use-allergy-prompt";
-import { AllergyPrompt } from "#/components/allergy-prompt";
+import { AllergyNudge } from "#/components/allergy-nudge";
 import { EventRegistrationCard } from "#/components/event-registration-card";
 import { EventRulesConsent } from "#/components/event-rules-consent";
 import { IconActionButton } from "#/components/icon-action-button";
@@ -145,9 +144,6 @@ function EventDetailPage() {
         refetchIntervalInBackground: true,
     });
     const { data: session } = useQuery(authQueryOptions);
-    const { showAllergyPrompt, dismissAllergyPrompt } = useAllergyPrompt(
-        event.id,
-    );
 
     // Same rule as the API: the permission (a group-scoped one counts), or
     // having created the event.
@@ -652,11 +648,10 @@ function EventDetailPage() {
                                 : undefined
                         }
                         postJoinSlot={
-                            showAllergyPrompt ? (
-                                <AllergyPrompt
-                                    onDismiss={dismissAllergyPrompt}
-                                />
-                            ) : null
+                            <AllergyNudge
+                                eventId={event.id}
+                                hasPaid={event.registration?.hasPaid ?? false}
+                            />
                         }
                         requiresEventRulesConsent={eventRules.mustAccept}
                         eventRulesSlot={

--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -23,7 +23,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from "@tihlde/ui/ui/empty";
-import { FileSignature, ListTodo } from "lucide-react";
+import { FileSignature, ListTodo, UtensilsCrossed } from "lucide-react";
 
 export const Route = createFileRoute("/_app/profil/$id/")({
     component: RouteComponent,
@@ -106,10 +106,17 @@ function RouteComponent() {
             ) : null}
             <ProfileLinksSection links={links} />
             {isOwnProfile ? (
-                <ContractBanner
-                    hasActiveContract={Boolean(activeContract)}
-                    signature={mySignature}
-                />
+                <>
+                    <ContractBanner
+                        hasActiveContract={Boolean(activeContract)}
+                        signature={mySignature}
+                    />
+                    <AllergyBanner
+                        hasAnswered={
+                            session?.user.settings?.allergiesConfirmedAt != null
+                        }
+                    />
+                </>
             ) : null}
 
             {/* Gruppene vises direkte i stedet for et telle-kort. Kortet så
@@ -162,6 +169,42 @@ function RouteComponent() {
                 </>
             ) : null}
         </>
+    );
+}
+
+/**
+ * Vises til allergispørsmålet er besvart.
+ *
+ * Prikken i headeren peker hit, og et merke uten forklaring er bare irritasjon
+ * — så det er her det står hva som mangler og hvor man svarer. Forsvinner også
+ * når svaret er «jeg har ingen»: det er et svar, ikke en tom liste.
+ */
+function AllergyBanner({ hasAnswered }: { hasAnswered: boolean }) {
+    if (hasAnswered) return null;
+
+    return (
+        <Alert>
+            <UtensilsCrossed className="size-4" />
+            <AlertTitle>Du har ikke sagt om du har allergier</AlertTitle>
+            <AlertDescription className="flex items-center justify-between gap-4">
+                <span>
+                    Arrangørene bruker svaret når de bestiller mat. Har du
+                    ingen, tar det ett trykk.
+                </span>
+                <Button
+                    size="sm"
+                    variant="outline"
+                    render={
+                        <Link
+                            to="/profil/$id/innstillinger"
+                            params={{ id: "me" }}
+                        />
+                    }
+                >
+                    Svar nå
+                </Button>
+            </AlertDescription>
+        </Alert>
     );
 }
 

--- a/apps/kvark/src/routes/_app/profil/$id/innstillinger.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/innstillinger.tsx
@@ -156,14 +156,19 @@ function AllergiesCard() {
     }, [savedKey]);
 
     async function handleSave(next: AllergySelection) {
-        await updateSettings.mutateAsync({
-            data: {
-                allergies: next.allergies,
-                customAllergies: next.customAllergies,
-            },
-        });
-        // Allergiene leses av sesjonen, ikke av en egen spørring.
-        await invalidateAuth();
+        try {
+            await updateSettings.mutateAsync({
+                data: {
+                    allergies: next.allergies,
+                    customAllergies: next.customAllergies,
+                },
+            });
+            // Allergiene leses av sesjonen, ikke av en egen spørring.
+            await invalidateAuth();
+        } catch {
+            // Feilen vises fra `updateSettings.isError`. Fanges likevel, ellers
+            // blir et mislykket lagringsforsøk en ubehandlet rejection.
+        }
     }
 
     return (

--- a/apps/kvark/src/routes/_app/profil/$id/innstillinger.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/innstillinger.tsx
@@ -155,11 +155,11 @@ function AllergiesCard() {
         });
     }, [savedKey]);
 
-    async function handleSave() {
+    async function handleSave(next: AllergySelection) {
         await updateSettings.mutateAsync({
             data: {
-                allergies: selection.allergies,
-                customAllergies: selection.customAllergies,
+                allergies: next.allergies,
+                customAllergies: next.customAllergies,
             },
         });
         // Allergiene leses av sesjonen, ikke av en egen spørring.
@@ -190,21 +190,32 @@ function AllergiesCard() {
                     disabled={updateSettings.isPending}
                 />
 
-                {!hasAnswered ? (
-                    <p className="text-sm text-muted-foreground">
-                        Om du ikke har noen allergier, lagrer du bare med tomt
-                        felt.
-                    </p>
-                ) : null}
-
-                <div>
+                <div className="flex flex-wrap gap-2">
                     <Button
                         type="button"
                         disabled={updateSettings.isPending}
-                        onClick={handleSave}
+                        onClick={() => handleSave(selection)}
                     >
                         Lagre allergier
                     </Button>
+                    {/* «Ingen allergier» var å lagre et tomt felt — et svar
+                        ingen gjettet at de kunne gi. Nå er det en knapp, og
+                        den forsvinner så snart spørsmålet er besvart. */}
+                    {!hasAnswered ? (
+                        <Button
+                            type="button"
+                            variant="outline"
+                            disabled={updateSettings.isPending}
+                            onClick={() =>
+                                handleSave({
+                                    allergies: [],
+                                    customAllergies: [],
+                                })
+                            }
+                        >
+                            Jeg har ingen
+                        </Button>
+                    ) : null}
                 </div>
 
                 {updateSettings.isError ? (


### PR DESCRIPTION
## Hvorfor

Arrangørene bestiller mat etter påmeldingslista, men de fleste svarer aldri på allergispørsmålet. Det sto bare i innstillingene, og dit går ingen uoppfordret.

## Hva

**Oppfordringen krever nå betalt plass.** Da er påmeldingen ferdig, så spørsmålet forstyrrer ingenting. Betaling er også nærmeste vi kommer «her blir det mat» — det finnes ikke noe serveringsflagg på arrangementer.

**Svaret gis der man står.** «Jeg har ingen» lagrer med én gang. «Legg inn allergier» folder velgeren ut i selve påmeldingskortet.

**En prikk på avataren** (og på Meny og «Min profil» under `lg`) blir stående til spørsmålet er besvart. Ingen ekstra kall — `allergiesConfirmedAt` ligger i sesjonen fra før.

**Profilen har fått et banner** som sier hva som mangler og lenker til innstillingene, bygget likt kontraktbanneret. Uten det peker prikken ingensteds.

**«Jeg har ingen» er blitt en knapp i innstillingene.** Før var svaret å lagre et tomt felt, noe ingen gjettet at var et svar.

Ingenting av dette står i veien for å melde seg på eller betale. Varselet står i `postJoinSlot`, altså etter at plassen er sikret.

## Hvorfor inline og ikke dialog

Velgeren lå først i en dialog. Det virker ikke, og begge utveier er dårlige:

- Nedtrekkslista portaleres til `body`, og da leser dialogen et klikk i lista som et klikk *utenfor* seg selv og lukker — uten å velge noe.
- Portalerer man lista inn i dialogen i stedet, teller klikket, men `DialogContent`/`DialogBody` er `overflow-y-auto` og blir lista sin clipping-ancestor. `--available-height` krympet til to rader.

Inline har lista hele vinduet: `max-height` 333 px og alle 18 valgene synlige. Det ble ett klikk mindre på kjøpet.

## API

Urørt. `allergiesConfirmedAt` stemples allerede når allergifeltene er med i oppdateringen, også når begge listene er tomme. Ingen migrasjon.

## Testet lokalt

Mot lokal API og database, med en betalt påmelding satt opp i dev-basen:

- Varselet vises kun med betalt plass.
- Valgte «Melk» i den utfoldede velgeren og lagret → `allergies_confirmed_at` satt, `milk` i basen, varsel og prikk borte uten refresh.
- Ett trykk på «Jeg har ingen» → `allergies_confirmed_at` satt, ingen allergirader, varsel og prikk borte.
- Å lukke velgeren uten å lagre stempler ingenting.
- Banneret og prikken forsvinner så snart spørsmålet er besvart, også når svaret er «ingen».

`bun run typecheck`, `lint`, `format` og `build` er grønne. Testdataen i dev-basen er ryddet bort igjen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)