### PR TITLE
refactor(admin): bytt window.confirm mot bekreftelsesdialogen

### DIFF
--- a/apps/kvark/src/components/confirm-delete-dialog.tsx
+++ b/apps/kvark/src/components/confirm-delete-dialog.tsx
@@ -8,7 +8,7 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from "@tihlde/ui/ui/alert-dialog";
-import type { ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 
 type ConfirmDeleteDialogProps = {
     open: boolean;
@@ -60,4 +60,27 @@ export function ConfirmDeleteDialog({
             </AlertDialogContent>
         </AlertDialog>
     );
+}
+
+/**
+ * State for en bekreftelsesdialog som gjelder ett element i en liste.
+ *
+ * `shown` henger igjen på det forrige elementet mens dialogen animeres ut.
+ * Uten det bytter tittelen til «undefined» i det halve sekundet lukkingen
+ * tar, siden `pending` allerede er nullet når siste render kjører.
+ */
+export function usePendingConfirm<T>() {
+    const [pending, setPending] = useState<T | null>(null);
+    const lastShown = useRef<T | null>(null);
+    if (pending) lastShown.current = pending;
+
+    return {
+        /** Elementet som venter på bekreftelse, eller `null`. */
+        pending,
+        /** Elementet dialogen skal vise — også mens den lukkes. */
+        shown: pending ?? lastShown.current,
+        open: pending !== null,
+        request: (item: T) => setPending(item),
+        clear: () => setPending(null),
+    };
 }

--- a/apps/kvark/src/routes/admin/_super-admin/api-keys.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/api-keys.tsx
@@ -43,6 +43,10 @@ import {
 } from "#/api/queries/api-keys";
 import { Stagger } from "@tihlde/ui/ui/motion";
 
+import {
+    ConfirmDeleteDialog,
+    usePendingConfirm,
+} from "#/components/confirm-delete-dialog";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import { OSLO_DATE_OPTIONS } from "#/lib/date";
@@ -115,6 +119,8 @@ function ApiKeysTable({
     const { data: apiKeys } = useSuspenseQuery(getApiKeysQuery(0));
     const regenerate = useMutation(regenerateApiKeyMutation);
     const remove = useMutation(deleteApiKeyMutation);
+    const confirmRotate = usePendingConfirm<ApiKey>();
+    const confirmDelete = usePendingConfirm<ApiKey>();
 
     if (apiKeys.length === 0) {
         return (
@@ -131,125 +137,145 @@ function ApiKeysTable({
     }
 
     async function handleRegenerate(apiKey: ApiKey) {
-        if (
-            window.confirm(
-                `Regenerere nøkkelen "${apiKey.name}"? Den gamle nøkkelen slutter å virke umiddelbart.`,
-            )
-        ) {
-            const result = await regenerate.mutateAsync({
-                apiKeyId: apiKey.id,
-            });
-            onRevealSecret(result.key);
-        }
-    }
-
-    function handleDelete(apiKey: ApiKey) {
-        if (
-            window.confirm(
-                `Slette nøkkelen "${apiKey.name}"? Dette kan ikke angres.`,
-            )
-        ) {
-            remove.mutate({ apiKeyId: apiKey.id });
-        }
+        const result = await regenerate.mutateAsync({ apiKeyId: apiKey.id });
+        onRevealSecret(result.key);
     }
 
     return (
-        <Card>
-            <CardContent className="p-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Navn</TableHead>
-                            <TableHead>Prefiks</TableHead>
-                            <TableHead>Tilganger</TableHead>
-                            <TableHead>Sist brukt</TableHead>
-                            <TableHead className="text-right">
-                                Handlinger
-                            </TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {apiKeys.map((apiKey) => (
-                            <TableRow key={apiKey.id}>
-                                <TableCell>
-                                    <div className="flex flex-col gap-0.5">
-                                        <span>{apiKey.name}</span>
-                                        <span className="text-xs text-muted-foreground">
-                                            {apiKey.description}
-                                        </span>
-                                    </div>
-                                </TableCell>
-                                <TableCell>
-                                    <code className="text-xs">
-                                        {apiKey.keyPrefix}…
-                                    </code>
-                                </TableCell>
-                                <TableCell>
-                                    <div className="flex flex-wrap gap-1">
-                                        {apiKey.permissions.length === 0 ? (
-                                            <span className="text-xs text-muted-foreground">
-                                                Ingen
-                                            </span>
-                                        ) : (
-                                            apiKey.permissions.map(
-                                                (permission) => (
-                                                    <Badge
-                                                        key={permission}
-                                                        variant="secondary"
-                                                    >
-                                                        {permission}
-                                                    </Badge>
-                                                ),
-                                            )
-                                        )}
-                                    </div>
-                                </TableCell>
-                                <TableCell>
-                                    {apiKey.lastUsedAt
-                                        ? new Date(
-                                              apiKey.lastUsedAt,
-                                          ).toLocaleDateString(
-                                              "nb-NO",
-                                              OSLO_DATE_OPTIONS,
-                                          )
-                                        : "Aldri"}
-                                </TableCell>
-                                <TableCell>
-                                    <div className="flex justify-end gap-2">
-                                        <Button
-                                            variant="outline"
-                                            size="sm"
-                                            onClick={() => onEdit(apiKey)}
-                                        >
-                                            <PencilIcon className="size-4" />
-                                        </Button>
-                                        <Button
-                                            variant="outline"
-                                            size="sm"
-                                            disabled={regenerate.isPending}
-                                            onClick={() =>
-                                                handleRegenerate(apiKey)
-                                            }
-                                        >
-                                            <RefreshCwIcon className="size-4" />
-                                            Roter
-                                        </Button>
-                                        <Button
-                                            variant="destructive"
-                                            size="sm"
-                                            disabled={remove.isPending}
-                                            onClick={() => handleDelete(apiKey)}
-                                        >
-                                            <Trash2 className="size-4" />
-                                        </Button>
-                                    </div>
-                                </TableCell>
+        <>
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Navn</TableHead>
+                                <TableHead>Prefiks</TableHead>
+                                <TableHead>Tilganger</TableHead>
+                                <TableHead>Sist brukt</TableHead>
+                                <TableHead className="text-right">
+                                    Handlinger
+                                </TableHead>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </CardContent>
-        </Card>
+                        </TableHeader>
+                        <TableBody>
+                            {apiKeys.map((apiKey) => (
+                                <TableRow key={apiKey.id}>
+                                    <TableCell>
+                                        <div className="flex flex-col gap-0.5">
+                                            <span>{apiKey.name}</span>
+                                            <span className="text-xs text-muted-foreground">
+                                                {apiKey.description}
+                                            </span>
+                                        </div>
+                                    </TableCell>
+                                    <TableCell>
+                                        <code className="text-xs">
+                                            {apiKey.keyPrefix}…
+                                        </code>
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex flex-wrap gap-1">
+                                            {apiKey.permissions.length === 0 ? (
+                                                <span className="text-xs text-muted-foreground">
+                                                    Ingen
+                                                </span>
+                                            ) : (
+                                                apiKey.permissions.map(
+                                                    (permission) => (
+                                                        <Badge
+                                                            key={permission}
+                                                            variant="secondary"
+                                                        >
+                                                            {permission}
+                                                        </Badge>
+                                                    ),
+                                                )
+                                            )}
+                                        </div>
+                                    </TableCell>
+                                    <TableCell>
+                                        {apiKey.lastUsedAt
+                                            ? new Date(
+                                                  apiKey.lastUsedAt,
+                                              ).toLocaleDateString(
+                                                  "nb-NO",
+                                                  OSLO_DATE_OPTIONS,
+                                              )
+                                            : "Aldri"}
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex justify-end gap-2">
+                                            <Button
+                                                variant="outline"
+                                                size="sm"
+                                                onClick={() => onEdit(apiKey)}
+                                            >
+                                                <PencilIcon className="size-4" />
+                                            </Button>
+                                            <Button
+                                                variant="outline"
+                                                size="sm"
+                                                disabled={regenerate.isPending}
+                                                onClick={() =>
+                                                    confirmRotate.request(
+                                                        apiKey,
+                                                    )
+                                                }
+                                            >
+                                                <RefreshCwIcon className="size-4" />
+                                                Roter
+                                            </Button>
+                                            <Button
+                                                variant="destructive"
+                                                size="sm"
+                                                disabled={remove.isPending}
+                                                onClick={() =>
+                                                    confirmDelete.request(
+                                                        apiKey,
+                                                    )
+                                                }
+                                            >
+                                                <Trash2 className="size-4" />
+                                            </Button>
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+
+            {/* Rotering sletter ingenting, men den gamle nøkkelen dør i samme
+            øyeblikk — samme «dette kan ikke angres»-bekreftelse som sletting. */}
+            <ConfirmDeleteDialog
+                open={confirmRotate.open}
+                onOpenChange={(open) => !open && confirmRotate.clear()}
+                title={`Rotere nøkkelen «${confirmRotate.shown?.name}»?`}
+                description="Den gamle nøkkelen slutter å virke umiddelbart, og alt som bruker den mister tilgangen til API-et."
+                confirmLabel="Roter nøkkel"
+                isPending={regenerate.isPending}
+                onConfirm={() => {
+                    if (!confirmRotate.pending) return;
+                    void handleRegenerate(confirmRotate.pending);
+                    confirmRotate.clear();
+                }}
+            />
+
+            <ConfirmDeleteDialog
+                open={confirmDelete.open}
+                onOpenChange={(open) => !open && confirmDelete.clear()}
+                title={`Slette nøkkelen «${confirmDelete.shown?.name}»?`}
+                description="Alt som bruker nøkkelen mister tilgangen til API-et. Dette kan ikke angres."
+                confirmLabel="Slett nøkkel"
+                isPending={remove.isPending}
+                onConfirm={() => {
+                    if (!confirmDelete.pending) return;
+                    remove.mutate({ apiKeyId: confirmDelete.pending.id });
+                    confirmDelete.clear();
+                }}
+            />
+        </>
     );
 }
 

--- a/apps/kvark/src/routes/admin/_super-admin/oauth-clients.tsx
+++ b/apps/kvark/src/routes/admin/_super-admin/oauth-clients.tsx
@@ -41,6 +41,10 @@ import {
     type CreatedOAuthClient,
     type OAuthClientFull,
 } from "#/api/queries/oauth";
+import {
+    ConfirmDeleteDialog,
+    usePendingConfirm,
+} from "#/components/confirm-delete-dialog";
 
 type RevealedSecret = { clientId: string; clientSecret: string };
 
@@ -59,6 +63,7 @@ function OAuthClientsPage() {
 
     const rotate = useMutation(rotateOAuthClientSecretMutation);
     const remove = useMutation(deleteOAuthClientMutation);
+    const confirmDelete = usePendingConfirm<OAuthClientFull>();
 
     async function handleRotate(client: OAuthClientFull) {
         const result = await rotate.mutateAsync({ clientId: client.client_id });
@@ -66,18 +71,6 @@ function OAuthClientsPage() {
             clientId: result.client_id,
             clientSecret: result.client_secret,
         });
-    }
-
-    function handleDelete(client: OAuthClientFull) {
-        if (
-            window.confirm(
-                `Er du sikker på at du vil slette ${
-                    client.client_name ?? client.client_id
-                }? Alle tilkoblede brukere blir logget ut av appen.`,
-            )
-        ) {
-            remove.mutate({ clientId: client.client_id });
-        }
     }
 
     return (
@@ -104,7 +97,7 @@ function OAuthClientsPage() {
                     rotatePending={rotate.isPending}
                     removePending={remove.isPending}
                     onRotate={handleRotate}
-                    onDelete={handleDelete}
+                    onDelete={confirmDelete.request}
                 />
             </Suspense>
 
@@ -122,6 +115,22 @@ function OAuthClientsPage() {
             <SecretRevealDialog
                 secret={revealedSecret}
                 onClose={() => setRevealedSecret(null)}
+            />
+
+            <ConfirmDeleteDialog
+                open={confirmDelete.open}
+                onOpenChange={(open) => !open && confirmDelete.clear()}
+                title={`Slette ${confirmDelete.shown?.client_name ?? confirmDelete.shown?.client_id}?`}
+                description="Alle tilkoblede brukere blir logget ut av appen, og klienten må registreres på nytt for å virke igjen."
+                confirmLabel="Slett klient"
+                isPending={remove.isPending}
+                onConfirm={() => {
+                    if (!confirmDelete.pending) return;
+                    remove.mutate({
+                        clientId: confirmDelete.pending.client_id,
+                    });
+                    confirmDelete.clear();
+                }}
             />
         </Stagger>
     );

--- a/apps/kvark/src/routes/admin/annonser.tsx
+++ b/apps/kvark/src/routes/admin/annonser.tsx
@@ -60,6 +60,10 @@ import {
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import {
+    ConfirmDeleteDialog,
+    usePendingConfirm,
+} from "#/components/confirm-delete-dialog";
 import { richRegistry } from "#/components/markdown/directives/presets";
 import {
     useAnyScopePermission,
@@ -260,6 +264,7 @@ function JobsTable({
     // buttons follow the item, not just the global permission.
     const canEdit = useCanActOnResource(["jobs:update", "jobs:manage"]);
     const canDelete = useCanActOnResource(["jobs:delete", "jobs:manage"]);
+    const confirmDelete = usePendingConfirm<JobListItem>();
 
     // Listen ligger her, ikke i forelderen, så oppslaget av `?rediger=<id>`
     // må også gjøres her. Kjører kun når id-en endrer seg, slik at dialogen
@@ -301,85 +306,98 @@ function JobsTable({
         );
     }
 
-    function handleDelete(job: JobListItem) {
-        if (
-            window.confirm(
-                `Slette annonsen "${job.title}"? Dette kan ikke angres.`,
-            )
-        ) {
-            remove.mutate({ jobId: job.id });
-        }
-    }
-
     return (
-        <Card>
-            <CardContent className="p-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Tittel</TableHead>
-                            <TableHead>Bedrift</TableHead>
-                            <TableHead>Type</TableHead>
-                            <TableHead>Frist</TableHead>
-                            <TableHead>Status</TableHead>
-                            <TableHead className="text-right">
-                                Handlinger
-                            </TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {filtered.map((job) => (
-                            <TableRow key={job.id}>
-                                <TableCell>{job.title}</TableCell>
-                                <TableCell>{job.company}</TableCell>
-                                <TableCell>
-                                    {JOB_TYPE_LABELS[job.jobType as JobType] ??
-                                        job.jobType}
-                                </TableCell>
-                                <TableCell>
-                                    {job.isContinuouslyHiring
-                                        ? "Fortløpende"
-                                        : formatDeadline(job.deadline)}
-                                </TableCell>
-                                <TableCell>
-                                    {job.expired ? (
-                                        <Badge variant="outline">Utløpt</Badge>
-                                    ) : (
-                                        <Badge variant="secondary">Aktiv</Badge>
-                                    )}
-                                </TableCell>
-                                <TableCell>
-                                    <div className="flex justify-end gap-2">
-                                        {canEdit(job.createdById) ? (
-                                            <Button
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() => onEdit(job)}
-                                            >
-                                                <PencilIcon className="size-4" />
-                                                Rediger
-                                            </Button>
-                                        ) : null}
-                                        {canDelete(job.createdById) ? (
-                                            <Button
-                                                variant="destructive"
-                                                size="sm"
-                                                disabled={remove.isPending}
-                                                onClick={() =>
-                                                    handleDelete(job)
-                                                }
-                                            >
-                                                <Trash2 className="size-4" />
-                                            </Button>
-                                        ) : null}
-                                    </div>
-                                </TableCell>
+        <>
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Tittel</TableHead>
+                                <TableHead>Bedrift</TableHead>
+                                <TableHead>Type</TableHead>
+                                <TableHead>Frist</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead className="text-right">
+                                    Handlinger
+                                </TableHead>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </CardContent>
-        </Card>
+                        </TableHeader>
+                        <TableBody>
+                            {filtered.map((job) => (
+                                <TableRow key={job.id}>
+                                    <TableCell>{job.title}</TableCell>
+                                    <TableCell>{job.company}</TableCell>
+                                    <TableCell>
+                                        {JOB_TYPE_LABELS[
+                                            job.jobType as JobType
+                                        ] ?? job.jobType}
+                                    </TableCell>
+                                    <TableCell>
+                                        {job.isContinuouslyHiring
+                                            ? "Fortløpende"
+                                            : formatDeadline(job.deadline)}
+                                    </TableCell>
+                                    <TableCell>
+                                        {job.expired ? (
+                                            <Badge variant="outline">
+                                                Utløpt
+                                            </Badge>
+                                        ) : (
+                                            <Badge variant="secondary">
+                                                Aktiv
+                                            </Badge>
+                                        )}
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex justify-end gap-2">
+                                            {canEdit(job.createdById) ? (
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={() => onEdit(job)}
+                                                >
+                                                    <PencilIcon className="size-4" />
+                                                    Rediger
+                                                </Button>
+                                            ) : null}
+                                            {canDelete(job.createdById) ? (
+                                                <Button
+                                                    variant="destructive"
+                                                    size="sm"
+                                                    disabled={remove.isPending}
+                                                    onClick={() =>
+                                                        confirmDelete.request(
+                                                            job,
+                                                        )
+                                                    }
+                                                >
+                                                    <Trash2 className="size-4" />
+                                                </Button>
+                                            ) : null}
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+
+            <ConfirmDeleteDialog
+                open={confirmDelete.open}
+                onOpenChange={(open) => !open && confirmDelete.clear()}
+                title={`Slette annonsen «${confirmDelete.shown?.title}»?`}
+                description="Annonsen fjernes fra karrieresiden for godt. Dette kan ikke angres."
+                confirmLabel="Slett annonse"
+                isPending={remove.isPending}
+                onConfirm={() => {
+                    if (!confirmDelete.pending) return;
+                    remove.mutate({ jobId: confirmDelete.pending.id });
+                    confirmDelete.clear();
+                }}
+            />
+        </>
     );
 }
 

--- a/apps/kvark/src/routes/admin/bannere.tsx
+++ b/apps/kvark/src/routes/admin/bannere.tsx
@@ -43,6 +43,10 @@ import { Stagger } from "@tihlde/ui/ui/motion";
 import { requireAdminSection } from "#/lib/admin-access";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import {
+    ConfirmDeleteDialog,
+    usePendingConfirm,
+} from "#/components/confirm-delete-dialog";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 import { OSLO_TIME_ZONE } from "#/lib/date";
 
@@ -111,6 +115,7 @@ function BannersTable({ onEdit }: { onEdit: (banner: Banner) => void }) {
         "banners:delete",
         "banners:manage",
     ]);
+    const confirmDelete = usePendingConfirm<Banner>();
 
     if (banners.length === 0) {
         return (
@@ -126,76 +131,86 @@ function BannersTable({ onEdit }: { onEdit: (banner: Banner) => void }) {
         );
     }
 
-    function handleDelete(banner: Banner) {
-        if (
-            window.confirm(
-                `Slette banneret "${banner.title}"? Dette kan ikke angres.`,
-            )
-        ) {
-            remove.mutate({ bannerId: banner.id });
-        }
-    }
-
     return (
-        <Card>
-            <CardContent className="p-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Tittel</TableHead>
-                            <TableHead>Synlig fra</TableHead>
-                            <TableHead>Synlig til</TableHead>
-                            <TableHead>Status</TableHead>
-                            <TableHead className="text-right">
-                                Handlinger
-                            </TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {banners.map((banner) => (
-                            <TableRow key={banner.id}>
-                                <TableCell>{banner.title}</TableCell>
-                                <TableCell>
-                                    {formatDateTime(banner.visibleFrom)}
-                                </TableCell>
-                                <TableCell>
-                                    {formatDateTime(banner.visibleUntil)}
-                                </TableCell>
-                                <TableCell>
-                                    <BannerStatusBadge banner={banner} />
-                                </TableCell>
-                                <TableCell>
-                                    <div className="flex justify-end gap-2">
-                                        {canEdit ? (
-                                            <Button
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() => onEdit(banner)}
-                                            >
-                                                <PencilIcon className="size-4" />
-                                                Rediger
-                                            </Button>
-                                        ) : null}
-                                        {canDelete ? (
-                                            <Button
-                                                variant="destructive"
-                                                size="sm"
-                                                disabled={remove.isPending}
-                                                onClick={() =>
-                                                    handleDelete(banner)
-                                                }
-                                            >
-                                                <Trash2 className="size-4" />
-                                            </Button>
-                                        ) : null}
-                                    </div>
-                                </TableCell>
+        <>
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Tittel</TableHead>
+                                <TableHead>Synlig fra</TableHead>
+                                <TableHead>Synlig til</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead className="text-right">
+                                    Handlinger
+                                </TableHead>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </CardContent>
-        </Card>
+                        </TableHeader>
+                        <TableBody>
+                            {banners.map((banner) => (
+                                <TableRow key={banner.id}>
+                                    <TableCell>{banner.title}</TableCell>
+                                    <TableCell>
+                                        {formatDateTime(banner.visibleFrom)}
+                                    </TableCell>
+                                    <TableCell>
+                                        {formatDateTime(banner.visibleUntil)}
+                                    </TableCell>
+                                    <TableCell>
+                                        <BannerStatusBadge banner={banner} />
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex justify-end gap-2">
+                                            {canEdit ? (
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={() =>
+                                                        onEdit(banner)
+                                                    }
+                                                >
+                                                    <PencilIcon className="size-4" />
+                                                    Rediger
+                                                </Button>
+                                            ) : null}
+                                            {canDelete ? (
+                                                <Button
+                                                    variant="destructive"
+                                                    size="sm"
+                                                    disabled={remove.isPending}
+                                                    onClick={() =>
+                                                        confirmDelete.request(
+                                                            banner,
+                                                        )
+                                                    }
+                                                >
+                                                    <Trash2 className="size-4" />
+                                                </Button>
+                                            ) : null}
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+
+            <ConfirmDeleteDialog
+                open={confirmDelete.open}
+                onOpenChange={(open) => !open && confirmDelete.clear()}
+                title={`Slette banneret «${confirmDelete.shown?.title}»?`}
+                description="Banneret fjernes for godt. Dette kan ikke angres."
+                confirmLabel="Slett banner"
+                isPending={remove.isPending}
+                onConfirm={() => {
+                    if (!confirmDelete.pending) return;
+                    remove.mutate({ bannerId: confirmDelete.pending.id });
+                    confirmDelete.clear();
+                }}
+            />
+        </>
     );
 }
 

--- a/apps/kvark/src/routes/admin/brukere.tsx
+++ b/apps/kvark/src/routes/admin/brukere.tsx
@@ -68,6 +68,10 @@ import {
     updateUserStudyMutation,
     updateUserStudyYearMutation,
 } from "#/api/queries/user";
+import {
+    ConfirmDeleteDialog,
+    usePendingConfirm,
+} from "#/components/confirm-delete-dialog";
 import { AdminAllergyPicker } from "#/components/admin-allergy-picker";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminGroupPicker } from "#/components/admin-group-picker";
@@ -1316,6 +1320,7 @@ function MembersTable({
     const [study, setStudy] = useState<string>(ALL);
     const [role, setRole] = useState<string>(ALL);
     const [year, setYear] = useState<string>(ALL);
+    const confirmRemove = usePendingConfirm<GroupMember>();
 
     const debouncedSearch = useDebounced(search);
 
@@ -1398,16 +1403,6 @@ function MembersTable({
                 </CardContent>
             </Card>
         );
-    }
-
-    function handleRemove(member: GroupMember) {
-        if (
-            window.confirm(
-                `Fjerne ${member.user.name} fra gruppen? Dette kan ikke angres.`,
-            )
-        ) {
-            remove.mutate({ groupSlug, userId: member.userId });
-        }
     }
 
     return (
@@ -1602,7 +1597,9 @@ function MembersTable({
                                                             remove.isPending
                                                         }
                                                         onClick={() =>
-                                                            handleRemove(member)
+                                                            confirmRemove.request(
+                                                                member,
+                                                            )
                                                         }
                                                     >
                                                         <Trash2 className="size-4" />
@@ -1618,6 +1615,23 @@ function MembersTable({
                     </CardContent>
                 </Card>
             )}
+
+            <ConfirmDeleteDialog
+                open={confirmRemove.open}
+                onOpenChange={(open) => !open && confirmRemove.clear()}
+                title={`Fjerne ${confirmRemove.shown?.user.name} fra gruppen?`}
+                description="Medlemmet mister tilgangene gruppen gir. Brukeren beholdes, og kan legges inn igjen."
+                confirmLabel="Fjern medlem"
+                isPending={remove.isPending}
+                onConfirm={() => {
+                    if (!confirmRemove.pending) return;
+                    remove.mutate({
+                        groupSlug,
+                        userId: confirmRemove.pending.userId,
+                    });
+                    confirmRemove.clear();
+                }}
+            />
         </div>
     );
 }

--- a/apps/kvark/src/routes/admin/galleri.tsx
+++ b/apps/kvark/src/routes/admin/galleri.tsx
@@ -63,6 +63,10 @@ import {
     getGalleriesQuery,
     updateGalleryMutation,
 } from "#/api/queries/galleries";
+import {
+    ConfirmDeleteDialog,
+    usePendingConfirm,
+} from "#/components/confirm-delete-dialog";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import z from "zod";
@@ -469,6 +473,14 @@ function UploadPicturesCard() {
     );
 }
 
+/** «og alle 0 bildene» leser feil på et tomt galleri, og «1 bildene» like ille. */
+function galleryDeleteScope(pictureCount: number): string {
+    if (pictureCount === 0) return "Galleriet slettes for godt.";
+    if (pictureCount === 1)
+        return "Galleriet og bildet i det slettes for godt.";
+    return `Galleriet og alle ${pictureCount} bildene i det slettes for godt.`;
+}
+
 function GalleryTable({ onEdit }: { onEdit: (gallery: Gallery) => void }) {
     const { data } = useSuspenseQuery(getGalleriesQuery(0));
     const deleteGallery = useMutation(deleteGalleryMutation);
@@ -480,6 +492,7 @@ function GalleryTable({ onEdit }: { onEdit: (gallery: Gallery) => void }) {
         "galleries:delete",
         "galleries:manage",
     ]);
+    const confirmDelete = usePendingConfirm<Gallery>();
 
     if (data.items.length === 0) {
         return (
@@ -496,78 +509,93 @@ function GalleryTable({ onEdit }: { onEdit: (gallery: Gallery) => void }) {
     }
 
     return (
-        <Card>
-            <CardContent className="p-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Tittel</TableHead>
-                            <TableHead>Arrangement</TableHead>
-                            <TableHead>Bilder</TableHead>
-                            <TableHead className="text-right">
-                                Handlinger
-                            </TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {data.items.map((gallery) => (
-                            <TableRow key={gallery.id}>
-                                <TableCell>
-                                    <Link
-                                        to="/galleri/$slug"
-                                        params={{ slug: gallery.slug }}
-                                    >
-                                        {gallery.title}
-                                    </Link>
-                                </TableCell>
-                                <TableCell>
-                                    {gallery.event?.title ?? "—"}
-                                </TableCell>
-                                <TableCell>{gallery.pictureCount}</TableCell>
-                                <TableCell className="text-right">
-                                    <div className="flex justify-end gap-2">
-                                        {canEdit ? (
-                                            <Button
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() => onEdit(gallery)}
-                                            >
-                                                <PencilIcon className="size-4" />
-                                                Rediger
-                                            </Button>
-                                        ) : null}
-                                        {canDelete ? (
-                                            <Button
-                                                type="button"
-                                                variant="destructive"
-                                                size="icon"
-                                                aria-label={`Slett ${gallery.title}`}
-                                                disabled={
-                                                    deleteGallery.isPending
-                                                }
-                                                onClick={() => {
-                                                    if (
-                                                        !window.confirm(
-                                                            `Slette "${gallery.title}" og alle bildene i det?`,
-                                                        )
-                                                    ) {
-                                                        return;
-                                                    }
-                                                    deleteGallery.mutate({
-                                                        slug: gallery.slug,
-                                                    });
-                                                }}
-                                            >
-                                                <Trash2Icon className="size-4" />
-                                            </Button>
-                                        ) : null}
-                                    </div>
-                                </TableCell>
+        <>
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Tittel</TableHead>
+                                <TableHead>Arrangement</TableHead>
+                                <TableHead>Bilder</TableHead>
+                                <TableHead className="text-right">
+                                    Handlinger
+                                </TableHead>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </CardContent>
-        </Card>
+                        </TableHeader>
+                        <TableBody>
+                            {data.items.map((gallery) => (
+                                <TableRow key={gallery.id}>
+                                    <TableCell>
+                                        <Link
+                                            to="/galleri/$slug"
+                                            params={{ slug: gallery.slug }}
+                                        >
+                                            {gallery.title}
+                                        </Link>
+                                    </TableCell>
+                                    <TableCell>
+                                        {gallery.event?.title ?? "—"}
+                                    </TableCell>
+                                    <TableCell>
+                                        {gallery.pictureCount}
+                                    </TableCell>
+                                    <TableCell className="text-right">
+                                        <div className="flex justify-end gap-2">
+                                            {canEdit ? (
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={() =>
+                                                        onEdit(gallery)
+                                                    }
+                                                >
+                                                    <PencilIcon className="size-4" />
+                                                    Rediger
+                                                </Button>
+                                            ) : null}
+                                            {canDelete ? (
+                                                <Button
+                                                    type="button"
+                                                    variant="destructive"
+                                                    size="icon"
+                                                    aria-label={`Slett ${gallery.title}`}
+                                                    disabled={
+                                                        deleteGallery.isPending
+                                                    }
+                                                    onClick={() =>
+                                                        confirmDelete.request(
+                                                            gallery,
+                                                        )
+                                                    }
+                                                >
+                                                    <Trash2Icon className="size-4" />
+                                                </Button>
+                                            ) : null}
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+
+            <ConfirmDeleteDialog
+                open={confirmDelete.open}
+                onOpenChange={(open) => !open && confirmDelete.clear()}
+                title={`Slette «${confirmDelete.shown?.title}»?`}
+                description={`${galleryDeleteScope(
+                    confirmDelete.shown?.pictureCount ?? 0,
+                )} Dette kan ikke angres.`}
+                confirmLabel="Slett galleri"
+                isPending={deleteGallery.isPending}
+                onConfirm={() => {
+                    if (!confirmDelete.pending) return;
+                    deleteGallery.mutate({ slug: confirmDelete.pending.slug });
+                    confirmDelete.clear();
+                }}
+            />
+        </>
     );
 }

--- a/apps/kvark/src/routes/admin/nyheter.tsx
+++ b/apps/kvark/src/routes/admin/nyheter.tsx
@@ -42,6 +42,10 @@ import {
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import {
+    ConfirmDeleteDialog,
+    usePendingConfirm,
+} from "#/components/confirm-delete-dialog";
 import { richRegistry } from "#/components/markdown/directives/presets";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 import { formatInOslo } from "#/lib/date";
@@ -140,6 +144,7 @@ function NewsTable({
     const remove = useMutation(deleteNewsMutation);
     const canEdit = useAnyScopePermission(["news:update", "news:manage"]);
     const canDelete = useAnyScopePermission(["news:delete", "news:manage"]);
+    const confirmDelete = usePendingConfirm<NewsListItem>();
 
     // Listen ligger her, ikke i forelderen, så oppslaget av `?rediger=<id>`
     // må også gjøres her. Kjører kun når id-en endrer seg, slik at dialogen
@@ -165,71 +170,79 @@ function NewsTable({
         );
     }
 
-    function handleDelete(news: NewsListItem) {
-        if (
-            window.confirm(
-                `Slette nyheten «${news.title}»? Dette kan ikke angres.`,
-            )
-        ) {
-            remove.mutate({ newsId: news.id });
-        }
-    }
-
     return (
-        <Card>
-            <CardContent className="p-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Tittel</TableHead>
-                            <TableHead>Utdrag</TableHead>
-                            <TableHead>Publisert</TableHead>
-                            <TableHead className="text-right">
-                                Handlinger
-                            </TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {data.items.map((news) => (
-                            <TableRow key={news.id}>
-                                <TableCell>{news.title}</TableCell>
-                                <TableCell>{news.header}</TableCell>
-                                <TableCell>
-                                    {formatDate(news.createdAt)}
-                                </TableCell>
-                                <TableCell className="text-right">
-                                    <div className="flex justify-end gap-2">
-                                        {canEdit ? (
-                                            <Button
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() => onEdit(news)}
-                                            >
-                                                <PencilIcon className="size-4" />
-                                                Rediger
-                                            </Button>
-                                        ) : null}
-                                        {canDelete ? (
-                                            <Button
-                                                variant="destructive"
-                                                size="icon"
-                                                aria-label={`Slett ${news.title}`}
-                                                disabled={remove.isPending}
-                                                onClick={() =>
-                                                    handleDelete(news)
-                                                }
-                                            >
-                                                <Trash2 className="size-4" />
-                                            </Button>
-                                        ) : null}
-                                    </div>
-                                </TableCell>
+        <>
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Tittel</TableHead>
+                                <TableHead>Utdrag</TableHead>
+                                <TableHead>Publisert</TableHead>
+                                <TableHead className="text-right">
+                                    Handlinger
+                                </TableHead>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </CardContent>
-        </Card>
+                        </TableHeader>
+                        <TableBody>
+                            {data.items.map((news) => (
+                                <TableRow key={news.id}>
+                                    <TableCell>{news.title}</TableCell>
+                                    <TableCell>{news.header}</TableCell>
+                                    <TableCell>
+                                        {formatDate(news.createdAt)}
+                                    </TableCell>
+                                    <TableCell className="text-right">
+                                        <div className="flex justify-end gap-2">
+                                            {canEdit ? (
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={() => onEdit(news)}
+                                                >
+                                                    <PencilIcon className="size-4" />
+                                                    Rediger
+                                                </Button>
+                                            ) : null}
+                                            {canDelete ? (
+                                                <Button
+                                                    variant="destructive"
+                                                    size="icon"
+                                                    aria-label={`Slett ${news.title}`}
+                                                    disabled={remove.isPending}
+                                                    onClick={() =>
+                                                        confirmDelete.request(
+                                                            news,
+                                                        )
+                                                    }
+                                                >
+                                                    <Trash2 className="size-4" />
+                                                </Button>
+                                            ) : null}
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+
+            <ConfirmDeleteDialog
+                open={confirmDelete.open}
+                onOpenChange={(open) => !open && confirmDelete.clear()}
+                title={`Slette «${confirmDelete.shown?.title}»?`}
+                description="Nyheten fjernes fra siden for godt. Dette kan ikke angres."
+                confirmLabel="Slett nyhet"
+                isPending={remove.isPending}
+                onConfirm={() => {
+                    if (!confirmDelete.pending) return;
+                    remove.mutate({ newsId: confirmDelete.pending.id });
+                    confirmDelete.clear();
+                }}
+            />
+        </>
     );
 }
 

--- a/apps/kvark/src/routes/admin/prikker.tsx
+++ b/apps/kvark/src/routes/admin/prikker.tsx
@@ -47,6 +47,10 @@ import { requireAdminSection } from "#/lib/admin-access";
 import { searchUsersQuery } from "#/api/queries/roles";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import {
+    ConfirmDeleteDialog,
+    usePendingConfirm,
+} from "#/components/confirm-delete-dialog";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 import {
     UserSearchCombobox,
@@ -114,6 +118,7 @@ function StrikesSection() {
         "events:update",
         "events:manage",
     ]);
+    const confirmDelete = usePendingConfirm<Strike>();
 
     if (isPending) {
         return (
@@ -141,12 +146,6 @@ function StrikesSection() {
                 </CardContent>
             </Card>
         );
-    }
-
-    function handleDelete(strike: Strike) {
-        if (window.confirm("Slette denne prikken? Dette kan ikke angres.")) {
-            remove.mutate({ strikeId: strike.id });
-        }
     }
 
     return (
@@ -212,7 +211,9 @@ function StrikesSection() {
                                                     size="sm"
                                                     disabled={remove.isPending}
                                                     onClick={() =>
-                                                        handleDelete(strike)
+                                                        confirmDelete.request(
+                                                            strike,
+                                                        )
                                                     }
                                                 >
                                                     <Trash2 className="size-4" />
@@ -250,6 +251,24 @@ function StrikesSection() {
                     </Button>
                 </div>
             )}
+
+            <ConfirmDeleteDialog
+                open={confirmDelete.open}
+                onOpenChange={(open) => !open && confirmDelete.clear()}
+                title="Slette denne prikken?"
+                description={
+                    confirmDelete.shown
+                        ? `Prikken på ${confirmDelete.shown.user.name} fjernes for godt. Dette kan ikke angres.`
+                        : ""
+                }
+                confirmLabel="Slett prikk"
+                isPending={remove.isPending}
+                onConfirm={() => {
+                    if (!confirmDelete.pending) return;
+                    remove.mutate({ strikeId: confirmDelete.pending.id });
+                    confirmDelete.clear();
+                }}
+            />
         </div>
     );
 }

--- a/apps/kvark/src/routes/admin/roller.tsx
+++ b/apps/kvark/src/routes/admin/roller.tsx
@@ -61,6 +61,10 @@ import {
     updateMemberPermissionsMutation,
     updatePositionMutation,
 } from "#/api/queries/roles";
+import {
+    ConfirmDeleteDialog,
+    usePendingConfirm,
+} from "#/components/confirm-delete-dialog";
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminPageHeader } from "#/components/admin-page-header";
 import {
@@ -412,6 +416,7 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
     const remove = useMutation(deletePositionMutation);
     const [editing, setEditing] = useState<GroupPosition | null>(null);
     const [createOpen, setCreateOpen] = useState(false);
+    const confirmDelete = usePendingConfirm<GroupPosition>();
     // The rows below list only what a holder has beyond the group, so they
     // need the group's own two lists. Reading them requires managing the
     // group; without them the column falls back to the full list.
@@ -442,16 +447,6 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                 ))}
             </div>
         );
-    }
-
-    function handleDelete(position: GroupPosition) {
-        if (
-            window.confirm(
-                `Slette vervet «${position.name}»? Alle holdere mister tilgangene.`,
-            )
-        ) {
-            remove.mutate({ groupSlug, positionId: position.id });
-        }
     }
 
     return (
@@ -547,7 +542,9 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                                             <DropdownMenuItem
                                                 variant="destructive"
                                                 onClick={() =>
-                                                    handleDelete(position)
+                                                    confirmDelete.request(
+                                                        position,
+                                                    )
                                                 }
                                             >
                                                 Slett
@@ -609,6 +606,23 @@ function PositionsTable({ groupSlug }: { groupSlug: string }) {
                     position={editing}
                 />
             )}
+
+            <ConfirmDeleteDialog
+                open={confirmDelete.open}
+                onOpenChange={(open) => !open && confirmDelete.clear()}
+                title={`Slette vervet «${confirmDelete.shown?.name}»?`}
+                description="Alle som har vervet mister tilgangene det gir. Dette kan ikke angres."
+                confirmLabel="Slett verv"
+                isPending={remove.isPending}
+                onConfirm={() => {
+                    if (!confirmDelete.pending) return;
+                    remove.mutate({
+                        groupSlug,
+                        positionId: confirmDelete.pending.id,
+                    });
+                    confirmDelete.clear();
+                }}
+            />
         </>
     );
 }

--- a/apps/kvark/src/routes/admin/toddel.tsx
+++ b/apps/kvark/src/routes/admin/toddel.tsx
@@ -40,6 +40,10 @@ import {
 import { AdminEmptyState } from "#/components/admin-empty-state";
 import { AdminImageField } from "#/components/admin-image-field";
 import { AdminPageHeader } from "#/components/admin-page-header";
+import {
+    ConfirmDeleteDialog,
+    usePendingConfirm,
+} from "#/components/confirm-delete-dialog";
 import { errorStatus } from "#/lib/utils";
 import { useAnyScopePermission } from "#/hooks/use-permission";
 
@@ -146,6 +150,7 @@ function IssuesTable({ onEdit }: { onEdit: (issue: ToddelIssue) => void }) {
     const remove = useMutation(deleteToddelMutation);
     const canEdit = useAnyScopePermission(["toddel:update", "toddel:manage"]);
     const canDelete = useAnyScopePermission(["toddel:delete", "toddel:manage"]);
+    const confirmDelete = usePendingConfirm<ToddelIssue>();
 
     if (issues.length === 0) {
         return (
@@ -161,95 +166,105 @@ function IssuesTable({ onEdit }: { onEdit: (issue: ToddelIssue) => void }) {
         );
     }
 
-    function handleDelete(issue: ToddelIssue) {
-        if (
-            window.confirm(
-                `Fjerne utgave ${issue.edition} – "${issue.title}" fra arkivet?`,
-            )
-        ) {
-            remove.mutate({ edition: issue.edition });
-        }
-    }
-
     return (
-        <Card>
-            <CardContent className="p-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Utgave</TableHead>
-                            <TableHead>Tittel</TableHead>
-                            <TableHead>Publisert</TableHead>
-                            <TableHead>Filer</TableHead>
-                            <TableHead className="text-right">
-                                Handlinger
-                            </TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {issues.map((issue) => (
-                            <TableRow key={issue.edition}>
-                                <TableCell>{issue.edition}</TableCell>
-                                <TableCell>{issue.title}</TableCell>
-                                <TableCell>{issue.publishedAt}</TableCell>
-                                <TableCell>
-                                    <div className="flex gap-3">
-                                        <a
-                                            className="underline"
-                                            href={issue.pdfUrl}
-                                            target="_blank"
-                                            rel="noreferrer"
-                                        >
-                                            PDF
-                                        </a>
-                                        {issue.imageUrl ? (
+        <>
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Utgave</TableHead>
+                                <TableHead>Tittel</TableHead>
+                                <TableHead>Publisert</TableHead>
+                                <TableHead>Filer</TableHead>
+                                <TableHead className="text-right">
+                                    Handlinger
+                                </TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {issues.map((issue) => (
+                                <TableRow key={issue.edition}>
+                                    <TableCell>{issue.edition}</TableCell>
+                                    <TableCell>{issue.title}</TableCell>
+                                    <TableCell>{issue.publishedAt}</TableCell>
+                                    <TableCell>
+                                        <div className="flex gap-3">
                                             <a
                                                 className="underline"
-                                                href={issue.imageUrl}
+                                                href={issue.pdfUrl}
                                                 target="_blank"
                                                 rel="noreferrer"
                                             >
-                                                Forside
+                                                PDF
                                             </a>
-                                        ) : (
-                                            <span className="text-muted-foreground">
-                                                Ingen forside
-                                            </span>
-                                        )}
-                                    </div>
-                                </TableCell>
-                                <TableCell>
-                                    <div className="flex justify-end gap-2">
-                                        {canEdit ? (
-                                            <Button
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() => onEdit(issue)}
-                                            >
-                                                <PencilIcon className="size-4" />
-                                                Rediger
-                                            </Button>
-                                        ) : null}
-                                        {canDelete ? (
-                                            <Button
-                                                variant="destructive"
-                                                size="sm"
-                                                disabled={remove.isPending}
-                                                onClick={() =>
-                                                    handleDelete(issue)
-                                                }
-                                            >
-                                                <Trash2 className="size-4" />
-                                            </Button>
-                                        ) : null}
-                                    </div>
-                                </TableCell>
-                            </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </CardContent>
-        </Card>
+                                            {issue.imageUrl ? (
+                                                <a
+                                                    className="underline"
+                                                    href={issue.imageUrl}
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                >
+                                                    Forside
+                                                </a>
+                                            ) : (
+                                                <span className="text-muted-foreground">
+                                                    Ingen forside
+                                                </span>
+                                            )}
+                                        </div>
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex justify-end gap-2">
+                                            {canEdit ? (
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={() =>
+                                                        onEdit(issue)
+                                                    }
+                                                >
+                                                    <PencilIcon className="size-4" />
+                                                    Rediger
+                                                </Button>
+                                            ) : null}
+                                            {canDelete ? (
+                                                <Button
+                                                    variant="destructive"
+                                                    size="sm"
+                                                    disabled={remove.isPending}
+                                                    onClick={() =>
+                                                        confirmDelete.request(
+                                                            issue,
+                                                        )
+                                                    }
+                                                >
+                                                    <Trash2 className="size-4" />
+                                                </Button>
+                                            ) : null}
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+
+            <ConfirmDeleteDialog
+                open={confirmDelete.open}
+                onOpenChange={(open) => !open && confirmDelete.clear()}
+                title={`Fjerne utgave ${confirmDelete.shown?.edition} fra arkivet?`}
+                description="Utgaven forsvinner fra TÖDDEL-siden. PDF-en og forsidebildet blir liggende, men ingen kommer til dem."
+                confirmLabel="Slett utgave"
+                isPending={remove.isPending}
+                onConfirm={() => {
+                    if (!confirmDelete.pending) return;
+                    remove.mutate({ edition: confirmDelete.pending.edition });
+                    confirmDelete.clear();
+                }}
+            />
+        </>
     );
 }
 


### PR DESCRIPTION
## Hva

`ConfirmDeleteDialog` ble laget for å erstatte `window.confirm` — doc-kommentaren sier det rett ut — men var bare tatt i bruk ett sted (`admin/arrangementer.$eventId`). Elleve andre steder i admin gikk fortsatt gjennom nettleserens egen boks. Denne PR-en konverterer alle.

Hvorfor det er verdt å bytte:

- `window.confirm` viser domenet over teksten («photon.tihlde.org sier»), kan ikke ha en rød «Slett»-knapp, og alt må presses inn i én setning.
- Den blokkerer JS-tråden mens den står åpen.
- Nettleseren lar brukeren huke av «ikke vis flere dialoger fra denne siden». Gjør noen det mens de rydder, forsvinner bekreftelsen helt, og neste klikk på søppelbøtta sletter uten å spørre.

## Nytt: `usePendingConfirm`

Hver liste trenger state for hva som venter på bekreftelse. Hooken ligger sammen med dialogen og gjør det på ett sted.

`shown` henger igjen på det forrige elementet mens dialogen animeres ut. Uten det bytter tittelen til «undefined» i det halve sekundet lukkingen tar — det skjedde faktisk under verifiseringen, og er grunnen til at hooken finnes.

## Rotering av API-nøkler

Bruker samme dialog. Den sletter ingenting, men den gamle nøkkelen dør i samme øyeblikk, så bekreftelsen er den samme. Det står en kommentar om det på stedet.

## Verifisert

Hver eneste dialog åpnet i nettleseren mot lokal API, med tekst lest av og bekreftelse kjørt helt gjennom til raden faktisk forsvant:

| Sted | Dialog | Slettet |
|---|---|---|
| Nyheter | «Slette «Testnyhet to»?» | ja |
| Bannere | «Slette banneret «Testbanner to»?» | ja |
| Annonser | «Slette annonsen «Testannonse»?» | ja |
| Galleri | «Slette «Testgalleri fire»?» | ja |
| Prikker | «Slette denne prikken?» | ja |
| Tilganger | «Slette vervet «Testverv»?» | ja |
| Brukere | «Fjerne Brotherman Testern fra gruppen?» | ja |
| API-nøkler (roter) | «Rotere nøkkelen «Testnokkel»?» | ja, ny hemmelighet vist |
| API-nøkler (slett) | «Slette nøkkelen «Testnokkel»?» | ja |
| OAuth-klienter | «Slette Testklient?» | ja |
| TÖDDEL | «Fjerne utgave 1 fra arkivet?» | ja |

Avbryt-knappen ble også testet (banner, annonse): dialogen lukkes og raden blir stående. Tittelen ble lest av midt i utgangsanimasjonen for å bekrefte at «undefined»-glippen er borte. All testdata er ryddet bort igjen.

`bun run typecheck`, `bun run build` og lint er grønne.

## To ting jeg så underveis

- **«Fjern medlem» i Brukere er utilgjengelig i dag.** Studienedtrekket viser bare STUDY-grupper, og de er alltid `readOnly` — så knappen (og dialogen) rendres aldri. Jeg verifiserte den bak en midlertidig lokal patch, som er reversert. Verdt en egen sak; jeg har ikke rørt logikken her.
- **Diffen er større enn endringen.** Å pakke `<Card>` i et fragment re-indenterer hele JSX-treet. Slå på «Hide whitespace» i diff-visningen — da er den 227 linjer, ikke 549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)