### PR TITLE
fix(påmeldte): stram inn kortene for kull og studie

### DIFF
--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -757,7 +757,13 @@ function rankStudy(bucket: string, count: number): [number, number, string] {
     return [bucket === NO_STUDY ? 1 : 0, -count, bucket];
 }
 
-/** Ett tall i fordelingen. Hele kortet er knappen som slår filteret av og på. */
+/**
+ * Ett tall i fordelingen. Hele brikken er knappen som slår filteret av og på.
+ *
+ * Bredden følger etiketten i stedet for en kolonne i et rutenett: bøttene er
+ * få og korte, og strukket ut over hele bredden ble «Ukjent studie 1» like
+ * stort som studiet 64 går på.
+ */
 function BreakdownCard({
     label,
     count,
@@ -770,36 +776,30 @@ function BreakdownCard({
     onClick: () => void;
 }) {
     return (
-        <Card
-            render={<button type="button" />}
+        <button
+            type="button"
             aria-pressed={active}
             onClick={onClick}
             className={cn(
-                "cursor-pointer text-left transition-colors",
+                "inline-flex max-w-full cursor-pointer items-center gap-2 rounded-lg bg-card px-3 py-1.5 text-sm ring-1 transition-colors",
                 active
-                    ? "border-primary bg-primary/10 ring-1 ring-primary"
-                    : "hover:border-foreground/20",
+                    ? "bg-primary/10 text-primary ring-primary"
+                    : "text-muted-foreground ring-card-border hover:ring-foreground/20",
             )}
         >
-            <CardContent className="flex items-start justify-between gap-2 px-4 py-3">
-                <div className="flex min-w-0 flex-col gap-1">
-                    <span
-                        className={cn(
-                            "truncate text-sm",
-                            active
-                                ? "font-medium text-primary"
-                                : "text-muted-foreground",
-                        )}
-                    >
-                        {label}
-                    </span>
-                    <span className="text-2xl leading-none">{count}</span>
-                </div>
-                {active ? (
-                    <CheckIcon className="size-4 shrink-0 text-primary" />
-                ) : null}
-            </CardContent>
-        </Card>
+            <span className="truncate">{label}</span>
+            <span
+                className={cn(
+                    "font-semibold tabular-nums",
+                    active ? "text-primary" : "text-foreground",
+                )}
+            >
+                {count}
+            </span>
+            {active ? (
+                <CheckIcon className="size-3.5 shrink-0 text-primary" />
+            ) : null}
+        </button>
     );
 }
 
@@ -819,11 +819,11 @@ function BreakdownSection({
     if (buckets.length === 0) return null;
 
     return (
-        <div className="flex flex-col gap-2">
-            <h3 className="text-sm font-medium text-muted-foreground">
+        <div className="flex flex-col gap-1.5">
+            <h3 className="text-xs font-medium text-muted-foreground">
                 {title}
             </h3>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+            <div className="flex flex-wrap gap-1.5">
                 {buckets.map(({ bucket, count }) => (
                     <BreakdownCard
                         key={bucket}
@@ -936,7 +936,7 @@ function RegistrationsTab({ eventId }: { eventId: string }) {
             </Tabs>
 
             {participants.length > 0 ? (
-                <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-3">
                     <BreakdownSection
                         title="Kull"
                         buckets={classLevelBuckets}


### PR DESCRIPTION
Kortene fra #676 var kort i navnet bare: hvert tall satt i et rutenett med fire kolonner, med `Card` sin egen `py-4` utenpå `CardContent` sin `py-3`. Fire bøtter dekket to rader av halve skjermen, og «Ukjent studie 1» ble like stort som studiet 64 går på — øyet leste det som like viktig.

Nå er de brikker som følger etiketten i bredden og legger seg etter hverandre på linja: etikett, tall, og haken når filteret er på. Tallet står ved siden av etiketten i stedet for under, i samme størrelse — det er en teller, ikke en overskrift.

Ingen oppførsel er endret: `aria-pressed`, filtrering og opptellingen er som før.

## Verifisert
- `bun run typecheck`, `bun run lint`, `bun run build` grønt.
- Kjørt lokalt mot API på 4100 med 158 syntetiske påmeldte fordelt som i prod (131/19/7/1 kull, 64/49/31/13/1 studie). Klikk på «2. klasse» gir ramme, hake, «Viser 19 av 158 påmeldte» og studiekort som teller innenfor filteret (13 + 6 = 19). Testdataene er slettet igjen.
- Sjekket på både 1280px og 375px — brikkene brytes pent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)