### PR TITLE
fix(prod): la Redis overleve en omstart

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -18,3 +18,23 @@ services:
         image: redis:alpine
         pull_policy: always
         restart: unless-stopped
+        # Redis er ikke en cache her: køen er eneste hukommelse om arbeid som
+        # skal skje senere. Mister vi den, blir ingen betalingsfrist håndhevet
+        # — ingenting i basen feier `event_payment.expiresAt`, så en ubetalt
+        # plass blir aldri inndratt og ventelista rykker aldri.
+        #
+        # `--save ""` slår av RDB-øyeblikksbildene til fordel for AOF alene:
+        # AOF-en skrives fortløpende, mens et øyeblikksbilde per definisjon
+        # ligger etter og ville gitt oss en halv kø tilbake. Samme oppsett som
+        # dev har hatt hele tiden.
+        command: ["redis-server", "--save", "", "--appendonly", "yes"]
+        volumes:
+            - redis_data:/data
+        healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+
+volumes:
+    redis_data:

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -15,7 +15,17 @@ services:
             - photon.tihlde.org-redis
     photon.tihlde.org-redis:
         container_name: photon.tihlde.org-redis
-        image: redis:alpine
+        # Pinnet til major 8, som er det `redis:alpine` løser til i dag
+        # (8.10.1). Med `pull_policy: always` på et bevegelig tag kunne prod
+        # tidligere hoppe major-versjon på en hvilken som helst deploy, uten
+        # at noe sa fra. Det var ufarlig så lenge alt lå i minnet og gikk tapt
+        # uansett — men nå som AOF-en overlever, er det et format det er verdt
+        # å ha kontroll på hvem som skriver.
+        #
+        # Fortsatt bevegelig innenfor major, så sikkerhetsoppdateringer
+        # kommer inn av seg selv. Med volumet på plass er en gjenskaping av
+        # containeren ikke lenger et datatap.
+        image: redis:8-alpine
         pull_policy: always
         restart: unless-stopped
         # Redis er ikke en cache her: køen er eneste hukommelse om arbeid som


### PR DESCRIPTION
Prod-Redis kjørte uten volum og uten persistens — alt lå i minnet. Dev har hatt volum, `--save "" --appendonly yes` og healthcheck siden fila ble skrevet; dette er i praksis bare å gi prod det samme.

## Hvorfor det haster

Redis er ikke en cache i Photon. Den forsinkede BullMQ-jobben er **eneste** hukommelse om at en betalingsfrist finnes:

- `createPaymentObligation` legger en `payment-expiration`-jobb i køen med delay fram til fristen
- ingenting i basen feier `event_payment.expiresAt`
- de fem cron-jobbene i `apps/api/src/lib/jobs.ts` går in-process og overlever en Redis-vask, men **ingen av dem håndhever fristen** — «payment review»-cronen gjelder betalinger fra folk *uten* plass, noe helt annet

Blir køen borte, blir ubetalte plasser aldri inndratt og ventelista rykker aldri. Det retter seg ikke selv.

Vipps-webhooken lå der også. Den selvheler — med tom Redis registrerer `setupWebhooks()` en ny — men den gamle registreringen slettes aldri hos Vipps, så de hoper seg opp, og leveranser signert med den gamle hemmeligheten feiler validering.

## Verifisert

Reprodusert mot ekte containere, med negativ kontroll så jeg vet testen kan feile:

| | før gjenskaping | etter |
|---|---|---|
| `redis:alpine`, uten volum (dagens prod) | 1 jobb | **0 jobber** |
| `redis:8-alpine` + volum + AOF (denne PR-en) | 1 jobb, secret satt | **1 jobb, secret intakt** |

`docker compose config` validerer.

## To commits, kan skilles

1. **Persistensen** — volum, `--save "" --appendonly yes`, healthcheck. `--save ""` slår av RDB til fordel for AOF alene: et øyeblikksbilde ligger per definisjon etter og ville gitt oss en halv kø tilbake.
2. **Pinningen** — `redis:alpine` løser i dag til **8.10.1**, mens dev kjører **7.4.8**. Med `pull_policy: always` på et bevegelig major-tag kunne prod hoppe versjon på en hvilken som helst deploy uten at noe sa fra. Ufarlig så lenge alt gikk tapt uansett, men nå som AOF-en overlever er det et filformat verdt å ha kontroll på. Pinnet til den majoren prod allerede kjører, fortsatt bevegelig innenfor major. Drop commiten om dere heller vil pinne til noe annet.

## ⚠️ Deployen som lander denne, vasker Redis én siste gang

Compose-spesifikasjonen endrer seg, så containeren gjenskapes — og volumet er tomt første gang. Sjekk derfor før dere slipper:

```bash
docker exec photon.tihlde.org-redis redis-cli ZCARD bull:payment:delayed
```

Er den 0, har ingen en åpen betalingsfrist og deployen er ufarlig. Er den ikke 0, vent til fristene har løpt ut. Fra og med neste deploy er problemet borte.

## Utenfor scope

Dev kjører Redis 7.4 og prod 8.x. Den drifta er eldre enn denne PR-en, og å lukke den betyr å flytte en av dem — deres valg, ikke noe jeg smugler inn her.

🤖 Generated with [Claude Code](https://claude.com/claude-code)