### PR TITLE
fix(ui): gi klikkbare elementer musepeker igjen

### DIFF
--- a/packages/ui/src/components/ui/combobox.tsx
+++ b/packages/ui/src/components/ui/combobox.tsx
@@ -141,7 +141,7 @@ function ComboboxItem({
         <ComboboxPrimitive.Item
             data-slot="combobox-item"
             className={cn(
-                "relative flex w-full cursor-default items-center gap-2 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+                "relative flex w-full cursor-pointer items-center gap-2 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
                 className,
             )}
             {...props}

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -153,7 +153,7 @@ function CommandItem({
         <CommandPrimitive.Item
             data-slot="command-item"
             className={cn(
-                "group/command-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-muted data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-foreground",
+                "group/command-item relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-muted data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-foreground",
                 className,
             )}
             {...props}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -336,6 +336,33 @@
     * {
         @apply border-border outline-ring/50;
     }
+    /* Musepekeren skal si at noe er klikkbart. Tailwind v4 fjernet nettleserens
+     * gamle `cursor: pointer` på knapper, så uten denne står markøren som en
+     * pil over knapper, brytere, avkryssingsbokser, menyvalg og faner — og
+     * hvert komponent måtte hatt sin egen `cursor-pointer`-klasse.
+     *
+     * Ligger i base-laget, så en `cursor-*`-verktøyklasse i en komponent
+     * (`cursor-text` i input-group, `cursor-w-resize` i sidebar) overstyrer den
+     * som før. Avslått tilstand kommer sist og vinner over resten. */
+    button,
+    summary,
+    label[for],
+    [role="button"],
+    [role="tab"],
+    [role="switch"],
+    [role="checkbox"],
+    [role="radio"],
+    [role="option"],
+    [role="menuitem"],
+    [role="menuitemcheckbox"],
+    [role="menuitemradio"] {
+        cursor: pointer;
+    }
+    :disabled,
+    [aria-disabled="true"],
+    [data-disabled]:not([data-disabled="false"]) {
+        cursor: default;
+    }
     body {
         background-color: var(--background);
         color: var(--foreground);


### PR DESCRIPTION
Markøren sto som en pil over brytere (f.eks. på profil → innstillinger), avkryssingsbokser, menyvalg og faner. Tailwind v4 fjernet nettleserens gamle `cursor: pointer` på knapper, og komponentene hadde ingen egen klasse.

## Endring

Én base-regel i `@tihlde/ui` (`packages/ui/src/styles.css`) i stedet for en `cursor-pointer`-klasse per komponent:

- pointer på `button`, `summary`, `label[for]` og `role` = button/tab/switch/checkbox/radio/option/menuitem(+checkbox/radio)
- `default` igjen på `:disabled`, `aria-disabled="true"` og `data-disabled`

Regelen ligger i base-laget, så en `cursor-*`-verktøyklasse overstyrer den som før (`cursor-text` i input-group, `cursor-w-resize` i sidebar, `cursor-not-allowed` på avslåtte felt).

Combobox- og command-radene hadde eksplisitt `cursor-default` på klikkbare rader, som ville vunnet over base-regelen — de er nå `cursor-pointer`.

## Verifisert

Computed style i nettleserpreview av kvark:

- vanlig knapp → `pointer`, lenke → `pointer`, `role="switch"`-knapp (som `Switch` rendrer) → `pointer`
- `disabled`-knapp → `default`
- knapp med `cursor-text`-klasse → `text`, altså vinner verktøyklasser fortsatt

Gikk gjennom alle `onClick` på ikke-knapp-elementer i `apps/kvark` og `packages/ui`: de er enten allerede dekket (Badge som rendrer `<button>`, `<li role="button">` med egen `cursor-pointer`) eller skal ikke ha pointer (kolon-separatoren i time-picker, input-group-addon som fokuserer feltet).

`lint`, `format` og `typecheck` er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)