### PR TITLE
fix(tilganger): la gruppas «Spørreskjema» nå helt fram til svarene

### DIFF
--- a/apps/api/src/routes/groups/form/list.ts
+++ b/apps/api/src/routes/groups/form/list.ts
@@ -1,3 +1,4 @@
+import { hasScopedPermission } from "@photon/auth/rbac";
 import { schema } from "@photon/db";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
@@ -58,8 +59,22 @@ export const listGroupFormsRoute = route().get(
                 and(eq(m.groupSlug, groupSlug), eq(m.userId, user.id)),
         });
 
-        const isLeader = membership?.role === "leader";
         const isMember = !!membership;
+
+        // Hvem som ser hele lista, ikke bare det som er åpent nå. Lederskap
+        // var lenge det eneste svaret, men «Spørreskjema» huket av på et verv
+        // gir `forms:*` scopet til gruppen — og den som skal forvalte skjemaene
+        // må se dem før de åpner og etter at de stenger. Uten dette forsvant
+        // et ferdig opptaksskjema ut av lista for alle andre enn lederen,
+        // enda API-et slipper dem inn på selve svarene.
+        const canManageForms =
+            membership?.role === "leader" ||
+            (await hasScopedPermission(
+                ctx,
+                user.id,
+                ["forms:update", "forms:manage"],
+                `group:${groupSlug}`,
+            ));
 
         // Get all group forms
         const groupForms = await db.query.formGroupForm.findMany({
@@ -71,10 +86,10 @@ export const listGroupFormsRoute = route().get(
 
         // Filter forms based on permissions. Et skjema som er planlagt fram i
         // tid teller som stengt her, så det dukker ikke opp for andre enn
-        // lederne før det faktisk har åpnet.
+        // dem som forvalter skjemaene før det faktisk har åpnet.
         const visibleForms = groupForms.filter((gf) => {
-            // Leaders see all forms
-            if (isLeader) return true;
+            // Den som forvalter skjemaene ser alle
+            if (canManageForms) return true;
 
             const isOpenNow = isGroupFormOpen(gf);
 

--- a/apps/api/src/test/form/group-scoped-access.test.ts
+++ b/apps/api/src/test/form/group-scoped-access.test.ts
@@ -197,4 +197,84 @@ describe("group-scoped forms access", () => {
         },
         500_000,
     );
+
+    /**
+     * Samme grant, ett steg tidligere: lista over gruppas skjema filtrerte
+     * utelukkende på lederskap og medlemskap, og spurte aldri om tilganger.
+     * Et stengt skjema — et opptak som er ferdig, eller ett som ennå ikke har
+     * åpnet — var derfor usynlig for alle andre enn lederen, enda den som
+     * holder «Spørreskjema» for gruppa slipper inn på selve svarene.
+     */
+    integrationTest(
+        "a scoped «Spørreskjema» grant sees the group's closed forms in the list",
+        async ({ ctx }) => {
+            const leader = await ctx.utils.createTestUser();
+            const helper = await ctx.utils.createTestUser();
+            const plainMember = await ctx.utils.createTestUser();
+
+            const group = await ctx.utils.createTestGroup({
+                slug: "forms-liste-eier",
+            });
+
+            await ctx.db.insert(schema.groupMembership).values([
+                { userId: leader.id, groupSlug: group.slug, role: "leader" },
+                { userId: helper.id, groupSlug: group.slug, role: "member" },
+                {
+                    userId: plainMember.id,
+                    groupSlug: group.slug,
+                    role: "member",
+                },
+            ]);
+
+            // Grantet ligger på personen, ikke på medlemskapet: da skiller
+            // testen mellom den som har fått «Spørreskjema» og den som bare
+            // er med i gruppa.
+            await ctx.db.insert(schema.userPermission).values({
+                userId: helper.id,
+                permission: "forms:manage",
+                scope: `group:${group.slug}`,
+            });
+
+            const leaderClient = await ctx.utils.clientForUser(leader);
+            const helperClient = await ctx.utils.clientForUser(helper);
+            const memberClient = await ctx.utils.clientForUser(plainMember);
+
+            // Et stengt skjema — opptaket er over.
+            const created = await leaderClient.api.groups[":slug"].forms.$post({
+                param: { slug: group.slug },
+                json: {
+                    title: "Opptak som er stengt",
+                    description: "Ferdig",
+                    template: false,
+                    group: group.slug,
+                    can_submit_multiple: false,
+                    is_open_for_submissions: false,
+                    only_for_group_members: false,
+                    fields: [
+                        {
+                            title: "Hvorfor søker du?",
+                            type: "text_answer",
+                            required: true,
+                            order: 0,
+                        },
+                    ],
+                },
+            });
+            expect(created.status).toBe(201);
+
+            const forHelper = await helperClient.api.groups[":slug"].forms.$get(
+                { param: { slug: group.slug } },
+            );
+            expect(forHelper.status).toBe(200);
+            expect(await forHelper.json()).toHaveLength(1);
+
+            // Medlemskapet alene rekker fortsatt bare til det som er åpent.
+            const forMember = await memberClient.api.groups[":slug"].forms.$get(
+                { param: { slug: group.slug } },
+            );
+            expect(forMember.status).toBe(200);
+            expect(await forMember.json()).toHaveLength(0);
+        },
+        500_000,
+    );
 });

--- a/apps/kvark/src/components/group-forms-tab.tsx
+++ b/apps/kvark/src/components/group-forms-tab.tsx
@@ -7,14 +7,18 @@ import type { Form } from "#/lib/group";
 
 type GroupFormsTabProps = {
     forms: Form[];
-    isAdmin: boolean;
+    /** Får opprette nye skjema for gruppen — `forms:create` her, eller ledervervet. */
+    canCreate: boolean;
+    /** Får redigere skjemaene og lese svarene — `forms:update`, eller ledervervet. */
+    canManage: boolean;
     onNewForm: () => void;
     onEditForm: (form: Form) => void;
 };
 
 export function GroupFormsTab({
     forms,
-    isAdmin,
+    canCreate,
+    canManage,
     onNewForm,
     onEditForm,
 }: GroupFormsTabProps) {
@@ -23,7 +27,7 @@ export function GroupFormsTab({
             <GroupPageHeader
                 title="Spørreskjema"
                 action={
-                    isAdmin ? (
+                    canCreate ? (
                         <Button onClick={onNewForm}>
                             <Plus />
                             Nytt spørreskjema
@@ -37,7 +41,7 @@ export function GroupFormsTab({
                         <li key={form.id}>
                             <GroupFormRow
                                 form={form}
-                                canManage={isAdmin}
+                                canManage={canManage}
                                 onEdit={() => onEditForm(form)}
                             />
                         </li>

--- a/apps/kvark/src/routes/_app/grupper.$slug.tsx
+++ b/apps/kvark/src/routes/_app/grupper.$slug.tsx
@@ -227,12 +227,27 @@ function GroupDetail() {
         `group:${slug}`,
     );
     const canManageMembers = hasGroupsManage || isLeader;
-    // Creating forms: a global forms:create/manage grant, or leadership of
-    // THIS group — exactly what POST /groups/:slug/form checks. The previous
-    // "in any scope" check let anyone holding forms:create for their own
-    // group manage forms on every other group's page.
-    const hasFormsPermission = usePermission(["forms:create", "forms:manage"]);
-    const canManageForms = hasFormsPermission || isLeader;
+    // Skjemaene til gruppen er scopet hit, akkurat som resten av siden: et
+    // grant for denne gruppen teller, et grant for en annen gruppe gjør ikke.
+    // Det var en global sjekk her, og den er strengere enn API-et — «Spørre-
+    // skjema» huket av på et verv gir `forms:*` scopet til `group:<slug>`, og
+    // da så nestlederen skjemaet uten å komme til «Rediger» og «Se svar»,
+    // enda POST /groups/:slug/form og canManageForm begge slipper hen inn.
+    //
+    // De to spørsmålene stilles hver for seg fordi API-et stiller dem hver for
+    // seg: å opprette krever forms:create, å redigere og lese svar krever
+    // forms:update. Slått sammen ville et grant på den ene vist knappene for
+    // den andre, og de knappene svarer 403.
+    const canCreateForms =
+        useScopedPermission(
+            ["forms:create", "forms:manage"],
+            `group:${slug}`,
+        ) || isLeader;
+    const canManageForms =
+        useScopedPermission(
+            ["forms:update", "forms:manage"],
+            `group:${slug}`,
+        ) || isLeader;
     // Arrangementer er scopet på samme måte: lederskap alene gir ikke
     // events:create — det avhenger av gruppens leaderPermissions — så vi
     // spør om selve tilgangen for nettopp denne gruppen.
@@ -899,7 +914,8 @@ function GroupDetail() {
                     {activeTab === "sporreskjema" ? (
                         <GroupFormsTab
                             forms={forms}
-                            isAdmin={canManageForms}
+                            canCreate={canCreateForms}
+                            canManage={canManageForms}
                             onNewForm={openNewForm}
                             onEditForm={handleEditForm}
                         />


### PR DESCRIPTION
Oppfølger til #647. Backend slipper nå inn den som har fått «Spørreskjema» for gruppa, men to ledd på veien spurte fortsatt om noe annet, så tilgangen var i praksis like usynlig som før.

Konkret tilfellet som utløste dette: Kristoffer har vervet Nestleder i Sosialen, med `forms:*` scopet til `group:sosialen`. Han ser opptaksskjemaet, men ikke «Rediger» eller «Se svar» — og kommer altså ikke til de 37 søknadene.

## Kvark spurte globalt der API-et spør scopet

`usePermission(["forms:create", "forms:manage"])` godtar bare et grant uten scope. «Spørreskjema» huket av på et verv gir `forms:*` scopet til `group:<slug>`, så sjekken slo aldri til — enda både `POST /groups/:slug/form` og `canManageForm` bruker `hasScopedPermission` og slipper hen inn. Siden bruker allerede `useScopedPermission` for grupper og arrangementer; skjemaene følger nå samme mønster.

De to spørsmålene stilles hver for seg, fordi API-et gjør det: å opprette krever `forms:create`, å redigere og lese svar krever `forms:update`. Slått sammen ville et grant på den ene vist knappene for den andre, og de knappene svarer 403. `GroupFormsTab` tar derfor `canCreate` og `canManage` i stedet for ett `isAdmin`.

## Lista spurte aldri om tilganger i det hele tatt

`GET /groups/:slug/forms` filtrerte utelukkende på lederskap og medlemskap. Et stengt skjema — et opptak som er ferdig, eller ett som ennå ikke har åpnet — var usynlig for alle andre enn lederen. Den som skal forvalte skjemaene må se dem både før de åpner og etter at de stenger, så ruta godtar nå et grant scopet til gruppa på lik linje med ledervervet.

Det er også den som ville slått til neste gang: Sosialens skjema står åpent nå, så Kristoffer ser det. Idet de stenger opptaket forsvinner det helt.

## Verifisert

- Ny integrasjonstest for lista. Kjørt mot den gamle koden for å se at den biter: den scopede tilgangen fikk `[]` der lederen fikk skjemaet. 3/3 grønne med fiksen.
- `bun run typecheck` (9/9), `bun run lint`, `bun run build` (4/4).
- Frontend-endringen er **ikke** verifisert i nettleser — den lokale dev-databasen på port 5436 er korrupt etter at disken gikk full (`could not open file "global/pg_filenode.map": Input/output error`), og krever `docker:fresh` for å komme tilbake. Endringen er ett bytte fra global til scopet sjekk, med samme helper som resten av gruppesiden allerede bruker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)