### PR TITLE
feat(deploy): bak release-taggen inn i imaget

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,13 @@ jobs:
             # Tagger imaget med release-taggen, så Drift kan bruke den som
             # deploy-markør på containeren i tillegg til latest + sha.
             extra_tags: type=ref,event=tag
+            # Bakes inn som ENV og serveres av GET /api/version. Uten dem kan
+            # ingen se utenfra hvilken kode som faktisk kjører — bare at noe
+            # startet på nytt. `ref_name` er release-taggen både når taggen
+            # trigger kjøringen og ved rollback via workflow_dispatch --ref.
+            build_args: |
+                APP_VERSION=${{ github.ref_name }}
+                GIT_SHA=${{ github.sha }}
 
     deploy:
         needs: build


### PR DESCRIPTION
Siste ledd av [#675](https://github.com/TIHLDE/Photon/pull/675). Nå som [tihlde-workflows#11](https://github.com/TIHLDE/tihlde-workflows/pull/11) er inne, kan `deploy.yml` sende argumentene.

```yaml
build_args: |
    APP_VERSION=${{ github.ref_name }}
    GIT_SHA=${{ github.sha }}
```

## Hvorfor det trengs

`GET /api/version` kan allerede si at containeren startet på nytt. Den kan ikke si hvilken kode som kom opp — `version` og `commit` står som `"unknown"` i prod, fordi ingenting fyller dem.

Det er **rollback** som trenger dem. Der er `startedAt` fersk, og likevel er det den gamle koden som kjører: uten `version` ser det ut akkurat som en vellykket deploy.

## Verifisert

**At uttrykkene resolver og havner i imaget.** En midlertidig workflow speilet build-jobben her (uten notify, eget image-navn så `photon:latest` ikke ble rørt). Imaget den bygde:

```
APP_VERSION=claude/deploy-build-args
GIT_SHA=2ab321256ad13d67ce049b3b2c3abf2276266821
```

`GIT_SHA` matcher grenens commit eksakt. På en grenpush er `ref_name` grennavnet, som forventet.

**At `ref_name` er release-taggen på en tag-kjøring.** Ikke en dokumentasjonspåstand — `release_notes`-jobben i denne samme workflowen bruker allerede `${GITHUB_REF_NAME}`, og kjøringen for `2026-08-22.release-1` produserte en release med nettopp den tittelen.

De to leddene dekker til sammen tag-tilfellet. Rollback via `gh workflow run deploy.yml --ref <tag>` gir samme `ref_name`, siden det er ref-en kjøringen står på.

**At kallere uten `build_args` er upåvirket** ble verifisert før #11 ble merget — egen kjøring, grønn.

Verifiseringsworkflowen og testgrenene er slettet. Testpakken `ghcr.io/tihlde/photon-buildargs-test` ligger igjen i GHCR og bør slettes manuelt — tokenet mitt mangler `delete:packages`.

## Etter merge

Første release som tagges bakes med sin egen tag, og `GET /api/version` svarer med den i stedet for `"unknown"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)