### PR TITLE
fix(ui): la bunnlinja bli stående i bunn etter en tur innom Vipps

### DIFF
--- a/packages/ui/src/components/ui/bottom-bar.tsx
+++ b/packages/ui/src/components/ui/bottom-bar.tsx
@@ -3,14 +3,81 @@ import * as React from "react";
 
 import { cn } from "#/lib/utils";
 
-function BottomBar({ className, ...props }: React.ComponentProps<"nav">) {
+/**
+ * Setter linja på plass igjen når iOS Safari har mistet den.
+ *
+ * Safari tegner `position: fixed` i et eget lag, og laget følger ikke alltid
+ * med når viewporten endrer seg mens sida ligger i bakgrunnen. Å komme
+ * tilbake fra Vipps er nettopp et slikt øyeblikk: sida fryses, Vipps overtar
+ * skjermen, og når medlemmet er tilbake blir linja stående igjen midt på
+ * skjermen. Ingenting i CSS-en kan uttrykke «tegn denne på nytt», så vi tvinger
+ * fram en ny layout av elementet i det sida kommer til syne igjen. Det koster
+ * ingenting når alt er som det skal.
+ */
+function useRepinOnViewportChange(ref: React.RefObject<HTMLElement | null>) {
+    React.useEffect(() => {
+        const node = ref.current;
+        if (!node) return;
+
+        function repin() {
+            if (!node) return;
+            const previous = node.style.display;
+            node.style.display = "none";
+            // Lesingen er poenget: den tvinger fram layouten før vi setter
+            // display tilbake, ellers slår nettleseren de to sammen til ingen
+            // endring i det hele tatt.
+            void node.offsetHeight;
+            node.style.display = previous;
+        }
+
+        function onPageShow(event: PageTransitionEvent) {
+            // Bare den gjenopprettede sida er interessant; en fersk lasting
+            // har aldri et gammelt lag å rette opp.
+            if (event.persisted) repin();
+        }
+
+        function onVisibilityChange() {
+            if (document.visibilityState === "visible") repin();
+        }
+
+        // Bare de to hendelsene: `visualViewport`-endringer fyrer i tett
+        // rekkefølge mens Safari skjuler adresselinja under scrolling, og en
+        // ny layout per hendelse ville kostet mer enn den retter opp.
+        window.addEventListener("pageshow", onPageShow);
+        document.addEventListener("visibilitychange", onVisibilityChange);
+
+        return () => {
+            window.removeEventListener("pageshow", onPageShow);
+            document.removeEventListener(
+                "visibilitychange",
+                onVisibilityChange,
+            );
+        };
+    }, [ref]);
+}
+
+function BottomBar({ className, ref, ...props }: React.ComponentProps<"nav">) {
+    const innerRef = React.useRef<HTMLElement | null>(null);
+    useRepinOnViewportChange(innerRef);
+
     return (
         <nav
             data-slot="bottom-bar"
+            ref={(node) => {
+                innerRef.current = node;
+                if (typeof ref === "function") return ref(node);
+                if (ref) ref.current = node;
+            }}
             className={cn(
                 // `pb-safe` keeps the row clear of the iOS home indicator, which
                 // otherwise sits right on top of the labels.
-                "fixed inset-x-0 bottom-0 z-40 border-t bg-background/90 pb-[env(safe-area-inset-bottom)] backdrop-blur supports-backdrop-filter:bg-background/70",
+                //
+                // Ingen `backdrop-filter` her, i motsetning til headeren:
+                // et fastlåst element med bakgrunnsuskarphet får sitt eget
+                // komposittlag i WebKit, og det er nettopp de lagene som blir
+                // hengende igjen på feil sted. Bakgrunnen er derfor tett nok
+                // til å stå på egne bein.
+                "fixed inset-x-0 bottom-0 z-40 border-t bg-background pb-[env(safe-area-inset-bottom)]",
                 className,
             )}
             {...props}


### PR DESCRIPTION
Elliot betalte for immeballet med Vipps, og da han kom tilbake til nettleseren sto bunnlinja midt på skjermen. iPhone, Safari.

## Hva som er gjort

**Bakgrunnsuskarpheten er fjernet fra bunnlinja.** Et fastlåst element med `backdrop-filter` får sitt eget komposittlag i WebKit, og et slikt lag følger ikke alltid med når viewporten endrer seg mens sida ligger frosset i bakgrunnen — som den gjør mens Vipps har skjermen. Bakgrunnen er nå tett (`bg-background`) i stedet for `bg-background/90` + blur. Headeren beholder sin uskarphet.

**Linja tegnes på nytt når sida kommer til syne igjen.** En liten effekt tvinger fram ny layout av `<nav>` på `pageshow` for den gjenopprettede sida og på `visibilitychange`. `visualViewport` er bevisst utelatt: den fyrer i tett rekkefølge mens Safari skjuler adresselinja under scrolling, og en ny layout per hendelse ville kostet mer enn den retter opp.

## Verifisering

`typecheck`, `lint`, `format` og `build` er grønne.

Chrome, 375×812: `backdrop-filter: none`, `rectBottom 812 = innerHeight 812`. `pageshow` med `persisted: true` gir to style-endringer på `<nav>` (av og på igjen), en fersk lasting gir null.

iOS-simulator (iPhone 17 Pro, iOS 26.2, Safari), ekte HOME → tilbake til Safari, med en midlertidig måler tegnet inn i appen:

| Runde | Situasjon | Avlesning |
|---|---|---|
| 1 | uscrollet, full adresselinje | `repins=1`, `rectBottom=714 innerHeight=714 avvik=0`, `blur=none` |
| 2 | scrollet ned, minimert adresselinje | `repins=2`, `rectBottom=754 innerHeight=754 avvik=0`, `blur=none` |

Telleren økte for hver app-retur, så lytteren fyrer på nøyaktig den veien Elliot går, og geometrien er riktig i begge viewport-tilstandene.

## Det dette ikke beviser

Selve feilen lot seg ikke fremkalle lokalt. Jeg bygde tre testsider som etterlignet oppsettet — fast bunnlinje med blur, `html { overflow-x: clip }`, innhold som vokser over og under folden mens sida er scrollet, appbytte, bfcache-retur, pinch-zoom — og WebKit oppførte seg riktig hver gang. Det eneste som faktisk løsnet linja var pinch-zoom, og skjermbildet fra Elliot ser ikke zoomet ut.

Fiksen er altså rettet mot mekanismen, ikke mot en reprodusert feiltilstand. Det avgjørende beviset må komme fra én ekte Vipps-betaling etter at dette er ute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)