### PR TITLE
fix(påmelding): la serveren håndheve påmeldingsvinduet, ikke bare knappen

### DIFF
--- a/apps/api/src/routes/event/registration/create.ts
+++ b/apps/api/src/routes/event/registration/create.ts
@@ -105,6 +105,33 @@ export const registerToEventRoute = route().post(
             });
         }
 
+        /**
+         * The registration window, enforced by the server rather than only by
+         * the button.
+         *
+         * It was only the button. When the immatrikuleringsball opened on
+         * 2026-08-21, nine members were already registered before the opening
+         * second — the earliest by 16 seconds. It cost nobody a spot that time,
+         * because the event did not fill up, but on an event that does, those
+         * are the first spots, handed out by whoever bypassed the frontend or
+         * whose clock ran fast.
+         *
+         * `createdAt` is the server's own timestamp and the resolver decides in
+         * that order, so the only way to make the queue honest is to refuse the
+         * ones that arrive early here.
+         */
+        if (event.registrationStart && now < event.registrationStart) {
+            throw new HTTPException(409, {
+                message: "Registration has not opened yet",
+            });
+        }
+
+        if (event.registrationEnd && now > event.registrationEnd) {
+            throw new HTTPException(409, {
+                message: "Registration has closed",
+            });
+        }
+
         // Checked before every event-specific rule so the message a member
         // gets is the one thing they can act on. The frontend shows the same
         // block ahead of time — hitting it here means they went around it.

--- a/apps/api/src/test/event/registration-window.test.ts
+++ b/apps/api/src/test/event/registration-window.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+import type { IntegrationTestContext } from "~/test/config/integration";
+
+const HOUR = 60 * 60 * 1000;
+
+/**
+ * The registration window belongs to the server.
+ *
+ * Until this was enforced here, `registrationStart` was a frontend rule: the
+ * button unlocked at the right second, and a request that arrived earlier was
+ * accepted anyway. Nine members were registered to the immatrikuleringsball
+ * before it opened on 2026-08-21, the earliest by 16 seconds. The event did not
+ * fill up that day, so it cost nobody a spot — on one that does, those are the
+ * first spots.
+ */
+async function memberWhoMayRegister(ctx: IntegrationTestContext) {
+    const user = await ctx.utils.createTestUser();
+    await ctx.utils.giveUserPermissions(user, ["events:registrations:create"]);
+    await ctx.utils.acceptEventRules(user.id);
+    return { user, client: await ctx.utils.clientForUser(user) };
+}
+
+describe("Registration window", () => {
+    integrationTest(
+        "refuses a sign-up that arrives before registration opens",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const now = Date.now();
+            const event = await ctx.utils.createTestEvent({
+                registrationStart: new Date(now + HOUR),
+                registrationEnd: new Date(now + 48 * HOUR),
+                start: new Date(now + 72 * HOUR),
+                end: new Date(now + 76 * HOUR),
+            });
+
+            const { client } = await memberWhoMayRegister(ctx);
+            const res = await client.api.event[":eventId"].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            expect(res.status).toBe(409);
+            const body = (await res.json()) as unknown as { message: string };
+            expect(body.message).toContain("not opened yet");
+
+            const rows = await ctx.db.query.eventRegistration.findMany({
+                where: (reg, { eq }) => eq(reg.eventId, event.id),
+            });
+            expect(rows).toHaveLength(0);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "refuses a sign-up that arrives after the deadline",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const now = Date.now();
+            const event = await ctx.utils.createTestEvent({
+                registrationStart: new Date(now - 48 * HOUR),
+                registrationEnd: new Date(now - HOUR),
+                start: new Date(now + 24 * HOUR),
+                end: new Date(now + 28 * HOUR),
+            });
+
+            const { client } = await memberWhoMayRegister(ctx);
+            const res = await client.api.event[":eventId"].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            expect(res.status).toBe(409);
+            const body = (await res.json()) as unknown as { message: string };
+            expect(body.message).toContain("has closed");
+
+            const rows = await ctx.db.query.eventRegistration.findMany({
+                where: (reg, { eq }) => eq(reg.eventId, event.id),
+            });
+            expect(rows).toHaveLength(0);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "lets a sign-up inside the window through",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const now = Date.now();
+            const event = await ctx.utils.createTestEvent({
+                registrationStart: new Date(now - HOUR),
+                registrationEnd: new Date(now + 48 * HOUR),
+                start: new Date(now + 72 * HOUR),
+                end: new Date(now + 76 * HOUR),
+            });
+
+            const { client } = await memberWhoMayRegister(ctx);
+            const res = await client.api.event[":eventId"].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            expect(res.status).toBe(200);
+
+            const rows = await ctx.db.query.eventRegistration.findMany({
+                where: (reg, { eq }) => eq(reg.eventId, event.id),
+            });
+            expect(rows).toHaveLength(1);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "an event with no window set stays open",
+        async ({ ctx }) => {
+            await ctx.utils.setupGroups();
+            await ctx.utils.setupEventCategories();
+
+            const now = Date.now();
+            const event = await ctx.utils.createTestEvent({
+                registrationStart: null,
+                registrationEnd: null,
+                start: new Date(now + 72 * HOUR),
+                end: new Date(now + 76 * HOUR),
+            });
+
+            const { client } = await memberWhoMayRegister(ctx);
+            const res = await client.api.event[":eventId"].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            expect(res.status).toBe(200);
+        },
+        500_000,
+    );
+});

--- a/apps/kvark/src/lib/event.ts
+++ b/apps/kvark/src/lib/event.ts
@@ -166,6 +166,14 @@ export function registrationErrorMessage(error: unknown): string {
     if (message.includes("not open for registration")) {
         return "Dette arrangementet er ikke åpent for påmelding.";
     }
+    // Klokka på serveren er fasit. Treffer du denne, gikk du enten et sekund
+    // for tidlig eller har en klokke som ligger foran.
+    if (message.includes("Registration has not opened yet")) {
+        return "Påmeldingen har ikke åpnet ennå. Vent til klokkeslettet over og prøv igjen.";
+    }
+    if (message.includes("Registration has closed")) {
+        return "Påmeldingsfristen har gått ut.";
+    }
     if (message.includes("already registered")) {
         return "Du er allerede påmeldt. Last siden på nytt for å se påmeldingen din.";
     }


### PR DESCRIPTION
## Hullet

`registrationStart` var en frontend-regel. Knappen låser seg opp på rett sekund, men påmeldingsruta sjekket bare `isRegistrationClosed` og `requiresSigningUp` — en POST som kom tidligere ble tatt imot.

Ni medlemmer var påmeldt immatrikuleringsballet før påmeldingen åpnet 21. august:

| Sekunder før åpning | Antall |
|---|---|
| 16,0 | 1 |
| 4,7 | 1 |
| 2,8 | 1 |
| under 2 | 6 |

De seks nederste ser ut som klokkeavvik mellom en telefon og serveren. De tre øverste er vanskeligere å forklare med drift alene.

Det kostet ingen en plass denne gangen — 155 påmeldte på 163 plasser. På et arrangement som blir fullt, er dette de første plassene, og de går til den som kommer utenom knappen eller har en klokke som går fort.

`created_at` er serverens eget tidsstempel, og resolveren deler ut plassene i den rekkefølgen. Det eneste som gjør køen ærlig er å avvise de som kommer for tidlig.

## Fiksen

To sjekker i påmeldingsruta, begge 409:

- før `registrationStart`: «Registration has not opened yet»
- etter `registrationEnd`: «Registration has closed» — det hullet var der på samme måte, og er med her

Begge oversatt i Kvark, så medlemmet får «Påmeldingen har ikke åpnet ennå. Vent til klokkeslettet over og prøv igjen.» og «Påmeldingsfristen har gått ut.»

Arrangementer uten vindu satt (begge felt `null`) er upåvirket.

## Tester

Fire nye i `registration-window.test.ts`: for tidlig avvises, etter fristen avvises, innenfor vinduet slipper gjennom, og et arrangement uten vindu står åpent. Hele API-suiten er grønn: 116 filer, 777 tester. Typecheck, lint og build kjørt.

## Merk

Ikke deployet. Betalingsfristene for immeball ligger som forsinkede jobber i Redis, og prod-Redis kjører uten volum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)