### PR TITLE
feat(tilbakemelding): gjør tilbakemeldinger anonyme

### DIFF
--- a/apps/api/src/routes/feedback/create.ts
+++ b/apps/api/src/routes/feedback/create.ts
@@ -49,11 +49,7 @@ export const createRoute = route().post(
                 status: created.status,
                 title: created.title,
                 description: created.description,
-                author: {
-                    id: user.id,
-                    name: user.name,
-                    image: user.image ?? null,
-                },
+                isAuthor: true,
                 upvotes: 0,
                 downvotes: 0,
                 myVote: null,

--- a/apps/api/src/routes/feedback/list.ts
+++ b/apps/api/src/routes/feedback/list.ts
@@ -56,6 +56,9 @@ export const listRoute = route().get(
         const totalPages = getTotalPages(totalCount, pageSize);
 
         /**
+         * The author is selected only to answer "did I file this?" — feedback
+         * is shown anonymously, so no name or picture leaves the database.
+         *
          * Vote counts are aggregated in the query rather than by loading every
          * vote row: the page shows a running tally per item and nothing else,
          * and a popular idea can collect hundreds of votes that would then be
@@ -70,9 +73,7 @@ export const listRoute = route().get(
                 description: schema.feedback.description,
                 createdAt: schema.feedback.createdAt,
                 updatedAt: schema.feedback.updatedAt,
-                authorId: schema.user.id,
-                authorName: schema.user.name,
-                authorImage: schema.user.image,
+                authorId: schema.feedback.authorId,
                 upvotes:
                     sql<number>`count(*) filter (where ${schema.feedbackVote.value} = 'up')`.mapWith(
                         Number,
@@ -86,13 +87,12 @@ export const listRoute = route().get(
                 >`max(${schema.feedbackVote.value}::text) filter (where ${schema.feedbackVote.userId} = ${userId})`,
             })
             .from(schema.feedback)
-            .leftJoin(schema.user, eq(schema.feedback.authorId, schema.user.id))
             .leftJoin(
                 schema.feedbackVote,
                 eq(schema.feedbackVote.feedbackId, schema.feedback.id),
             )
             .where(where)
-            .groupBy(schema.feedback.id, schema.user.id)
+            .groupBy(schema.feedback.id)
             .orderBy(desc(schema.feedback.createdAt))
             .limit(pageSize)
             .offset(getPageOffset(page, pageSize));
@@ -103,13 +103,7 @@ export const listRoute = route().get(
             status: row.status,
             title: row.title,
             description: row.description,
-            author: row.authorId
-                ? {
-                      id: row.authorId,
-                      name: row.authorName ?? "",
-                      image: row.authorImage ?? null,
-                  }
-                : null,
+            isAuthor: row.authorId === userId,
             upvotes: row.upvotes,
             downvotes: row.downvotes,
             myVote: row.myVote,

--- a/apps/api/src/routes/feedback/schema.ts
+++ b/apps/api/src/routes/feedback/schema.ts
@@ -57,15 +57,6 @@ export const listFeedbackQuerySchema = z.object({
 
 // ===== RESPONSE SCHEMAS =====
 
-const feedbackAuthorSchema = z
-    .object({
-        id: z.string(),
-        name: z.string(),
-        image: z.string().nullable(),
-    })
-    .nullable()
-    .meta({ description: "Author, null if the user has been deleted" });
-
 export const feedbackItemSchema = Schema(
     "FeedbackItem",
     z.object({
@@ -74,7 +65,10 @@ export const feedbackItemSchema = Schema(
         status: z.enum(feedbackStatusVariants),
         title: z.string(),
         description: z.string(),
-        author: feedbackAuthorSchema,
+        isAuthor: z.boolean().meta({
+            description:
+                "Whether the requesting user filed this. Feedback is anonymous: the author is never exposed to anyone else.",
+        }),
         upvotes: z.number(),
         downvotes: z.number(),
         myVote: z

--- a/apps/api/src/routes/feedback/update.ts
+++ b/apps/api/src/routes/feedback/update.ts
@@ -109,26 +109,13 @@ export const updateRoute = route().patch(
             ),
         });
 
-        const author = updated.authorId
-            ? await db.query.user.findFirst({
-                  where: eq(schema.user.id, updated.authorId),
-                  columns: { id: true, name: true, image: true },
-              })
-            : null;
-
         return c.json({
             id: updated.id,
             type: updated.type,
             status: updated.status,
             title: updated.title,
             description: updated.description,
-            author: author
-                ? {
-                      id: author.id,
-                      name: author.name,
-                      image: author.image ?? null,
-                  }
-                : null,
+            isAuthor: updated.authorId === userId,
             upvotes: counts?.upvotes ?? 0,
             downvotes: counts?.downvotes ?? 0,
             myVote: myVote?.value ?? null,

--- a/apps/api/src/test/feedback/feedback.test.ts
+++ b/apps/api/src/test/feedback/feedback.test.ts
@@ -31,7 +31,7 @@ describe("Feedback", () => {
             const idea = await ideaResponse.json();
             expect(idea.type).toBe("idea");
             expect(idea.status).toBe("open");
-            expect(idea.author?.id).toBe(author.id);
+            expect(idea.isAuthor).toBe(true);
             expect(idea.upvotes).toBe(0);
             expect(idea.myVote).toBeNull();
 
@@ -75,6 +75,19 @@ describe("Feedback", () => {
             const found = await searchResponse.json();
             expect(found.totalCount).toBe(1);
             expect(found.items[0]?.id).toBe(idea.id);
+
+            // Feedback is anonymous: nothing in the payload names the author,
+            // and the only trace of them is the flag the author sees on their
+            // own row.
+            expect(found.items[0]).not.toHaveProperty("author");
+            expect(found.items[0]?.isAuthor).toBe(false);
+
+            const ownList = await (
+                await authorClient.api.feedback.$get({
+                    query: { search: "telefonnummer" },
+                })
+            ).json();
+            expect(ownList.items[0]?.isAuthor).toBe(true);
 
             // === VOTES ===
 

--- a/apps/kvark/src/routes/_app/tilbakemelding.tsx
+++ b/apps/kvark/src/routes/_app/tilbakemelding.tsx
@@ -71,7 +71,7 @@ import {
     voteFeedbackMutation,
 } from "#/api/queries/feedback";
 import { LoadMoreButton } from "#/components/load-more-button";
-import { useCanActOnResource, usePermission } from "#/hooks/use-permission";
+import { usePermission } from "#/hooks/use-permission";
 import { OSLO_TIME_ZONE } from "#/lib/date";
 
 export const Route = createFileRoute("/_app/tilbakemelding")({
@@ -186,8 +186,9 @@ function VoteButtons({ item }: { item: FeedbackItem }) {
 function FeedbackRow({ item }: { item: FeedbackItem }) {
     const [open, setOpen] = useState(false);
     const canModerate = usePermission(MODERATE_PERMISSIONS);
-    const canActOnResource = useCanActOnResource(MODERATE_PERMISSIONS);
-    const canDelete = canActOnResource(item.author?.id);
+    // Feedback is anonymous, so there is no author id to compare against —
+    // the API tells us whether this row is ours.
+    const canDelete = canModerate || item.isAuthor;
 
     const remove = useMutation(deleteFeedbackMutation);
     const update = useMutation(updateFeedbackMutation);
@@ -224,7 +225,7 @@ function FeedbackRow({ item }: { item: FeedbackItem }) {
 
                 <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
                     <p className="text-sm text-muted-foreground">
-                        {item.author?.name ?? "Slettet bruker"} ·{" "}
+                        {item.isAuthor ? "Din" : "Anonym"} ·{" "}
                         {formatDate(item.createdAt)}
                     </p>
 

--- a/packages/db/src/schema/feedback.ts
+++ b/packages/db/src/schema/feedback.ts
@@ -55,6 +55,10 @@ export const feedback = pgTable(
         /**
          * Nullable on purpose: a member leaving TIHLDE must not delete the
          * bug reports they filed. Lepton did the same (`SET NULL`).
+         *
+         * Kept private: the API only ever answers whether the caller is the
+         * author, so they can edit or delete their own. Feedback is shown
+         * anonymously — no name reaches other members or moderators.
          */
         authorId: text("author_id").references(() => user.id, {
             onDelete: "set null",

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -4313,12 +4313,8 @@ export interface components {
             status: "open" | "in_progress" | "closed" | "rejected";
             title: string;
             description: string;
-            /** @description Author, null if the user has been deleted */
-            author: {
-                id: string;
-                name: string;
-                image: string | null;
-            } | null;
+            /** @description Whether the requesting user filed this. Feedback is anonymous: the author is never exposed to anyone else. */
+            isAuthor: boolean;
             upvotes: number;
             downvotes: number;
             /** @description The requesting user's own vote, if any */


### PR DESCRIPTION
Navnet på den som sendte inn en idé eller feilmelding ble vist til alle som åpnet raden på /tilbakemelding. Nå vises ingenting om avsenderen.

## Hva som er endret

- **API**: `author` (id, navn, bilde) er byttet ut med `isAuthor: boolean` i `FeedbackItem`. Det er det eneste sporet av avsenderen som sendes ut, og bare til avsenderen selv.
- `GET /api/feedback` joiner ikke lenger mot `user` — den henter bare `author_id` for å svare «er dette min?».
- **Frontend**: raden viser «Din · dato» eller «Anonym · dato». Slett-knappen styres av `canModerate || item.isAuthor` i stedet for å sammenligne bruker-id-er.
- SDK-typene er regenerert.

`author_id` blir liggende i databasen — den trengs for at du skal kunne redigere og slette din egen, og for `ON DELETE SET NULL`. Ingen skjemaendring, altså ingen migrasjon.

## Verdt å merke seg

Moderatorer ser heller ikke hvem som har sendt inn. Skal Index kunne se avsenderen, må det bli et eget felt bak en tilgang.

## Testing

- `bun run typecheck` grønt i alle 9 pakker, `lint` og `format` uten nye funn.
- Feedback-integrasjonstesten passerer (2/2), med nye sjekker på at `author` ikke finnes i responsen og at `isAuthor` er `false` for andre og `true` for avsenderen.
- Ikke verifisert i nettleser: port 4100 var opptatt av API-et fra en annen worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)