### PR TITLE
feat(spørreskjema): vis egne svar tilbake, og studie/kull i svarlista

### DIFF
--- a/apps/api/src/routes/form/index.ts
+++ b/apps/api/src/routes/form/index.ts
@@ -9,6 +9,7 @@ import { deleteSubmissionWithReasonRoute } from "./submission/delete";
 import { downloadSubmissionsRoute } from "./submission/download";
 import { getSubmissionRoute } from "./submission/get";
 import { listSubmissionsRoute } from "./submission/list";
+import { listOwnSubmissionsRoute } from "./submission/mine";
 import { updateRoute } from "./update";
 
 export const formRoutes = route()
@@ -22,10 +23,12 @@ export const formRoutes = route()
     // Form statistics
     .route("/", statisticsRoute)
 
-    // Submissions. `/submissions/download` må stå før `/submissions/:id`, ellers
-    // matcher id-ruten først og «download» brukes som innsendings-id.
+    // Submissions. `/submissions/download` og `/submissions/me` må stå før
+    // `/submissions/:id`, ellers matcher id-ruten først og ordet brukes som
+    // innsendings-id.
     .route("/", createSubmissionRoute)
     .route("/", listSubmissionsRoute)
     .route("/", downloadSubmissionsRoute)
+    .route("/", listOwnSubmissionsRoute)
     .route("/", getSubmissionRoute)
     .route("/", deleteSubmissionWithReasonRoute);

--- a/apps/api/src/routes/form/schema.ts
+++ b/apps/api/src/routes/form/schema.ts
@@ -313,6 +313,13 @@ const submissionUserSchema = z.object({
     id: z.string(),
     name: z.string(),
     email: z.string(),
+    /**
+     * Studieretning og kull, utledet på samme måte som på profilen og i
+     * deltakerlista. Skjemaeieren leser svarene per kull like ofte som per
+     * person, og måtte før slå opp hver enkelt manuelt (issue #681).
+     */
+    study_program: z.string().nullable(),
+    study_start_year: z.number().nullable(),
 });
 
 export const submissionDetailSchema = Schema(

--- a/apps/api/src/routes/form/submission/get.ts
+++ b/apps/api/src/routes/form/submission/get.ts
@@ -2,6 +2,7 @@ import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import { canManageForm } from "~/lib/form/service";
+import { deriveStudyFromGroups, loadStudyGroupRows } from "~/lib/user/study";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
@@ -26,7 +27,8 @@ export const getSubmissionRoute = route().get(
         .build(),
     requireAuth,
     async (c) => {
-        const { db, ...ctx } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const user = c.get("user");
         const formId = c.req.param("formId");
         const submissionId = c.req.param("id");
@@ -65,7 +67,7 @@ export const getSubmissionRoute = route().get(
 
         // Check permissions: own submission OR can manage form
         const isOwnSubmission = submission.userId === user.id;
-        const canManage = await canManageForm({ db, ...ctx }, formId, user.id);
+        const canManage = await canManageForm(ctx, formId, user.id);
 
         if (!isOwnSubmission && !canManage) {
             throw new HTTPException(403, {
@@ -73,12 +75,20 @@ export const getSubmissionRoute = route().get(
             });
         }
 
+        const study = deriveStudyFromGroups(
+            (await loadStudyGroupRows(ctx, [submission.userId])).get(
+                submission.userId,
+            ) ?? [],
+        );
+
         return c.json({
             id: submission.id,
             user: {
                 id: submission.user.id,
                 name: submission.user.name,
                 email: submission.user.email,
+                study_program: study.studyProgram,
+                study_start_year: study.studyStartYear,
             },
             created_at: submission.createdAt.toISOString(),
             updated_at: submission.updatedAt.toISOString(),

--- a/apps/api/src/routes/form/submission/list.ts
+++ b/apps/api/src/routes/form/submission/list.ts
@@ -2,6 +2,7 @@ import { schema } from "@photon/db";
 import { and, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import { canManageForm } from "~/lib/form/service";
+import { deriveStudyFromGroups, loadStudyGroupRows } from "~/lib/user/study";
 import { describeRoute } from "~/lib/openapi";
 import { route } from "~/lib/route";
 import { requireAuth } from "~/middleware/auth";
@@ -26,7 +27,8 @@ export const listSubmissionsRoute = route().get(
         .build(),
     requireAuth,
     async (c) => {
-        const { db, ...ctx } = c.get("ctx");
+        const ctx = c.get("ctx");
+        const { db } = ctx;
         const user = c.get("user");
         const formId = c.req.param("formId");
 
@@ -48,7 +50,7 @@ export const listSubmissionsRoute = route().get(
         }
 
         // Check permissions
-        const canManage = await canManageForm({ db, ...ctx }, formId, user.id);
+        const canManage = await canManageForm(ctx, formId, user.id);
 
         if (!canManage) {
             throw new HTTPException(403, {
@@ -101,26 +103,41 @@ export const listSubmissionsRoute = route().get(
             );
         }
 
+        // Studieretning og kull for hele lista i én spørring, utledet med den
+        // samme rangeringen som profilen bruker — ellers kunne skjemaet og
+        // profilen vist to ulike studier for samme person.
+        const studyByUser = await loadStudyGroupRows(
+            ctx,
+            submissions.map((s) => s.userId),
+        );
+
         return c.json(
-            submissions.map((submission) => ({
-                id: submission.id,
-                user: {
-                    id: submission.user.id,
-                    name: submission.user.name,
-                    email: submission.user.email,
-                },
-                created_at: submission.createdAt.toISOString(),
-                updated_at: submission.updatedAt.toISOString(),
-                answers: submission.answers.map((answer) => ({
-                    id: answer.id,
-                    field_id: answer.fieldId,
-                    answer_text: answer.answerText,
-                    selected_options: answer.selectedOptions.map((so) => ({
-                        id: so.option.id,
-                        title: so.option.title,
+            submissions.map((submission) => {
+                const study = deriveStudyFromGroups(
+                    studyByUser.get(submission.userId) ?? [],
+                );
+                return {
+                    id: submission.id,
+                    user: {
+                        id: submission.user.id,
+                        name: submission.user.name,
+                        email: submission.user.email,
+                        study_program: study.studyProgram,
+                        study_start_year: study.studyStartYear,
+                    },
+                    created_at: submission.createdAt.toISOString(),
+                    updated_at: submission.updatedAt.toISOString(),
+                    answers: submission.answers.map((answer) => ({
+                        id: answer.id,
+                        field_id: answer.fieldId,
+                        answer_text: answer.answerText,
+                        selected_options: answer.selectedOptions.map((so) => ({
+                            id: so.option.id,
+                            title: so.option.title,
+                        })),
                     })),
-                })),
-            })),
+                };
+            }),
         );
     },
 );

--- a/apps/api/src/routes/form/submission/mine.ts
+++ b/apps/api/src/routes/form/submission/mine.ts
@@ -1,0 +1,98 @@
+import { schema } from "@photon/db";
+import { and, eq } from "drizzle-orm";
+import { HTTPException } from "hono/http-exception";
+import { describeRoute } from "~/lib/openapi";
+import { deriveStudyFromGroups, loadStudyGroupRows } from "~/lib/user/study";
+import { route } from "~/lib/route";
+import { requireAuth } from "~/middleware/auth";
+import { submissionListSchema } from "../schema";
+
+/**
+ * Egne svar på ett skjema.
+ *
+ * Skjemasiden trenger dem for å kunne si «du har allerede svart» og vise hva
+ * som faktisk ble sendt inn — også når skjemaet tar imot flere svar, der
+ * brukeren tidligere fikk et blankt skjema uten et hint om at de hadde svart
+ * før (issue #672). Ruten er bevisst egen og ikke et filter på
+ * `/submissions`: den lista krever tilgang til å administrere skjemaet.
+ */
+export const listOwnSubmissionsRoute = route().get(
+    "/:formId/submissions/me",
+    describeRoute({
+        tags: ["forms"],
+        summary: "List own submissions",
+        operationId: "listOwnFormSubmissions",
+        description:
+            "List the authenticated user's own submissions for a form, newest first. Available to any authenticated user; no form management permission needed.",
+    })
+        .schemaResponse({
+            statusCode: 200,
+            schema: submissionListSchema,
+            description: "Success",
+        })
+        .unauthorized({ description: "Authentication required" })
+        .notFound({ description: "Form not found" })
+        .build(),
+    requireAuth,
+    async (c) => {
+        const ctx = c.get("ctx");
+        const { db } = ctx;
+        const user = c.get("user");
+        const formId = c.req.param("formId");
+
+        const form = await db.query.form.findFirst({
+            where: eq(schema.form.id, formId),
+            columns: { id: true },
+        });
+
+        if (!form) {
+            throw new HTTPException(404, { message: "Form not found" });
+        }
+
+        const submissions = await db.query.formSubmission.findMany({
+            where: and(
+                eq(schema.formSubmission.formId, formId),
+                eq(schema.formSubmission.userId, user.id),
+            ),
+            with: {
+                user: true,
+                answers: {
+                    with: {
+                        selectedOptions: {
+                            with: { option: true },
+                        },
+                    },
+                },
+            },
+            orderBy: (submissions, { desc }) => [desc(submissions.createdAt)],
+        });
+
+        const study = deriveStudyFromGroups(
+            (await loadStudyGroupRows(ctx, [user.id])).get(user.id) ?? [],
+        );
+
+        return c.json(
+            submissions.map((submission) => ({
+                id: submission.id,
+                user: {
+                    id: submission.user.id,
+                    name: submission.user.name,
+                    email: submission.user.email,
+                    study_program: study.studyProgram,
+                    study_start_year: study.studyStartYear,
+                },
+                created_at: submission.createdAt.toISOString(),
+                updated_at: submission.updatedAt.toISOString(),
+                answers: submission.answers.map((answer) => ({
+                    id: answer.id,
+                    field_id: answer.fieldId,
+                    answer_text: answer.answerText,
+                    selected_options: answer.selectedOptions.map((so) => ({
+                        id: so.option.id,
+                        title: so.option.title,
+                    })),
+                })),
+            })),
+        );
+    },
+);

--- a/apps/kvark/src/api/queries/forms.ts
+++ b/apps/kvark/src/api/queries/forms.ts
@@ -163,6 +163,22 @@ export const getFormSubmissionsQuery = (
             }),
     });
 
+/**
+ * Egne svar på ett skjema.
+ *
+ * Skjemasiden viser dem tilbake til den som allerede har svart — også når
+ * skjemaet tar imot flere svar, der man før bare fikk et blankt skjema uten
+ * noe hint om at man hadde svart før (issue #672).
+ */
+export const getOwnFormSubmissionsQuery = (formId: string) =>
+    queryOptions({
+        queryKey: [...FormQueryKeys.submissions, formId, "me"],
+        queryFn: () =>
+            apiClient.get("/api/forms/{formId}/submissions/me", {
+                params: { formId },
+            }),
+    });
+
 export const getFormSubmissionByIdQuery = (
     formId: string,
     submissionId: string,
@@ -204,6 +220,12 @@ export const createSubmissionMutation = mutationOptions({
         });
         ctx.client.invalidateQueries({
             queryKey: [...FormQueryKeys.statistics, vars.formId],
+            exact: false,
+        });
+        // `viewer_has_answered` ligger på selve skjemaet, så uten denne står
+        // siden igjen og tror man ikke har svart.
+        ctx.client.invalidateQueries({
+            queryKey: [...FormQueryKeys.detail, vars.formId],
             exact: false,
         });
         // Svaret kan ha vært evalueringen som sperret for påmelding, så

--- a/apps/kvark/src/components/form-own-answers.tsx
+++ b/apps/kvark/src/components/form-own-answers.tsx
@@ -1,0 +1,78 @@
+import { Skeleton } from "@tihlde/ui/ui/skeleton";
+
+export type OwnSubmission = {
+    id: string;
+    submittedAt: string;
+    answers: { fieldId: string | null; text: string }[];
+};
+
+type FormOwnAnswersProps = {
+    /** Spørsmålene i skjemaets rekkefølge, så svarene står i samme orden. */
+    questions: { id: string; title: string }[];
+    submissions: OwnSubmission[];
+    isLoading?: boolean;
+};
+
+/**
+ * Svarene den innloggede allerede har sendt inn på dette skjemaet.
+ *
+ * Vises både når skjemaet er ferdig besvart og når det tar imot flere svar —
+ * i det siste tilfellet fikk man før bare et blankt skjema, uten noe tegn til
+ * at man hadde svart før (issue #672).
+ */
+export function FormOwnAnswers({
+    questions,
+    submissions,
+    isLoading,
+}: FormOwnAnswersProps) {
+    if (isLoading) {
+        return (
+            <div className="flex flex-col gap-2">
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="h-20 w-full" />
+            </div>
+        );
+    }
+
+    if (submissions.length === 0) return null;
+
+    return (
+        <div className="flex flex-col gap-5">
+            {submissions.map((submission, index) => (
+                <div key={submission.id} className="flex flex-col gap-3">
+                    <p className="text-sm font-medium">
+                        {submissions.length > 1
+                            ? `Svar ${submissions.length - index} · sendt inn ${submission.submittedAt}`
+                            : `Sendt inn ${submission.submittedAt}`}
+                    </p>
+                    <dl className="flex flex-col gap-3">
+                        {questions.map((question) => {
+                            const answer = submission.answers.find(
+                                (a) => a.fieldId === question.id,
+                            );
+                            return (
+                                <div
+                                    key={question.id}
+                                    className="flex flex-col gap-0.5"
+                                >
+                                    <dt className="text-sm text-muted-foreground">
+                                        {question.title}
+                                    </dt>
+                                    <dd className="text-sm">
+                                        {answer?.text ? (
+                                            answer.text
+                                        ) : (
+                                            <span className="text-muted-foreground">
+                                                Ikke besvart
+                                            </span>
+                                        )}
+                                    </dd>
+                                </div>
+                            );
+                        })}
+                    </dl>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/apps/kvark/src/components/form-submissions-table.tsx
+++ b/apps/kvark/src/components/form-submissions-table.tsx
@@ -7,7 +7,7 @@ import {
     TableRow,
 } from "@tihlde/ui/ui/table";
 
-import type { FormSubmissionRow } from "#/lib/form";
+import { type FormSubmissionRow, formatSubmissionStudy } from "#/lib/form";
 
 type FormSubmissionsTableProps = {
     /** Spørsmålene, i skjemaets rekkefølge. Én kolonne hver. */
@@ -59,6 +59,20 @@ export function FormSubmissionsTable({
                                 <span className="text-xs text-muted-foreground">
                                     {submission.userEmail}
                                 </span>
+                                {/* Studie og kull hører til personen, ikke til
+                                    et eget spørsmål: skjemaeieren leser svarene
+                                    per kull like ofte som per navn (#681). */}
+                                {formatSubmissionStudy(
+                                    submission.studyProgram,
+                                    submission.studyStartYear,
+                                ) ? (
+                                    <span className="text-xs text-muted-foreground">
+                                        {formatSubmissionStudy(
+                                            submission.studyProgram,
+                                            submission.studyStartYear,
+                                        )}
+                                    </span>
+                                ) : null}
                             </div>
                         </TableCell>
                         <TableCell>{submission.submittedAt}</TableCell>

--- a/apps/kvark/src/lib/form.ts
+++ b/apps/kvark/src/lib/form.ts
@@ -81,6 +81,10 @@ export type FormSubmissionRow = {
     id: string;
     userName: string;
     userEmail: string;
+    /** Studieretningen personen går på nå, om vi kjenner den. */
+    studyProgram: string | null;
+    /** Kullet, altså året de startet. */
+    studyStartYear: number | null;
     submittedAt: string;
     answers: FormAnswer[];
 };
@@ -92,6 +96,8 @@ export function mapSubmission(
         id: submission.id,
         userName: submission.user.name,
         userEmail: submission.user.email,
+        studyProgram: submission.user.study_program,
+        studyStartYear: submission.user.study_start_year,
         submittedAt: formatInOslo(submission.created_at, "d. MMM yyyy"),
         answers: submission.answers.map((answer) => ({
             fieldId: answer.field_id,
@@ -130,4 +136,18 @@ export function mapFormStatistics(
             percentage: option.answer_percentage,
         })),
     }));
+}
+
+/**
+ * «BIDATA · kull 2023» — studieretning og kull på én linje, slik det står i
+ * den første kolonnen i svarlista (issue #681). Tom når vi ikke vet noe.
+ */
+export function formatSubmissionStudy(
+    programme: string | null,
+    startYear: number | null,
+): string | null {
+    const parts = [programme, startYear ? `kull ${startYear}` : null].filter(
+        Boolean,
+    );
+    return parts.length > 0 ? parts.join(" · ") : null;
 }

--- a/apps/kvark/src/routes/_app/sporreskjema.$id.tsx
+++ b/apps/kvark/src/routes/_app/sporreskjema.$id.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { Alert, AlertDescription, AlertTitle } from "@tihlde/ui/ui/alert";
 import { Button } from "@tihlde/ui/ui/button";
@@ -21,12 +21,14 @@ import { authClientWithRedirect } from "#/api/auth";
 import {
     createSubmissionMutation,
     getFormByIdQuery,
+    getOwnFormSubmissionsQuery,
 } from "#/api/queries/forms";
+import { FormOwnAnswers } from "#/components/form-own-answers";
 import { richRegistry } from "#/components/markdown/directives/presets";
 import { formHandlers, useAppForm } from "#/hooks/form";
 import { useGoBack } from "#/hooks/use-go-back";
 import { formatEventDate } from "#/lib/event";
-import { formatFormOpensAt } from "#/lib/form";
+import { formatFormOpensAt, mapSubmission } from "#/lib/form";
 
 export const Route = createFileRoute("/_app/sporreskjema/$id")({
     component: FormPage,
@@ -157,37 +159,84 @@ function FormBody({ form }: { form: FormDetail }) {
     const canAnswerAgain =
         form.resource_type === "GroupForm" && Boolean(form.can_submit_multiple);
 
-    if (form.viewer_has_answered && !canAnswerAgain) {
-        return <AlreadyAnswered />;
+    if (form.viewer_has_answered) {
+        return <AlreadyAnswered form={form} canAnswerAgain={canAnswerAgain} />;
     }
 
     return <AnswerForm form={form} />;
 }
 
-function AlreadyAnswered() {
+/**
+ * Beskjed om at man allerede har svart, sammen med svaret man sendte.
+ *
+ * Skjemaer som tar imot flere svar viste før bare et blankt skjema på nytt, så
+ * man verken visste at man hadde svart eller hva man hadde svart (issue #672).
+ * De får derfor beskjeden og svarene sine først, og skjemaet under.
+ */
+function AlreadyAnswered({
+    form,
+    canAnswerAgain,
+}: {
+    form: FormDetail;
+    canAnswerAgain: boolean;
+}) {
+    const { data: ownSubmissions, isPending } = useQuery(
+        getOwnFormSubmissionsQuery(form.id),
+    );
+    const questions = form.fields.map((field) => ({
+        id: field.id,
+        title: field.title,
+    }));
+    const submissions = (ownSubmissions ?? []).map(mapSubmission);
+
     return (
         <div className="flex flex-col gap-4">
             <Alert>
                 <CheckCircle2 />
                 <AlertTitle>Du har allerede svart på dette skjemaet</AlertTitle>
-                <AlertDescription>Takk for svaret ditt!</AlertDescription>
+                <AlertDescription>
+                    {canAnswerAgain
+                        ? "Skjemaet tar imot flere svar. Under ser du hva du har svart før, og du kan sende inn et nytt svar."
+                        : "Takk for svaret ditt! Under ser du hva du svarte."}
+                </AlertDescription>
             </Alert>
-            <div className="flex flex-col gap-2 sm:flex-row">
-                <Button
-                    variant="outline"
-                    className="w-full"
-                    render={<Link to="/" />}
-                >
-                    Gå til forsiden
-                </Button>
-                <Button
-                    variant="outline"
-                    className="w-full"
-                    render={<Link to="/profil/$id" params={{ id: "me" }} />}
-                >
-                    Gå til profilen din
-                </Button>
-            </div>
+
+            <FormOwnAnswers
+                questions={questions}
+                submissions={submissions.map((submission) => ({
+                    id: submission.id,
+                    submittedAt: submission.submittedAt,
+                    answers: submission.answers,
+                }))}
+                isLoading={isPending}
+            />
+
+            {canAnswerAgain ? (
+                <>
+                    <Separator />
+                    <h2 className="text-lg font-medium">
+                        Send inn et nytt svar
+                    </h2>
+                    <AnswerForm form={form} />
+                </>
+            ) : (
+                <div className="flex flex-col gap-2 sm:flex-row">
+                    <Button
+                        variant="outline"
+                        className="w-full"
+                        render={<Link to="/" />}
+                    >
+                        Gå til forsiden
+                    </Button>
+                    <Button
+                        variant="outline"
+                        className="w-full"
+                        render={<Link to="/profil/$id" params={{ id: "me" }} />}
+                    >
+                        Gå til profilen din
+                    </Button>
+                </div>
+            )}
         </div>
     );
 }

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -1230,6 +1230,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/forms/{formId}/submissions/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List own submissions
+         * @description List the authenticated user's own submissions for a form, newest first. Available to any authenticated user; no form management permission needed.
+         */
+        get: operations["listOwnFormSubmissions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/forms/{formId}/submissions/{id}": {
         parameters: {
             query?: never;
@@ -4592,6 +4612,8 @@ export interface components {
                 id: string;
                 name: string;
                 email: string;
+                study_program: string | null;
+                study_start_year: number | null;
             };
             created_at: string;
             updated_at: string;
@@ -4614,6 +4636,8 @@ export interface components {
                 id: string;
                 name: string;
                 email: string;
+                study_program: string | null;
+                study_start_year: number | null;
             };
             created_at: string;
             updated_at: string;
@@ -9748,6 +9772,53 @@ export interface operations {
                 };
             };
             /** @description Form not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listOwnFormSubmissions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                formId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubmissionList"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Kontoen din venter på godkjenning fra en administrator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPAppException"];
+                };
+            };
+            /** @description Not Found - Form not found */
             404: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Lukker #672 og #681.

**Hvorfor to issues i én PR:** begge utvider `submissionUserSchema` og de samme submission-rutene. Den nye `/submissions/me`-ruta må returnere de nye brukerfeltene, så de lar seg ikke skille uten å stable PR-er på hverandre.

## Egne svar (#672)

Et skjema som tar imot flere svar ga deg bare et blankt skjema på nytt. Du fikk verken vite at du hadde svart før, eller se hva du svarte.

- Ny rute `GET /api/forms/{formId}/submissions/me` gir dine egne innsendinger. Åpen for enhver innlogget, i motsetning til `/submissions`, som krever tilgang til å administrere skjemaet. Registrert **før** `/submissions/:id`, ellers leses «me» som en innsendings-id.
- Skjemasiden viser nå beskjeden og svarene dine først, og selve skjemaet under når flere svar er tillatt.
- Innsendingen invaliderer nå skjemadetaljene, som den ikke gjorde: `viewer_has_answered` ble stående usann til man lastet siden på nytt.

## Studie og kull (#681)

Svarlista viste navn og e-post. Skjemaeieren leser svarene per kull like ofte som per person, og måtte slå opp hver enkelt manuelt.

Studieretning og kull hentes nå med de samme hjelperne som profilen og deltakerlista bruker (`loadStudyGroupRows`/`deriveStudyFromGroups`), så de tre stedene ikke kan vise tre ulike studier for samme person. Én spørring for hele sida.

**CSV-eksporten er urørt** — issuet gjelder kolonnen i tabellen. Si fra hvis den skal med.

## Verifisert
`bun run typecheck` grønt på denne grenen alene. Alle skjema-suitene passerer (`forms`, `answered-questions`, `group-scoped-access`, `scheduled-open`, `submission-notification-email`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)