### PR TITLE
feat(påmeldte): vis kull og studie som kort du kan filtrere på

### DIFF
--- a/apps/api/src/routes/event/registration/list.ts
+++ b/apps/api/src/routes/event/registration/list.ts
@@ -7,6 +7,11 @@ import z from "zod";
 import { canActOnEvent } from "~/lib/event/access";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
+import {
+    type StudyGroupRow,
+    deriveStudyFromGroups,
+    loadStudyGroupRows,
+} from "~/lib/user/study";
 import { requireAuth } from "~/middleware/auth";
 import {
     PaginationSchema,
@@ -186,11 +191,25 @@ export const getAllRegistrationsForEventsRoute = route().get(
             }
         }
 
+        // Study programme and cohort, for the admin-facing breakdown of who
+        // signed up. Loaded for the whole page in one query and derived with
+        // the shared ranking, so the study shown here and the one on the
+        // member's profile can never be two different programmes.
+        const studyByUser = isEventAdmin
+            ? await loadStudyGroupRows(
+                  ctx,
+                  registrations.map((r) => r.userId),
+              )
+            : new Map<string, StudyGroupRow[]>();
+
         const totalPages = getTotalPages(registrationCount, pageSize);
 
         const returnRegistrations = registrations.map((r, index) => {
             const payment = paymentByUserId.get(r.userId);
             const isAnonymous = anonymousUserIds.has(r.userId);
+            const study = deriveStudyFromGroups(
+                studyByUser.get(r.userId) ?? [],
+            );
             return {
                 // The user id is left out for anonymised rows: it identifies
                 // the member just as well as the name does.
@@ -222,6 +241,8 @@ export const getAllRegistrationsForEventsRoute = route().get(
                                         null,
                                 }
                               : null,
+                          studyProgram: study.studyProgram,
+                          studyStartYear: study.studyStartYear,
                       }
                     : {}),
             };

--- a/apps/api/src/routes/event/schema.ts
+++ b/apps/api/src/routes/event/schema.ts
@@ -1062,6 +1062,14 @@ export const registeredUserSchema = Schema(
             description:
                 "The user's payment for this event, if any. Only included for event admins.",
         }),
+        studyProgram: z.string().nullable().optional().meta({
+            description:
+                "Name of the member's study programme, derived from their STUDY group membership. Null when they have none. Only included for event admins.",
+        }),
+        studyStartYear: z.number().int().nullable().optional().meta({
+            description:
+                "The year the member started studying (kull), derived from their study programme or STUDYYEAR group. Null when unknown. Only included for event admins.",
+        }),
     }),
 );
 

--- a/apps/api/src/test/event/registration-list.test.ts
+++ b/apps/api/src/test/event/registration-list.test.ts
@@ -230,6 +230,121 @@ describe("Event registration listing", () => {
     );
 
     integrationTest(
+        // The «Påmeldte»-fanen teller kull og studie fra disse to feltene, og
+        // en master skal telles på sitt eget kull — ikke på kullgruppa, som
+        // for de fleste bærer året bacheloren startet.
+        "serves the member's current programme and cohort to admins",
+        async ({ ctx }) => {
+            const { event, registered } = await seedRegistrations(ctx);
+
+            await ctx.utils.createTestGroup({
+                slug: "digital-forretningsutvikling",
+                name: "Digital forretningsutvikling",
+                type: "STUDY",
+            });
+            await ctx.utils.createTestGroup({
+                slug: "digital-samhandling",
+                name: "Digital transformasjon",
+                type: "STUDY",
+            });
+            await ctx.utils.createTestGroup({
+                slug: "2023",
+                name: "2023",
+                type: "STUDYYEAR",
+            });
+
+            const [bachelor] = await ctx.db
+                .insert(schema.studyProgram)
+                .values({
+                    slug: "digital-forretningsutvikling",
+                    feideCode: "ITBAITBEDR",
+                    displayName: "Digital Forretningsutvikling",
+                    type: "bachelor",
+                })
+                .returning({ id: schema.studyProgram.id });
+            const [master] = await ctx.db
+                .insert(schema.studyProgram)
+                .values({
+                    slug: "digital-samhandling",
+                    feideCode: "ITMAIKTSA",
+                    displayName: "Digital Samhandling",
+                    type: "master",
+                })
+                .returning({ id: schema.studyProgram.id });
+
+            await ctx.db.insert(schema.groupMembership).values([
+                {
+                    userId: registered.id,
+                    groupSlug: "digital-forretningsutvikling",
+                    role: "member",
+                },
+                {
+                    userId: registered.id,
+                    groupSlug: "digital-samhandling",
+                    role: "member",
+                },
+                { userId: registered.id, groupSlug: "2023", role: "member" },
+            ]);
+            await ctx.db.insert(schema.studyProgramMembership).values([
+                {
+                    userId: registered.id,
+                    studyProgramId: bachelor?.id as number,
+                    startYear: 2023,
+                    startYearSource: "derived",
+                    feideActive: false,
+                },
+                {
+                    userId: registered.id,
+                    studyProgramId: master?.id as number,
+                    startYear: 2026,
+                    startYearSource: "derived",
+                    feideActive: true,
+                },
+            ]);
+
+            const admin = await ctx.utils.createTestUser();
+            await ctx.utils.giveUserPermissions(admin, ["events:manage"]);
+            const client = await ctx.utils.clientForUser(admin);
+
+            const res = await client.api.event[":eventId"].registration.$get({
+                param: { eventId: event.id },
+                query: {},
+            });
+
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            const row = body.registeredUsers.find(
+                (u) => u.id === registered.id,
+            );
+            expect(row?.studyProgram).toBe("Digital transformasjon");
+            expect(row?.studyStartYear).toBe(2026);
+        },
+        500_000,
+    );
+
+    integrationTest(
+        // Studie og kull sier like mye om et medlem som e-posten gjør, og
+        // hører til samme lås.
+        "keeps programme and cohort out of the ordinary member's view",
+        async ({ ctx }) => {
+            const { event } = await seedRegistrations(ctx);
+
+            const member = await ctx.utils.createTestUser();
+            const client = await ctx.utils.clientForUser(member);
+            const res = await client.api.event[":eventId"].registration.$get({
+                param: { eventId: event.id },
+                query: {},
+            });
+
+            const body = await res.json();
+            const [user] = body.registeredUsers;
+            expect(user?.studyProgram).toBeUndefined();
+            expect(user?.studyStartYear).toBeUndefined();
+        },
+        500_000,
+    );
+
+    integrationTest(
         "rejects status filtering from non-admins",
         async ({ ctx }) => {
             const { event } = await seedRegistrations(ctx);

--- a/apps/kvark/src/lib/utils.ts
+++ b/apps/kvark/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import { computeClassYear } from "@photon/auth/academic-year";
 import type { ClassValue } from "clsx";
 import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
@@ -52,6 +53,35 @@ export function programmeLength(programme: string | undefined): number {
     return MASTER_PROGRAMME_MARKERS.some((marker) => name.includes(marker))
         ? 5
         : 3;
+}
+
+/**
+ * Hvor et medlem står i løpet, som en bøtte det går an å telle på:
+ * `"1"`–`"5"` for klassetrinnet, `"alumni"` for den som er ferdig, og
+ * `"unknown"` når vi ikke vet nok til å plassere dem.
+ *
+ * Samme regel som studielinja ellers i admin: klassetrinnet gjelder så lenge
+ * programmet varer (3 år på bachelor, 5 på master), og den som har passert det
+ * er alumni. Uten kull vet vi ingenting — også når studiet er kjent, for det
+ * er kullet som sier når de begynte.
+ */
+export function classLevelBucket(
+    programme: string | null | undefined,
+    startYear: number | null | undefined,
+): string {
+    if (startYear === null || startYear === undefined) return "unknown";
+    const classYear = computeClassYear(startYear);
+    if (classYear < 1) return "unknown";
+    return classYear <= programmeLength(programme ?? undefined)
+        ? String(classYear)
+        : "alumni";
+}
+
+/** Etiketten som hører til en {@link classLevelBucket}. */
+export function classLevelBucketLabel(bucket: string): string {
+    if (bucket === "alumni") return "Alumni";
+    if (bucket === "unknown") return "Ukjent kull";
+    return `${bucket}. klasse`;
 }
 
 /**

--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -18,6 +18,7 @@ import {
     CircleCheckBigIcon,
     ExternalLink,
     EyeIcon,
+    FilterIcon,
     PlusIcon,
     TriangleAlertIcon,
     CheckIcon,
@@ -103,7 +104,12 @@ import {
     useCanActOnGroupResource,
 } from "#/hooks/use-permission";
 import { extractErrorMessage } from "#/lib/api-error";
-import { cn } from "#/lib/utils";
+import {
+    classLevelBucket,
+    classLevelBucketLabel,
+    cn,
+    formatStudyLabel,
+} from "#/lib/utils";
 import { EVENT_FORM_ERRORS } from "#/lib/event";
 import { isCohortGroupType } from "#/lib/group";
 import { useDebounced } from "#/lib/use-debounced";
@@ -665,11 +671,179 @@ const REGISTRATION_FILTERS = [
     { value: "venteliste", label: "Venteliste", status: "waitlisted" },
 ] as const;
 
+/**
+ * Kullet og studiet til de påmeldte, som klikkbare tall.
+ *
+ * Bøttene regnes ut i nettleseren fra `studyProgram` og `studyStartYear` på
+ * hver påmelding — arrangøren laster allerede hele lista for å kunne søke i
+ * den, så et eget statistikk-endepunkt ville bare telt de samme radene en gang
+ * til.
+ */
+type RegistrationFacets = {
+    /** Klassetrinn-bøtte, se `classLevelBucket`. */
+    classLevel: string | null;
+    /** Studieprogram etter navn, eller `NO_STUDY` for dem uten. */
+    study: string | null;
+};
+
+const NO_FACETS: RegistrationFacets = { classLevel: null, study: null };
+
+/** Bøtte for den som ikke har noe studieprogram registrert. */
+const NO_STUDY = "__none__";
+
+type BreakdownParticipant = {
+    studyProgram?: string | null;
+    studyStartYear?: number | null;
+};
+
+function studyBucket(participant: BreakdownParticipant): string {
+    return participant.studyProgram ?? NO_STUDY;
+}
+
+/**
+ * Klassetrinnet til studielinja i tabellen, eller null for alumni og dem vi
+ * ikke vet nok om — da står studiet alene, uten et årstall som antyder at de
+ * fortsatt går der.
+ */
+function classYearOf(participant: BreakdownParticipant): number | null {
+    const bucket = levelBucket(participant);
+    const year = Number.parseInt(bucket, 10);
+    return Number.isFinite(year) ? year : null;
+}
+
+function levelBucket(participant: BreakdownParticipant): string {
+    return classLevelBucket(
+        participant.studyProgram,
+        participant.studyStartYear,
+    );
+}
+
+/**
+ * Teller opp en bøtte og sorterer den slik den skal leses: klassetrinnene
+ * stigende, så alumni, så de vi ikke vet noe om. Studiene sorteres på antall,
+ * med «ukjent studie» sist uansett hvor mange de er.
+ */
+function countBuckets(
+    participants: BreakdownParticipant[],
+    bucketOf: (participant: BreakdownParticipant) => string,
+    rank: (bucket: string, count: number) => [number, number, string],
+): Array<{ bucket: string; count: number }> {
+    const counts = new Map<string, number>();
+    for (const participant of participants) {
+        const bucket = bucketOf(participant);
+        counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+    }
+
+    return [...counts.entries()]
+        .map(([bucket, count]) => ({ bucket, count }))
+        .sort((a, b) => {
+            const rankA = rank(a.bucket, a.count);
+            const rankB = rank(b.bucket, b.count);
+            return (
+                rankA[0] - rankB[0] ||
+                rankA[1] - rankB[1] ||
+                rankA[2].localeCompare(rankB[2], "nb-NO")
+            );
+        });
+}
+
+function rankClassLevel(bucket: string): [number, number, string] {
+    if (bucket === "alumni") return [1, 0, bucket];
+    if (bucket === "unknown") return [2, 0, bucket];
+    return [0, Number.parseInt(bucket, 10), bucket];
+}
+
+function rankStudy(bucket: string, count: number): [number, number, string] {
+    return [bucket === NO_STUDY ? 1 : 0, -count, bucket];
+}
+
+/** Ett tall i fordelingen. Hele kortet er knappen som slår filteret av og på. */
+function BreakdownCard({
+    label,
+    count,
+    active,
+    onClick,
+}: {
+    label: string;
+    count: number;
+    active: boolean;
+    onClick: () => void;
+}) {
+    return (
+        <Card
+            render={<button type="button" />}
+            aria-pressed={active}
+            onClick={onClick}
+            className={cn(
+                "cursor-pointer text-left transition-colors",
+                active
+                    ? "border-primary bg-primary/10 ring-1 ring-primary"
+                    : "hover:border-foreground/20",
+            )}
+        >
+            <CardContent className="flex items-start justify-between gap-2 px-4 py-3">
+                <div className="flex min-w-0 flex-col gap-1">
+                    <span
+                        className={cn(
+                            "truncate text-sm",
+                            active
+                                ? "font-medium text-primary"
+                                : "text-muted-foreground",
+                        )}
+                    >
+                        {label}
+                    </span>
+                    <span className="text-2xl leading-none">{count}</span>
+                </div>
+                {active ? (
+                    <CheckIcon className="size-4 shrink-0 text-primary" />
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}
+
+function BreakdownSection({
+    title,
+    buckets,
+    active,
+    labelOf,
+    onToggle,
+}: {
+    title: string;
+    buckets: Array<{ bucket: string; count: number }>;
+    active: string | null;
+    labelOf: (bucket: string) => string;
+    onToggle: (bucket: string) => void;
+}) {
+    if (buckets.length === 0) return null;
+
+    return (
+        <div className="flex flex-col gap-2">
+            <h3 className="text-sm font-medium text-muted-foreground">
+                {title}
+            </h3>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+                {buckets.map(({ bucket, count }) => (
+                    <BreakdownCard
+                        key={bucket}
+                        label={labelOf(bucket)}
+                        count={count}
+                        active={active === bucket}
+                        onClick={() => onToggle(bucket)}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
 function RegistrationsTab({ eventId }: { eventId: string }) {
     const [filter, setFilter] =
         useState<(typeof REGISTRATION_FILTERS)[number]["value"]>("aktive");
     const status = REGISTRATION_FILTERS.find((f) => f.value === filter)?.status;
     const [search, setSearch] = useState("");
+    const [facets, setFacets] = useState<RegistrationFacets>(NO_FACETS);
 
     const registrationsQuery = useInfiniteQuery(
         getEventRegistrationsInfiniteQuery(eventId, status ? { status } : {}),
@@ -685,13 +859,61 @@ function RegistrationsTab({ eventId }: { eventId: string }) {
     );
     const isPending = registrationsQuery.isPending;
 
+    /**
+     * Tallene på kortene teller alle påmeldte, men hver fordeling ser bort fra
+     * sitt eget filter og respekterer det andre: står du på «2. klasse», viser
+     * studiekortene hvor mange andreklassinger som går hvert studie. Ellers
+     * ville kortet sagt 12 og tabellen vist 3.
+     */
+    const classLevelBuckets = useMemo(
+        () =>
+            countBuckets(
+                participants.filter(
+                    (p) =>
+                        facets.study === null ||
+                        studyBucket(p) === facets.study,
+                ),
+                levelBucket,
+                rankClassLevel,
+            ),
+        [participants, facets.study],
+    );
+
+    const studyBuckets = useMemo(
+        () =>
+            countBuckets(
+                participants.filter(
+                    (p) =>
+                        facets.classLevel === null ||
+                        levelBucket(p) === facets.classLevel,
+                ),
+                studyBucket,
+                rankStudy,
+            ),
+        [participants, facets.classLevel],
+    );
+
+    const hasFacet = facets.classLevel !== null || facets.study !== null;
+
+    const facetedParticipants = useMemo(
+        () =>
+            participants.filter(
+                (participant) =>
+                    (facets.classLevel === null ||
+                        levelBucket(participant) === facets.classLevel) &&
+                    (facets.study === null ||
+                        studyBucket(participant) === facets.study),
+            ),
+        [participants, facets.classLevel, facets.study],
+    );
+
     const query = search.trim().toLowerCase();
     const visibleParticipants = useMemo(
         () =>
-            participants.filter((participant) =>
+            facetedParticipants.filter((participant) =>
                 matchesQuery([participant.name, participant.email], query),
             ),
-        [participants, query],
+        [facetedParticipants, query],
     );
 
     return (
@@ -712,6 +934,70 @@ function RegistrationsTab({ eventId }: { eventId: string }) {
                     ))}
                 </TabsList>
             </Tabs>
+
+            {participants.length > 0 ? (
+                <div className="flex flex-col gap-4">
+                    <BreakdownSection
+                        title="Kull"
+                        buckets={classLevelBuckets}
+                        active={facets.classLevel}
+                        labelOf={classLevelBucketLabel}
+                        onToggle={(bucket) =>
+                            setFacets((current) => ({
+                                ...current,
+                                classLevel:
+                                    current.classLevel === bucket
+                                        ? null
+                                        : bucket,
+                            }))
+                        }
+                    />
+                    <BreakdownSection
+                        title="Studie"
+                        buckets={studyBuckets}
+                        active={facets.study}
+                        labelOf={(bucket) =>
+                            bucket === NO_STUDY ? "Ukjent studie" : bucket
+                        }
+                        onToggle={(bucket) =>
+                            setFacets((current) => ({
+                                ...current,
+                                study: current.study === bucket ? null : bucket,
+                            }))
+                        }
+                    />
+                </div>
+            ) : null}
+
+            {hasFacet ? (
+                <div className="flex flex-wrap items-center gap-2 rounded-md border border-primary bg-primary/5 px-3 py-2 text-sm">
+                    <FilterIcon className="size-4 shrink-0 text-primary" />
+                    <span>
+                        Viser {facetedParticipants.length} av{" "}
+                        {participants.length} påmeldte:
+                    </span>
+                    {facets.classLevel !== null ? (
+                        <Badge variant="secondary">
+                            {classLevelBucketLabel(facets.classLevel)}
+                        </Badge>
+                    ) : null}
+                    {facets.study !== null ? (
+                        <Badge variant="secondary">
+                            {facets.study === NO_STUDY
+                                ? "Ukjent studie"
+                                : facets.study}
+                        </Badge>
+                    ) : null}
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="ml-auto"
+                        onClick={() => setFacets(NO_FACETS)}
+                    >
+                        Nullstill
+                    </Button>
+                </div>
+            ) : null}
 
             {participants.length > 0 ? (
                 <SearchField
@@ -739,7 +1025,11 @@ function RegistrationsTab({ eventId }: { eventId: string }) {
                         <AdminEmptyState
                             icon={UsersIcon}
                             title="Ingen treff"
-                            description={`Ingen påmeldte matcher «${search.trim()}».`}
+                            description={
+                                query
+                                    ? `Ingen påmeldte matcher «${search.trim()}».`
+                                    : "Ingen påmeldte i utvalget du har filtrert på."
+                            }
                         />
                     </CardContent>
                 </Card>
@@ -751,6 +1041,7 @@ function RegistrationsTab({ eventId }: { eventId: string }) {
                                 <TableRow>
                                     <TableHead>Navn</TableHead>
                                     <TableHead>E-post</TableHead>
+                                    <TableHead>Studie</TableHead>
                                     <TableHead>Status</TableHead>
                                     <TableHead>Betaling</TableHead>
                                     <TableHead>Påmeldt</TableHead>
@@ -771,6 +1062,16 @@ function RegistrationsTab({ eventId }: { eventId: string }) {
                                             </TableCell>
                                             <TableCell>
                                                 {participant.email ?? "—"}
+                                            </TableCell>
+                                            <TableCell>
+                                                {formatStudyLabel({
+                                                    programme:
+                                                        participant.studyProgram,
+                                                    classYear:
+                                                        classYearOf(
+                                                            participant,
+                                                        ),
+                                                }) ?? "—"}
                                             </TableCell>
                                             <TableCell>
                                                 <Badge

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -4062,6 +4062,10 @@ export interface components {
             waitlistPosition?: number | null;
             /** @description The user's payment for this event, if any. Only included for event admins. */
             payment?: components["schemas"]["EventRegistrationPayment"] | null;
+            /** @description Name of the member's study programme, derived from their STUDY group membership. Null when they have none. Only included for event admins. */
+            studyProgram?: string | null;
+            /** @description The year the member started studying (kull), derived from their study programme or STUDYYEAR group. Null when unknown. Only included for event admins. */
+            studyStartYear?: number | null;
         };
         EventRegistrationList: {
             /** @description Total number of items available */


### PR DESCRIPTION
## Hva

Arrangøren så bare en liste med navn og e-post på «Påmeldte»-fanen, og måtte telle selv for å vite hvem som faktisk kom. «Hvor mange førsteklassinger meldte seg på bedpressen?» krevde et manuelt oppslag per deltaker.

Fanen teller nå opp to fordelinger over de påmeldte, som kort du kan klikke for å filtrere:

- **Kull** — `1.`–`5. klasse`, `Alumni`, `Ukjent kull`
- **Studie** — ett kort per studieprogram, sortert på antall, med `Ukjent studie` sist

## Backend

`GET /event/:eventId/registration` serverer `studyProgram` og `studyStartYear` per rad, bak samme lås som e-post og betaling — studie og kull sier like mye om et medlem som e-posten gjør.

Feltene er utledet med den delte rangeringen fra `deriveStudyFromGroups`, slik at studiet her og studiet på profilen aldri kan bli to forskjellige programmer, og hentes i én spørring for hele siden.

## Frontend

Klassetrinnet gjelder så lenge programmet varer — tre år på bachelor, fem på master — samme regel som brukerlista bruker. Den som har passert det er alumni. Ny delt hjelpefunksjon `classLevelBucket` i `lib/utils.ts`.

De to filtrene kan kombineres, og hver fordeling teller innenfor det andre filteret: står du på «2. klasse» viser studiekortene hvor mange andreklassinger som går hvert studie. Ellers ville kortet sagt 12 mens tabellen viste 3.

At filteret er på vises tre steder:
1. Kortet får ramme, tint og hake
2. En linje over tabellen: «Viser 3 av 12 påmeldte» med filterpiller og **Nullstill**
3. En ny **Studie**-kolonne i tabellen, som gjør utvalget etterprøvbart

## Verifisert

Kjørt mot en egen API-instans med 12 seedede påmeldte fordelt på tre programmer og fem kull. Alle tallene stemte (1.kl 3, 2.kl 3, 3.kl 2, 4.kl 2, Alumni 1, Ukjent 1 — Dataingeniør 5, Digital forretningsutvikling 4, Digital transformasjon 2, Ukjent 1). Kombinert filtrering og «Nullstill» fungerte, sjekket i lys og mørk modus og på mobil, ingen nye konsollfeil.

`typecheck`, `lint` og `build` er grønne. To nye tester dekker at feltene serveres til arrangøren — med masterens eget kull, ikke kullgruppa — og at de holdes skjult for vanlige medlemmer.

## Vurdering verdt å si fra om

«Kull» er tolket som klassetrinn + alumni, ikke rå kullår (2023, 2024 …). Det er slik resten av admin snakker om det, og «alumni» gir bare mening som motstykke til et klassetrinn. Lett å bytte om det var årstallene som var ønsket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)