### PR TITLE
feat(sporreskjema): vis kull og studieretning som donut på statistikk-siden

### DIFF
--- a/apps/kvark/src/components/form-study-charts.tsx
+++ b/apps/kvark/src/components/form-study-charts.tsx
@@ -1,0 +1,154 @@
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@tihlde/ui/ui/card";
+import {
+    type ChartConfig,
+    ChartContainer,
+    ChartTooltip,
+    ChartTooltipContent,
+} from "@tihlde/ui/ui/chart";
+import { useMemo } from "react";
+import { Cell, Pie, PieChart } from "recharts";
+
+import type { FormStudySlice } from "#/lib/form";
+
+/**
+ * Faste farger med god avstand i fargesirkelen, så nabosektorer er lette å
+ * skille. Skalaen i temaet har bare fem trinn av samme farge, som ville gjort
+ * et diagram med mange kull uleselig.
+ */
+const SLICE_COLORS = [
+    "oklch(0.62 0.17 250)",
+    "oklch(0.70 0.15 160)",
+    "oklch(0.75 0.15 75)",
+    "oklch(0.62 0.19 20)",
+    "oklch(0.62 0.16 305)",
+    "oklch(0.70 0.12 200)",
+    "oklch(0.66 0.15 340)",
+    "oklch(0.72 0.15 120)",
+];
+/** Restposten «Ukjent» skal ikke konkurrere med de ekte kategoriene. */
+const UNKNOWN_COLOR = "oklch(0.65 0.02 260)";
+
+function sliceColor(slice: FormStudySlice, index: number): string {
+    return slice.key === "ukjent"
+        ? UNKNOWN_COLOR
+        : SLICE_COLORS[index % SLICE_COLORS.length];
+}
+
+type FormStudyDonutProps = {
+    title: string;
+    description: string;
+    slices: FormStudySlice[];
+};
+
+function FormStudyDonut({ title, description, slices }: FormStudyDonutProps) {
+    const config = useMemo<ChartConfig>(
+        () =>
+            Object.fromEntries(
+                slices.map((slice, index) => [
+                    slice.key,
+                    { label: slice.label, color: sliceColor(slice, index) },
+                ]),
+            ),
+        [slices],
+    );
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>{title}</CardTitle>
+                <CardDescription>{description}</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+                <ChartContainer
+                    config={config}
+                    className="mx-auto aspect-square w-full max-w-64"
+                >
+                    <PieChart>
+                        <ChartTooltip
+                            content={
+                                <ChartTooltipContent nameKey="key" hideLabel />
+                            }
+                        />
+                        <Pie
+                            data={slices}
+                            dataKey="count"
+                            nameKey="key"
+                            innerRadius={55}
+                            outerRadius={95}
+                            paddingAngle={2}
+                            strokeWidth={0}
+                            isAnimationActive={false}
+                        >
+                            {slices.map((slice, index) => (
+                                <Cell
+                                    key={slice.key}
+                                    fill={sliceColor(slice, index)}
+                                />
+                            ))}
+                        </Pie>
+                    </PieChart>
+                </ChartContainer>
+                <ul className="flex flex-col gap-2">
+                    {slices.map((slice, index) => (
+                        <li
+                            key={slice.key}
+                            className="flex items-center gap-2 text-sm"
+                        >
+                            <span
+                                aria-hidden
+                                className="size-2.5 shrink-0 rounded-[2px]"
+                                style={{
+                                    backgroundColor: sliceColor(slice, index),
+                                }}
+                            />
+                            <span className="truncate">{slice.label}</span>
+                            <span className="ml-auto font-medium tabular-nums text-muted-foreground">
+                                {slice.count} ({slice.percentage} %)
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+            </CardContent>
+        </Card>
+    );
+}
+
+type FormStudyChartsProps = {
+    cohorts: FormStudySlice[];
+    programs: FormStudySlice[];
+    /** Antall svar fordelingene er regnet ut av. */
+    total: number;
+};
+
+export function FormStudyCharts({
+    cohorts,
+    programs,
+    total,
+}: FormStudyChartsProps) {
+    if (total === 0) {
+        return null;
+    }
+
+    const description = `${total} svar`;
+
+    return (
+        <div className="grid gap-4 sm:grid-cols-2">
+            <FormStudyDonut
+                title="Kull"
+                description={description}
+                slices={cohorts}
+            />
+            <FormStudyDonut
+                title="Studieretning"
+                description={description}
+                slices={programs}
+            />
+        </div>
+    );
+}

--- a/apps/kvark/src/components/form-study-charts.tsx
+++ b/apps/kvark/src/components/form-study-charts.tsx
@@ -35,7 +35,7 @@ const SLICE_COLORS = [
 const UNKNOWN_COLOR = "oklch(0.65 0.02 260)";
 
 function sliceColor(slice: FormStudySlice, index: number): string {
-    return slice.key === "ukjent"
+    return slice.unknown
         ? UNKNOWN_COLOR
         : SLICE_COLORS[index % SLICE_COLORS.length];
 }

--- a/apps/kvark/src/lib/form.ts
+++ b/apps/kvark/src/lib/form.ts
@@ -154,12 +154,19 @@ export function formatSubmissionStudy(
 
 /** Én andel i et sirkeldiagram, f.eks. ett kull eller én studieretning. */
 export type FormStudySlice = {
-    /** Nøkkelen diagrammet bruker, unik innenfor sitt diagram. */
+    /**
+     * Nøkkelen diagrammet bruker. Syntetisk, ikke navnet på kullet eller
+     * studiet: den ender som CSS-variabelnavn i `ChartStyle`, som skriver
+     * `<style>` med `dangerouslySetInnerHTML`. Et gruppenavn har mellomrom og
+     * er skrevet av et menneske, og hører ikke hjemme der.
+     */
     key: string;
     label: string;
     count: number;
     /** Andel av alle svarene, avrundet til hele prosent. */
     percentage: number;
+    /** Restposten for dem vi ikke kjenner kullet eller studiet til. */
+    unknown: boolean;
 };
 
 export type FormStudyDistribution = {
@@ -167,67 +174,101 @@ export type FormStudyDistribution = {
     programs: FormStudySlice[];
 };
 
-const UNKNOWN_KEY = "ukjent";
+/** Én kategori med antallet svar som faller i den. `value: null` er restposten. */
+type StudyBucket = {
+    value: string | null;
+    label: string;
+    count: number;
+};
 
 function toSlices(
-    counts: Map<string, { label: string; count: number }>,
+    buckets: StudyBucket[],
     total: number,
-    compare: (a: FormStudySlice, b: FormStudySlice) => number,
+    keyPrefix: string,
+    compare: (a: StudyBucket, b: StudyBucket) => number,
 ): FormStudySlice[] {
-    const slices = [...counts.entries()].map(([key, { label, count }]) => ({
-        key,
-        label,
-        count,
-        percentage: total > 0 ? Math.round((count / total) * 100) : 0,
-    }));
+    return (
+        [...buckets]
+            // Restposten sist uansett hvordan resten sorteres — den er ikke et
+            // kull eller et studieprogram på linje med de andre.
+            .sort((a, b) => {
+                if (a.value === null) return 1;
+                if (b.value === null) return -1;
+                return compare(a, b);
+            })
+            .map((bucket, index) => ({
+                key:
+                    bucket.value === null
+                        ? `${keyPrefix}-ukjent`
+                        : `${keyPrefix}-${index}`,
+                label: bucket.label,
+                count: bucket.count,
+                percentage:
+                    total > 0 ? Math.round((bucket.count / total) * 100) : 0,
+                unknown: bucket.value === null,
+            }))
+    );
+}
 
-    // «Ukjent» sist uansett hvordan resten sorteres — den er en restpost, ikke
-    // et kull eller et studieprogram på linje med de andre.
-    return slices.sort((a, b) => {
-        if (a.key === UNKNOWN_KEY) return 1;
-        if (b.key === UNKNOWN_KEY) return -1;
-        return compare(a, b);
-    });
+/** Teller opp én kategori per svar, med `null` for dem vi ikke vet noe om. */
+function countBy(
+    submissions: FormSubmissionRow[],
+    valueOf: (submission: FormSubmissionRow) => string | null,
+    labelOf: (value: string | null) => string,
+): StudyBucket[] {
+    const counts = new Map<string | null, number>();
+
+    for (const submission of submissions) {
+        const value = valueOf(submission);
+        counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+
+    return [...counts.entries()].map(([value, count]) => ({
+        value,
+        label: labelOf(value),
+        count,
+    }));
 }
 
 /**
  * Fordelingen av kull og studieretning blant dem som har svart. Regnes ut av
  * svarlista, som allerede har med studiet til hver enkelt, slik at
  * statistikken alltid kan vises — også for skjemaer uten valgspørsmål.
+ *
+ * Én andel er ett svar, ikke én person, slik at summen stemmer med antallet
+ * svar som står i fanen ved siden av.
  */
 export function summarizeFormStudy(
     submissions: FormSubmissionRow[],
 ): FormStudyDistribution {
-    const cohorts = new Map<string, { label: string; count: number }>();
-    const programs = new Map<string, { label: string; count: number }>();
-
-    for (const submission of submissions) {
-        const cohortKey = submission.studyStartYear
-            ? String(submission.studyStartYear)
-            : UNKNOWN_KEY;
-        const cohortLabel = submission.studyStartYear
-            ? `Kull ${submission.studyStartYear}`
-            : "Ukjent kull";
-        const programKey = submission.studyProgram ?? UNKNOWN_KEY;
-        const programLabel = submission.studyProgram ?? "Ukjent studieretning";
-
-        const cohort = cohorts.get(cohortKey);
-        if (cohort) cohort.count += 1;
-        else cohorts.set(cohortKey, { label: cohortLabel, count: 1 });
-
-        const program = programs.get(programKey);
-        if (program) program.count += 1;
-        else programs.set(programKey, { label: programLabel, count: 1 });
-    }
-
     const total = submissions.length;
+
+    const cohorts = countBy(
+        submissions,
+        (submission) =>
+            submission.studyStartYear === null
+                ? null
+                : String(submission.studyStartYear),
+        (value) => (value === null ? "Ukjent kull" : `Kull ${value}`),
+    );
+    const programs = countBy(
+        submissions,
+        (submission) => submission.studyProgram,
+        (value) => value ?? "Ukjent studieretning",
+    );
 
     return {
         // Nyeste kull først, mens studieretningene sorteres på størrelse.
-        cohorts: toSlices(cohorts, total, (a, b) => b.key.localeCompare(a.key)),
+        cohorts: toSlices(
+            cohorts,
+            total,
+            "kull",
+            (a, b) => Number(b.value) - Number(a.value),
+        ),
         programs: toSlices(
             programs,
             total,
+            "studie",
             (a, b) => b.count - a.count || a.label.localeCompare(b.label, "nb"),
         ),
     };

--- a/apps/kvark/src/lib/form.ts
+++ b/apps/kvark/src/lib/form.ts
@@ -151,3 +151,84 @@ export function formatSubmissionStudy(
     );
     return parts.length > 0 ? parts.join(" · ") : null;
 }
+
+/** Én andel i et sirkeldiagram, f.eks. ett kull eller én studieretning. */
+export type FormStudySlice = {
+    /** Nøkkelen diagrammet bruker, unik innenfor sitt diagram. */
+    key: string;
+    label: string;
+    count: number;
+    /** Andel av alle svarene, avrundet til hele prosent. */
+    percentage: number;
+};
+
+export type FormStudyDistribution = {
+    cohorts: FormStudySlice[];
+    programs: FormStudySlice[];
+};
+
+const UNKNOWN_KEY = "ukjent";
+
+function toSlices(
+    counts: Map<string, { label: string; count: number }>,
+    total: number,
+    compare: (a: FormStudySlice, b: FormStudySlice) => number,
+): FormStudySlice[] {
+    const slices = [...counts.entries()].map(([key, { label, count }]) => ({
+        key,
+        label,
+        count,
+        percentage: total > 0 ? Math.round((count / total) * 100) : 0,
+    }));
+
+    // «Ukjent» sist uansett hvordan resten sorteres — den er en restpost, ikke
+    // et kull eller et studieprogram på linje med de andre.
+    return slices.sort((a, b) => {
+        if (a.key === UNKNOWN_KEY) return 1;
+        if (b.key === UNKNOWN_KEY) return -1;
+        return compare(a, b);
+    });
+}
+
+/**
+ * Fordelingen av kull og studieretning blant dem som har svart. Regnes ut av
+ * svarlista, som allerede har med studiet til hver enkelt, slik at
+ * statistikken alltid kan vises — også for skjemaer uten valgspørsmål.
+ */
+export function summarizeFormStudy(
+    submissions: FormSubmissionRow[],
+): FormStudyDistribution {
+    const cohorts = new Map<string, { label: string; count: number }>();
+    const programs = new Map<string, { label: string; count: number }>();
+
+    for (const submission of submissions) {
+        const cohortKey = submission.studyStartYear
+            ? String(submission.studyStartYear)
+            : UNKNOWN_KEY;
+        const cohortLabel = submission.studyStartYear
+            ? `Kull ${submission.studyStartYear}`
+            : "Ukjent kull";
+        const programKey = submission.studyProgram ?? UNKNOWN_KEY;
+        const programLabel = submission.studyProgram ?? "Ukjent studieretning";
+
+        const cohort = cohorts.get(cohortKey);
+        if (cohort) cohort.count += 1;
+        else cohorts.set(cohortKey, { label: cohortLabel, count: 1 });
+
+        const program = programs.get(programKey);
+        if (program) program.count += 1;
+        else programs.set(programKey, { label: programLabel, count: 1 });
+    }
+
+    const total = submissions.length;
+
+    return {
+        // Nyeste kull først, mens studieretningene sorteres på størrelse.
+        cohorts: toSlices(cohorts, total, (a, b) => b.key.localeCompare(a.key)),
+        programs: toSlices(
+            programs,
+            total,
+            (a, b) => b.count - a.count || a.label.localeCompare(b.label, "nb"),
+        ),
+    };
+}

--- a/apps/kvark/src/routes/_app/sporreskjema.$id_.svar.tsx
+++ b/apps/kvark/src/routes/_app/sporreskjema.$id_.svar.tsx
@@ -34,9 +34,14 @@ import {
     getFormSubmissionsQuery,
 } from "#/api/queries/forms";
 import { FormStatisticsList } from "#/components/form-statistics-list";
+import { FormStudyCharts } from "#/components/form-study-charts";
 import { FormSubmissionsTable } from "#/components/form-submissions-table";
 import { useGoBack } from "#/hooks/use-go-back";
-import { mapFormStatistics, mapSubmission } from "#/lib/form";
+import {
+    mapFormStatistics,
+    mapSubmission,
+    summarizeFormStudy,
+} from "#/lib/form";
 import { errorStatus } from "#/lib/utils";
 
 const searchSchema = z.object({
@@ -81,6 +86,10 @@ function FormSubmissionsPage() {
         () => mapFormStatistics(apiStatistics?.statistics ?? []),
         [apiStatistics],
     );
+    // Kull og studieretning regnes ut av svarlista, ikke av statistikk-
+    // endepunktet, slik at fordelingen vises også for skjemaer uten
+    // valgspørsmål.
+    const study = useMemo(() => summarizeFormStudy(submissions), [submissions]);
     const questions = useMemo(
         () =>
             form.fields.map((field) => ({ id: field.id, title: field.title })),
@@ -196,7 +205,16 @@ function FormSubmissionsPage() {
                                     submissions={submissions}
                                 />
                             ) : (
-                                <FormStatisticsList statistics={statistics} />
+                                <div className="flex flex-col gap-4">
+                                    <FormStudyCharts
+                                        cohorts={study.cohorts}
+                                        programs={study.programs}
+                                        total={submissions.length}
+                                    />
+                                    <FormStatisticsList
+                                        statistics={statistics}
+                                    />
+                                </div>
                             )}
                         </>
                     )}


### PR DESCRIPTION
## Hva

Statistikk-fanen på et spørreskjema viser nå alltid to donut-diagrammer øverst: **kull** og **studieretning** blant dem som har sendt inn. Under hvert diagram står en liste med farge, etikett og «antall (prosent)».

## Hvorfor

Fanen viste bare fordelingen per valgspørsmål, så et skjema uten alternativer hadde ingenting å vise. Kull og studieretning er det skjemaeieren leser oftest, og måtte før leses ut av svarlista rad for rad.

## Hvordan

- `summarizeFormStudy` i `lib/form.ts` teller opp fordelingene fra svarlista. Kull sorteres nyest først, studieretning etter størrelse, og «Ukjent» havner alltid sist.
- Ingen API-endring: svarlista har allerede med `study_program` og `study_start_year` per person (#681) og er upaginert, så fordelingen kan regnes ut i frontend av hele svarsettet. Det er også grunnen til at den vises for skjemaer uten valgspørsmål, der statistikk-endepunktet svarer tomt.
- Sektorene tegnes med `isAnimationActive={false}` — med recharts' standardanimasjon rendret ikke sektorene seg ved første visning.

## Verifisert

`typecheck`, `lint` og `build` er grønne. Siden er sjekket i nettleser med 21 seedede svar (testdataene er slettet igjen): donutene tegner riktig i både lyst og mørkt tema, stables på mobil, og prosentene summerer til 100 — kull 19/24/24/19/14 og studieretning 52/19/14/14 med «Ukjent» i grått.

🤖 Generated with [Claude Code](https://claude.com/claude-code)