### PR TITLE
fix(profil): «Svar nå» i allergibanneret går til innstillingene

### DIFF
--- a/apps/kvark/src/routes/_app/profil/$id.tsx
+++ b/apps/kvark/src/routes/_app/profil/$id.tsx
@@ -47,6 +47,28 @@ import {
 } from "#/components/profile-header";
 import { formatStudyLabel } from "#/lib/utils";
 
+/**
+ * Underrutene på profilen, slik at aliaset «me» beholder siden man var på vei
+ * til. Uten dette havnet f.eks. «Svar nå» i allergibanneret på oversikten i
+ * stedet for innstillingene lenken peker på.
+ */
+const PROFILE_SUBROUTES = [
+    "/profil/$id/arrangementer",
+    "/profil/$id/innstillinger",
+    "/profil/$id/medlemskap",
+    "/profil/$id/prikker",
+    "/profil/$id/sporreskjemaer",
+] as const;
+
+function subrouteFor(
+    pathname: string,
+): (typeof PROFILE_SUBROUTES)[number] | undefined {
+    const suffix = pathname
+        .slice(`/profil/${OWN_PROFILE_ALIAS}`.length)
+        .replace(/\/$/, "");
+    return PROFILE_SUBROUTES.find((route) => route === `/profil/$id${suffix}`);
+}
+
 export const Route = createFileRoute("/_app/profil/$id")({
     component: RouteComponent,
     beforeLoad: async ({ location, params }) => {
@@ -55,8 +77,9 @@ export const Route = createFileRoute("/_app/profil/$id")({
         // Bytt aliaset med den lesbare varianten når kontoen har en.
         if (params.id === OWN_PROFILE_ALIAS) {
             throw redirect({
-                to: "/profil/$id",
+                to: subrouteFor(location.pathname) ?? "/profil/$id",
                 params: { id: auth.user.username ?? auth.user.id },
+                search: location.search,
                 replace: true,
             });
         }


### PR DESCRIPTION
## Problem

«Svar nå»-knappen i allergibanneret på profilen landet på profiloversikten i stedet for innstillingene, der man faktisk legger inn allergier.

Knappen lenket riktig — feilen lå i `beforeLoad` på `/_app/profil/$id`. Aliaset `/profil/me` ble byttet mot brukernavnet med `to: "/profil/$id"`, altså foreldreruta, så underruta ble kastet bort. Det traff alt under `/profil/me/*`: innstillinger, prikker, medlemskap, arrangementer og spørreskjemaer.

## Løsning

Redirecten peker nå på den underruta man var på vei til, og tar med søkeparameterne. Ukjente stier faller til oversikten som før.

## Verifisert

- Rutelista er komplett mot `routeTree.gen.ts` — nøyaktig fem barn + index.
- Ingen `basepath` i routeren, så prefikset `/profil/me` er alltid riktig å kutte.
- Forelderens `beforeLoad` kjører før barnets, så `requireOwnProfile` får brukernavnet — ingen ny redirect eller løkke.
- Innlogging bevarer stien: uinnlogget gir `redirectTo=%2Fprofil%2Fme%2Finnstillinger`, som treffer fiksen etter innlogging.
- Kanttilfeller: `/profil/me` og `/profil/me/` → oversikten, de fem underrutene → riktig side, `/profil/me/tull` og `/profil/me//innstillinger` → oversikten.
- `bun run typecheck` grønt (9/9), oxlint rent.

Selve klikket er ikke klikket gjennom i nettleser — siden krever innlogging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)