### PR TITLE
fix(grupper): still lederen og e-posten under hverandre

### DIFF
--- a/apps/kvark/src/components/group-detail-header.tsx
+++ b/apps/kvark/src/components/group-detail-header.tsx
@@ -68,7 +68,10 @@ export function GroupDetailHeader({
                 </div>
             }
             badges={
-                <>
+                /* Lederen og kontakt-e-posten står under hverandre, ikke side
+                   om side: begge er lange nok til at de sammen presset seg
+                   forbi tittelen og så ut som én ordløs rad (issue #670). */
+                <div className="flex flex-col items-start gap-2">
                     {group.leader ? (
                         <Badge
                             variant="secondary"
@@ -91,7 +94,7 @@ export function GroupDetailHeader({
                             {group.contactEmail}
                         </Badge>
                     ) : null}
-                </>
+                </div>
             }
             actions={
                 canGiveFine || isAdmin ? (


### PR DESCRIPTION
Lukker #670.

Begge pillene er lange nok til at de sammen la seg som én bred rad ved siden av gruppenavnet, og leste som ett sammenhengende felt uten skille. De stables nå loddrett, venstrestilt og med sin egen bredde.

Endringen ligger i `GroupDetailHeader`, ikke i den delte `DetailHeader`: andre sider bruker samme header med færre og kortere pill-er, der en vannrett rad fortsatt er riktig.

## Verifisert
Skjermbilde tatt lokalt av `/grupper/index` med både leder-pill og e-post-pill satt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)