### PR TITLE
feat(meta): la API-et fortelle hvilken versjon som faktisk kjører

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,6 +17,7 @@ import { clearStaleHostOnlySessionCookies } from "~/lib/auth-cookies";
 import { globalErrorHandler, notFoundHandler } from "~/lib/errors";
 import { emailRoutes } from "~/routes/email";
 import { eventRoutes } from "~/routes/event";
+import { versionRoutes } from "~/routes/version";
 import { formRoutes } from "~/routes/form";
 import { pinoLoggerMiddleware } from "./middleware/logger";
 import { apiKeyRoutes } from "./routes/api-key";
@@ -83,6 +84,7 @@ export const createApp = async (variables?: Variables) => {
         .get("/", (c) => {
             return c.text("Healthy!");
         })
+        .route("/version", versionRoutes)
         .route("/api-keys", apiKeyRoutes)
         .route("/applications", applicationRoutes)
         .route("/assets", assetRoutes)

--- a/apps/api/src/lib/openapi.ts
+++ b/apps/api/src/lib/openapi.ts
@@ -31,6 +31,7 @@ const tags = [
     "gallery",
     "jobs",
     "laws",
+    "meta",
     "motetid",
     "news",
     "notifications",

--- a/apps/api/src/routes/version/index.ts
+++ b/apps/api/src/routes/version/index.ts
@@ -1,0 +1,4 @@
+import { route } from "~/lib/route";
+import { versionRoute } from "./list";
+
+export const versionRoutes = route().route("/", versionRoute);

--- a/apps/api/src/routes/version/list.ts
+++ b/apps/api/src/routes/version/list.ts
@@ -1,0 +1,50 @@
+import { describeRoute } from "~/lib/openapi";
+import { route } from "~/lib/route";
+import { versionResponseSchema } from "./schema";
+
+/**
+ * Captured when the module is first loaded, which is process boot — not the
+ * first request. Reading the clock inside the handler would make every
+ * response say "now", and the route would never reveal the thing it exists
+ * for: a container that was never swapped.
+ */
+const startedAt = new Date();
+
+/**
+ * Baked in by the image build; see `infra/docker/Dockerfile`. A container that
+ * did not come from the release pipeline — a local `docker build`, or a run
+ * straight from source — has neither, and says so rather than reporting a
+ * version it invented.
+ */
+const version = process.env.APP_VERSION || "unknown";
+const commit = process.env.GIT_SHA || "unknown";
+
+export const versionRoute = route().get(
+    "/",
+    describeRoute({
+        tags: ["meta"],
+        summary: "Build and uptime of the running instance",
+        operationId: "getVersion",
+        description:
+            "What is actually running right now. A deploy is only finished once the host has swapped the container, which is minutes after the workflow reports success — and the workflow reporting success is not evidence that it happened. Before this route, the only way to tell from outside was to find a schema that happened to change in that release; 2026-08-22.release-1 changed none, so its deploy could not be confirmed at all. Public, and carries nothing but build metadata.",
+    })
+        .schemaResponse({
+            statusCode: 200,
+            schema: versionResponseSchema,
+            description: "OK",
+        })
+        .build(),
+    (c) => {
+        return c.json(
+            {
+                version,
+                commit,
+                startedAt: startedAt.toISOString(),
+                uptimeSeconds: Math.floor(
+                    (Date.now() - startedAt.getTime()) / 1000,
+                ),
+            },
+            200,
+        );
+    },
+);

--- a/apps/api/src/routes/version/schema.ts
+++ b/apps/api/src/routes/version/schema.ts
@@ -1,0 +1,22 @@
+import z from "zod";
+import { Schema } from "~/lib/openapi";
+
+export const versionResponseSchema = Schema(
+    "Version",
+    z.object({
+        version: z.string().meta({
+            description:
+                "Release tag the image was built from, e.g. '2026-08-22.release-1'. 'unknown' when the image did not come from the release pipeline.",
+        }),
+        commit: z.string().meta({
+            description:
+                "Commit the image was built from, or 'unknown' outside the release pipeline.",
+        }),
+        startedAt: z.string().meta({
+            description: "When this process booted (ISO 8601).",
+        }),
+        uptimeSeconds: z.number().meta({
+            description: "Seconds since this process booted.",
+        }),
+    }),
+);

--- a/apps/api/src/test/meta/version.test.ts
+++ b/apps/api/src/test/meta/version.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, vi } from "vitest";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * The route exists to answer one question from outside: is the container
+ * serving right now the one the deploy just built?
+ *
+ * Until it existed, that could only be answered by finding some schema that
+ * happened to change in that release — `FeedbackItem` served as the
+ * fingerprint for 2026-08-21.release-1, and 2026-08-22.release-1 had none at
+ * all, so its swap could not be confirmed.
+ */
+describe("GET /api/version", () => {
+    integrationTest("reports build metadata and uptime", async ({ ctx }) => {
+        const client = ctx.utils.client();
+        const res = await client.api.version.$get();
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+
+        // The test process has nothing baked in, which is exactly the case a
+        // container built outside the release pipeline is in. It must say so
+        // rather than answer `undefined`.
+        expect(body.version).toBe("unknown");
+        expect(body.commit).toBe("unknown");
+
+        expect(Number.isFinite(body.uptimeSeconds)).toBe(true);
+        expect(body.uptimeSeconds).toBeGreaterThanOrEqual(0);
+        expect(new Date(body.startedAt).getTime()).toBeLessThanOrEqual(
+            Date.now(),
+        );
+    });
+
+    integrationTest(
+        "startedAt is the boot, not the request",
+        async ({ ctx }) => {
+            /**
+             * The bug this guards against: reading the clock inside the
+             * handler. It would look right in every single response and be
+             * useless for the one thing the route is for — a `startedAt` that
+             * always says "now" can never reveal a container that was never
+             * swapped.
+             */
+            const client = ctx.utils.client();
+            const first = await (await client.api.version.$get()).json();
+            await new Promise((r) => setTimeout(r, 1100));
+            const second = await (await client.api.version.$get()).json();
+
+            expect(second.startedAt).toBe(first.startedAt);
+            expect(second.uptimeSeconds).toBeGreaterThan(first.uptimeSeconds);
+        },
+        500_000,
+    );
+
+    /**
+     * The half the fallback above cannot reach: a container that *was* built by
+     * the pipeline. `APP_VERSION`/`GIT_SHA` arrive as Docker build args and are
+     * read once at module load, so this loads the module fresh with them set —
+     * the same order a container boots in.
+     */
+    integrationTest(
+        "reports the release tag the image was built with",
+        async () => {
+            const before = {
+                v: process.env.APP_VERSION,
+                s: process.env.GIT_SHA,
+            };
+            process.env.APP_VERSION = "2026-08-22.release-99";
+            process.env.GIT_SHA = "deadbeef";
+
+            try {
+                vi.resetModules();
+                const { versionRoute } = await import("~/routes/version/list");
+                const res = await versionRoute.request("/");
+                const body = (await res.json()) as {
+                    version: string;
+                    commit: string;
+                };
+
+                expect(body.version).toBe("2026-08-22.release-99");
+                expect(body.commit).toBe("deadbeef");
+            } finally {
+                process.env.APP_VERSION = before.v;
+                process.env.GIT_SHA = before.s;
+                vi.resetModules();
+            }
+        },
+    );
+});

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -51,6 +51,15 @@ COPY --from=build /usr/src/app/packages/db/drizzle ./drizzle
 COPY --from=install /usr/src/app/node_modules ./node_modules
 COPY --from=install /usr/src/app/apps/api/node_modules ./apps/api/node_modules
 
+# Build metadata, served by GET /api/version. Declared last so a new release
+# tag reuses every cached layer above — only this ARG and the ENV below are
+# rebuilt. Both default to "unknown": a local `docker build` has no release to
+# name, and the route says so rather than reporting a version it invented.
+ARG APP_VERSION=unknown
+ARG GIT_SHA=unknown
+ENV APP_VERSION=$APP_VERSION
+ENV GIT_SHA=$GIT_SHA
+
 USER bun
 EXPOSE 4000/tcp
 # Migrate before serving. `&&` aborts the boot when a migration fails instead of

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -4,6 +4,26 @@
  */
 
 export interface paths {
+    "/api/version": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Build and uptime of the running instance
+         * @description What is actually running right now. A deploy is only finished once the host has swapped the container, which is minutes after the workflow reports success — and the workflow reporting success is not evidence that it happened. Before this route, the only way to tell from outside was to find a schema that happened to change in that release; 2026-08-22.release-1 changed none, so its deploy could not be confirmed at all. Public, and carries nothing but build metadata.
+         */
+        get: operations["getVersion"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/api-keys": {
         parameters: {
             query?: never;
@@ -2882,6 +2902,16 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        Version: {
+            /** @description Release tag the image was built from, e.g. '2026-08-22.release-1'. 'unknown' when the image did not come from the release pipeline. */
+            version: string;
+            /** @description Commit the image was built from, or 'unknown' outside the release pipeline. */
+            commit: string;
+            /** @description When this process booted (ISO 8601). */
+            startedAt: string;
+            /** @description Seconds since this process booted. */
+            uptimeSeconds: number;
+        };
         CreateApiKeyResponse: {
             /**
              * Format: uuid
@@ -6423,6 +6453,26 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    getVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Version"];
+                };
+            };
+        };
+    };
     listApiKeys: {
         parameters: {
             query?: never;

--- a/packages/sdk/src/generated/schemas.ts
+++ b/packages/sdk/src/generated/schemas.ts
@@ -243,6 +243,7 @@ export type UserSettings = Schemas["UserSettings"];
 export type UserSettingsBase = Schemas["UserSettingsBase"];
 export type ValidateApiKeyInput = Schemas["ValidateApiKeyInput"];
 export type ValidateApiKeyResponse = Schemas["ValidateApiKeyResponse"];
+export type Version = Schemas["Version"];
 export type VisibleBanner = Schemas["VisibleBanner"];
 export type VisibleBannerList = Schemas["VisibleBannerList"];
 export type VoteFeedback = Schemas["VoteFeedback"];


### PR DESCRIPTION
## Problemet

En deploy er ikke ferdig når workflowen melder grønt. Den er ferdig når Drift har byttet container, og det skjer minutter senere.

Fram til nå måtte forskjellen avgjøres ved å lete etter et skjema som tilfeldigvis endret seg i akkurat den releasen. For `2026-08-21.release-1` gikk det — `FeedbackItem` byttet fra `author` til `isAuthor`, synlig i OpenAPI-spec-en. For `2026-08-22.release-1` endret ingen rute-metadata seg, og **byttet kunne ikke bekreftes i det hele tatt**. Alt jeg kunne si var at pipelinen var grønn og at API-et svarte — begge deler like sant om den gamle containeren fortsatt kjørte.

## `GET /api/version`

```json
{
  "version": "2026-08-22.release-1",
  "commit": "f302876",
  "startedAt": "2026-08-22T12:38:11.204Z",
  "uptimeSeconds": 4127
}
```

**`startedAt` er kjernen,** og den er ikke avhengig av noe i pipelinen: et tidsstempel fra før deployen betyr at den gamle containeren fortsatt serverer. Den leses ved modullasting, altså ved oppstart — leses klokka i handleren i stedet, sier hvert svar «nå», og ruta kan aldri avsløre det den finnes for.

**`version` og `commit`** bakes inn som docker build args. De svarer på *hvilken* kode det er, ikke bare at noe startet på nytt. Det er rollback som trenger dem: der er `startedAt` fersk, og likevel er det den gamle koden som kjører.

Begge defaulter til `"unknown"`. Et lokalt `docker build` har ingen release å navngi, og ruta sier det heller enn å finne på en versjon.

## Rekkefølge

`deploy.yml` kan først sende build-argumentene når [TIHLDE/tihlde-workflows#11](https://github.com/TIHLDE/tihlde-workflows/pull/11) er inne — den delte workflowen eier `docker/build-push-action`-kallet, og et `build_args` den ikke kjenner feiler på validering.

**Denne PR-en kan merges alene.** Fram til #11 er inne svarer `version`/`commit` `"unknown"` i prod, mens `startedAt` virker fra første deploy. `ARG`-ene i Dockerfilen er harmløse uten dem.

## Verifisert

- **Hele testsuiten: 805/805** (125 filer), `typecheck`, `lint`, `format` grønt
- **Kjeden `--build-arg` → `ARG` → `ENV` → svar, i en ekte container:** bygget imaget med `APP_VERSION=2026-08-22.release-99`, kjørte det mot postgres/redis/minio, og ruta svarte med nettopp den verdien
- **`startedAt` er oppstart, ikke forespørsel:** identisk over to kall mens `uptimeSeconds` gikk 35 → 38

Tre tester dekker det: grunnform og `"unknown"`-fallback, at `startedAt` står stille mens uptime teller, og at et innbakt build-arg når fram til svaret.

## Utenfor scope, men funnet underveis

Dockerfilen **bygger ikke på Apple Silicon** — `bun build` finner ikke `msgpackr-extract`, en native pakke som følger BullMQs `msgpackr`. Uendret `main` feiler helt likt, så det er ikke nytt her, og CI er amd64 så det merkes ikke der. Men ingen kan bygge imaget lokalt på en Mac. Samme klasse som `sharp`-saken. Container-sjekken over måtte kjøres med `--platform linux/amd64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)