### PR TITLE
fix(kontrakt): e-postfeil velter ikke signeringen, og banneret nager bare de som skal signere

### DIFF
--- a/apps/api/src/routes/contracts/my-signature.ts
+++ b/apps/api/src/routes/contracts/my-signature.ts
@@ -33,13 +33,29 @@ export const mySignatureRoute = route().get(
 
         const { db } = c.get("ctx");
 
+        // Only members of a group that requires signing are actually obliged
+        // to sign, so callers can nag the right people instead of everyone.
+        // Mirrors the groups sign.ts notifies on signing.
+        const memberships = await db.query.groupMembership.findMany({
+            where: eq(schema.groupMembership.userId, user.id),
+            with: { group: true },
+        });
+        const requiresSigning = memberships.some(
+            (m) => m.group.contractSigningRequired,
+        );
+
         const activeContract = await db.query.contract.findFirst({
             where: eq(schema.contract.isActive, true),
         });
 
         if (!activeContract) {
             return c.json(
-                { hasSigned: false, signedAt: null, signedName: null },
+                {
+                    hasSigned: false,
+                    signedAt: null,
+                    signedName: null,
+                    requiresSigning,
+                },
                 200,
             );
         }
@@ -56,6 +72,7 @@ export const mySignatureRoute = route().get(
                 hasSigned: !!signature,
                 signedAt: signature?.signedAt?.toISOString() ?? null,
                 signedName: signature?.signedName ?? null,
+                requiresSigning,
             },
             200,
         );

--- a/apps/api/src/routes/contracts/schema.ts
+++ b/apps/api/src/routes/contracts/schema.ts
@@ -101,6 +101,10 @@ export const signatureStatusSchema = Schema(
         hasSigned: z.boolean(),
         signedAt: z.string().nullable(),
         signedName: z.string().nullable(),
+        requiresSigning: z.boolean().meta({
+            description:
+                "Whether the user is in at least one group that requires contract signing",
+        }),
     }),
 );
 

--- a/apps/api/src/routes/contracts/sign.ts
+++ b/apps/api/src/routes/contracts/sign.ts
@@ -59,6 +59,7 @@ require contract signing.`,
 
         const body = c.req.valid("json");
         const { db, email, bucket } = c.get("ctx");
+        const logger = c.get("logger");
 
         const activeContract = await db.query.contract.findFirst({
             where: eq(schema.contract.isActive, true),
@@ -211,20 +212,31 @@ require contract signing.`,
                 grp.contactEmail ?? leaderEmailByGroup.get(grp.slug) ?? null;
 
             if (notifyEmail) {
-                await email.sendEmailTemplate(
-                    {
-                        from: env.MAIL_FROM,
-                        to: notifyEmail,
-                        subject: `${user.name} har signert frivillighetskontrakten`,
-                    },
-                    "ContractSignedEmail",
-                    {
-                        memberName: user.name,
-                        groupName: grp.name,
-                        signedAt: signature.signedAt.toISOString(),
-                        logoUrl: `${env.WEBSITE_URL}/logo512.png`,
-                    },
-                );
+                // The signature is already committed, so a failing notification
+                // must not fail the request: the member would be shown an error
+                // for a signing that went through, and their retry would come
+                // back as 409 "already signed".
+                try {
+                    await email.sendEmailTemplate(
+                        {
+                            from: env.MAIL_FROM,
+                            to: notifyEmail,
+                            subject: `${user.name} har signert frivillighetskontrakten`,
+                        },
+                        "ContractSignedEmail",
+                        {
+                            memberName: user.name,
+                            groupName: grp.name,
+                            signedAt: signature.signedAt.toISOString(),
+                            logoUrl: `${env.WEBSITE_URL}/logo512.png`,
+                        },
+                    );
+                } catch (error) {
+                    logger.error(
+                        { err: error, userId: user.id, groupSlug: grp.slug },
+                        "Failed to queue contract signed email",
+                    );
+                }
             }
         }
 

--- a/apps/api/src/routes/contracts/sign.ts
+++ b/apps/api/src/routes/contracts/sign.ts
@@ -232,8 +232,10 @@ require contract signing.`,
                         },
                     );
                 } catch (error) {
+                    // The signer is already bound to the request logger by the
+                    // auth middleware, so only the group is added here.
                     logger.error(
-                        { err: error, userId: user.id, groupSlug: grp.slug },
+                        { err: error, groupSlug: grp.slug },
                         "Failed to queue contract signed email",
                     );
                 }

--- a/apps/api/src/test/contracts/contracts.test.ts
+++ b/apps/api/src/test/contracts/contracts.test.ts
@@ -240,6 +240,149 @@ describe("contracts", () => {
         );
     });
 
+    describe("notification failures", () => {
+        integrationTest(
+            "keeps the signature when the notification email fails",
+            async ({ ctx }) => {
+                // The signature row is written before the leaders are told.
+                // If a failing email took the request down with it, the member
+                // saw an error for a signing that went through — and their
+                // retry came back as 409 "already signed".
+                const admin = await ctx.utils.createTestUser();
+                const adminClient = await ctx.utils.clientForUser(admin);
+                await ctx.utils.giveUserPermissions(admin, [
+                    "contracts:create",
+                    "contracts:update",
+                ]);
+
+                const fileKey = "test/contract-mail.pdf";
+                await ctx.bucket.upload(fileKey, await makeContractPdf(), {
+                    originalFilename: "contract.pdf",
+                    contentType: "application/pdf",
+                });
+                const created = await adminClient.api.contracts.$post({
+                    json: {
+                        title: "Kontrakt",
+                        version: "1",
+                        fileKey,
+                        signaturePlacement: PLACEMENT,
+                    },
+                });
+                const contract = await created.json();
+                await adminClient.api.contracts[":id"].activate.$patch({
+                    param: { id: contract.id },
+                });
+
+                const group = await ctx.utils.createTestGroup({
+                    slug: "mail-failing-group",
+                });
+                await ctx.db
+                    .update(schema.group)
+                    .set({ contractSigningRequired: true })
+                    .where(eq(schema.group.slug, group.slug));
+
+                const member = await ctx.utils.createTestUser();
+                await ctx.db.insert(schema.groupMembership).values({
+                    userId: member.id,
+                    groupSlug: group.slug,
+                });
+
+                ctx.email.sendEmailTemplate = () => {
+                    throw new Error("SMTP is down");
+                };
+
+                const memberClient = await ctx.utils.clientForUser(member);
+                const signed = await memberClient.api.contracts.sign.$post({
+                    json: {
+                        signedName: "Kari Nordmann",
+                        signatureDataUrl: SIGNATURE_DATA_URL,
+                    },
+                });
+                expect(signed.status).toBe(201);
+
+                const row = await ctx.db.query.contractSignature.findFirst();
+                expect(row?.userId).toBe(member.id);
+
+                const status =
+                    await memberClient.api.contracts["my-signature"].$get();
+                expect(await status.json()).toMatchObject({ hasSigned: true });
+            },
+            500_000,
+        );
+    });
+
+    describe("signature status", () => {
+        integrationTest(
+            "requires signing only from members of a signing group",
+            async ({ ctx }) => {
+                // The profile banner nags on this flag. Without it every user
+                // was told to sign, including those in no group that asks for
+                // a contract.
+                const admin = await ctx.utils.createTestUser();
+                const adminClient = await ctx.utils.clientForUser(admin);
+                await ctx.utils.giveUserPermissions(admin, [
+                    "contracts:create",
+                    "contracts:update",
+                ]);
+
+                const fileKey = "test/contract-status.pdf";
+                await ctx.bucket.upload(fileKey, await makeContractPdf(), {
+                    originalFilename: "contract.pdf",
+                    contentType: "application/pdf",
+                });
+                const created = await adminClient.api.contracts.$post({
+                    json: {
+                        title: "Kontrakt",
+                        version: "1",
+                        fileKey,
+                        signaturePlacement: PLACEMENT,
+                    },
+                });
+                const contract = await created.json();
+                await adminClient.api.contracts[":id"].activate.$patch({
+                    param: { id: contract.id },
+                });
+
+                const signingGroup = await ctx.utils.createTestGroup({
+                    slug: "signing-group",
+                });
+                await ctx.db
+                    .update(schema.group)
+                    .set({ contractSigningRequired: true })
+                    .where(eq(schema.group.slug, signingGroup.slug));
+
+                const plainGroup = await ctx.utils.createTestGroup({
+                    slug: "plain-group",
+                });
+
+                const obliged = await ctx.utils.createTestUser();
+                const bystander = await ctx.utils.createTestUser();
+                await ctx.db.insert(schema.groupMembership).values([
+                    { userId: obliged.id, groupSlug: signingGroup.slug },
+                    { userId: bystander.id, groupSlug: plainGroup.slug },
+                ]);
+
+                const obligedStatus = await (
+                    await ctx.utils.clientForUser(obliged)
+                ).api.contracts["my-signature"].$get();
+                expect(obligedStatus.status).toBe(200);
+                expect(await obligedStatus.json()).toMatchObject({
+                    hasSigned: false,
+                    requiresSigning: true,
+                });
+
+                const bystanderStatus = await (
+                    await ctx.utils.clientForUser(bystander)
+                ).api.contracts["my-signature"].$get();
+                expect(await bystanderStatus.json()).toMatchObject({
+                    hasSigned: false,
+                    requiresSigning: false,
+                });
+            },
+            500_000,
+        );
+    });
+
     describe("signed pdf download", () => {
         integrationTest(
             "serves the signer their own PDF but not another member's",

--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -209,9 +209,10 @@ function AllergyBanner({ hasAnswered }: { hasAnswered: boolean }) {
 }
 
 /**
- * Vises bare når det finnes en aktiv kontrakt som ikke er signert. Uten
- * `signature` er statusen fortsatt ukjent — da sier vi ingenting, framfor å
- * påstå at den ikke er signert.
+ * Vises bare når det finnes en aktiv kontrakt som ikke er signert, og bare til
+ * medlemmer av en gruppe som krever signering — resten har ingenting å signere.
+ * Uten `signature` er statusen fortsatt ukjent — da sier vi ingenting, framfor
+ * å påstå at den ikke er signert.
  */
 function ContractBanner({
     hasActiveContract,
@@ -222,6 +223,7 @@ function ContractBanner({
 }) {
     if (!hasActiveContract) return null;
     if (!signature || signature.hasSigned) return null;
+    if (!signature.requiresSigning) return null;
 
     return (
         <Alert>

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -5539,6 +5539,8 @@ export interface components {
             hasSigned: boolean;
             signedAt: string | null;
             signedName: string | null;
+            /** @description Whether the user is in at least one group that requires contract signing */
+            requiresSigning: boolean;
         };
         SignContractResponse: {
             message: string;


### PR DESCRIPTION
To feil rundt frivillighetskontrakten, funnet mens vi verifiserte at en signering faktisk lagres.

## 1. E-postvarsel kunne gi falsk feilmelding

Signaturen lagres før gruppekontaktene varsles, men varselet lå uten `try/catch` inne i requesten. Feilet e-posten, fikk medlemmet 500 for en signering som gikk gjennom — og neste forsøk kom tilbake som 409 «already signed». Varselet logges nå i stedet, samme mønster som `routes/user/approve.ts` allerede bruker.

## 2. Banneret vistes til alle innloggede

Bannerert på profilsiden dukket opp for enhver innlogget bruker så lenge det fantes en aktiv kontrakt, mens sign-ruta bare varsler grupper med `contractSigningRequired`. `/api/contracts/my-signature` svarer nå med `requiresSigning` etter samme regel, og banneret følger den.

## Tester

To nye integrasjonstester:
- «keeps the signature when the notification email fails» — kaster fra `sendEmailTemplate`, forventer 201, rad i basen og `hasSigned: true`
- «requires signing only from members of a signing group» — medlem i signeringsgruppe får `true`, medlem i vanlig gruppe får `false`

## Verifisert

- `bun run typecheck` 9/9, `bun run build` 4/4, lint/format rent
- Kontrakttestene 8/8
- SDK-typene regenerert med `bun run codegen`

Ingen skjemaendring, så deployen trenger ingen migrasjon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)