### PR TITLE
fix(søknader): la kvitteringen komme fram, og gjør stille skjemafeil synlige

### DIFF
--- a/apps/kvark/src/components/form/form-errors.tsx
+++ b/apps/kvark/src/components/form/form-errors.tsx
@@ -1,6 +1,43 @@
 import { useFormContext } from "#/hooks/form";
 import { FieldError } from "@tihlde/ui/ui/field";
 
+type Issue = { message?: string; path?: PropertyKey[] };
+
+/**
+ * Collect the errors no field can show.
+ *
+ * A schema keeps the issue at the path that failed, and only top-level paths
+ * have a field rendering them. An issue on `receipts[0]` — one bad file inside
+ * the array — is keyed to a field that does not exist in the form, so nothing
+ * marks itself invalid and nothing scrolls into view: the submit button just
+ * looks dead. Those issues are surfaced here instead.
+ */
+function collectUnmapped(error: unknown, out: Issue[]): void {
+    if (!error) return;
+
+    if (Array.isArray(error)) {
+        for (const entry of error) collectUnmapped(entry, out);
+        return;
+    }
+
+    if (typeof error === "string") {
+        out.push({ message: error });
+        return;
+    }
+
+    if (typeof error !== "object") return;
+
+    const issue = error as Issue;
+    if (typeof issue.message === "string") {
+        // A top-level path belongs to a field, which renders it itself.
+        if (!issue.path || issue.path.length > 1) out.push(issue);
+        return;
+    }
+
+    // Standard-schema validators hand back a map of field name -> issues.
+    for (const entry of Object.values(error)) collectUnmapped(entry, out);
+}
+
 export function FormErrors(
     props: Omit<React.ComponentProps<typeof FieldError>, "errors">,
 ) {
@@ -8,7 +45,11 @@ export function FormErrors(
 
     return (
         <form.Subscribe selector={(state) => state.errors}>
-            {(errors) => <FieldError {...props} errors={errors} />}
+            {(errors) => {
+                const unmapped: Issue[] = [];
+                collectUnmapped(errors, unmapped);
+                return <FieldError {...props} errors={unmapped} />;
+            }}
         </form.Subscribe>
     );
 }

--- a/apps/kvark/src/components/soknader/expense-form.tsx
+++ b/apps/kvark/src/components/soknader/expense-form.tsx
@@ -33,7 +33,9 @@ const schema = z.object({
         error: "Kontonummer må være i formatet xxxx.xx.xxxxx",
     }),
     receipts: z
-        .array(z.instanceof(File))
+        .array(
+            z.instanceof(File, { error: "Ugyldig fil. Last den opp på nytt." }),
+        )
         .min(1, { error: "Legg ved minst én kvittering" }),
 });
 

--- a/apps/kvark/src/components/soknader/hs-case-form.tsx
+++ b/apps/kvark/src/components/soknader/hs-case-form.tsx
@@ -29,7 +29,9 @@ const schema = z
             .min(1, { error: "Feltet er påkrevd" })
             .max(10000),
         recommendation: z.string().max(10000),
-        attachments: z.array(z.instanceof(File)),
+        attachments: z.array(
+            z.instanceof(File, { error: "Ugyldig fil. Last den opp på nytt." }),
+        ),
     })
     // The old portal marked this required in the UI but left it optional in
     // validation, so a Vedtakssak could be submitted without an innstilling.

--- a/apps/kvark/src/components/soknader/support-form.tsx
+++ b/apps/kvark/src/components/soknader/support-form.tsx
@@ -32,7 +32,9 @@ const schema = z.object({
         .positive({ error: "Beløpet må være større enn 0" }),
     budgetLink: z.union([z.literal(""), z.url({ error: "Ugyldig lenke" })]),
     summary: z.string().max(5000),
-    budgetImages: z.array(z.instanceof(File)),
+    budgetImages: z.array(
+        z.instanceof(File, { error: "Ugyldig fil. Last den opp på nytt." }),
+    ),
 });
 
 export type SupportFormValues = z.infer<typeof schema>;

--- a/packages/ui/src/lib/image-compression.ts
+++ b/packages/ui/src/lib/image-compression.ts
@@ -47,6 +47,36 @@ function inferMimeFromFilename(name: string): string | null {
     }
 }
 
+const EXTENSION_BY_MIME: Record<string, string> = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/gif": "gif",
+    "application/pdf": "pdf",
+};
+
+/**
+ * Wrap the compressed data in a real `File`.
+ *
+ * `imageCompression` hands back a `Blob` with a `name` property glued on — it
+ * looks like a `File` in the preview and in FormData, but it fails
+ * `instanceof File`. Schemas that require a `File` then reject the value, and
+ * an upload posted straight from the Blob reaches the server named "blob".
+ *
+ * The original name is kept, with the extension corrected when the compressor
+ * changed the format.
+ */
+function toFile(data: Blob, originalName: string, type: string): File {
+    const extension = EXTENSION_BY_MIME[type];
+    const currentExtension = originalName.toLowerCase().split(".").pop();
+    const name =
+        extension && currentExtension !== extension
+            ? `${originalName.replace(/\.[^.]+$/, "")}.${extension}`
+            : originalName;
+
+    return new File([data], name, { type });
+}
+
 /**
  * Shrink an image file. Non-images, GIFs, and anything that fails to compress
  * are returned untouched — a failed optimization must never cost the user their
@@ -63,15 +93,14 @@ export async function compressImageFile(file: File): Promise<File> {
         // Already-small images can come back larger than they went in.
         if (compressed.size >= file.size) return file;
 
-        if (compressed.type) return compressed as File;
-
-        // Some browsers drop the MIME type on the resulting Blob. Re-wrap it so
-        // the server still receives a recognizable Content-Type.
-        const fallbackType =
+        // Some browsers drop the MIME type on the resulting Blob, so fall back
+        // to the type the file came in with.
+        const type =
+            compressed.type ||
             file.type ||
             inferMimeFromFilename(file.name) ||
             "application/octet-stream";
-        return new File([compressed], file.name, { type: fallbackType });
+        return toFile(compressed, file.name, type);
     } catch {
         return file;
     }


### PR DESCRIPTION
## Problemet

«Send inn utlegg» gjorde ingenting. Knappen reagerte på klikket, men ingen feilmelding, ingen scroll, ingen request — og ingen søknad i databasen.

## Årsaken

Kvitteringen komprimeres i nettleseren før opplasting. `browser-image-compression` returnerer et **Blob** med `.name` limt på: det ser ut som en fil i forhåndsvisningen og i FormData, men `instanceof File` er `false`. Koden løy om det (`return compressed as File`), mens skjemaet krever `z.array(z.instanceof(File))`.

Zod legger da feilen på stien `receipts[0]` — et felt ingen komponent tegner. Ingen rød tekst, ingen `data-invalid`, ingenting å scrolle til. Små bilder komprimeres ikke i det hele tatt, og derfor virket skjemaet i alle tidligere tester.

Fingeravtrykket i prod: kvitteringsopplastinger lagret som `blob.webp` (navnet FormData gir et Blob uten filnavn).

Samme feil rammet støtte- og HS-sak-skjemaene, og ga en kryptisk engelsk feilmelding på profilbilde og arrangementsbilde.

## Fiksen

- `compressImageFile` pakker alltid resultatet i en ekte `File`, med originalt filnavn og filendelse rettet til det formatet komprimeringen faktisk ga.
- `FormErrors` viser feil som ligger på nøstede stier, så denne klassen feil ikke kan forsvinne i stillhet igjen.
- Søknadsskjemaene får en norsk melding («Ugyldig fil. Last den opp på nytt.») i stedet for Zods engelske.

## Verifisert

Reprodusert lokalt med et 5,6 MB «foto»: fullt utfylt skjema → klikk → `receipts[0]: Invalid input: expected File, received Blob`, ingen synlig feil, ingen request. Etter fiksen: `instanceof File: true`, innsending gikk gjennom med banneret «Utlegget er sendt inn», og asset-raden ble lagret som `kvittering.webp` i stedet for `blob.webp`. Et manuelt innsneket Blob gir nå «Ugyldig fil. Last den opp på nytt.» rett over knappen.

`typecheck`, `lint`, `format` og `build` er grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)