### PR TITLE
fix(arrangement): skjul billettsalget til arrangementet er fullt

### DIFF
--- a/apps/kvark/src/components/event-registration-card.tsx
+++ b/apps/kvark/src/components/event-registration-card.tsx
@@ -74,8 +74,8 @@ type EventRegistrationCardProps = {
     postJoinSlot?: ReactNode;
     /**
      * Lenka til Facebook-gruppa for billettsalg. Settes bare når medlemmet har
-     * betalt for plassen sin, så tilbudet om å selge billetten videre kun
-     * dukker opp for dem som faktisk har en billett å selge.
+     * betalt for plassen sin og arrangementet er fullt — da finnes det noen
+     * som vil ha billetten. Med ledige plasser igjen er tilbudet bare støy.
      */
     ticketResaleUrl?: string;
     /**

--- a/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
+++ b/apps/kvark/src/routes/_app/arrangementer.$slug.tsx
@@ -306,6 +306,9 @@ function EventDetailPage() {
 
     const price = formatEventPrice(event.isPaidEvent, event.payInfo?.price);
     const registeredCount = event.registeredCount;
+    // Fullt = ingen ledige plasser igjen. Medlemmet holder selv en av dem, så
+    // dette kan ikke leses av `registrationState`, som står på «joined».
+    const isFull = event.capacity != null && registeredCount >= event.capacity;
     const registrants = (registrationPages?.pages ?? []).flatMap((page) =>
         page.registeredUsers.map((u) => ({
             id: u.id,
@@ -672,9 +675,11 @@ function EventDetailPage() {
                         }
                         // Har man betalt for plassen sin, er billetten noe man
                         // kan bli sittende igjen med. Da tilbyr vi samme utvei
-                        // som før: legg den ut i Facebook-gruppa.
+                        // som før: legg den ut i Facebook-gruppa. Men bare når
+                        // arrangementet er fullt — er det ledige plasser igjen,
+                        // finnes det ingen kjøper, og tilbudet er bare støy.
                         ticketResaleUrl={
-                            event.registration?.hasPaid
+                            event.registration?.hasPaid && isFull
                                 ? TICKET_RESALE_GROUP_URL
                                 : undefined
                         }


### PR DESCRIPTION
«Selg billetten din her»-knappen dukket opp så snart plassen var betalt — også på arrangementer med ledige plasser igjen. Da finnes det ingen kjøper (den som vil ha plass melder seg bare på), og knappen var bare støy.

## Endring

- `isFull` regnes ut i `arrangementer.$slug.tsx` fra `capacity` og `registeredCount`. Medlemmet holder selv en av plassene, så dette kan ikke leses av `registrationState`, som står på `"joined"`.
- `ticketResaleUrl` settes nå bare når `hasPaid && isFull`. Kortet er urørt — det skjuler allerede knappen når lenka mangler.

Arrangementer uten kapasitetsgrense (`capacity === null`) blir aldri fulle, så der vises knappen ikke lenger i det hele tatt.

## Verifisering

- `bun run typecheck` grønt for hele monorepoet
- `bun run lint` uten nye advarsler
- Ingen nettleser-verifisering: krever et fullt, betalt arrangement i dev-databasen

🤖 Generated with [Claude Code](https://claude.com/claude-code)