### PR TITLE
fix(innlogging): gi tilbake medlemsrollen en mislykket Feide-synk aldri delte ut

### DIFF
--- a/apps/api/src/test/feide/baseline-role-recovery.test.ts
+++ b/apps/api/src/test/feide/baseline-role-recovery.test.ts
@@ -1,0 +1,165 @@
+import { recoverMissingBaselineRole } from "@photon/auth/feide";
+import { schema } from "@photon/db";
+import { and, eq, inArray } from "drizzle-orm";
+import { afterEach, describe, expect, vi } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+import type { IntegrationTestContext } from "~/test/config/integration";
+
+/**
+ * A member whose Feide sync failed in the callback stays signed in without a
+ * baseline role, and nothing retried it. In production on 2026-08-21 that
+ * surfaced as "Kontoen din har ikke tilgang til å melde seg på" when the
+ * immatrikuleringsball opened — on a session two weeks old, with a Feide
+ * account that had synced fine before.
+ */
+
+const dataportenGroups = [
+    {
+        id: "fc:fs:fs:kull:ntnu.no:BIDATA:2026H",
+        type: "fc:fs:kull",
+        displayName: "Kull for Høst 2026 BIDATA",
+        membership: { active: true },
+    },
+];
+
+const stubDataporten = () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes("groups-api.dataporten.no")) {
+            return new Response(JSON.stringify(dataportenGroups), {
+                status: 200,
+            });
+        }
+        if (url.includes("auth.dataporten.no/openid/userinfo")) {
+            return new Response(
+                JSON.stringify({
+                    sub: "feide-sub",
+                    "dataporten-userid_sec": ["feide:testuser@ntnu.no"],
+                }),
+                { status: 200 },
+            );
+        }
+        throw new Error(`Unexpected fetch in test: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+};
+
+async function seedStudyProgramme(ctx: IntegrationTestContext) {
+    await ctx.db.insert(schema.group).values({
+        slug: "dataingenior",
+        name: "Dataingeniør",
+        type: "STUDY",
+        finesInfo: "",
+        finesActivated: false,
+    });
+    await ctx.db.insert(schema.studyProgram).values({
+        slug: "dataingenior",
+        feideCode: "BIDATA",
+        displayName: "Dataingeniør",
+        type: "bachelor",
+    });
+    await ctx.db
+        .insert(schema.role)
+        .values([{ name: "member" }, { name: "alumni" }])
+        .onConflictDoNothing();
+}
+
+async function linkFeideAccount(
+    ctx: IntegrationTestContext,
+    userId: string,
+    accountId: string,
+) {
+    await ctx.db.insert(schema.account).values({
+        id: `acc-${accountId}`,
+        userId,
+        providerId: "feide",
+        accountId,
+        accessToken: "token-from-the-login",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+}
+
+async function baselineRolesOf(ctx: IntegrationTestContext, userId: string) {
+    const rows = await ctx.db
+        .select({ name: schema.role.name })
+        .from(schema.userRole)
+        .innerJoin(schema.role, eq(schema.role.id, schema.userRole.roleId))
+        .where(
+            and(
+                eq(schema.userRole.userId, userId),
+                inArray(schema.role.name, ["member", "alumni"]),
+            ),
+        );
+    return rows.map((r) => r.name);
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("recoverMissingBaselineRole", () => {
+    integrationTest(
+        "gives back the member role a failed callback sync never assigned",
+        async ({ ctx }) => {
+            stubDataporten();
+            await seedStudyProgramme(ctx);
+
+            const user = await ctx.utils.createTestUser();
+            await linkFeideAccount(ctx, user.id, "feide-recovery-1");
+
+            expect(await baselineRolesOf(ctx, user.id)).toEqual([]);
+
+            await recoverMissingBaselineRole(ctx.db, user.id);
+
+            expect(await baselineRolesOf(ctx, user.id)).toEqual(["member"]);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "costs nothing for the members who already have a role",
+        async ({ ctx }) => {
+            const fetchMock = stubDataporten();
+            await seedStudyProgramme(ctx);
+
+            const user = await ctx.utils.createTestUser();
+            await linkFeideAccount(ctx, user.id, "feide-recovery-2");
+
+            const [memberRole] = await ctx.db
+                .select({ id: schema.role.id })
+                .from(schema.role)
+                .where(eq(schema.role.name, "member"));
+            await ctx.db
+                .insert(schema.userRole)
+                .values({ userId: user.id, roleId: memberRole?.id ?? 0 });
+
+            await recoverMissingBaselineRole(ctx.db, user.id);
+
+            // Every session goes through this: it must not talk to Feide for
+            // the overwhelming majority who are fine.
+            expect(fetchMock).not.toHaveBeenCalled();
+            expect(await baselineRolesOf(ctx, user.id)).toEqual(["member"]);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "leaves a self-registered account without a Feide login alone",
+        async ({ ctx }) => {
+            const fetchMock = stubDataporten();
+            await seedStudyProgramme(ctx);
+
+            // No role and no Feide account is not a broken state: this is
+            // someone waiting for an admin to approve them.
+            const user = await ctx.utils.createTestUser();
+
+            await recoverMissingBaselineRole(ctx.db, user.id);
+
+            expect(fetchMock).not.toHaveBeenCalled();
+            expect(await baselineRolesOf(ctx, user.id)).toEqual([]);
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -181,8 +181,12 @@ export function registrationErrorMessage(error: unknown): string {
             ? `Dette arrangementet er kun for studenter ved ${institute}.`
             : "Dette arrangementet er kun for studenter ved ett bestemt institutt.";
     }
+    // Nesten alltid en medlemsrolle som aldri kom på plass ved innlogging, og
+    // da fikser en ny innlogging det på egen hånd. «Ta kontakt med Index» sto
+    // her før, og sendte folk til en support-kanal for noe de kunne løst selv
+    // på ti sekunder.
     if (message.includes("requires permission")) {
-        return "Kontoen din har ikke tilgang til å melde seg på arrangementer. Ta kontakt med Index hvis dette ser feil ut.";
+        return "Kontoen din mangler tilgang til å melde seg på. Logg ut og inn igjen — det pleier å løse det. Hjelper det ikke, si fra til Index.";
     }
     if (message.includes("Authentication required")) {
         return "Du må være innlogget for å melde deg på.";

--- a/packages/auth/src/feide.ts
+++ b/packages/auth/src/feide.ts
@@ -392,6 +392,64 @@ export async function syncFeideForUser(
 }
 
 /**
+ * Run the Feide sync again for a member who came out of a login without a
+ * baseline role.
+ *
+ * The sync in the callback is best-effort by design: it runs after the session
+ * cookie is set, so throwing there would hand a logged-in member a 500 instead
+ * of the website. The cost, spelled out in that comment, is that a failed sync
+ * leaves them without a baseline role "until the next login" — and nothing ever
+ * checked at the next login either. They stay signed in, permission-less, and
+ * find out when they press "Meld deg på": on 2026-08-21 a member hit exactly
+ * that at the immatrikuleringsball, on a session from two weeks earlier, and
+ * the only cure was to guess that logging out and in again would help.
+ *
+ * Every new session is the natural place to notice. The check is one indexed
+ * lookup for the overwhelming majority who already have a role, and the repair
+ * only runs for those who do not.
+ *
+ * Silent for members who simply have no Feide account — a self-registered
+ * account with no role is not broken, it is waiting for approval.
+ */
+export async function recoverMissingBaselineRole(
+    db: AuthCreateContext["db"],
+    userId: string,
+): Promise<void> {
+    const [existing] = await db
+        .select({ roleId: userRole.roleId })
+        .from(userRole)
+        .innerJoin(role, eq(role.id, userRole.roleId))
+        .where(
+            and(
+                eq(userRole.userId, userId),
+                inArray(role.name, ["member", "alumni"]),
+            ),
+        )
+        .limit(1);
+
+    if (existing) return;
+
+    const [feideAccount] = await db
+        .select({ id: account.id })
+        .from(account)
+        .where(
+            and(
+                eq(account.userId, userId),
+                eq(account.providerId, FEIDE_PROVIDER_ID),
+            ),
+        )
+        .limit(1);
+
+    if (!feideAccount) return;
+
+    console.warn(
+        `User ${userId} signed in without a baseline role; retrying the Feide sync.`,
+    );
+
+    await syncFeideForUser(db, userId);
+}
+
+/**
  * Write a parsed Feide result to the database.
  *
  * Split out from {@link syncFeideForUser} so the integration tests can drive

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -26,6 +26,7 @@ import { env } from "@photon/core/env";
 import { getUserPermissions } from "./rbac/permissions";
 import {
     feidePlugin,
+    recoverMissingBaselineRole,
     redirectToPasswordSetupAfterRevoke,
     revokeUnprovenCredentials,
     syncFeideHook,
@@ -580,6 +581,26 @@ export function createAuth(options: CreateAuthOptions) {
                         } catch (error) {
                             console.error(
                                 "Failed to sync De Eldstes Raad membership",
+                                error,
+                            );
+                        }
+
+                        /**
+                         * The callback's own sync may have failed and left
+                         * this member without a baseline role. Every new
+                         * session is a chance to notice — see
+                         * {@link recoverMissingBaselineRole}. Swallowed for
+                         * the same reason as the sync above: a member who is
+                         * already signed in must not be handed a 500.
+                         */
+                        try {
+                            await recoverMissingBaselineRole(
+                                options.services.db,
+                                session.userId,
+                            );
+                        } catch (error) {
+                            console.error(
+                                "Failed to recover a missing baseline role",
                                 error,
                             );
                         }


### PR DESCRIPTION
## Hva som skjedde

Et medlem prøvde å melde seg på immatrikuleringsballet kl. 12:01 og fikk «Kontoen din har ikke tilgang til å melde seg på arrangementer. Ta kontakt med Index hvis dette ser feil ut.»

Kontoen var helt i orden. Den manglet bare `member`-rollen, og fikk den i det sekundet hun logget inn på nytt kl. 12:07:12 — påmeldt tolv sekunder senere. Sesjonen hun satt med var fra 7. august, opprettet av en innlogging der Feide-synken feilet.

Synken i callbacken er best-effort med vilje ([index.ts:795](https://github.com/TIHLDE/Photon/blob/main/packages/auth/src/index.ts#L795)): den kjører etter at sesjonskapselen er satt, så en feil der ville gitt et innlogget medlem en 500 i stedet for nettsida. Kommentaren sier hva det koster — «A failed sync costs them their baseline role until the next login» — men ingen sjekket ved neste innlogging heller. Du blir stående innlogget, uten tilganger, og finner det ut når du trykker «Meld deg på».

**Tolv kontoer har en levende sesjon og ingen rolle akkurat nå**, ti av dem med Feide-konto. Alle får samme feil hvis de prøver seg på et arrangement.

## Fiksen

**`recoverMissingBaselineRole`, kjørt ved hver sesjonsopprettelse.** Har medlemmet allerede `member` eller `alumni`, koster det ett indeksert oppslag og ingenting mer. Mangler rollen og kontoen har en Feide-innlogging, kjøres synken på nytt. Kontoer uten Feide røres ikke — en selvregistrert konto uten rolle er ikke ødelagt, den venter på godkjenning.

Den er koblet på samme `session.create.after`-hook som De Eldstes Raad-synken, og feil svelges der på samme måte og av samme grunn.

**Meldingen** sier nå «Logg ut og inn igjen — det pleier å løse det. Hjelper det ikke, si fra til Index», i stedet for å sende folk til en support-kanal for noe de løser selv på ti sekunder.

## Bevisst ikke gjort

Ingen backfill av de tolv. De fikses av seg selv ved neste innlogging når dette er ute, og en engangsskriving i prod ville ikke hjulpet den neste som havner i samme situasjon.

## Tester

Tre nye integrasjonstester i `baseline-role-recovery.test.ts`: rollen kommer tilbake for en Feide-konto uten rolle, ingen som allerede har rollen fører til et eneste kall mot Feide, og en konto uten Feide-innlogging blir latt i fred. Hele `src/test/feide` er grønn (14 filer, 100 tester), det samme er `auth` og `rbac` (60 tester). Typecheck, lint og build kjørt.

## Merk

Ikke deployet. Betalingsfristene for immeball ligger som forsinkede jobber i Redis, og prod-Redis kjører uten volum — en restart tømmer dem. Vent med merge til betalingsvinduet er over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)