### PR TITLE
fix(innlogging): la autofylte felt beholde sin egen bakgrunn

### DIFF
--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -10,7 +10,6 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
             data-slot="input"
             className={cn(
                 "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-                "autofill:[-webkit-box-shadow:0_0_0_1000px_var(--color-background)_inset] autofill:[-webkit-text-fill-color:var(--color-foreground)] autofill:[caret-color:var(--color-foreground)] autofill:[transition:background-color_99999s_ease-in-out_0s]",
                 className,
             )}
             {...props}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -583,7 +583,13 @@ body:has([data-slot="drawer-content"][data-state="open"])
    med ring-variablene selv så ringen fortsatt tegnes.
 
    Fargen etterligner et vanlig felt: gjennomsiktig over --card i lys modus,
-   `bg-input/30` over --card i mørk. */
+   `bg-input/30` over --card i mørk.
+
+   De to blokkene under er med vilje like. `:autofill` er den standardiserte
+   formen og `:-webkit-autofill` den gamle, og en nettleser som ikke kjenner
+   selektoren forkaster HELE regelen den står i — ikke bare den ene
+   selektoren. Slår vi dem sammen til én liste, mister vi altså regelen i den
+   nettleseren som bare kjenner den andre. */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
@@ -598,5 +604,20 @@ select:-webkit-autofill {
     caret-color: var(--foreground);
     /* Chrome animerer bakgrunnen tilbake til sin egen etter autofyll; en
        absurd lang transition parkerer den på vår. */
+    transition: background-color 99999s ease-in-out 0s;
+}
+
+input:autofill,
+input:autofill:hover,
+input:autofill:focus,
+input:autofill:active,
+textarea:autofill,
+select:autofill {
+    box-shadow:
+        var(--tw-ring-offset-shadow, 0 0 #0000),
+        var(--tw-ring-shadow, 0 0 #0000),
+        0 0 0 1000px var(--input-autofill) inset;
+    -webkit-text-fill-color: var(--foreground);
+    caret-color: var(--foreground);
     transition: background-color 99999s ease-in-out 0s;
 }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -82,6 +82,8 @@
     --sidebar-accent-foreground: oklch(0.205 0 0);
     --sidebar-border: oklch(0.922 0 0);
     --sidebar-ring: var(--logo);
+    /* Flaten et autofylt felt males med; se autofyll-regelen nederst i fila. */
+    --input-autofill: var(--card);
 }
 
 .dark {
@@ -134,6 +136,8 @@
     --sidebar-ring: #1b61e4;
     /* On the dark navy background the logo stays light for contrast */
     --logo: var(--foreground);
+    /* Speiler `dark:bg-input/30` lagt over --card. */
+    --input-autofill: color-mix(in oklab, var(--input) 30%, var(--card));
 }
 
 @theme inline {
@@ -566,4 +570,33 @@ body:has([data-slot="drawer-content"][data-state="open"])
         animation-delay: 0ms !important;
         transition-delay: 0ms !important;
     }
+}
+
+/* Autofyll: Chrome maler sin egen bakgrunn på utfylte felt, og i mørk modus er
+   den en lys blåtone som ikke ligner noe annet i grensesnittet. Den eneste
+   måten å overstyre den på er en `inset box-shadow` som dekker hele feltet.
+
+   Regelen må ligge her, utenfor `@layer`, og ikke som en `autofill:`-utility på
+   selve inputen: fokusringen er også en box-shadow, og med lik spesifisitet
+   vant `focus-visible:ring-3` over autofyll-skyggen — så feltet ble blått i det
+   øyeblikket det fikk fokus (issue #669). Ulagd CSS slår alle lag, og vi tar
+   med ring-variablene selv så ringen fortsatt tegnes.
+
+   Fargen etterligner et vanlig felt: gjennomsiktig over --card i lys modus,
+   `bg-input/30` over --card i mørk. */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active,
+textarea:-webkit-autofill,
+select:-webkit-autofill {
+    box-shadow:
+        var(--tw-ring-offset-shadow, 0 0 #0000),
+        var(--tw-ring-shadow, 0 0 #0000),
+        0 0 0 1000px var(--input-autofill) inset;
+    -webkit-text-fill-color: var(--foreground);
+    caret-color: var(--foreground);
+    /* Chrome animerer bakgrunnen tilbake til sin egen etter autofyll; en
+       absurd lang transition parkerer den på vår. */
+    transition: background-color 99999s ease-in-out 0s;
 }


### PR DESCRIPTION
Lukker #669.

## Hva som egentlig var galt

Autofyll-overstyringen fantes fra før som utilities på selve inputen, og den kompilerte helt fint. Den tapte bare kaskaden:

- fokusringen er også en `box-shadow`
- `.focus-visible\:ring-3:focus-visible` har **lik spesifisitet** som `.autofill\:[…]:autofill`, og står **seinere** i arket (posisjon 102803 mot 96560 i det bygde CSS-et)

Så i det øyeblikket feltet fikk fokus, overskrev ringen inset-skyggen og Chromes blå autofyll-bakgrunn slo gjennom. Det er nøyaktig det skjermbildet i issuet viser — brukernavnfeltet er det fokuserte.

## Fiksen

Regelen flyttes til ulagd CSS nederst i `styles.css`. Ulagd CSS slår ethvert `@layer` uansett spesifisitet, og vi tar med ring-variablene selv så ringen fortsatt tegnes.

Fargen er et nytt token, `--input-autofill`, som etterligner et vanlig felt: `--card` i lys modus, `bg-input/30` lagt over `--card` i mørk.

Ulagd CSS treffer dessuten **alle** felt, ikke bare `Input`: passordfeltet bruker `InputGroupInput`, som ikke hadde noen autofyll-håndtering i det hele tatt.

## Verifisert

Ekte Chrome-autofyll lar seg ikke framtvinge i forhåndsvisningen, så dette er verifisert i CSSOM på den kjørende innloggingssiden:

- den nye regelen rapporterer `layer: "(unlayered)"`, `focus-visible:ring-3` rapporterer `layer: "utilities"` → ringen kan ikke lenger vinne
- feltets faktiske bakgrunn er `oklab(… / 0.3)` over kortets `rgb(6, 21, 50)`; tokenet løser til `color-mix(in oklab, #0d3172 30%, #061532)` — samme farge, bare ugjennomsiktig

🤖 Generated with [Claude Code](https://claude.com/claude-code)