### PR TITLE
fix(påmelding): la en kansellert plass slippe deg på igjen

### DIFF
--- a/apps/api/src/routes/event/registration/create.ts
+++ b/apps/api/src/routes/event/registration/create.ts
@@ -1,4 +1,5 @@
 import { schema } from "@photon/db";
+import { sql } from "drizzle-orm";
 import { validator } from "hono-openapi";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "~/lib/openapi";
@@ -178,8 +179,17 @@ export const registerToEventRoute = route().post(
             }
         }
 
-        // Check if user is already registered
-        if (existingRegistration) {
+        // Check if user is already registered.
+        //
+        // En kansellert rad er ikke en påmelding — den er sporet etter en som
+        // tok slutt: fristen gikk ut, prikkene sperret, eller påmeldingen ble
+        // stengt. Varselet brukeren får sier rett ut «Du kan melde deg på på
+        // nytt», men raden ble liggende og svarte 409 på forsøket. Sperren
+        // gjelder bare plasser som faktisk står.
+        if (
+            existingRegistration &&
+            existingRegistration.status !== "cancelled"
+        ) {
             throw new HTTPException(409, {
                 message: "User is already registered for this event",
             });
@@ -191,13 +201,38 @@ export const registerToEventRoute = route().post(
         const allowPhoto =
             body.allowPhoto ?? userSettings?.allowsPhotosByDefault ?? true;
 
-        // Create pending registration in database
-        await db.insert(schema.eventRegistration).values({
-            eventId,
-            userId,
-            status: "pending",
-            allowPhoto,
-        });
+        // Create pending registration in database.
+        //
+        // Primærnøkkelen er (bruker, arrangement), så en ny påmelding etter en
+        // kansellert er den samme raden om igjen. Alt som hørte til den forrige
+        // runden nullstilles: ventelisteplassen, og oppmøtet — som ikke kan
+        // stamme fra en påmelding som ble kansellert, men som en gammel
+        // Lepton-importert rad kan bære.
+        await db
+            .insert(schema.eventRegistration)
+            .values({
+                eventId,
+                userId,
+                status: "pending",
+                allowPhoto,
+            })
+            .onConflictDoUpdate({
+                target: [
+                    schema.eventRegistration.userId,
+                    schema.eventRegistration.eventId,
+                ],
+                set: {
+                    status: "pending",
+                    allowPhoto,
+                    waitlistPosition: null,
+                    attendedAt: null,
+                    // Samme klokke som kolonnedefaulten, ikke en JS-Date:
+                    // resolveren køordner på `createdAt`, og to tidskilder
+                    // ville gitt den nye påmeldingen feil plass i køen.
+                    createdAt: sql`now()`,
+                    updatedAt: sql`now()`,
+                },
+            });
 
         /**
          * Be om at plassen avgjøres med én gang, i stedet for å vente på

--- a/apps/api/src/test/event/reregister-after-cancellation.test.ts
+++ b/apps/api/src/test/event/reregister-after-cancellation.test.ts
@@ -1,0 +1,122 @@
+import { schema } from "@photon/db";
+import { and, eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { resolveRegistrationsForEvent } from "~/lib/event/resolve-registration";
+import { integrationTest } from "~/test/config/integration";
+import type { IntegrationTestContext } from "~/test/config/integration";
+
+/**
+ * En kansellert påmelding er sporet etter en som tok slutt — fristen gikk ut,
+ * prikkene sperret, eller påmeldingen ble stengt. Varselet brukeren får sier
+ * «Du kan melde deg på på nytt», men raden ble liggende og svarte 409 på
+ * forsøket. Det låste ute alle som mistet plassen på Immatrikuleringsball 2026
+ * uten å betale i tide.
+ */
+async function seedCancelledRegistration(ctx: IntegrationTestContext) {
+    await ctx.utils.setupGroups();
+    await ctx.utils.setupEventCategories();
+
+    const event = await ctx.utils.createTestEvent({ capacity: 10 });
+    const user = await ctx.utils.createTestUser();
+    await ctx.utils.giveUserPermissions(user, ["events:registrations:create"]);
+    await ctx.utils.acceptEventRules(user.id);
+
+    await ctx.db.insert(schema.eventRegistration).values({
+        eventId: event.id,
+        userId: user.id,
+        status: "cancelled",
+        waitlistPosition: 3,
+    });
+
+    return { event, user };
+}
+
+describe("melde seg på igjen etter en kansellert plass", () => {
+    integrationTest(
+        "en kansellert rad sperrer ikke for en ny påmelding",
+        async ({ ctx }) => {
+            const { event, user } = await seedCancelledRegistration(ctx);
+            const client = await ctx.utils.clientForUser(user);
+
+            const response = await client.api.event[
+                ":eventId"
+            ].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            expect(response.status).toBe(200);
+
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const reg = await ctx.db.query.eventRegistration.findFirst({
+                where: (r, { and, eq }) =>
+                    and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+            });
+            expect(reg?.status).toBe("registered");
+            // Ventelisteplassen hørte til runden som tok slutt.
+            expect(reg?.waitlistPosition).toBeNull();
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "en plass som står blir fortsatt avvist",
+        async ({ ctx }) => {
+            const { event, user } = await seedCancelledRegistration(ctx);
+
+            await ctx.db
+                .update(schema.eventRegistration)
+                .set({ status: "registered", waitlistPosition: null })
+                .where(
+                    and(
+                        eq(schema.eventRegistration.eventId, event.id),
+                        eq(schema.eventRegistration.userId, user.id),
+                    ),
+                );
+
+            const client = await ctx.utils.clientForUser(user);
+            const response = await client.api.event[
+                ":eventId"
+            ].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            expect(response.status).toBe(409);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "en ny påmelding stiller bakerst i køen, ikke der den gamle sto",
+        async ({ ctx }) => {
+            const { event, user } = await seedCancelledRegistration(ctx);
+
+            // Den kansellerte raden er fra da påmeldingen åpnet.
+            const gammel = new Date(Date.now() - 60 * 60 * 1000);
+            await ctx.db
+                .update(schema.eventRegistration)
+                .set({ createdAt: gammel })
+                .where(
+                    and(
+                        eq(schema.eventRegistration.eventId, event.id),
+                        eq(schema.eventRegistration.userId, user.id),
+                    ),
+                );
+
+            const client = await ctx.utils.clientForUser(user);
+            await client.api.event[":eventId"].registration.$post({
+                param: { eventId: event.id },
+                json: {},
+            });
+
+            const reg = await ctx.db.query.eventRegistration.findFirst({
+                where: (r, { and, eq }) =>
+                    and(eq(r.eventId, event.id), eq(r.userId, user.id)),
+            });
+            expect(reg?.createdAt.getTime()).toBeGreaterThan(gammel.getTime());
+        },
+        500_000,
+    );
+});


### PR DESCRIPTION
## Problemet

Mister du plassen — fristen gikk ut, prikkene sperret, eller påmeldingen ble stengt — blir raden liggende som `cancelled`. Varselet du får sier rett ut «Du kan melde deg på på nytt», men forsøket ble møtt med **409 «already registered»**. Sperren så bare etter om det fantes en rad, ikke etter om den var en plass som faktisk sto.

På **Immatrikuleringsball 2026** låste det ute elleve som ikke rakk å betale i tide — med fjorten ledige plasser og tom venteliste.

## Endringen

Sperren gjelder nå bare plasser som står (`pending`, `registered`, `waitlisted`, `attended`). En ny påmelding gjenbruker raden — primærnøkkelen er (bruker, arrangement) — via `onConflictDoUpdate`, og nullstiller alt som hørte til forrige runde: ventelisteplassen, oppmøtet og `createdAt`.

`createdAt` er den som betyr noe. Resolveren køordner på den, så uten nullstillingen ville en gjenpåmelding arvet køplassen fra første forsøk og gått foran alle som meldte seg på i mellomtiden. Den settes med `now()` fra databasen framfor en JS-`Date`, slik at den er sammenlignbar med kolonnedefaulten alle andre rader får — to tidskilder i samme kolonne gir feil rekkefølge i køen.

Prikk-sperren er trygg å prøve på nytt: `canRegisterBasedOnStrikes` vurderes på nytt ved neste runde, så en som fortsatt er sperret blir kansellert igjen.

## Verifisering

- `bun run typecheck --force`, `bun run lint`, `bun run format`, `bun run build --force` — grønt
- `vitest run src/test/event` — 234 tester, alle grønne
- Tre nye tester i `reregister-after-cancellation.test.ts`: gjenpåmelding går gjennom, en plass som står avvises fortsatt med 409, og køplassen blir fersk

## Sammenheng

Henger sammen med #664, men står for seg selv: #664 handler om betalingstimeren som tok plasser den ikke skulle, denne om at de rammede ikke kom inn igjen etterpå.

Fem personer er rettet manuelt i prod i mellomtiden. Maya El Deek ble rammet to ganger — hun meldte seg på igjen og betalte, og et gammelt krav tok den nye plassen 22 minutter senere. Begge PR-ene bør ut før neste betalte arrangement åpner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)