### PR TITLE
fix(arrangement): sorter ventelista med den neste inn øverst

### DIFF
--- a/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
+++ b/apps/kvark/src/routes/admin/arrangementer.$eventId.tsx
@@ -862,13 +862,23 @@ function RegistrationsTab({ eventId }: { eventId: string }) {
     );
     useLoadAllPages(registrationsQuery);
 
-    const participants = useMemo(
-        () =>
+    const participants = useMemo(() => {
+        const rows =
             registrationsQuery.data?.pages.flatMap(
                 (page) => page.registeredUsers,
-            ) ?? [],
-        [registrationsQuery.data],
-    );
+            ) ?? [];
+        // Ventelista leses ovenfra og ned: den som står øverst er den som får
+        // plassen når noen melder seg av. Lista kommer nyeste først fra API-et,
+        // som er riktig for påmeldte, men snur ventelista på hodet.
+        if (status !== "waitlisted") {
+            return rows;
+        }
+        return [...rows].sort(
+            (a, b) =>
+                (a.waitlistPosition ?? Number.MAX_SAFE_INTEGER) -
+                (b.waitlistPosition ?? Number.MAX_SAFE_INTEGER),
+        );
+    }, [registrationsQuery.data, status]);
     const isPending = registrationsQuery.isPending;
 
     /**
@@ -1066,11 +1076,16 @@ function RegistrationsTab({ eventId }: { eventId: string }) {
                                     return (
                                         <TableRow key={participant.id}>
                                             <TableCell>
-                                                {participant.name}
                                                 {participant.waitlistPosition !=
-                                                null
-                                                    ? ` (#${participant.waitlistPosition})`
-                                                    : ""}
+                                                null ? (
+                                                    <span className="text-muted-foreground mr-2 tabular-nums">
+                                                        {
+                                                            participant.waitlistPosition
+                                                        }
+                                                        .
+                                                    </span>
+                                                ) : null}
+                                                {participant.name}
                                             </TableCell>
                                             <TableCell>
                                                 {participant.email ?? "—"}


### PR DESCRIPTION
## Problem

Venteliste-fanen på admin-siden for et arrangement arvet rekkefølgen fra `/events/:id/registration`, som sorterer på `createdAt` synkende. Det er riktig for påmeldte, men snur ventelista: den som får plassen når noen melder seg av — posisjon 1 — lå nederst i tabellen.

Plassnummeret sto dessuten bak navnet, som `Navn (#3)`, så man måtte lese til slutten av hver rad for å finne rekkefølgen.

## Løsning

- Radene sorteres på `waitlistPosition` stigende når venteliste-fanen er valgt. Rader uten posisjon havner bakerst. Påmeldte-fanen er urørt.
- Sorteringen gjøres i nettleseren, ikke i API-et: hele lista lastes allerede ned der for søk og fasetter, og endepunktet deles med den offentlige deltakerlista som skal beholde sin rekkefølge.
- Nummeret flyttet foran navnet — `3. Navn` — dempet og med `tabular-nums`, så tallene står rett under hverandre og lista leses ovenfra og ned.

## Verifisert

- `bun run typecheck` (9/9), `bun run lint` (ingen nye advarsler i fila) og `bun run build` er grønne.
- Ikke klikket gjennom i nettleser: det krever en innlogget arrangør på et arrangement med faktisk venteliste, som ikke finnes i lokal database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)