### PR TITLE
fix(profil): fjern medlemskap-seksjonen fra egen oversikt

### DIFF
--- a/apps/kvark/src/routes/_app/profil/$id/index.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id/index.tsx
@@ -88,9 +88,7 @@ function RouteComponent() {
     const membershipDescription =
         memberships.length > 0
             ? `${memberships.length} ${memberships.length === 1 ? "gruppe" : "grupper"}`
-            : isOwnProfile
-              ? "Du er ikke medlem i noen grupper"
-              : "Ikke medlem i noen grupper";
+            : "Ikke medlem i noen grupper";
 
     return (
         <>
@@ -119,25 +117,26 @@ function RouteComponent() {
                 </>
             ) : null}
 
-            {/* Gruppene vises direkte i stedet for et telle-kort. Kortet så
-                klikkbart ut uten å være det, og på andres profil var det alt
-                sidens innhold besto av. */}
-            <div className="flex flex-col gap-3">
-                <h3>Medlemskap</h3>
-                {memberships.length > 0 ? (
-                    <ProfileMembershipChips
-                        groups={memberships.map((group) => ({
-                            slug: group.slug,
-                            name: group.name,
-                            canOpen: canOpenGroup(group),
-                        }))}
-                    />
-                ) : (
-                    <p className="text-sm text-muted-foreground">
-                        {membershipDescription}
-                    </p>
-                )}
-            </div>
+            {/* Bare på andres profil: der er dette omtrent alt siden har å
+                vise. På egen profil holder det med Medlemskap-fanen. */}
+            {!isOwnProfile ? (
+                <div className="flex flex-col gap-3">
+                    <h3>Medlemskap</h3>
+                    {memberships.length > 0 ? (
+                        <ProfileMembershipChips
+                            groups={memberships.map((group) => ({
+                                slug: group.slug,
+                                name: group.name,
+                                canOpen: canOpenGroup(group),
+                            }))}
+                        />
+                    ) : (
+                        <p className="text-sm text-muted-foreground">
+                            {membershipDescription}
+                        </p>
+                    )}
+                </div>
+            ) : null}
 
             {/* Kommende arrangementer og oppgaver er personlige og vises kun på
                 egen profil. */}


### PR DESCRIPTION
Medlemskap-seksjonen på Oversikt-fanen er borte på egen profil — Medlemskap-fanen dekker det samme.

Seksjonen står igjen på andres profil: der er Oversikt praktisk talt tom uten den (bare navn og «Om»).

## Verifisert
- Egen profil (`/profil/me`): Om → Kommende → Må gjøres, ingen Medlemskap-seksjon.
- Annen bruker: Medlemskap med gruppene vises fortsatt.
- `bun run typecheck`, `bun run lint`, `bun run format` grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)