### PR TITLE
fix(banner): sentrer pila i hero-banneret

### DIFF
--- a/apps/kvark/src/components/info-banner.tsx
+++ b/apps/kvark/src/components/info-banner.tsx
@@ -29,7 +29,7 @@ export function InfoBanner({
             <AlertTitle>{title}</AlertTitle>
             <AlertDescription>{description}</AlertDescription>
             {url ? (
-                <AlertAction className="flex items-center gap-1.5">
+                <AlertAction className="top-1/2 flex -translate-y-1/2 items-center gap-1.5">
                     {linkText ? <span>{linkText}</span> : null}
                     <ArrowRightIcon />
                 </AlertAction>


### PR DESCRIPTION
Lukker #668.

`AlertAction` i `@tihlde/ui` er absolutt posisjonert på `top-2`, så pila la seg i overkant av banneret i stedet for på midten så snart meldingen gikk over to linjer — som den gjør på forsiden.

Overstyres lokalt fremfor i UI-pakken: dette er den eneste bruken av `AlertAction`, og en toppstilt handling er fortsatt riktig for et alert med mye innhold.

## Verifisert
Kjørt lokalt mot dev-API-et med et banner med samme tekst som i issuet. Pila måler nå `deltaFromCenter: 0` i et 60px høyt tolinjers banner (var ~10px for høyt før).

🤖 Generated with [Claude Code](https://claude.com/claude-code)