### PR TITLE
fix(betaling): stopp den doble forpliktelsen som avlyste en betalt plass

### DIFF
--- a/apps/api/src/lib/event/payment.ts
+++ b/apps/api/src/lib/event/payment.ts
@@ -164,6 +164,36 @@ export async function createPaymentObligation(
     }
 
     const now = new Date();
+
+    /**
+     * An obligation that is still running its own countdown covers this member
+     * already, and a second one is actively harmful: its timer judges them on a
+     * row their money never touched.
+     *
+     * That is how it happened. A member unregistered and signed up again while
+     * their Vipps checkout was in the air. {@link hasPaidForEvent} above says
+     * "not paid" — the checkout was still `pending` — so they were handed a
+     * second obligation, Vipps confirmed the first one seconds later, and the
+     * spare row's timer stood ready to cancel a paid seat.
+     *
+     * Only a live obligation is reused. An expired one is spent, and reusing it
+     * would hand out a deadline that has already passed.
+     */
+    const liveObligation = await ctx.db.query.eventPayment.findFirst({
+        columns: { id: true },
+        where: (p, { and, eq, gt }) =>
+            and(
+                eq(p.eventId, event.id),
+                eq(p.userId, userId),
+                eq(p.status, "pending"),
+                gt(p.expiresAt, now),
+            ),
+    });
+
+    if (liveObligation) {
+        return { id: liveObligation.id };
+    }
+
     const expiresAt = paymentDeadline(graceMinutes, event.start, now);
     const delay = Math.max(0, expiresAt.getTime() - now.getTime());
 
@@ -619,6 +649,21 @@ export async function handlePaymentExpiration(
         payment.status === "paid" ||
         payment.status === "refunded"
     ) {
+        return;
+    }
+
+    /**
+     * The member paid — just not on the row this timer points at.
+     *
+     * A second obligation can exist alongside a live checkout (see
+     * {@link createPaymentObligation}), and the reconciliation below only ever
+     * asks Vipps about the *pending* rows. An obligation without a
+     * `providerPaymentId` is judged "dead" without a single call, so a member
+     * whose money was collected on the other row lost their spot — 510 kr paid,
+     * seat given away. Ask the question the verdict actually depends on before
+     * reclaiming anything.
+     */
+    if (await hasPaidForEvent(ctx, eventId, userId)) {
         return;
     }
 

--- a/apps/api/src/routes/event/registration/delete.ts
+++ b/apps/api/src/routes/event/registration/delete.ts
@@ -2,6 +2,7 @@ import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import { promoteFromWaitlist } from "~/lib/event/payment";
+import { cancelPayment, getPaymentDetails } from "~/lib/vipps";
 import { issueStrike } from "~/lib/event/strikes";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "../../../lib/route";
@@ -67,6 +68,75 @@ export const deleteEventRegistrationRoute = route().delete(
                     message:
                         "Du kan ikke melde deg av et arrangement du har betalt for. Ta kontakt med arrangøren for refusjon.",
                 });
+            }
+
+            /**
+             * A checkout that is still open is a payment on its way in for a
+             * spot the member is giving up this second. Left alone it lands
+             * after the registration is gone — money without a seat — and if
+             * they sign up again in the meantime, they end up holding two
+             * obligations at once.
+             *
+             * Vipps decides which of the two it is, exactly as the checkout
+             * route asks it: money already reserved or drawn settles on its
+             * own and must not be cancelled behind the member's back, while an
+             * untouched session is theirs to close.
+             */
+            const startedPayment = await db.query.eventPayment.findFirst({
+                columns: { id: true, providerPaymentId: true },
+                where: (payment, { eq, and, isNotNull }) =>
+                    and(
+                        eq(payment.userId, userId),
+                        eq(payment.eventId, eventId),
+                        eq(payment.status, "pending"),
+                        isNotNull(payment.providerPaymentId),
+                    ),
+            });
+
+            if (startedPayment?.providerPaymentId) {
+                const reference = startedPayment.providerPaymentId;
+                let details: Awaited<ReturnType<typeof getPaymentDetails>>;
+
+                try {
+                    details = await getPaymentDetails(reference);
+                } catch {
+                    // Without an answer we cannot tell a paid checkout from an
+                    // abandoned one, and deleting the registration is the
+                    // irreversible half. Ask them to try again.
+                    throw new HTTPException(409, {
+                        message:
+                            "Vi får ikke tak i betalingsstatusen din akkurat nå. Prøv igjen om litt.",
+                    });
+                }
+
+                if (
+                    details.state === "AUTHORIZED" ||
+                    details.aggregate.capturedAmount.value > 0 ||
+                    details.aggregate.authorizedAmount.value > 0
+                ) {
+                    throw new HTTPException(400, {
+                        message:
+                            "Betalingen din er under behandling. Vent til den er bekreftet, og ta kontakt med arrangøren for refusjon.",
+                    });
+                }
+
+                if (details.state === "CREATED") {
+                    try {
+                        await cancelPayment(reference);
+                    } catch {
+                        throw new HTTPException(409, {
+                            message:
+                                "Vi fikk ikke avbrutt betalingen din. Prøv igjen om litt.",
+                        });
+                    }
+                }
+
+                // Nothing was paid and nothing is left open: the obligation is
+                // spent, and its timer will find it already dealt with.
+                await db
+                    .update(schema.eventPayment)
+                    .set({ status: "failed" })
+                    .where(eq(schema.eventPayment.id, startedPayment.id));
             }
         }
 

--- a/apps/api/src/test/event/payment-duplicate-obligation.test.ts
+++ b/apps/api/src/test/event/payment-duplicate-obligation.test.ts
@@ -1,0 +1,239 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect, vi } from "vitest";
+import {
+    createPaymentObligation,
+    handlePaymentExpiration,
+} from "~/lib/event/payment";
+import { resolveRegistrationsForEvent } from "~/lib/event/resolve-registration";
+import * as vipps from "~/lib/vipps";
+import { integrationTest } from "~/test/config/integration";
+
+vi.mock("~/lib/vipps", () => ({
+    refundPayment: vi.fn().mockResolvedValue(undefined),
+    capturePayment: vi.fn().mockResolvedValue(undefined),
+    cancelPayment: vi.fn().mockResolvedValue(undefined),
+    createPayment: vi.fn(),
+    getPaymentDetails: vi.fn(),
+    setupWebhooks: vi.fn(),
+    verifyVippsWebhookRequest: vi.fn(),
+}));
+
+/** A Vipps checkout the member opened but never touched. */
+const UNTOUCHED_CHECKOUT = {
+    state: "CREATED",
+    aggregate: {
+        authorizedAmount: { value: 0 },
+        capturedAmount: { value: 0 },
+        refundedAmount: { value: 0 },
+        cancelledAmount: { value: 0 },
+    },
+};
+
+/** A checkout where Vipps has already reserved the money. */
+const RESERVED_CHECKOUT = {
+    state: "AUTHORIZED",
+    aggregate: {
+        authorizedAmount: { value: 51000 },
+        capturedAmount: { value: 0 },
+        refundedAmount: { value: 0 },
+        cancelledAmount: { value: 0 },
+    },
+};
+
+describe("Duplicate payment obligations", () => {
+    integrationTest(
+        "the deadline timer leaves a spot alone when the member paid on another row",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 10,
+                isPaidEvent: true,
+                priceMinor: 51000,
+            });
+
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, user.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            // The obligation they actually paid: a checkout Vipps confirmed.
+            const paid = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { and, eq }) =>
+                    and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+            });
+            await ctx.db
+                .update(schema.eventPayment)
+                .set({
+                    status: "paid",
+                    provider: "vipps",
+                    providerPaymentId: "vipps-ref-123",
+                    receivedPaymentAt: new Date(),
+                })
+                .where(eq(schema.eventPayment.id, paid?.id ?? ""));
+
+            // The spare row a re-registration left behind, with no checkout of
+            // its own — this is the one whose timer fires.
+            const [stray] = await ctx.db
+                .insert(schema.eventPayment)
+                .values({
+                    eventId: event.id,
+                    userId: user.id,
+                    amountMinor: 51000,
+                    currency: "NOK",
+                    status: "pending",
+                    expiresAt: new Date(Date.now() + 1000),
+                })
+                .returning();
+
+            await handlePaymentExpiration(ctx, {
+                eventId: event.id,
+                userId: user.id,
+                paymentId: stray?.id ?? "",
+            });
+
+            const registration = await ctx.db.query.eventRegistration.findFirst(
+                {
+                    where: (r, { and, eq }) =>
+                        and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+                },
+            );
+
+            expect(registration?.status).toBe("registered");
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "a member with a live obligation does not get a second one",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 10,
+                isPaidEvent: true,
+                priceMinor: 51000,
+            });
+
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, user.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const first = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { and, eq }) =>
+                    and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+            });
+
+            // They opened a checkout, then signed up again while it was in the
+            // air — the same call that handed out the spare row in production.
+            await ctx.db
+                .update(schema.eventPayment)
+                .set({ provider: "vipps", providerPaymentId: "vipps-ref-123" })
+                .where(eq(schema.eventPayment.id, first?.id ?? ""));
+
+            const second = await createPaymentObligation(ctx, event, user.id);
+
+            expect(second?.id).toBe(first?.id);
+
+            const rows = await ctx.db.query.eventPayment.findMany({
+                where: (p, { and, eq }) =>
+                    and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+            });
+            expect(rows).toHaveLength(1);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "unregistering closes an untouched checkout instead of leaving it open",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            vi.mocked(vipps.getPaymentDetails).mockResolvedValue(
+                UNTOUCHED_CHECKOUT as never,
+            );
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 10,
+                isPaidEvent: true,
+                priceMinor: 51000,
+            });
+
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, user.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const obligation = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { and, eq }) =>
+                    and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+            });
+            await ctx.db
+                .update(schema.eventPayment)
+                .set({ provider: "vipps", providerPaymentId: "vipps-ref-123" })
+                .where(eq(schema.eventPayment.id, obligation?.id ?? ""));
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[":eventId"].registration.$delete(
+                {
+                    param: { eventId: event.id },
+                },
+            );
+
+            expect(res.status).toBe(200);
+            expect(vipps.cancelPayment).toHaveBeenCalledWith("vipps-ref-123");
+
+            const after = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { eq }) => eq(p.id, obligation?.id ?? ""),
+            });
+            expect(after?.status).toBe("failed");
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "unregistering is refused while Vipps holds the money",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+            vi.mocked(vipps.getPaymentDetails).mockResolvedValue(
+                RESERVED_CHECKOUT as never,
+            );
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 10,
+                isPaidEvent: true,
+                priceMinor: 51000,
+            });
+
+            const user = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, user.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const obligation = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { and, eq }) =>
+                    and(eq(p.eventId, event.id), eq(p.userId, user.id)),
+            });
+            await ctx.db
+                .update(schema.eventPayment)
+                .set({ provider: "vipps", providerPaymentId: "vipps-ref-456" })
+                .where(eq(schema.eventPayment.id, obligation?.id ?? ""));
+
+            const client = await ctx.utils.clientForUser(user);
+            const res = await client.api.event[":eventId"].registration.$delete(
+                {
+                    param: { eventId: event.id },
+                },
+            );
+
+            expect(res.status).toBe(400);
+
+            // The spot is still theirs — the money is on its way to it.
+            const registration = await ctx.db.query.eventRegistration.findFirst(
+                {
+                    where: (r, { and, eq }) =>
+                        and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+                },
+            );
+            expect(registration?.status).toBe("registered");
+        },
+        500_000,
+    );
+});


### PR DESCRIPTION
## Hva som skjedde

Under påmeldingen til Immatrikuleringsball 2026 (21. august) meldte et medlem seg av og på igjen mens Vipps-checkouten fortsatt var i lufta:

| Klokkeslett | Hendelse |
|---|---|
| 11:59:42 | starter Vipps-betalingen |
| 11:59:55 | meldes av og på igjen → **ny** forpliktelse, frist 13:59:55 |
| 12:00:07 | Vipps bekrefter den første betalingen, 510 kr |

Resultat: én rad `paid`, én rad `pending`. Klokka 13:59:55 ville fristen på den løse raden ha satt påmeldingen til `cancelled` og sendt henne varselet «Du fullførte ikke betalingen innen fristen» — med pengene stående inne hos TIHLDE.

Raden ble slettet manuelt i prod før fristen løp ut, så ingen mistet plassen sin. Denne PR-en stenger veien dit.

## Tre ledd, tre sperrer

**1. Timeren spør om medlemmet har betalt** (`handlePaymentExpiration`). Den så bare på de `pending`-radene, og en rad uten `providerPaymentId` ble dømt «dead» uten et eneste kall til Vipps. Nå avsluttes den hvis medlemmet har en betalt rad for arrangementet. Dette er sikkerhetsnettet — det holder selv om de to neste svikter.

**2. Ingen forpliktelse nummer to** (`createPaymentObligation`). Sjekken var `hasPaidForEvent`, som ser etter status `paid` og dermed er blind for en checkout som pågår. Nå gjenbrukes en forpliktelse som fortsatt løper. Bare en levende rad — en utløpt er brukt opp, og å gjenbruke den ville delt ut en frist som allerede er gått.

**3. Avmelding lukker checkouten** (`DELETE /event/:eventId/registration`). Ruta blokkerte bare når en betaling var `paid`. Nå spør den Vipps, akkurat som betalingsruta gjør: en urørt session kanselleres, mens penger som alt er reservert eller trukket avviser avmeldingen — den betalingen gjør seg ferdig av seg selv og skal ikke kanselleres bak medlemmets rygg. Får vi ikke svar fra Vipps, avvises avmeldingen framfor å slette registreringen på et gjett.

## Tester

Fire nye integrasjonstester i `payment-duplicate-obligation.test.ts`, den første er reproduksjonen av hendelsen over (den feiler på `main` med `cancelled`). Hele `src/test/event` er grønn: 43 filer, 233 tester. Typecheck, lint og build kjørt.

## Merk

Ikke deployet. De 21 betalingsfristene som løper for immeball ligger som forsinkede jobber i Redis, og prod-Redis kjører uten volum — en restart tømmer dem. Vent med merge til betalingsvinduet er over.

De tre fiksene ligger i én PR fordi de er samme feilkjede og bør lande samlet: ledd 2 og 3 stenger veien inn, ledd 1 fanger radene som allerede finnes. Si fra hvis dere heller vil ha dem hver for seg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)