### PR TITLE
feat(sporreskjema): la statistikken telles per svar eller per person

### DIFF
--- a/apps/kvark/src/components/form-study-charts.tsx
+++ b/apps/kvark/src/components/form-study-charts.tsx
@@ -11,10 +11,23 @@ import {
     ChartTooltip,
     ChartTooltipContent,
 } from "@tihlde/ui/ui/chart";
-import { useMemo } from "react";
+import { Label } from "@tihlde/ui/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@tihlde/ui/ui/select";
+import { useMemo, useState } from "react";
 import { Cell, Pie, PieChart } from "recharts";
 
-import type { FormStudySlice } from "#/lib/form";
+import {
+    type FormStudyCountMode,
+    type FormStudySlice,
+    type FormSubmissionRow,
+    summarizeFormStudy,
+} from "#/lib/form";
 
 /**
  * Faste farger med god avstand i fargesirkelen, så nabosektorer er lette å
@@ -119,36 +132,71 @@ function FormStudyDonut({ title, description, slices }: FormStudyDonutProps) {
     );
 }
 
+const COUNT_MODES: { value: FormStudyCountMode; label: string }[] = [
+    { value: "submissions", label: "Per svar" },
+    { value: "people", label: "Per person" },
+];
+
 type FormStudyChartsProps = {
-    cohorts: FormStudySlice[];
-    programs: FormStudySlice[];
-    /** Antall svar fordelingene er regnet ut av. */
-    total: number;
+    submissions: FormSubmissionRow[];
 };
 
-export function FormStudyCharts({
-    cohorts,
-    programs,
-    total,
-}: FormStudyChartsProps) {
-    if (total === 0) {
+export function FormStudyCharts({ submissions }: FormStudyChartsProps) {
+    const [mode, setMode] = useState<FormStudyCountMode>("submissions");
+    const distribution = useMemo(
+        () => summarizeFormStudy(submissions, mode),
+        [submissions, mode],
+    );
+
+    if (submissions.length === 0) {
         return null;
     }
 
-    const description = `${total} svar`;
+    const { total } = distribution;
+    const description =
+        mode === "people"
+            ? `${total} ${total === 1 ? "person" : "personer"}`
+            : `${total} svar`;
 
     return (
-        <div className="grid gap-4 sm:grid-cols-2">
-            <FormStudyDonut
-                title="Kull"
-                description={description}
-                slices={cohorts}
-            />
-            <FormStudyDonut
-                title="Studieretning"
-                description={description}
-                slices={programs}
-            />
+        <div className="flex flex-col gap-4">
+            <div className="flex items-center gap-2">
+                <Label htmlFor="form-study-count-mode">Tell</Label>
+                <Select
+                    items={COUNT_MODES}
+                    value={mode}
+                    onValueChange={(value) =>
+                        setMode((value as FormStudyCountMode | null) ?? mode)
+                    }
+                >
+                    <SelectTrigger
+                        id="form-study-count-mode"
+                        className="w-44"
+                        aria-label="Hva én andel teller"
+                    >
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {COUNT_MODES.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+                <FormStudyDonut
+                    title="Kull"
+                    description={description}
+                    slices={distribution.cohorts}
+                />
+                <FormStudyDonut
+                    title="Studieretning"
+                    description={description}
+                    slices={distribution.programs}
+                />
+            </div>
         </div>
     );
 }

--- a/apps/kvark/src/lib/form.ts
+++ b/apps/kvark/src/lib/form.ts
@@ -79,6 +79,8 @@ export type FormAnswer = {
 
 export type FormSubmissionRow = {
     id: string;
+    /** Hvem som svarte. Brukes til å telle personer i stedet for svar. */
+    userId: string;
     userName: string;
     userEmail: string;
     /** Studieretningen personen går på nå, om vi kjenner den. */
@@ -94,6 +96,7 @@ export function mapSubmission(
 ): FormSubmissionRow {
     return {
         id: submission.id,
+        userId: submission.user.id,
         userName: submission.user.name,
         userEmail: submission.user.email,
         studyProgram: submission.user.study_program,
@@ -172,7 +175,16 @@ export type FormStudySlice = {
 export type FormStudyDistribution = {
     cohorts: FormStudySlice[];
     programs: FormStudySlice[];
+    /** Hva andelene er regnet ut av — svar eller personer, alt etter modus. */
+    total: number;
 };
+
+/**
+ * Om hvert svar teller for seg, eller om flere svar fra samme person teller
+ * som én. De skiller lag på skjemaer som tar imot mer enn ett svar per
+ * person, der den ivrigste ellers drar sitt eget kull opp.
+ */
+export type FormStudyCountMode = "submissions" | "people";
 
 /** Én kategori med antallet svar som faller i den. `value: null` er restposten. */
 type StudyBucket = {
@@ -235,16 +247,20 @@ function countBy(
  * svarlista, som allerede har med studiet til hver enkelt, slik at
  * statistikken alltid kan vises — også for skjemaer uten valgspørsmål.
  *
- * Én andel er ett svar, ikke én person, slik at summen stemmer med antallet
- * svar som står i fanen ved siden av.
+ * `mode` bestemmer hva én andel er: ett svar, slik at summen stemmer med
+ * antallet svar i fanen ved siden av, eller én person.
  */
 export function summarizeFormStudy(
     submissions: FormSubmissionRow[],
+    mode: FormStudyCountMode = "submissions",
 ): FormStudyDistribution {
-    const total = submissions.length;
+    // Nyeste svar først fra API-et, så det er det siste svaret fra hver person
+    // som blir stående når vi teller personer.
+    const rows = mode === "people" ? uniqueByUser(submissions) : submissions;
+    const total = rows.length;
 
     const cohorts = countBy(
-        submissions,
+        rows,
         (submission) =>
             submission.studyStartYear === null
                 ? null
@@ -252,12 +268,13 @@ export function summarizeFormStudy(
         (value) => (value === null ? "Ukjent kull" : `Kull ${value}`),
     );
     const programs = countBy(
-        submissions,
+        rows,
         (submission) => submission.studyProgram,
         (value) => value ?? "Ukjent studieretning",
     );
 
     return {
+        total,
         // Nyeste kull først, mens studieretningene sorteres på størrelse.
         cohorts: toSlices(
             cohorts,
@@ -272,4 +289,14 @@ export function summarizeFormStudy(
             (a, b) => b.count - a.count || a.label.localeCompare(b.label, "nb"),
         ),
     };
+}
+
+/** Ett svar per person, det første i lista. */
+function uniqueByUser(submissions: FormSubmissionRow[]): FormSubmissionRow[] {
+    const seen = new Set<string>();
+    return submissions.filter((submission) => {
+        if (seen.has(submission.userId)) return false;
+        seen.add(submission.userId);
+        return true;
+    });
 }

--- a/apps/kvark/src/routes/_app/sporreskjema.$id_.svar.tsx
+++ b/apps/kvark/src/routes/_app/sporreskjema.$id_.svar.tsx
@@ -37,11 +37,7 @@ import { FormStatisticsList } from "#/components/form-statistics-list";
 import { FormStudyCharts } from "#/components/form-study-charts";
 import { FormSubmissionsTable } from "#/components/form-submissions-table";
 import { useGoBack } from "#/hooks/use-go-back";
-import {
-    mapFormStatistics,
-    mapSubmission,
-    summarizeFormStudy,
-} from "#/lib/form";
+import { mapFormStatistics, mapSubmission } from "#/lib/form";
 import { errorStatus } from "#/lib/utils";
 
 const searchSchema = z.object({
@@ -86,10 +82,6 @@ function FormSubmissionsPage() {
         () => mapFormStatistics(apiStatistics?.statistics ?? []),
         [apiStatistics],
     );
-    // Kull og studieretning regnes ut av svarlista, ikke av statistikk-
-    // endepunktet, slik at fordelingen vises også for skjemaer uten
-    // valgspørsmål.
-    const study = useMemo(() => summarizeFormStudy(submissions), [submissions]);
     const questions = useMemo(
         () =>
             form.fields.map((field) => ({ id: field.id, title: field.title })),
@@ -206,10 +198,12 @@ function FormSubmissionsPage() {
                                 />
                             ) : (
                                 <div className="flex flex-col gap-4">
+                                    {/* Kull og studieretning regnes ut av
+                                        svarlista, ikke av statistikk-
+                                        endepunktet, slik at fordelingen vises
+                                        også for skjemaer uten valgspørsmål. */}
                                     <FormStudyCharts
-                                        cohorts={study.cohorts}
-                                        programs={study.programs}
-                                        total={submissions.length}
+                                        submissions={submissions}
                                     />
                                     <FormStatisticsList
                                         statistics={statistics}


### PR DESCRIPTION
## Hva

Et nedtrekk over kull- og studieretningsdiagrammene velger hva én andel teller: **Per svar** (standard) eller **Per person**.

## Hvorfor

Et skjema som tar imot flere svar fra samme person lot den ivrigste dra sitt eget kull opp. Oppfølging av #695, der dette var et bevisst valg jeg flagget i stedet for å gjette.

## Hvordan

- «Per svar» er standard, slik at summen stemmer med antallet svar i fanen ved siden av.
- «Per person» beholder det siste svaret fra hver enkelt — API-et sorterer nyeste først — og teller kullet og studieretningen én gang. `FormSubmissionRow` fikk derfor med `userId`.
- Fordelingen regnes ut i komponenten i stedet for i ruta, siden det nå er den som eier valget.

## Verifisert

`typecheck`, `lint` og `build` er grønne. Sjekket i nettleser med 24 svar fordelt på 21 personer, der én person hadde sendt inn fire ganger (testdataene er ryddet bort igjen):

- **Per svar:** «24 svar», Kull 2024 = 8 (33 %), Dataingeniør = 14 (58 %).
- **Per person:** «21 personer», Kull 2024 = 5 (24 %), Dataingeniør = 11 (52 %) — de tre ekstra svarene faller bort.

Fane-etiketten «24 svar» er uendret i begge modusene; den teller svar, ikke personer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)