### PR TITLE
fix(innlogging): rydd bort sesjonskapselen fra tiden før delt domene

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -13,6 +13,7 @@ import {
     createAppContext,
     createAppServices,
 } from "~/lib/ctx";
+import { clearStaleHostOnlySessionCookies } from "~/lib/auth-cookies";
 import { globalErrorHandler, notFoundHandler } from "~/lib/errors";
 import { emailRoutes } from "~/routes/email";
 import { eventRoutes } from "~/routes/event";
@@ -70,9 +71,14 @@ export const createApp = async (variables?: Variables) => {
 
     const api = new Hono<{ Variables: Variables }>()
         .basePath("/api")
-        .on(["POST", "GET"], "/auth/*", (c) => {
+        .on(["POST", "GET"], "/auth/*", async (c) => {
             const { auth } = c.get("ctx");
-            return auth.handler(c.req.raw);
+            // Sign-in and sign-out are also where a session cookie left over
+            // from the host-only days gets expired — see
+            // {@link clearStaleHostOnlySessionCookies}.
+            return clearStaleHostOnlySessionCookies(
+                await auth.handler(c.req.raw),
+            );
         })
         .get("/", (c) => {
             return c.text("Healthy!");

--- a/apps/api/src/lib/auth-cookies.ts
+++ b/apps/api/src/lib/auth-cookies.ts
@@ -1,0 +1,106 @@
+/**
+ * Session cookies are set for the shared parent domain (`.tihlde.org`), so the
+ * frontend can forward them from its own host during SSR. They did not always
+ * live there: before that, the API set them host-only for `photon.tihlde.org`.
+ *
+ * A host-only cookie is a different cookie as far as the browser is concerned,
+ * and nothing the API sets for `.tihlde.org` ever overwrites it. Members who
+ * signed in before the change therefore carry two cookies with the same name,
+ * and the browser sends both. Better Auth reads the first one in the header —
+ * if that is the old, long-revoked one, the member is "logged out" while a
+ * perfectly valid session sits in the second.
+ *
+ * That is what was happening on 2026-08-21: the stale `photon.tihlde.org`
+ * cookie matched no row in `auth_session`, the live `.tihlde.org` one did, and
+ * the member was thrown back to the login page every few minutes without ever
+ * losing their session. Logging in again does not help — it refreshes the
+ * domain-wide cookie and leaves the stale one exactly where it was.
+ *
+ * So whenever the API sets (or clears) a session cookie for the parent domain,
+ * it now expires the host-only twin as well. One login, and the ambiguity is
+ * gone for good.
+ */
+
+/** The Better Auth cookies that carry a session, whatever prefix they wear. */
+const SESSION_COOKIE_SUFFIXES = [".session_token", ".session_data"];
+
+function cookieName(setCookie: string): string | null {
+    const name = setCookie.split("=")[0]?.trim();
+    return name ? name : null;
+}
+
+function isSessionCookie(name: string): boolean {
+    return SESSION_COOKIE_SUFFIXES.some((suffix) => name.endsWith(suffix));
+}
+
+function hasDomainAttribute(setCookie: string): boolean {
+    return /;\s*domain=/i.test(setCookie);
+}
+
+/**
+ * The header that deletes the host-only twin: same name, no `Domain`, already
+ * expired.
+ *
+ * A `__Secure-` name is only accepted with `Secure` set, so the flag follows
+ * the name rather than being assumed — without it the browser drops the header
+ * and the stale cookie survives.
+ */
+function expiredHostOnlyCookie(name: string, secure: boolean): string {
+    return [
+        `${name}=`,
+        "Path=/",
+        "Max-Age=0",
+        "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+        "HttpOnly",
+        "SameSite=Lax",
+        ...(secure ? ["Secure"] : []),
+    ].join("; ");
+}
+
+/**
+ * Add a delete-header for every host-only session cookie whose domain-wide
+ * counterpart this response is setting.
+ *
+ * Returns the response unchanged when there is nothing to clean up, which is
+ * every request except a sign-in, a sign-out, and a session refresh.
+ */
+export function clearStaleHostOnlySessionCookies(response: Response): Response {
+    const setCookies = response.headers.getSetCookie();
+    if (setCookies.length === 0) return response;
+
+    const cleared = new Set<string>();
+    const additions: string[] = [];
+
+    for (const setCookie of setCookies) {
+        const name = cookieName(setCookie);
+
+        if (!name || cleared.has(name)) continue;
+        if (!isSessionCookie(name)) continue;
+        // Already host-only: this deployment does not use a parent domain (the
+        // localhost setup), and there is no twin to clean up.
+        if (!hasDomainAttribute(setCookie)) continue;
+
+        cleared.add(name);
+        additions.push(
+            expiredHostOnlyCookie(
+                name,
+                name.startsWith("__Secure-") || /;\s*secure/i.test(setCookie),
+            ),
+        );
+    }
+
+    if (additions.length === 0) return response;
+
+    // A response from Better Auth carries mutable headers, but copying them is
+    // cheap and cannot be caught out by an immutable one.
+    const headers = new Headers(response.headers);
+    for (const addition of additions) {
+        headers.append("set-cookie", addition);
+    }
+
+    return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+    });
+}

--- a/apps/api/src/test/auth/stale-host-only-cookies.test.ts
+++ b/apps/api/src/test/auth/stale-host-only-cookies.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { clearStaleHostOnlySessionCookies } from "~/lib/auth-cookies";
+
+/**
+ * A member who signed in before session cookies moved to the shared parent
+ * domain carries two cookies with the same name: the live `.tihlde.org` one and
+ * a host-only leftover for `photon.tihlde.org` that nothing ever overwrites.
+ * The browser sends both, and Better Auth reads whichever comes first — so a
+ * long-dead cookie logs them out while a valid session sits right behind it.
+ *
+ * Reproduced in production on 2026-08-21: the host-only cookie matched no row
+ * in `auth_session`, the domain-wide one did.
+ */
+
+const SECURE_TOKEN = "__Secure-tihlde.session_token";
+const SECURE_DATA = "__Secure-tihlde.session_data";
+
+function responseWith(setCookies: string[]): Response {
+    const headers = new Headers();
+    for (const cookie of setCookies) {
+        headers.append("set-cookie", cookie);
+    }
+    return new Response(null, { status: 200, headers });
+}
+
+function cookiesFrom(response: Response) {
+    return response.headers.getSetCookie();
+}
+
+describe("clearStaleHostOnlySessionCookies", () => {
+    it("expires the host-only twin when a session cookie is set", () => {
+        const response = clearStaleHostOnlySessionCookies(
+            responseWith([
+                `${SECURE_TOKEN}=abc123; Path=/; Domain=.tihlde.org; HttpOnly; Secure; SameSite=Lax`,
+            ]),
+        );
+
+        const cookies = cookiesFrom(response);
+        expect(cookies).toHaveLength(2);
+
+        const clearing = cookies.find((c) => !c.includes("Domain="));
+        expect(clearing).toBeDefined();
+        expect(clearing).toContain(`${SECURE_TOKEN}=;`);
+        expect(clearing).toContain("Max-Age=0");
+        // A `__Secure-` name is rejected without this, and the stale cookie
+        // would survive.
+        expect(clearing).toContain("Secure");
+        expect(clearing).toContain("HttpOnly");
+
+        // The real cookie is untouched.
+        expect(cookies).toContain(
+            `${SECURE_TOKEN}=abc123; Path=/; Domain=.tihlde.org; HttpOnly; Secure; SameSite=Lax`,
+        );
+    });
+
+    it("covers the cookie cache as well as the session token", () => {
+        const response = clearStaleHostOnlySessionCookies(
+            responseWith([
+                `${SECURE_TOKEN}=abc; Path=/; Domain=.tihlde.org; Secure`,
+                `${SECURE_DATA}=def; Path=/; Domain=.tihlde.org; Secure`,
+            ]),
+        );
+
+        const cleared = cookiesFrom(response).filter(
+            (c) => !c.includes("Domain="),
+        );
+        expect(cleared).toHaveLength(2);
+        expect(cleared.some((c) => c.startsWith(`${SECURE_TOKEN}=;`))).toBe(
+            true,
+        );
+        expect(cleared.some((c) => c.startsWith(`${SECURE_DATA}=;`))).toBe(
+            true,
+        );
+    });
+
+    it("cleans up on sign-out too, when the cookie is being cleared", () => {
+        const response = clearStaleHostOnlySessionCookies(
+            responseWith([
+                `${SECURE_TOKEN}=; Path=/; Domain=.tihlde.org; Max-Age=0; Secure`,
+            ]),
+        );
+
+        // Signing out has to take the twin with it, or the next page load
+        // authenticates as whoever the stale cookie points at.
+        expect(cookiesFrom(response)).toHaveLength(2);
+    });
+
+    it("leaves a host-only setup alone", () => {
+        // localhost dev: frontend and API share a hostname, so cookies are
+        // host-only by design and there is no twin.
+        const setCookie = "tihlde.session_token=abc; Path=/; HttpOnly";
+        const response = clearStaleHostOnlySessionCookies(
+            responseWith([setCookie]),
+        );
+
+        expect(cookiesFrom(response)).toEqual([setCookie]);
+    });
+
+    it("omits Secure for an unprefixed cookie that did not ask for it", () => {
+        const response = clearStaleHostOnlySessionCookies(
+            responseWith([
+                "tihlde.session_token=abc; Path=/; Domain=.tihlde.test; HttpOnly",
+            ]),
+        );
+
+        const clearing = cookiesFrom(response).find(
+            (c) => !c.includes("Domain="),
+        );
+        expect(clearing).toBeDefined();
+        expect(clearing).not.toContain("Secure");
+    });
+
+    it("ignores responses with no session cookie", () => {
+        const setCookie = "ui-theme=dark; Path=/";
+        const response = clearStaleHostOnlySessionCookies(
+            responseWith([setCookie]),
+        );
+
+        expect(cookiesFrom(response)).toEqual([setCookie]);
+    });
+
+    it("keeps the body and status of the response it wraps", async () => {
+        const headers = new Headers();
+        headers.append(
+            "set-cookie",
+            `${SECURE_TOKEN}=abc; Path=/; Domain=.tihlde.org; Secure`,
+        );
+        const original = new Response(JSON.stringify({ ok: true }), {
+            status: 201,
+            statusText: "Created",
+            headers,
+        });
+
+        const response = clearStaleHostOnlySessionCookies(original);
+
+        expect(response.status).toBe(201);
+        expect(await response.json()).toEqual({ ok: true });
+    });
+});


### PR DESCRIPTION
## Symptomet

Et medlem ble kastet til innloggingssiden med noen minutters mellomrom, hele dagen, uten å miste sesjonen sin. Bildet fra DevTools viste to kapsler med samme navn:

| Domene | Verdi starter på | Finnes i `auth_session`? |
|---|---|---|
| `photon.tihlde.org` | `HXafXo4RvTGkmbGF2z7Ac…` | **nei** |
| `.tihlde.org` | `VyH2WiPxlwEZeqPBOHrYe…` | ja, gyldig til 20. september |

Jeg slo begge opp i prod. Den domenebrede var en levende sesjon. Den vertsbundne fantes ikke i basen i det hele tatt.

## Hvorfor det skjer

Sesjonskapslene settes for det delte foreldredomenet, slik at fronten kan sende dem videre under SSR (`sharedParentDomain`, [index.ts:390](https://github.com/TIHLDE/Photon/blob/main/packages/auth/src/index.ts#L390)). Før den endringen satte API-et dem vertsbundet for `photon.tihlde.org`.

For nettleseren er det to forskjellige kapsler. Ingenting API-et setter for `.tihlde.org` overskriver den gamle — domene-attributtet er en del av identiteten. Så alle som logget inn før endringen går rundt med begge, nettleseren sender begge, og Better Auth leser den første i headeren. Er det den døde, er du utlogget.

Å logge inn på nytt hjelper ikke: det fornyer den domenebrede og lar den gamle ligge. Derfor kommer det tilbake igjen og igjen.

## Fiksen

Setter eller fjerner API-et en sesjonskapsel for foreldredomenet, sender det samtidig en utløpt kapsel med samme navn **uten** `Domain` — som er den eneste måten å treffe den vertsbundne tvillingen på. Én innlogging, og tvetydigheten er borte permanent.

Detaljer som måtte være riktige:

- **`Secure` følger navnet.** En `__Secure-`-kapsel avvises av nettleseren uten `Secure`, og da ville den gamle overlevd stille.
- **Gjelder også utlogging.** Fjernes den domenebrede uten at tvillingen ryker, autentiserer neste sidelasting deg som den gamle kapselen peker på.
- **Rører ikke localhost.** Der deler front og API vertsnavn, kapslene er vertsbundne med vilje, og det finnes ingen tvilling. Ingen `Domain` i responsen ⇒ ingen opprydding.
- **`session_data` også**, ikke bare `session_token` — cookie-cachen har nøyaktig samme problem.

## Tester

Sju enhetstester i `stale-host-only-cookies.test.ts`, inkludert utloggingstilfellet, `Secure`-regelen, localhost-oppsettet og at responsens kropp og status overlever. Hele API-suiten er grønn: 116 filer, 780 tester. Typecheck, lint og build kjørt.

## Merk

Ikke deployet. Betalingsfristene for immeball ligger fortsatt som forsinkede jobber i Redis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)