### PR TITLE
feat(betaling): håndhev forfalte betalingsfrister fra basen

### DIFF
--- a/apps/api/src/lib/event/payment-sweep.ts
+++ b/apps/api/src/lib/event/payment-sweep.ts
@@ -1,0 +1,74 @@
+import { schema } from "@photon/db";
+import { and, asc, eq, isNotNull, lte } from "drizzle-orm";
+import type { AppContext } from "../ctx";
+import { handlePaymentExpiration } from "./payment";
+
+/**
+ * Hvor mange forfalte forpliktelser én runde tar.
+ *
+ * `handlePaymentExpiration` spør betalingsleverandøren før den tar noe fra
+ * noen, så hver rad er et nettverkskall. Uten et tak ville en runde etter et
+ * køtap på et stort arrangement kunnet løpe inn i den neste. Resten står til
+ * neste tikk — de har allerede ventet, og rekkefølgen er eldste først.
+ */
+const SWEEP_BATCH_SIZE = 100;
+
+/**
+ * Håndhev betalingsfrister som har forfalt uten at timeren tok dem.
+ *
+ * Fristen håndheves normalt av en forsinket jobb i køen, lagt inn når
+ * forpliktelsen opprettes. Køen ligger i Redis, og Redis i prod har ingen
+ * varig lagring: en omstart tar med seg alle forsinkede jobber. Da fantes det
+ * ingen vei tilbake — ingenting leste `expires_at` fra basen, så en ubetalt
+ * plass ble aldri inndratt og ventelista rykket aldri.
+ *
+ * Dette er samme sikkerhetsnett som påmeldingene har hatt hele tiden (se
+ * `startRegistrationResolverCron`): basen er fasiten, køen bare en snarvei som
+ * gjør at fristen håndheves på sekundet i stedet for ved neste tikk.
+ *
+ * Kaller den samme handleren som køen, ikke en kopi av logikken. Den leser
+ * betalingen på nytt og står ned av seg selv om den er betalt, refundert,
+ * avmeldt eller erstattet av en nyere forpliktelse — så det gjør ingenting om
+ * både jobben og denne runden treffer samme rad.
+ *
+ * @returns Antall forpliktelser som ble håndtert i denne runden.
+ */
+export async function enforceExpiredPaymentDeadlines(
+    ctx: AppContext,
+): Promise<number> {
+    const overdue = await ctx.db.query.eventPayment.findMany({
+        columns: { id: true, eventId: true, userId: true },
+        where: and(
+            eq(schema.eventPayment.status, "pending"),
+            isNotNull(schema.eventPayment.expiresAt),
+            lte(schema.eventPayment.expiresAt, new Date()),
+        ),
+        // Eldste først: de har ventet lengst, og med et tak per runde er det
+        // dem som ellers ville blitt stående igjen.
+        orderBy: asc(schema.eventPayment.expiresAt),
+        limit: SWEEP_BATCH_SIZE,
+    });
+
+    let handled = 0;
+
+    for (const payment of overdue) {
+        try {
+            await handlePaymentExpiration(ctx, {
+                eventId: payment.eventId,
+                userId: payment.userId,
+                paymentId: payment.id,
+            });
+            handled += 1;
+        } catch (error) {
+            // Én rad som feiler skal ikke stoppe resten: de andre har like
+            // forfalte frister, og en leverandør som er nede for den ene er
+            // ikke nødvendigvis nede for de andre.
+            console.error(
+                `Error enforcing payment deadline for payment ${payment.id}:`,
+                error,
+            );
+        }
+    }
+
+    return handled;
+}

--- a/apps/api/src/lib/jobs.ts
+++ b/apps/api/src/lib/jobs.ts
@@ -4,6 +4,7 @@ import { startAssetCleanupCron } from "./asset/worker";
 import type { AppContext } from "./ctx";
 import { processNoShowStrikesForEndedEvents } from "./event/no-show";
 import { reviewPaymentsForStartedEvents } from "./event/payment-review";
+import { enforceExpiredPaymentDeadlines } from "./event/payment-sweep";
 import { startPaymentTimerWorker } from "./event/payment";
 import { sendUpcomingRegistrationReminders } from "./event/registration-reminder";
 import {
@@ -110,6 +111,50 @@ function startPaymentReviewCron(ctx: AppContext): void {
 }
 
 /**
+ * Start cron job that enforces payment deadlines the queue never got to.
+ *
+ * The deadline is normally enforced by a delayed job, scheduled when the
+ * obligation is created. That job lives in Redis, which has no durable storage
+ * in production — a restart takes every delayed job with it, and nothing read
+ * `expires_at` back out of the database. An unpaid spot was then never
+ * reclaimed and the waiting list never moved.
+ *
+ * Same safety net the registrations have always had, one floor down: the
+ * database is the source of truth, the queue only a shortcut that enforces the
+ * deadline on the second rather than at the next tick.
+ *
+ * Runs every 5 minutes. The deadline is measured in hours, so arriving a few
+ * minutes late costs nothing — and on a healthy queue this finds nothing.
+ */
+function startPaymentDeadlineSweepCron(ctx: AppContext): void {
+    // node-cron starter neste kjøring uansett om den forrige er ferdig, og en
+    // runde her kan holde på: hver rad koster et kall til betalings-
+    // leverandøren. Uten dette ville to runder kunnet gå løs på samme rader.
+    let running = false;
+
+    cron.schedule("*/5 * * * *", async () => {
+        if (running) return;
+        running = true;
+        try {
+            const handled = await enforceExpiredPaymentDeadlines(ctx);
+            if (handled > 0) {
+                console.log(
+                    `💸 Enforced ${handled} payment deadline(s) the queue missed`,
+                );
+            }
+        } catch (error) {
+            console.error("Error in payment deadline sweep cron:", error);
+        } finally {
+            running = false;
+        }
+    });
+
+    console.log(
+        "⏰ Payment deadline sweep cron started (runs every 5 minutes)",
+    );
+}
+
+/**
  * Initialize all background workers and cron jobs
  * Called once when the application starts
  */
@@ -140,4 +185,7 @@ export function startBackgroundJobs(ctx: AppContext): void {
 
     // Start the payments-without-a-spot review cron
     startPaymentReviewCron(ctx);
+
+    // Start the sweep that enforces deadlines the queue lost
+    startPaymentDeadlineSweepCron(ctx);
 }

--- a/apps/api/src/test/event/payment-deadline-sweep.test.ts
+++ b/apps/api/src/test/event/payment-deadline-sweep.test.ts
@@ -1,0 +1,152 @@
+import { schema } from "@photon/db";
+import { eq } from "drizzle-orm";
+import { describe, expect } from "vitest";
+import { enforceExpiredPaymentDeadlines } from "~/lib/event/payment-sweep";
+import { resolveRegistrationsForEvent } from "~/lib/event/resolve-registration";
+import { integrationTest } from "~/test/config/integration";
+
+/**
+ * Betalingsfristen håndheves normalt av en forsinket jobb i køen. Køen ligger
+ * i Redis, og prod-Redis har ingen varig lagring — en omstart tar med seg alle
+ * forsinkede jobber. Fram til nå fantes det ingen vei tilbake: ingenting leste
+ * `expires_at` fra basen, så en ubetalt plass ble aldri inndratt og ventelista
+ * rykket aldri.
+ *
+ * Testene under fyrer aldri av timeren. De etterligner et køtap ved å la
+ * fristen løpe ut i basen alene, og krever at sweepen tar den.
+ */
+describe("betalingsfrist-sweep når køen har mistet jobben", () => {
+    integrationTest(
+        "inndrar den ubetalte plassen og rykker ventelista, uten at timeren fyrte",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 1,
+                isPaidEvent: true,
+                priceMinor: 5000,
+            });
+
+            const unpaid = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, unpaid.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            await new Promise((resolve) => setTimeout(resolve, 10));
+
+            const waiting = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, waiting.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const obligation = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { and, eq }) =>
+                    and(eq(p.eventId, event.id), eq(p.userId, unpaid.id)),
+            });
+            expect(obligation?.status).toBe("pending");
+
+            // Køtapet: jobben finnes ikke lenger, og fristen går ut i basen
+            // alene. Ingen timer fyres i denne testen.
+            await ctx.db
+                .update(schema.eventPayment)
+                .set({ expiresAt: new Date(Date.now() - 60_000) })
+                .where(eq(schema.eventPayment.id, obligation?.id ?? ""));
+
+            const handled = await enforceExpiredPaymentDeadlines(ctx);
+            expect(handled).toBe(1);
+
+            const reclaimed = await ctx.db.query.eventRegistration.findFirst({
+                where: (r, { and, eq }) =>
+                    and(eq(r.eventId, event.id), eq(r.userId, unpaid.id)),
+            });
+            expect(reclaimed?.status).toBe("cancelled");
+
+            const closed = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { eq }) => eq(p.id, obligation?.id ?? ""),
+            });
+            expect(closed?.status).toBe("failed");
+
+            // Poenget med å inndra plassen: den neste skal få den.
+            const promoted = await ctx.db.query.eventRegistration.findFirst({
+                where: (r, { and, eq }) =>
+                    and(eq(r.eventId, event.id), eq(r.userId, waiting.id)),
+            });
+            expect(promoted?.status).toBe("registered");
+            expect(promoted?.waitlistPosition).toBeNull();
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "rører ikke en frist som fortsatt løper",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 5,
+                isPaidEvent: true,
+                priceMinor: 5000,
+            });
+
+            const member = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, member.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const obligation = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { and, eq }) =>
+                    and(eq(p.eventId, event.id), eq(p.userId, member.id)),
+            });
+            expect(obligation?.status).toBe("pending");
+
+            const handled = await enforceExpiredPaymentDeadlines(ctx);
+            expect(handled).toBe(0);
+
+            const untouched = await ctx.db.query.eventRegistration.findFirst({
+                where: (r, { and, eq }) =>
+                    and(eq(r.eventId, event.id), eq(r.userId, member.id)),
+            });
+            expect(untouched?.status).toBe("registered");
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "lar en betalt plass stå, selv om fristen er passert",
+        async ({ ctx }) => {
+            await ctx.utils.setupEventCategories();
+
+            const event = await ctx.utils.createTestEvent({
+                capacity: 5,
+                isPaidEvent: true,
+                priceMinor: 5000,
+            });
+
+            const member = await ctx.utils.createTestUser();
+            await ctx.utils.createPendingRegistration(event.id, member.id);
+            await resolveRegistrationsForEvent(event.id, ctx);
+
+            const obligation = await ctx.db.query.eventPayment.findFirst({
+                where: (p, { and, eq }) =>
+                    and(eq(p.eventId, event.id), eq(p.userId, member.id)),
+            });
+
+            // Betalt, men fristen står igjen i fortida — nøyaktig raden en
+            // sweep uten vett ville tatt.
+            await ctx.db
+                .update(schema.eventPayment)
+                .set({
+                    status: "paid",
+                    expiresAt: new Date(Date.now() - 60_000),
+                })
+                .where(eq(schema.eventPayment.id, obligation?.id ?? ""));
+
+            const handled = await enforceExpiredPaymentDeadlines(ctx);
+            expect(handled).toBe(0);
+
+            const kept = await ctx.db.query.eventRegistration.findFirst({
+                where: (r, { and, eq }) =>
+                    and(eq(r.eventId, event.id), eq(r.userId, member.id)),
+            });
+            expect(kept?.status).toBe("registered");
+        },
+        500_000,
+    );
+});


### PR DESCRIPTION
Gjør Redis om fra systemets hukommelse til en ren snarvei. Etter denne kan køen vaskes uten at en betalingsfrist forsvinner.

## Problemet

Betalingsfristen håndheves av en forsinket BullMQ-jobb, lagt inn når forpliktelsen opprettes. Køen ligger i Redis, og prod-Redis har ingen varig lagring — en omstart tar med seg alle forsinkede jobber.

Fram til nå fantes det **ingen vei tilbake**:

- ingenting leste `event_payment.expires_at` fra basen
- de fem cron-jobbene i `apps/api/src/lib/jobs.ts` overlever en Redis-vask, men ingen av dem håndhever fristen — «payment review» gjelder betalinger fra folk *uten* plass, noe helt annet

En ubetalt plass ble derfor aldri inndratt og ventelista rykket aldri. Permanent, og uten noe spor av at det skjedde.

## Løsningen

En cron hvert 5. minutt som spør basen etter forfalte forpliktelser og kaller **den samme handleren som køen** — ikke en kopi av logikken:

```sql
SELECT id, event_id, user_id FROM event_payment
WHERE status = 'pending' AND expires_at <= now()
```

`handlePaymentExpiration` leser betalingen på nytt og står ned av seg selv om den er betalt, refundert, avmeldt eller erstattet av en nyere forpliktelse. Den er altså trygg å kalle to ganger, så det gjør ingenting om både jobben og sweepen treffer samme rad.

Dette er ikke et nytt mønster i kodebasen. **Påmeldingene har hatt akkurat dette nettet hele tiden** — kommentaren over `startRegistrationResolverCron` nevner «an enqueue that failed because Redis was unreachable» som en av grunnene til at den finnes. Betalingene manglet bare søskenet, ett hakk ned.

Detaljer: runden tar maks 100 rader, fordi hver rad koster et kall til betalingsleverandøren, og cronen hopper over et tikk mens forrige runde fortsatt går. Fristen måles i timer, så fem minutters forsinkelse koster ingenting — og på en frisk kø finner den ingenting.

## Verifisert

Tre integrasjonstester som driver scenarioet **uten å fyre timeren i det hele tatt**:

1. Ubetalt plass inndras og ventelista rykker — bare basen visste at fristen var ute
2. En frist som fortsatt løper røres ikke
3. En betalt plass med frist i fortida står — nøyaktig raden en sweep uten vett ville tatt

Og jeg sjekket at testene faktisk kan feile, med to mutasjoner av sweepen:

| Mutasjon | Fanget av |
|---|---|
| Finner radene, teller dem, men håndhever ikke | `expected +0 to be 1` |
| Teller *og* rapporterer riktig, men gjør ingenting | `expected 'registered' to be 'cancelled'` |

Den andre er poenget: det er ikke bare telleren som vokter, men utfallet.

Full suite lokalt: **820 tester** (opp fra 817), typecheck og lint rene.

## Forhold til #688

[#688](https://github.com/TIHLDE/Photon/pull/688) gir Redis et volum så køen overlever en omstart. Den er fortsatt verdt å ta, men den smalner bare vinduet — mistes volumet, byttes verten eller korrumperes AOF-en, er fristene borte igjen og uten vei tilbake.

Denne fjerner klassen i stedet: basen er fasiten, og Redis blir en latens-optimalisering. Med den inne er #688 en ryddesak uten hastverk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)