### PR TITLE
fix(tilbakemelding): flytt snarveien opp i headeren, ved siden av bjella

### DIFF
--- a/apps/kvark/src/components/feedback-button.tsx
+++ b/apps/kvark/src/components/feedback-button.tsx
@@ -1,0 +1,19 @@
+import { Link } from "@tanstack/react-router";
+import { Bug } from "lucide-react";
+
+import { IconActionButton } from "./icon-action-button";
+
+/**
+ * Snarvei til tilbakemeldingsskjemaet, ved siden av varselbjella. Ligger i
+ * headeren og ikke i medlemsmenyen: en feil meldes der man står, ikke etter et
+ * søk gjennom menyen.
+ */
+export function FeedbackButton() {
+    return (
+        <IconActionButton
+            icon={Bug}
+            label="Foreslå noe nytt eller meld en feil"
+            render={<Link to="/tilbakemelding" />}
+        />
+    );
+}

--- a/apps/kvark/src/components/site-nav-items.ts
+++ b/apps/kvark/src/components/site-nav-items.ts
@@ -145,15 +145,6 @@ export function useSiteNavItems(
                                           "Send inn utlegg og søknader til TIHLDE",
                                   },
                                   {
-                                      kind: "internal",
-                                      label: "Tilbakemelding",
-                                      link: linkOptions({
-                                          to: "/tilbakemelding",
-                                      }),
-                                      description:
-                                          "Foreslå noe nytt eller meld en feil",
-                                  },
-                                  {
                                       kind: "external",
                                       label: "Kontres",
                                       href: "https://kontres.tihlde.org",

--- a/apps/kvark/src/routes/_app.tsx
+++ b/apps/kvark/src/routes/_app.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { authQueryOptions } from "#/api/auth";
 import { EventRulesConsent } from "#/components/event-rules-consent";
+import { FeedbackButton } from "#/components/feedback-button";
 import { NotificationBell } from "#/components/notification-bell";
 import { PendingApprovalNotice } from "#/components/pending-approval-notice";
 import { SetPasswordNotice } from "#/components/set-password-notice";
@@ -62,7 +63,10 @@ function AppLayout() {
                 // ingen varsler ennå.
                 actions={
                     isAuthenticated && !isPendingApproval ? (
-                        <NotificationBell />
+                        <>
+                            <FeedbackButton />
+                            <NotificationBell />
+                        </>
                     ) : null
                 }
             />


### PR DESCRIPTION
Tilbakemelding lå inne i «For Medlemmer»-menyen. Nå ligger den som et bug-ikon rett til venstre for varselbjella i headeren, slik den gjorde i gamle Kvark — samme plass, samme ikon.

- Ny `FeedbackButton` (bug-ikon → `/tilbakemelding`), bygget på eksisterende `IconActionButton`, så den får tooltip og aria-label.
- Vises i `_app.tsx` på samme betingelse som bjella: innlogget og ikke ventende godkjenning.
- «Tilbakemelding» fjernet fra medlemsmenyen i `site-nav-items.ts`.

## Verifisert
Lokalt mot API på 4100, innlogget som testbruker:
- Headeren: bug → bjelle (5 uleste) → tema → profil.
- «For Medlemmer» har nå sju punkter, uten Tilbakemelding.
- Klikk på ikonet går til `/tilbakemelding`, som laster (`GET /api/feedback → 200`).
- Ser riktig ut i mobilbredde (375px) også.
- `bun run typecheck`, oxlint og oxfmt er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)