### PR TITLE
feat(e-post): la e-post-API-et velge avsender og sette noen på kopi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,10 @@ OAUTH_PAIRWISE_SECRET=# Generate with: openssl rand -hex 32
 # MAIL_USER=
 # MAIL_PASS=
 # MAIL_FROM=no-reply@tihlde.org
+# Other addresses /api/email/send may send as, comma-separated. MAIL_FROM is
+# always allowed. Each address must also be one the SMTP account has "send as"
+# rights for, or the mail server rejects it.
+# MAIL_ALLOWED_FROM=hs@tihlde.org,au@tihlde.org
 
 # --- Email Proxy Worker (apps/proxy) -----------------------------------------
 # These are only needed when running or deploying the Cloudflare Worker proxy.

--- a/apps/api/src/routes/email/send.ts
+++ b/apps/api/src/routes/email/send.ts
@@ -52,7 +52,7 @@ export const sendEmailRoute = route().post(
         .unauthorized({
             description: "Missing or invalid Authorization header",
         })
-        .forbidden({ description: "Invalid API key" })
+        .forbidden({ description: "Invalid API key or disallowed sender" })
         .response({ statusCode: 503, description: "Email API not configured" })
         .build(),
     requireEmailApiKey,
@@ -60,6 +60,17 @@ export const sendEmailRoute = route().post(
     async (c) => {
         const body = c.req.valid("json");
         const { ctx } = c.var;
+
+        const from = body.from ?? env.MAIL_FROM;
+
+        // The API key is shared with tools outside this codebase, so a free
+        // choice of sender would let any holder of it write as any TIHLDE
+        // address. Only what the deployment has listed goes out.
+        if (!env.MAIL_ALLOWED_FROM_LIST.includes(from.toLowerCase())) {
+            throw new HTTPException(403, {
+                message: `Sender ${from} is not allowed. Allowed: ${env.MAIL_ALLOWED_FROM_LIST.join(", ")}`,
+            });
+        }
 
         try {
             // Normalize 'to' field to always be an array
@@ -69,9 +80,12 @@ export const sendEmailRoute = route().post(
                 recipients.map((recipient) =>
                     ctx.email.sendEmailTemplate(
                         {
-                            from: env.MAIL_FROM,
+                            from,
                             to: recipient,
                             subject: body.subject,
+                            ...(body.cc ? { cc: body.cc } : {}),
+                            ...(body.bcc ? { bcc: body.bcc } : {}),
+                            ...(body.replyTo ? { replyTo: body.replyTo } : {}),
                         },
                         "CustomEmail",
                         {

--- a/apps/api/src/test/email/send.test.ts
+++ b/apps/api/src/test/email/send.test.ts
@@ -264,4 +264,94 @@ describe("send email endpoint", () => {
         },
         500_000,
     );
+
+    integrationTest(
+        "Test that copy recipients and reply-to reach the queued email",
+        async ({ ctx }) => {
+            const client = ctx.utils.client({
+                Authorization: "Bearer test-email-api-key",
+            });
+
+            const response = await client.api.email.send.$post({
+                json: {
+                    to: "test@example.com",
+                    cc: ["au@test.tihlde.org"],
+                    bcc: ["arkiv@test.tihlde.org"],
+                    replyTo: "hs@test.tihlde.org",
+                    subject: "Copied Email",
+                    content: [{ type: "text", content: "Body." }],
+                },
+            });
+
+            expect(response.status).toBe(200);
+
+            const emailQueue =
+                ctx.queue.getQueue<EmailQueueJobData>(EMAIL_QUEUE_NAME);
+            const jobs = await emailQueue.getJobs(["waiting", "active"]);
+
+            expect(jobs).toHaveLength(1);
+            expect(jobs[0]?.data.options).toMatchObject({
+                to: "test@example.com",
+                cc: ["au@test.tihlde.org"],
+                bcc: ["arkiv@test.tihlde.org"],
+                replyTo: "hs@test.tihlde.org",
+            });
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "Test that an allowed sender overrides the default one",
+        async ({ ctx }) => {
+            const client = ctx.utils.client({
+                Authorization: "Bearer test-email-api-key",
+            });
+
+            const response = await client.api.email.send.$post({
+                json: {
+                    to: "test@example.com",
+                    from: "hs@test.tihlde.org",
+                    subject: "From HS",
+                    content: [{ type: "text", content: "Body." }],
+                },
+            });
+
+            expect(response.status).toBe(200);
+
+            const emailQueue =
+                ctx.queue.getQueue<EmailQueueJobData>(EMAIL_QUEUE_NAME);
+            const jobs = await emailQueue.getJobs(["waiting", "active"]);
+
+            expect(jobs[0]?.data.options.from).toBe("hs@test.tihlde.org");
+        },
+        500_000,
+    );
+
+    integrationTest(
+        "Test that a sender outside the allowlist is refused",
+        async ({ ctx }) => {
+            const client = ctx.utils.client({
+                Authorization: "Bearer test-email-api-key",
+            });
+
+            const response = await client.api.email.send.$post({
+                json: {
+                    to: "test@example.com",
+                    from: "styret@example.com",
+                    subject: "Spoofed",
+                    content: [{ type: "text", content: "Body." }],
+                },
+            });
+
+            expect(response.status).toBe(403);
+
+            // Nothing may be queued: a refused sender that still sent would be
+            // the whole point of the check.
+            const emailQueue =
+                ctx.queue.getQueue<EmailQueueJobData>(EMAIL_QUEUE_NAME);
+            const jobs = await emailQueue.getJobs(["waiting", "active"]);
+            expect(jobs).toHaveLength(0);
+        },
+        500_000,
+    );
 });

--- a/apps/api/src/test/setup-env.ts
+++ b/apps/api/src/test/setup-env.ts
@@ -14,6 +14,7 @@ const testEnv = {
     WEBSITE_URL: "http://localhost:3000",
     MAX_TEST_WORKERS: "1",
     MAIL_FROM: "no-reply@test.tihlde.org",
+    MAIL_ALLOWED_FROM: "hs@test.tihlde.org",
     EMAIL_API_KEY: "test-email-api-key",
 } satisfies TestEnv;
 

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -71,6 +71,18 @@ function toOrigin(url: string): string {
     }
 }
 
+/**
+ * The bare address out of a sender string.
+ *
+ * MAIL_FROM is allowed to carry a display name — `TIHLDE <no-reply@tihlde.org>`
+ * — but the allowlist is compared against what a caller sends, which is a plain
+ * address. Without this the configured sender would fail its own check.
+ */
+function toEmailAddress(sender: string): string {
+    const angled = /<([^>]+)>/.exec(sender);
+    return (angled?.[1] ?? sender).trim().toLowerCase();
+}
+
 const envSchema = z
     .object({
         // CONFIG
@@ -135,6 +147,17 @@ const envSchema = z
         MAIL_USER: z.string().optional(),
         MAIL_PASS: z.string().optional(),
         MAIL_FROM: z.string().default("no-reply@tihlde.org"),
+        /**
+         * Further addresses `/emails/send` may send as, comma-separated.
+         * MAIL_FROM is always allowed and need not be listed.
+         *
+         * An allowlist rather than a free choice: EMAIL_API_KEY is handed to
+         * tools outside this codebase, and without one any holder of the key
+         * could write as any tihlde.org address. The address must in any case
+         * be one the SMTP account has "send as" rights for — Gmail rejects the
+         * rest — so this is a limit, not a grant.
+         */
+        MAIL_ALLOWED_FROM: z.string().default(""),
         EMAIL_API_KEY: z.string().default("test-email-api-key"),
         /** Where the "for bedrifter" contact form delivers its submissions */
         COMPANY_CONTACT_EMAIL: z
@@ -206,9 +229,19 @@ const envSchema = z
               ? PRODUCTION_WEBSITE_ORIGINS
               : [];
 
+        const allowedFrom = vals.MAIL_ALLOWED_FROM.split(",")
+            .map((address) => address.trim())
+            .filter(Boolean);
+
         const resolved = {
             ...vals,
             WEBSITE_URL: websiteUrl,
+            /** Every address the email API may send as, MAIL_FROM included. */
+            MAIL_ALLOWED_FROM_LIST: [
+                ...new Set(
+                    [vals.MAIL_FROM, ...allowedFrom].map(toEmailAddress),
+                ),
+            ],
             /**
              * Every frontend origin the API accepts, WEBSITE_URL first. Only
              * WEBSITE_URL is used to *build* links (emails, redirects); the

--- a/packages/email/src/schema.ts
+++ b/packages/email/src/schema.ts
@@ -55,6 +55,28 @@ export const sendCustomEmailSchema = z.object({
             description:
                 "Recipient email address (string) or list of recipient email addresses (array)",
         }),
+    cc: z
+        .array(z.email("Each Cc recipient must be a valid email address"))
+        .optional()
+        .meta({
+            description:
+                "Addresses to put on copy. Note that the API sends one email per `to` recipient, so a Cc address receives one copy per recipient.",
+        }),
+    bcc: z
+        .array(z.email("Each Bcc recipient must be a valid email address"))
+        .optional()
+        .meta({
+            description:
+                "Addresses to put on blind copy. Same per-recipient caveat as `cc`.",
+        }),
+    from: z.email("Sender must be a valid email address").optional().meta({
+        description:
+            "Sender address. Must be one the server allows (MAIL_FROM plus MAIL_ALLOWED_FROM); defaults to MAIL_FROM.",
+    }),
+    replyTo: z
+        .email("Reply-to must be a valid email address")
+        .optional()
+        .meta({ description: "Where replies should go. Defaults to `from`." }),
     subject: z
         .string()
         .min(1, "Subject cannot be empty")


### PR DESCRIPTION
## Hva

`/api/email/send` kunne bare sende fra `MAIL_FROM`, uten kopi og uten svar-til. Denne PR-en legger til `from`, `replyTo`, `cc` og `bcc` på ruta.

Bakgrunnen er en konkret oppgave: HS skal sende ut mail til de 125 som søkte verv i to eller flere grupper i høstens opptak, og mailen skal komme fra `hs@tihlde.org`.

## Hvordan

- Tjenestelaget hadde allerede `cc`/`bcc`/`replyTo` i `SendOptions`, og SMTP-adapteren sender hele objektet videre til nodemailer. Det som manglet var bare at ruta eksponerte feltene.
- Avsender går gjennom en allowlist — ny `MAIL_ALLOWED_FROM` (komma-separert), med `MAIL_FROM` alltid inkludert. Et fritt valg hadde vært utrygt: `EMAIL_API_KEY` er delt med verktøy utenfor repoet, og uten lista kunne enhver med nøkkelen skrive som hvilken som helst tihlde.org-adresse. En avsender utenfor lista gir 403, og ingenting legges på køen.

## Verdt å vite ved bruk

Ruta sender én mail per mottaker i `to`. En `cc`-adresse får derfor én kopi per mottaker — 125 mailer i tilfellet over. Skal noen bare ha sporbarhet, er en egen oppsummeringsmail bedre. Dette står i API-dokumentasjonen på feltet.

Adressen må i tillegg være en SMTP-kontoen har «send as»-rett for i Google Workspace, ellers avviser Gmail sendingen uansett hva koden ber om. **Det må settes opp før `MAIL_ALLOWED_FROM=hs@tihlde.org` legges inn i prod-miljøet på Drift.**

## Testet

`bun run typecheck` og de 10 testene i `apps/api/src/test/email/send.test.ts` er grønne, inkludert tre nye: at kopi/blindkopi/svar-til når fram til den køede mailen, at en tillatt avsender overstyrer standarden, og at en avsender utenfor lista avvises med 403 uten å legge noe på køen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)